### PR TITLE
Fixes #22594: Allow listing upstream subs

### DIFF
--- a/app/controllers/katello/api/v2/upstream_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/upstream_subscriptions_controller.rb
@@ -1,0 +1,36 @@
+require 'katello/resources/candlepin'
+
+module Katello
+  class Api::V2::UpstreamSubscriptionsController < Api::V2::ApiController
+    before_action :find_organization
+
+    resource_description do
+      description "Red Hat subscriptions management platform."
+      api_version 'v2'
+    end
+
+    def_param_group :cp_search do
+      param :page, :number, :desc => N_("Page number, starting at 1")
+      param :per_page, :number, :desc => N_("Number of results per page to return.")
+      param :order, String, :desc => N_("The order to sort the results in. ['asc', 'desc'] Defaults to 'desc'.")
+      param :sort_by, String, :desc => N_("The field to sort the data by. Defaults to the created date.")
+    end
+
+    api :GET, "/organizations/:organization_id/upstream_subscriptions",
+      N_("List available subscriptions from Red Hat Subscription Management")
+    param :organization_id, :number, :desc => N_("Organization ID"), :required => true
+    param_group :cp_search
+    def index
+      pools = UpstreamPool.fetch_pools(@organization, upstream_pool_params)
+      collection = scoped_search_results(
+        pools, pools.count, nil, params[:page], params[:per_page], nil)
+      respond(collection: collection)
+    end
+
+    private
+
+    def upstream_pool_params
+      params.permit(:page, :per_page, :order, :sort_by, :organization_id)
+    end
+  end
+end

