### PR TITLE
Fixes #22254 - Add autocomplete component

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "axios-mock-adapter": "^1.10.0",
     "bootstrap-select": "^1.12.2",
     "classnames": "^2.2.5",
+    "downshift": "^1.28.0",
     "patternfly": "^3.31.2",
     "patternfly-react": "^0.22.1",
     "prop-types": "^15.6.0",

--- a/webpack/move_to_pf/TypeAhead/TypeAhead.js
+++ b/webpack/move_to_pf/TypeAhead/TypeAhead.js
@@ -1,0 +1,123 @@
+import React, { Component } from 'react';
+import Downshift from 'downshift';
+import PropTypes from 'prop-types';
+
+import { InputGroup, Button } from 'patternfly-react';
+import TypeAheadInput from './TypeAheadInput';
+import TypeAheadItems from './TypeAheadItems';
+import { getActiveItems } from './helpers';
+
+import './TypeAhead.scss';
+
+const KEY_CODES = { TAB_KEY: 9, ENTER_KEY: 13 };
+
+class TypeAhead extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      inputValue: '',
+    };
+
+    this.handleStateChange = this.handleStateChange.bind(this);
+  }
+
+  handleStateChange({ inputValue }) {
+    if (typeof inputValue === 'string') {
+      this.props.onInputUpdate(inputValue);
+      this.setState({ inputValue });
+    }
+  }
+
+  render() {
+    const {
+      onSearch, onInputUpdate, items, actionText, ...rest
+    } = this.props;
+
+    const activeItems = getActiveItems(items);
+
+    return (
+      <Downshift
+        onStateChange={this.handleStateChange}
+        defaultHighlightedIndex={0}
+        selectedItem={this.state.inputValue}
+        {...rest}
+        render={({
+          getInputProps,
+          getItemProps,
+          isOpen,
+          inputValue,
+          highlightedIndex,
+          selectedItem,
+          selectItem,
+        }) => {
+          const shouldShowItems = isOpen && items.length > 0;
+          const autoCompleteItemsProps = {
+            items,
+            highlightedIndex,
+            selectedItem,
+            getItemProps,
+            activeItems,
+          };
+
+          return (
+            <div>
+              <InputGroup>
+                <TypeAheadInput
+                  onKeyPress={(e) => {
+                    switch (e.keyCode) {
+                      case KEY_CODES.TAB_KEY:
+                        if (isOpen && activeItems[highlightedIndex]) {
+                          selectItem(activeItems[highlightedIndex]);
+                          e.preventDefault();
+                        }
+
+                        break;
+
+                      case KEY_CODES.ENTER_KEY:
+                        if (!isOpen || !activeItems[highlightedIndex]) {
+                          onSearch(this.state.inputValue);
+                          e.preventDefault();
+                        }
+
+                        break;
+
+                      default:
+                        break;
+                    }
+                  }}
+                  passedProps={getInputProps()}
+                />
+                <InputGroup.Button>
+                  <Button onClick={() => onSearch(inputValue)}>{actionText}</Button>
+                </InputGroup.Button>
+              </InputGroup>
+
+              {shouldShowItems && <TypeAheadItems {...autoCompleteItemsProps} />}
+            </div>
+          );
+        }}
+      />
+    );
+  }
+}
+
+TypeAhead.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.shape({
+    /* text to display in MenuItem  */
+    text: PropTypes.string,
+    /* item can be a header or divider or undefined for regular item */
+    type: PropTypes.oneOf(['header', 'divider']),
+    /* optionally disable a regular item */
+    disabled: PropTypes.bool,
+  })).isRequired,
+  onInputUpdate: PropTypes.func.isRequired,
+  onSearch: PropTypes.func.isRequired,
+  actionText: PropTypes.string,
+};
+
+TypeAhead.defaultProps = {
+  actionText: 'Search',
+};
+
+export default TypeAhead;

