### PR TITLE
Fixes #22614 - only detect non-library repos for cv publish check

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -299,7 +299,8 @@ module Katello
     end
 
     def duplicate_repositories_to_publish
-      repositories_to_publish_by_library_instance.select { |_key, val| val.count > 1 }.keys
+      return [] unless composite?
+      repositories_to_publish_by_library_instance.select { |key, val| val.count > 1 && key.present? }.keys
     end
 
     def components_with_repo(library_instance)

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -229,6 +229,15 @@ module Katello
       refute_empty composite.duplicate_repositories_to_publish
     end
 
+    def test_repo_conflicts_non_composite
+      view = ContentView.new
+      view.repositories << katello_repositories(:fedora_17_x86_64)
+      view.repositories << katello_repositories(:rhel_6_x86_64)
+
+      assert view.repositories.to_a.all? { |repo| repo.library_instance? } #should all be library instances
+      assert_empty view.duplicate_repositories_to_publish
+    end
+
     def test_puppet_module_conflicts
       composite = ContentView.find(katello_content_views(:composite_view).id)
       view1 = create(:katello_content_view)


### PR DESCRIPTION
this check was designed to warn when publishing
a composite repo where two components had the same
repo in them.  But for non-composite views, it was
mistakenly reporting this warning when any two repos were
added