--- a/app/lib/katello/resources/candlepin/consumer.rb
+++ b/app/lib/katello/resources/candlepin/consumer.rb
@@ -1,0 +1,240 @@
+module Katello
+  module Resources
+    module Candlepin
+      module ConsumerResource
+        def path(id = nil)
+          "#{self.prefix}/consumers/#{id}"
+        end
+      end
+
+      class Consumer < CandlepinResource
+        extend ConsumerResource
+
+        class << self
+          def all_uuids
+            cp_consumers = Organization.all.map do |org|
+              ::Katello::Resources::Candlepin::Consumer.get('owner' => org.label, :include_only => [:uuid])
+            end
+            cp_consumers.flatten!
+            cp_consumers.map { |consumer| consumer["uuid"] }
+          end
+
+          def get(params)
+            if params.is_a?(String)
+              JSON.parse(super(path(params), self.default_headers).body).with_indifferent_access
+            else
+              includes = params.key?(:include_only) ? "&" + included_list(params.delete(:include_only)) : ""
+              fetch_paged do |page_add|
+                response = super(path + hash_to_query(params) + includes + "&#{page_add}", self.default_headers).body
+                JSON.parse(response)
+              end
+            end
+          end
+
+          def create(env_id, parameters, activation_key_cp_ids)
+            parameters['installedProducts'] ||= [] #if installed products is nil, candlepin won't attach custom products
+            url = "/candlepin/environments/#{url_encode(env_id)}/consumers/"
+            url += "?activation_keys=" + activation_key_cp_ids.join(",") if activation_key_cp_ids.length > 0
+
+            response = self.post(url, parameters.to_json, self.default_headers).body
+            JSON.parse(response).with_indifferent_access
+          end
+
+          def async_hypervisors(owner, raw_json)
+            url = "/candlepin/hypervisors/#{owner}"
+            headers = self.default_headers
+            headers['content-type'] = 'text/plain'
+            response = self.post(url, raw_json, headers)
+            JSON.parse(response).with_indifferent_access
+          end
+
+          def register_hypervisors(params)
+            url = "/candlepin/hypervisors"
+            url << "?owner=#{params[:owner]}&env=#{params[:env]}"
+            attrs = params.except(:owner, :env)
+            response = self.post(url, attrs.to_json, self.default_headers).body
+            JSON.parse(response).with_indifferent_access
+          end
+
+          def update(uuid, params)
+            if params.empty?
+              true
+            else
+              self.put(path(uuid), params.to_json, self.default_headers).body
+            end
+            # consumer update doesn't return any data atm
+            # JSON.parse(response).with_indifferent_access
+          end
+
+          def destroy(uuid)
+            self.delete(path(uuid), User.cp_oauth_header).code.to_i
+          end
+
+          def serials(uuid)
+            response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'certificates/serials'))
+            JSON.parse(response.body)
+          end
+
+          def checkin(uuid, checkin_date)
+            checkin_date ||= Time.now
+            self.put(path(uuid), {:lastCheckin => checkin_date}.to_json, self.default_headers).body
+          end
+
+          def available_pools(owner_label, uuid, listall = false)
+            url = Pool.path(nil, owner_label) + "?consumer=#{uuid}&listall=#{listall}&add_future=true"
+            response = Candlepin::CandlepinResource.get(url, self.default_headers).body
+            JSON.parse(response)
+          end
+
+          def regenerate_identity_certificates(uuid)
+            response = self.post(path(uuid), {}, self.default_headers).body
+            JSON.parse(response).with_indifferent_access
+          end
+
+          def export(uuid)
+            # Export is a zip file
+            headers = self.default_headers
+            headers['accept'] = 'application/zip'
+            response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'export'), headers)
+            response
+          end
+
+          def entitlements(uuid)
+            response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'entitlements'), self.default_headers).body
+            ::Katello::Util::Data.array_with_indifferent_access JSON.parse(response)
+          end
+
+          def refresh_entitlements(uuid)
+            self.post(join_path(path(uuid), 'entitlements'), "", self.default_headers).body
+          end
+
+          def consume_entitlement(uuid, pool, quantity = nil)
+            uri = join_path(path(uuid), 'entitlements') + "?pool=#{pool}"
+            uri += "&quantity=#{quantity}" if quantity && quantity > 0
+            response = self.post(uri, "", self.default_headers).body
+            response.blank? ? [] : JSON.parse(response)
+          end
+
+          def remove_entitlement(uuid, ent_id)
+            uri = join_path(path(uuid), 'entitlements') + "/#{ent_id}"
+            self.delete(uri, self.default_headers).code.to_i
+          end
+
+          def remove_entitlements(uuid)
+            uri = join_path(path(uuid), 'entitlements')
+            self.delete(uri, self.default_headers).code.to_i
+          end
+
+          def remove_certificate(uuid, serial_id)
+            uri = join_path(path(uuid), 'certificates') + "/#{serial_id}"
+            self.delete(uri, self.default_headers).code.to_i
+          end
+
+          def virtual_guests(uuid)
+            response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'guests'), self.default_headers).body
+            ::Katello::Util::Data.array_with_indifferent_access JSON.parse(response)
+          rescue RestClient::Exception
+            return []
+          end
+
+          def virtual_host(uuid)
+            response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'host'), self.default_headers).body
+            if response.present?
+              JSON.parse(response).with_indifferent_access
+            else
+              return nil
+            end
+          rescue RestClient::Exception
+            return nil
+          end
+
+          def compliance(uuid)
+            response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'compliance'), self.default_headers(uuid)).body
+            if response.present?
+              json = JSON.parse(response).with_indifferent_access
+              if json['reasons']
+                json['reasons'].sort! { |x, y| x['attributes']['name'] <=> y['attributes']['name'] }
+              else
+                json['reasons'] = []
+              end
+              json
+            else
+              return nil
+            end
+          end
+
+          def events(uuid)
+            response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'events'), self.default_headers).body
+            if response.present?
+              ::Katello::Util::Data.array_with_indifferent_access JSON.parse(response)
+            else
+              return []
+            end
+          end
+
+          def content_overrides(id)
+            result = Candlepin::CandlepinResource.get(join_path(path(id), 'content_overrides'), self.default_headers).body
+            ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result))
+          end
+
+          # expected params
+          # id : UUID of the consumer
+          # content_overrides => Array of entitlement hashes objects
+          def update_content_overrides(id, content_overrides)
+            attrs_to_delete = []
+            attrs_to_update = []
+            content_overrides.each do |content_override|
+              if content_override[:value]
+                attrs_to_update << content_override
+              else
+                attrs_to_delete << content_override
+              end
+            end
+
+            if attrs_to_update.present?
+              result = Candlepin::CandlepinResource.put(join_path(path(id), 'content_overrides'),
+                                                        attrs_to_update.to_json, self.default_headers)
+            end
+            if attrs_to_delete.present?
+              client = Candlepin::CandlepinResource.rest_client(Net::HTTP::Delete, :delete,
+                                                                join_path(path(id), 'content_overrides'))
+              client.options[:payload] = attrs_to_delete.to_json
+              result = client.delete({:accept => :json, :content_type => :json}.merge(User.cp_oauth_header))
+            end
+            ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result))
+          end
+        end
+      end
+
+      class UpstreamConsumer < UpstreamCandlepinResource
+        extend ConsumerResource
+
+        class << self
+          def path(id = upstream_consumer_id)
+            super(id)
+          end
+
+          def export(url, client_cert, client_key, ca_file)
+            logger.debug "Sending GET request to upstream Candlepin: #{url}"
+            return resource(url, client_cert, client_key, ca_file).get
+          rescue RestClient::Exception => e
+            raise e
+          ensure
+            RestClient.proxy = ""
+          end
+
+          def update(url, client_cert, client_key, ca_file, attributes)
+            logger.debug "Sending POST request to upstream Candlepin: #{url} #{attributes.to_json}"
+
+            return resource(url, client_cert, client_key, ca_file).put(attributes.to_json,
+                                                                       'accept' => 'application/json',
+                                                                       'accept-language' => I18n.locale,
+                                                                       'content-type' => 'application/json')
+          ensure
+            RestClient.proxy = ""
+          end
+        end
+      end
+    end # Candlepin
+  end # Resources
+end # Katello