--- a/webpack/move_to_pf/TypeAhead/TypeAhead.scss
+++ b/webpack/move_to_pf/TypeAhead/TypeAhead.scss
@@ -1,0 +1,7 @@
+.typeahead-dropdown {
+  display: block;
+  position: absolute;
+  left: inherit;
+  margin-top: 0;
+  top: auto;
+}

--- a/webpack/move_to_pf/TypeAhead/TypeAheadInput.js
+++ b/webpack/move_to_pf/TypeAhead/TypeAheadInput.js
@@ -1,0 +1,45 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { FormControl } from 'patternfly-react';
+
+class TypeAheadInput extends Component {
+  constructor(props) {
+    super(props);
+    this.handleKeyPress = this.handleKeyPress.bind(this);
+  }
+
+  componentDidMount() {
+    if (this.ref) {
+      this.ref.addEventListener('keydown', this.handleKeyPress);
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.ref) {
+      this.ref.removeEventListener('keydown', this.handleKeyPress);
+    }
+  }
+
+  handleKeyPress(e) {
+    this.props.onKeyPress(e);
+  }
+
+  render() {
+    return (
+      <FormControl
+        inputRef={(ref) => {
+          this.ref = ref;
+        }}
+        type="text"
+        {...this.props.passedProps}
+      />
+    );
+  }
+}
+
+TypeAheadInput.propTypes = {
+  passedProps: PropTypes.shape({}).isRequired,
+  onKeyPress: PropTypes.func.isRequired,
+};
+
+export default TypeAheadInput;

--- a/webpack/move_to_pf/TypeAhead/TypeAheadItems.js
+++ b/webpack/move_to_pf/TypeAhead/TypeAheadItems.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Dropdown, MenuItem } from 'patternfly-react';
+
+const TypeAheadItems = ({
+  items, activeItems, getItemProps, highlightedIndex,
+}) => (
+  <Dropdown.Menu className="typeahead-dropdown">
+    {items.map(({ text, type, disabled = false }, index) => {
+      if (type === 'header') {
+        return (
+          <MenuItem key={text} header>
+            {text}
+          </MenuItem>
+        );
+      }
+
+      if (type === 'divider') {
+        // eslint-disable-next-line react/no-array-index-key
+        return <MenuItem key={`divider-${index}`} divider />;
+      }
+
+      if (disabled) {
+        return (
+          <MenuItem key={text} disabled>
+            {text}
+          </MenuItem>
+        );
+      }
+
+      const itemProps = getItemProps({
+        index: activeItems.indexOf(text),
+        item: text,
+        active: activeItems[highlightedIndex] === text,
+        onClick: (e) => {
+          // At this point the event.defaultPrevented
+          // is already set to true by react-bootstrap
+          // MenuItem. We need to set it back to false
+          // So downshift will execute it's own handler
+          e.defaultPrevented = false;
+        },
+      });
+
+      return (
+        <MenuItem {...itemProps} key={text}>
+          {text}
+        </MenuItem>
+      );
+    })}
+  </Dropdown.Menu>
+);
+
+TypeAheadItems.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.object).isRequired,
+  activeItems: PropTypes.arrayOf(PropTypes.string).isRequired,
+  highlightedIndex: PropTypes.number.isRequired,
+  getItemProps: PropTypes.func.isRequired,
+};
+
+export default TypeAheadItems;

--- a/webpack/move_to_pf/TypeAhead/helpers.js
+++ b/webpack/move_to_pf/TypeAhead/helpers.js
@@ -1,0 +1,5 @@
+// eslint-disable-next-line import/prefer-default-export
+export const getActiveItems = items =>
+  items
+    .filter(({ disabled, type }) => !disabled && !['header', 'divider'].includes(type))
+    .map(({ text }) => text);


### PR DESCRIPTION
Changed the component name to TypeAhead as recommended
by patternfly. This component will eventually be merged
into patternfly-react after the design is in pf-core.

http://projects.theforeman.org/issues/22254