### PR TITLE
Fixes #22597: add opt-out classes for jquery select plugins.

### DIFF
--- a/webpack/components/MultiSelect/index.js
+++ b/webpack/components/MultiSelect/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { FormGroup, ControlLabel } from 'react-bootstrap';
-import BootstrapSelect from '../react-bootstrap-select';
+import BootstrapSelect from '../../move_to_pf/react-bootstrap-select';
 
 function MultiSelect(props) {
   const options = props.options.map(option => (

--- a/webpack/move_to_pf/react-bootstrap-select/index.js
+++ b/webpack/move_to_pf/react-bootstrap-select/index.js
@@ -50,7 +50,9 @@ class BootstrapSelect extends React.Component {
   }
 
   render() {
-    return <FormControl {...this.props} componentClass="select" />;
+    // TODO: these classes are required because foreman assumes that all selects should use select2 and jquery multiselect
+    // TODO: see also http://projects.theforeman.org/issues/21952
+    return <FormControl {...this.props} componentClass="select" className="without_select2 without_jquery_multiselect"/>;
   }
 }
 


### PR DESCRIPTION
In order to prevent the Red Hat Repos multiselect from using the
jquery plugins jquery-multiselect and select2 we need to add these
classes.

http://projects.theforeman.org/issues/22597