--- a/app/lib/katello/resources/candlepin/owner.rb
+++ b/app/lib/katello/resources/candlepin/owner.rb
@@ -1,0 +1,146 @@
+module Katello
+  module Resources
+    module Candlepin
+      module OwnerResource
+        def path(id = nil)
+          "#{self.prefix}/owners/#{id}"
+        end
+      end
+
+      class Owner < CandlepinResource
+        extend OwnerResource
+
+        class << self
+          # Set the contentPrefix at creation time so that the client will get
+          # content only for the org it has been subscribed to
+          def create(key, description)
+            attrs = {:key => key, :displayName => description, :contentPrefix => "/#{key}/$env"}
+            owner_json = self.post(path, attrs.to_json, self.default_headers).body
+            JSON.parse(owner_json).with_indifferent_access
+          end
+
+          # create the first user for owner
+          def create_user(_key, username, password)
+            # create user with superadmin flag (no role, permissions etc)
+            CPUser.create(:username => name_to_key(username), :password => name_to_key(password), :superAdmin => true)
+          end
+
+          def destroy(key)
+            self.delete(path(key), User.cp_oauth_header).code.to_i
+          end
+
+          def find(key)
+            owner_json = self.get(path(key), {'accept' => 'application/json'}.merge(User.cp_oauth_header)).body
+            JSON.parse(owner_json).with_indifferent_access
+          end
+
+          def update(key, attrs)
+            owner = find(key)
+            owner.merge!(attrs)
+            self.put(path(key), JSON.generate(owner), self.default_headers).body
+          end
+
+          def import(organization_name, path_to_file, options)
+            path = join_path(path(organization_name), 'imports')
+            if options[:force] || SETTINGS[:katello].key?(:force_manifest_import)
+              path += "?force=#{SETTINGS[:katello][:force_manifest_import]}"
+            end
+
+            self.post(path, {:import => File.new(path_to_file, 'rb')}, self.default_headers.except('content-type'))
+          end
+
+          def product_content(organization_name)
+            Product.all(organization_name, [:id, :productContent])
+          end
+
+          def destroy_imports(organization_name, wait_until_complete = false)
+            response_json = self.delete(join_path(path(organization_name), 'imports'), self.default_headers)
+            response = JSON.parse(response_json).with_indifferent_access
+            if wait_until_complete && response['state'] == 'CREATED'
+              while !response['state'].nil? && response['state'] != 'FINISHED' && response['state'] != 'ERROR'
+                path = join_path('candlepin', response['statusPath'][1..-1])
+                response_json = self.get(path, self.default_headers)
+                response = JSON.parse(response_json).with_indifferent_access
+              end
+            end
+
+            response
+          end
+
+          def imports(organization_name)
+            imports_json = self.get(join_path(path(organization_name), 'imports'), self.default_headers)
+            ::Katello::Util::Data.array_with_indifferent_access JSON.parse(imports_json)
+          end
+
+          def pools(owner_label, filter = {})
+            filter[:add_future] ||= true
+            params = hash_to_query(filter)
+            if owner_label
+              # hash_to_query escapes the ":!" to "%3A%21" which candlepin rejects
+              params += '&attribute=unmapped_guests_only:!true'
+              json_str = self.get(join_path(path(owner_label), 'pools') + params, self.default_headers).body
+            else
+              json_str = self.get(join_path('candlepin', 'pools') + params, self.default_headers).body
+            end
+            ::Katello::Util::Data.array_with_indifferent_access JSON.parse(json_str)
+          end
+
+          def statistics(key)
+            json_str = self.get(join_path(path(key), 'statistics'), self.default_headers).body
+            ::Katello::Util::Data.array_with_indifferent_access JSON.parse(json_str)
+          end
+
+          def generate_ueber_cert(key)
+            ueber_cert_json = self.post(join_path(path(key), "uebercert"), {}.to_json, self.default_headers).body
+            JSON.parse(ueber_cert_json).with_indifferent_access
+          end
+
+          def get_ueber_cert(key)
+            ueber_cert_json = self.get(join_path(path(key), "uebercert"), {'accept' => 'application/json'}.merge(User.cp_oauth_header)).body
+            JSON.parse(ueber_cert_json).with_indifferent_access
+          end
+
+          def get_ueber_cert_pkcs12(key, name = nil, password = nil)
+            certs = get_ueber_cert(key)
+            c = OpenSSL::X509::Certificate.new certs["cert"]
+            p = OpenSSL::PKey::RSA.new certs["key"]
+            OpenSSL::PKCS12.create(password, name, p, c, nil, "PBE-SHA1-3DES", "PBE-SHA1-3DES")
+          end
+
+          def events(key)
+            response = self.get(join_path(path(key), 'events'), self.default_headers).body
+            ::Katello::Util::Data.array_with_indifferent_access JSON.parse(response)
+          end
+
+          def service_levels(uuid)
+            response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'servicelevels'), self.default_headers).body
+            if response.empty?
+              return []
+            else
+              JSON.parse(response)
+            end
+          end
+
+          def auto_attach(key)
+            response = self.post(join_path(path(key), 'entitlements'), "", self.default_headers).body
+            if response.empty?
+              return nil
+            else
+              JSON.parse(response)
+            end
+          end
+        end
+      end
+
+      class UpstreamOwner < UpstreamCandlepinResource
+        extend OwnerResource
+
+        class << self
+          def path(id = upstream_owner_id)
+            super(id)
+          end
+        end
+      end
+    end # Candlepin
+  end # Resources
+end # Katello

--- a/app/lib/katello/resources/candlepin/pool.rb
+++ b/app/lib/katello/resources/candlepin/pool.rb
@@ -1,0 +1,59 @@
+module Katello
+  module Resources
+    module Candlepin
+      module PoolResource
+        def path(id = nil, owner_label = nil)
+          if owner_label && id
+            "#{prefix}/owners/#{owner_label}/pools/#{id}"
+          elsif owner_label
+            "#{prefix}/owners/#{owner_label}/pools/"
+          else
+            "#{prefix}/pools/#{id}"
+          end
+        end
+      end
+
+      class Pool < CandlepinResource
+        extend PoolResource
+
+        class << self
+          def get_for_owner(owner_key, include_temporary_guests = false)
+            url = "#{prefix}/owners/#{owner_key}/pools?add_future=true"
+            url += "&attribute=unmapped_guests_only:!true" if include_temporary_guests
+            pools_json = self.get(url, self.default_headers).body
+            JSON.parse(pools_json)
+          end
+
+          def find(pool_id)
+            pool_json = self.get(path(pool_id), self.default_headers).body
+            fail ArgumentError, "pool id cannot contain ?" if pool_id["?"]
+            JSON.parse(pool_json).with_indifferent_access
+          end
+
+          def destroy(id)
+            fail ArgumentError, "pool id has to be specified" unless id
+            self.delete(path(id), self.default_headers).code.to_i
+          end
+
+          def entitlements(pool_id, included = [])
+            entitlement_json = self.get("#{path(pool_id)}/entitlements?#{included_list(included)}", self.default_headers).body
+            JSON.parse(entitlement_json)
+          end
+        end
+      end
+
+      class UpstreamPool < UpstreamCandlepinResource
+        extend PoolResource
+
+        class << self
+          def path(id = nil, owner_label = nil)
+            super(id, owner_label || upstream_owner_id)
+          end
+
+          delegate :[], to: :resource
+          delegate :get, to: :resource
+        end
+      end
+    end # Candlepin
+  end # Resources
+end # Katello

--- a/app/lib/katello/util/http_proxy.rb
+++ b/app/lib/katello/util/http_proxy.rb
@@ -1,0 +1,29 @@
+module Katello
+  module Util
+    module HttpProxy
+      def proxy_uri
+        URI("#{proxy_scheme}://#{proxy_user_info}@#{proxy_host}:#{proxy_port}").to_s if proxy_host
+      end
+
+      def proxy_user_info
+        "#{proxy_config[:user]}:#{proxy_config[:password]}" if proxy_config && proxy_config[:user]
+      end
+
+      def proxy_config
+        SETTINGS[:katello][:cdn_proxy]
+      end
+
+      def proxy_host
+        proxy_config && URI.parse(proxy_config[:host]).host
+      end
+
+      def proxy_scheme
+        proxy_config && URI.parse(proxy_config[:host]).scheme
+      end
+
+      def proxy_port
+        proxy_config && proxy_config[:port]
+      end
+    end # HttpProxy
+  end # Util
+end # Katello

--- a/app/models/katello/upstream_pool.rb
+++ b/app/models/katello/upstream_pool.rb
@@ -1,0 +1,45 @@
+require 'katello/resources/candlepin'
+
+module Katello
+  class UpstreamPool < OpenStruct
+    CP_POOL = Resources::Candlepin::UpstreamPool
+
+    class << self
+      def fetch_pools(organization, params)
+        CP_POOL.organization = organization
+        pools = JSON.parse(CP_POOL.get(params: cp_request_params.deep_merge(params)))
+        pools.map { |pool| self.new(map_attributes(pool)) }
+      ensure
+        CP_POOL.organization = nil
+      end
+
+      def map_attributes(pool)
+        {
+          pool_id: pool['id'],
+          active: pool['activeSubscription'],
+          quantity: pool['quantity'],
+          start_date: pool['startDate'],
+          end_date: pool['endDate'],
+          contract_number: pool['contractNumber'],
+          consumed: pool['consumed'],
+          product_name: pool['productName'],
+          product_id: pool['productId'],
+          subscription_id: pool['subscriptionId']
+        }
+      end
+
+      def cp_request_params
+        { include: ['id',
+                    'activeSubscription',
+                    'quantity',
+                    'startDate',
+                    'endDate',
+                    'contractNumber',
+                    'consumed',
+                    'productName',
+                    'productId',
+                    'subscriptionId'] }
+      end
+    end
+  end
+end

--- a/app/views/katello/api/v2/upstream_subscriptions/base.json.rabl
+++ b/app/views/katello/api/v2/upstream_subscriptions/base.json.rabl
@@ -1,0 +1,12 @@
+object @resource ||= @object
+
+attributes :pool_id
+attributes :status
+attributes :quantity
+attributes :start_date
+attributes :end_date
+attributes :contract_number
+attributes :consumed
+attributes :product_name
+attributes :product_id
+attributes :subscription_id

--- a/app/views/katello/api/v2/upstream_subscriptions/index.json.rabl
+++ b/app/views/katello/api/v2/upstream_subscriptions/index.json.rabl
@@ -1,0 +1,9 @@
+object false
+
+extends "katello/api/v2/common/metadata"
+
+node(:organization_id) { @organization.id }
+
+child @collection[:results] => :results do
+  extends "katello/api/v2/upstream_subscriptions/base"
+end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -317,6 +317,8 @@ Katello::Engine.routes.draw do
               put :refresh_manifest
             end
           end
+
+          api_resources :upstream_subscriptions, only: :index
         end
 
         api_resources :host_collections

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -321,7 +321,7 @@ module Katello
                          :resource_type => 'Katello::Product'
     end
 
-    def subscription_permissions
+    def subscription_permissions # rubocop:disable Metrics/MethodLength
       @plugin.permission :view_subscriptions,
                          {
                            'katello/api/v2/subscriptions' => [:index, :show, :available, :manifest_history, :auto_complete_search],
@@ -349,6 +349,11 @@ module Katello
       @plugin.permission :delete_manifest,
                          {
                            'katello/api/v2/subscriptions' => [:delete_manifest]
+                         },
+                         :resource_type => 'Katello::Subscription'
+      @plugin.permission :manage_subscription_allocations,
+                         {
+                           'katello/api/v2/upstream_subscriptions' => [:index]
                          },
                          :resource_type => 'Katello::Subscription'
     end

--- a/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
@@ -1,0 +1,42 @@
+# encoding: utf-8
+
+require "katello_test_helper"
+
+module Katello
+  class Api::V2::UpstreamSubscriptionsControllerTest < ActionController::TestCase
+    def models
+      @organization = get_organization
+    end
+
+    def permission
+      :manage_subscription_allocations
+    end
+
+    def setup
+      setup_controller_defaults_api
+      login_user(User.find(users(:admin).id))
+      models
+
+      @organization.stubs(:owner_details)
+        .returns("upstreamConsumer" => {'uuid' => '', 'idCert' => {'key' => '', 'cert' => ''}})
+    end
+
+    def test_index
+      params = { organization_id: @organization.id, page: '3', per_page: '7' }
+      Api::V2::UpstreamSubscriptionsController.any_instance.stubs(:upstream_pool_params).returns(params)
+      UpstreamPool.expects(:fetch_pools).with(@organization, params).returns([{}])
+      get :index, params: params
+
+      assert_response :success
+    end
+
+    def test_index_protected
+      allowed_perms = [permission]
+      denied_perms = []
+
+      assert_protected_action(:index, allowed_perms, denied_perms, [@organization]) do
+        get :index, params: { :organization_id => @organization.id }
+      end
+    end
+  end
+end

--- a/test/fixtures/vcr_cassettes/services/katello.yml
+++ b/test/fixtures/vcr_cassettes/services/katello.yml
@@ -1,0 +1,95 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://dev.example.com:8443/candlepin/consumers/fake-uuid-from-katello/guests
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Authorization:
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - a61ebc57-affc-4393-b05e-62746a292947
+      X-Version:
+      - 2.1.12-1
+      - 2.1.12-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 23 Feb 2018 17:38:57 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJkaXNwbGF5TWVzc2FnZSI6IkNvbnN1bWVyIHdpdGggaWQgZmFrZS11dWlk
+        LWZyb20ta2F0ZWxsbyBjb3VsZCBub3QgYmUgZm91bmQuIiwicmVxdWVzdFV1
+        aWQiOiJhNjFlYmM1Ny1hZmZjLTQzOTMtYjA1ZS02Mjc0NmEyOTI5NDcifQ==
+    http_version: 
+  recorded_at: Fri, 23 Feb 2018 17:38:57 GMT
+- request:
+    method: get
+    uri: https://dev.example.com:8443/candlepin/consumers/fake-uuid-from-katello/host
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Authorization:
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - ea0be6bb-c358-4943-803c-5c1dc49b94f0
+      X-Version:
+      - 2.1.12-1
+      - 2.1.12-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 23 Feb 2018 17:38:57 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJkaXNwbGF5TWVzc2FnZSI6IkNvbnN1bWVyIHdpdGggaWQgZmFrZS11dWlk
+        LWZyb20ta2F0ZWxsbyBjb3VsZCBub3QgYmUgZm91bmQuIiwicmVxdWVzdFV1
+        aWQiOiJlYTBiZTZiYi1jMzU4LTQ5NDMtODAzYy01YzFkYzQ5Yjk0ZjAifQ==
+    http_version: 
+  recorded_at: Fri, 23 Feb 2018 17:38:58 GMT
+recorded_with: VCR 3.0.3

--- a/test/lib/resources/candlepin_test.rb
+++ b/test/lib/resources/candlepin_test.rb
@@ -1,0 +1,27 @@
+require 'katello_test_helper'
+require 'katello/resources/candlepin'
+
+module Katello
+  module Resources
+    module Candlepin
+      class UpstreamCandlepinResourceTest < ActiveSupport::TestCase
+        def test_upstream_consumer_nil_current_organization
+          UpstreamCandlepinResource.organization = nil
+          UpstreamCandlepinResource.upstream_consumer
+          flunk("Failed to raise exception when current organization is nil.")
+        rescue RuntimeError => e
+          assert(e.message == "Current organization not set.", "Invalid message: #{e.message}")
+        end
+
+        def test_upstream_consumer_current_organization_no_imported_manifest
+          Organization.stubs(:current).returns(stub(owner_details: {}))
+          UpstreamCandlepinResource.upstream_consumer
+          flunk("Failed to raise exception when manifest is not imported.")
+        rescue RuntimeError => e
+          assert(e.message == "Current organization has no manifest imported.",
+                 "Invalid message: #{e.message}")
+        end
+      end
+    end
+  end
+end

--- a/test/lib/tasks/update_subscription_facet_backend_data_test.rb
+++ b/test/lib/tasks/update_subscription_facet_backend_data_test.rb
@@ -16,6 +16,8 @@ module Katello
       Katello::Host::SubscriptionFacet.where("id != #{@host.subscription_facet.id}").destroy_all
       Katello::Host::SubscriptionFacet.any_instance.stubs(:host).returns(@host)
       Katello::Candlepin::Consumer.any_instance.stubs(:consumer_attributes).returns(:facts => {:foo => :bar})
+      Katello::Resources::Candlepin::Consumer.stubs(:virtual_guests).returns([])
+      Katello::Resources::Candlepin::Consumer.stubs(:virtual_host).returns(nil)
 
       Katello::Host::SubscriptionFacet.expects(:update_facts).with(@host, :foo => :bar).once
 

--- a/test/models/host/subscription_facet_test.rb
+++ b/test/models/host/subscription_facet_test.rb
@@ -67,6 +67,8 @@ module Katello
 
     def test_update_from_consumer_attributes
       params = { :lastCheckin => Time.now, :autoheal => true, :serviceLevel => "Premium", :releaseVer => "7Server" }
+      Katello::Resources::Candlepin::Consumer.stubs(:virtual_guests).returns([])
+      Katello::Resources::Candlepin::Consumer.stubs(:virtual_host).returns(nil)
       subscription_facet.update_from_consumer_attributes(params.with_indifferent_access)
 
       assert_equal subscription_facet.last_checkin, params[:lastCheckin]
@@ -77,6 +79,8 @@ module Katello
 
     def test_update_from_consumer_attributes_release_version
       params = { :lastCheckin => Time.now, :autoheal => true, :serviceLevel => "Premium", :releaseVer => {'releaseVer' => "7Server" }}
+      Katello::Resources::Candlepin::Consumer.stubs(:virtual_guests).returns([])
+      Katello::Resources::Candlepin::Consumer.stubs(:virtual_host).returns(nil)
       subscription_facet.update_from_consumer_attributes(params.with_indifferent_access)
 
       assert_equal '7Server', subscription_facet.release_version

--- a/test/models/upstream_pool_test.rb
+++ b/test/models/upstream_pool_test.rb
@@ -1,0 +1,17 @@
+require 'katello_test_helper'
+
+module Katello
+  class UpstreamPoolTest < ActiveSupport::TestCase
+    def setup
+      @organization = get_organization
+    end
+
+    def test_fetch_pools
+      params = {}
+      UpstreamPool::CP_POOL.expects(:get)
+        .with(params: UpstreamPool.cp_request_params)
+        .returns("[]")
+      assert UpstreamPool.fetch_pools(@organization, params).first.nil?
+    end
+  end
+end


### PR DESCRIPTION
To test:

```JSON
GET /katello/api/v2/organizations/1/upstream_subscriptions?page=1&per_page=4&sort_by=quantity

# Example output
{
    "total": null,
    "subtotal": 4,
    "page": "1",
    "per_page": "4",
    "error": null,
    "search": null,
    "sort": {
        "by": "quantity",
        "order": null
    },
    "results": [
        {
            "pool_id": "c505f98c8a80e016060c4fcf8b23045d",
            "quantity": 125000,
            "start_date": "2016-03-24T04:00:00+0000",
            "end_date": "2022-01-01T04:59:59+0000",
            "contract_number": "10913844",
            "consumed": 30,
            "product_name": "Employee SKU",
            "product_id": "ES1390109",
            "subscription_id": "7883907"
        },
        ...
    ]
}
```

Verify:
- manifest refresh still functions properly