### PR TITLE
Refs #22620 - make UI honor enabled repo types

### DIFF
--- a/app/services/katello/repository_type_manager.rb
+++ b/app/services/katello/repository_type_manager.rb
@@ -7,7 +7,8 @@ module Katello
 
       # Plugin constructor
       def register(id, &block)
-        if find(id).blank?
+        configured = SETTINGS[:katello][:content_types].nil? || SETTINGS[:katello][:content_types].with_indifferent_access[id]
+        if find(id).blank? && configured
           repository_type = ::Katello::RepositoryType.new(id)
           repository_type.instance_eval(&block) if block_given?
           repository_types[id.to_s] = repository_type

--- a/config/katello.yaml.example
+++ b/config/katello.yaml.example
@@ -1,4 +1,14 @@
 :katello:
+  #if this block is not define, all types are enabled
+  #types are defined in lib/katello/repository_types/*.rb
+  :content_types:
+    :yum: true
+    :file: true
+    :deb: true
+    :puppet: true
+    :docker: true
+    :ostree: true
+
   :use_cp: true # set to true/false if you want to override default
   :use_pulp: true # set to true/false if you want to override default
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details.controller.js
@@ -13,8 +13,8 @@
  *   Provides the functionality specific to the Content View Details page.
  */
 angular.module('Bastion.content-views').controller('ContentViewDetailsController',
-    ['$scope', '$q', 'ContentView', 'translate', 'ApiErrorHandler', 'Notification',
-    function ($scope, $q, ContentView, translate, ApiErrorHandler, Notification) {
+    ['$scope', '$q', 'ContentView', 'translate', 'ApiErrorHandler', 'Notification', 'RepositoryTypesService',
+    function ($scope, $q, ContentView, translate, ApiErrorHandler, Notification, RepositoryTypesService) {
         $scope.saveSuccess = function () {
             Notification.setSuccessMessage(translate('Content View updated.'));
         };
@@ -29,6 +29,8 @@ angular.module('Bastion.content-views').controller('ContentViewDetailsController
             error: false,
             loading: true
         };
+
+        $scope.repositoryTypeEnabled = RepositoryTypesService.repositoryTypeEnabled;
 
         $scope.taskTypes = {
             publish: "Actions::Katello::ContentView::Publish",

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-details.html
@@ -61,7 +61,9 @@
 
       <li uib-dropdown
           ng-class="{active: stateIncludes('content-view.repositories.yum') || stateIncludes('content-view.yum.filters')}"
-          ng-hide="contentView.composite">
+          ng-hide="contentView.composite"
+          ng-show="repositoryTypeEnabled('yum')">
+
         <a uib-dropdown-toggle>
           <span translate>Yum Content</span>
           <i class="fa fa-chevron-down"></i>
@@ -81,21 +83,24 @@
       </li>
 
       <li ng-class="{active: stateIncludes('content-view.repositories.deb')}"
-          ng-hide="contentView.composite">
+          ng-hide="contentView.composite"
+          ng-show="repositoryTypeEnabled('deb')">
         <a ui-sref="content-view.repositories.deb.list" translate>
           Apt Repositories
         </a>
       </li>
 
       <li ng-class="{active: stateIncludes('content-view.repositories.file')}"
-          ng-hide="contentView.composite">
+          ng-hide="contentView.composite"
+          ng-show="repositoryTypeEnabled('file')">
         <a ui-sref="content-view.repositories.file.list" translate>
           File Repositories
         </a>
       </li>
 
       <li ng-class="{active: stateIncludes('content-view.puppet-modules')}"
-          ng-hide="contentView.composite">
+          ng-hide="contentView.composite"
+          ng-show="repositoryTypeEnabled('puppet')">
         <a ui-sref="content-view.puppet-modules.list" translate>
           Puppet Modules
         </a>
@@ -103,7 +108,8 @@
 
       <li uib-dropdown
           ng-class="{active: stateIncludes('content-view.repositories.docker') || stateIncludes('content-view.docker.filters')}"
-          ng-hide="contentView.composite">
+          ng-hide="contentView.composite"
+          ng-show="repositoryTypeEnabled('docker')">
         <a uib-dropdown-toggle>
           <span translate>Docker Content</span>
           <i class="fa fa-chevron-down"></i>
@@ -123,7 +129,8 @@
       </li>
 
       <li ng-class="{active: stateIncludes('content-view.repositories.ostree')}"
-          ng-hide="contentView.composite">
+          ng-hide="contentView.composite"
+          ng-show="repositoryTypeEnabled('ostree')">
         <a ui-sref="content-view.repositories.ostree.list" translate>
           OSTree Content
         </a>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/environment.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/environment.controller.js
@@ -8,7 +8,7 @@
      * @description
      *   Enter a description!
      */
-    function EnvironmentController($scope, Environment, translate, ContentService, ApiErrorHandler, Notification) {
+    function EnvironmentController($scope, Environment, translate, ContentService, ApiErrorHandler, Notification, RepositoryTypesService) {
 
         $scope.contentTypes = ContentService.contentTypes;
         $scope.panel = {
@@ -16,6 +16,7 @@
             loading: true
         };
 
+        $scope.repositoryTypeEnabled = RepositoryTypesService.repositoryTypeEnabled;
         $scope.environment = Environment.get({id: $scope.$stateParams.environmentId}, function () {
             $scope.panel.loading = false;
         }, function (response) {
@@ -67,6 +68,6 @@
         .module('Bastion.environments')
         .controller('EnvironmentController', EnvironmentController);
 
-    EnvironmentController.$inject = ['$scope', 'Environment', 'translate', 'ContentService', 'ApiErrorHandler'];
+    EnvironmentController.$inject = ['$scope', 'Environment', 'translate', 'ContentService', 'ApiErrorHandler', 'Notification', 'RepositoryTypesService'];
 
 })();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment.html
@@ -20,7 +20,8 @@
         </a>
       </li>
 
-      <li ng-repeat="type in contentTypes" ng-class="{active: isState('environment.' + type.state)}">
+      <li ng-repeat="type in contentTypes" ng-class="{active: isState('environment.' + type.state)}"
+          ng-show="type.repositoryType == undefined || repositoryTypeEnabled(type.repositoryType)">
         <a ng-href="{{ $state.href('environment.' + type.state, {environmentId: environment.id}) }}">
           <span translate>{{ type.display }}</span>
         </a>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/views/environments.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/views/environments.html
@@ -26,12 +26,24 @@
               <td class="info-block-head"><a ui-sref="environment.details({environmentId: library.id})" translate>Library</a></td>
               <td class="info-block" translate>Content Views <div>{{ library.counts.content_views || 0 }}</div></td>
               <td class="info-block" translate>Products <div>{{ library.counts.products || 0 }}</div></td>
-              <td class="info-block" translate>Yum Repositories <div>{{ library.counts.yum_repositories || 0 }}</div></td>
-              <td class="info-block" translate>OSTree Repositories <div>{{ library.counts.ostree_repositories || 0 }}</div></td>
-              <td class="info-block" translate>Docker Repositories <div>{{ library.counts.docker_repositories || 0 }}</div></td>
-              <td class="info-block" translate>Packages <div>{{ library.counts.packages || 0 }}</div></td>
-              <td class="info-block" translate>Errata <div>{{ library.counts.errata.total || 0 }}</div></td>
-              <td class="info-block" translate>Puppet Modules <div>{{ library.counts.puppet_modules || 0 }}</div></td>
+              <td class="info-block" ng-hide="library.counts.yum_repositories == 0" translate>
+                Yum Repositories <div>{{ library.counts.yum_repositories || 0 }}</div>
+              </td>
+              <td class="info-block" ng-hide="library.counts.ostree_repositories == 0" translate>
+                OSTree Repositories <div>{{ library.counts.ostree_repositories || 0 }}</div>
+              </td>
+              <td class="info-block" ng-hide="library.counts.docker_repositories == 0" translate>
+                Docker Repositories <div>{{ library.counts.docker_repositories || 0 }}</div>
+              </td>
+              <td class="info-block" ng-hide="library.counts.packages == 0" translate>
+                Packages <div>{{ library.counts.packages || 0 }}</div>
+              </td>
+              <td class="info-block" ng-hide="library.counts.errata.total == 0" translate>
+                Errata <div>{{ library.counts.errata.total || 0 }}</div>
+              </td>
+              <td class="info-block" ng-hide="library.counts.puppet_modules == 0"  translate>
+                Puppet Modules <div>{{ library.counts.puppet_modules || 0 }}</div>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/new-repository.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/new-repository.controller.js
@@ -15,13 +15,14 @@
  * @requires DownloadPolicy
  * @requires OstreeUpstreamSyncPolicy
  * @requires Architecture
+ * @requires RepositoryTypesService
  *
  * @description
  *   Controls the creation of an empty Repository object for use by sub-controllers.
  */
 angular.module('Bastion.repositories').controller('NewRepositoryController',
-    ['$scope', 'Repository', 'Product', 'ContentCredential', 'FormUtils', 'translate', 'Notification', 'ApiErrorHandler', 'BastionConfig', 'Checksum', 'DownloadPolicy', 'OstreeUpstreamSyncPolicy', 'Architecture',
-    function ($scope, Repository, Product, ContentCredential, FormUtils, translate, Notification, ApiErrorHandler, BastionConfig, Checksum, DownloadPolicy, OstreeUpstreamSyncPolicy, Architecture) {
+    ['$scope', 'Repository', 'Product', 'ContentCredential', 'FormUtils', 'translate', 'Notification', 'ApiErrorHandler', 'BastionConfig', 'Checksum', 'DownloadPolicy', 'OstreeUpstreamSyncPolicy', 'Architecture', 'RepositoryTypesService',
+    function ($scope, Repository, Product, ContentCredential, FormUtils, translate, Notification, ApiErrorHandler, BastionConfig, Checksum, DownloadPolicy, OstreeUpstreamSyncPolicy, Architecture, RepositoryTypesService) {
 
         function success() {
             Notification.setSuccessMessage(translate('Repository %s successfully created.').replace('%s', $scope.repository.name));
@@ -69,9 +70,8 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
             ApiErrorHandler.handleGETRequestErrors(response, $scope);
         });
 
-        Repository.repositoryTypes({'creatable': true}, function (data) {
-            $scope.repositoryTypes = data;
-        });
+        $scope.repositoryTypes = RepositoryTypesService.creatable();
+        $scope.repositoryTypes = _.sortBy($scope.repositoryTypes, 'name');
 
         $scope.checksums = Checksum.checksums;
         $scope.downloadPolicies = DownloadPolicy.downloadPolicies;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repository-types.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repository-types.service.js
@@ -1,0 +1,39 @@
+(function () {
+    'use strict';
+
+    /**
+     * @ngdoc service
+     * @name  Bastion.products.details.repositories.service:RepositoryTypes
+     *
+     * @description
+     *   Provides common functions for managing content types and can build a Nutupane
+     *   pre-configured for the content type based on params that are passed in and the
+     *   current state of the application.
+     */
+    function RepositoryTypesService(repositoryTypes) {
+
+        this.repositoryTypes = function () {
+            return repositoryTypes;
+        };
+
+        this.creatable = function() {
+            return _.filter(repositoryTypes, function (type) {
+                return type.creatable;
+            });
+        };
+
+        this.repositoryTypeEnabled = function (desiredType) {
+            var found = _.find(repositoryTypes, function(type) {
+                return type.id === desiredType;
+            });
+            return angular.isDefined(found);
+        };
+    }
+
+    angular
+        .module('Bastion.environments')
+        .service('RepositoryTypesService', RepositoryTypesService);
+
+    RepositoryTypesService.$inject = ['repositoryTypes'];
+
+})();

--- a/engines/bastion_katello/test/content-views/details/content-view-details.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/content-view-details.controller.test.js
@@ -5,12 +5,14 @@ describe('Controller: ContentViewDetailsController', function() {
 
     beforeEach(inject(function($injector) {
         var $controller = $injector.get('$controller'),
-            translate = $injector.get('translateMock');
+            translate = $injector.get('translateMock'),
+            RepositoryTypesService = {};
 
         newContentView = {id: 7};
         ContentView = $injector.get('MockResource').$new();
         ContentView.copy = function(params, success){success(newContentView)};
 
+        RepositoryTypesService.repositoryTypeEnabled = function(){};
         ContentViewVersion = $injector.get('MockResource').$new();
         AggregateTask = {newAggregate: function(){}};
 
@@ -30,12 +32,17 @@ describe('Controller: ContentViewDetailsController', function() {
             ContentViewVersion: ContentViewVersion,
             AggregateTask: AggregateTask,
             translate: translate,
-            Notification: Notification
+            Notification: Notification,
+            RepositoryTypesService: RepositoryTypesService
         });
     }));
 
     it("retrieves and puts the content view on the scope", function() {
         expect($scope.contentView).toBeDefined();
+    });
+
+    it("stores repositoryTypeEnabled on the scope", function() {
+        expect($scope.repositoryTypeEnabled).toBeDefined();
     });
 
     it('provides a method to save a product', function() {

--- a/engines/bastion_katello/test/environments/details/environment.controller.test.js
+++ b/engines/bastion_katello/test/environments/details/environment.controller.test.js
@@ -6,20 +6,27 @@ describe('Controller: EnvrionmentController', function () {
     beforeEach(inject(function($injector) {
         var $controller = $injector.get('$controller'),
             Envrionment = $injector.get('MockResource').$new(),
-            translate = $injector.get('translateMock');
+            translate = $injector.get('translateMock'),
+            RepositoryTypesService = {};
 
+        RepositoryTypesService.repositoryTypeEnabled = function(){};
         $scope = $injector.get('$rootScope').$new();
         $scope.$stateParams = {environmentId: 1};
 
         $controller('EnvironmentController', {
             $scope: $scope,
             Envrionment: Envrionment,
-            translate: translate
+            translate: translate,
+            RepositoryTypesService: RepositoryTypesService
         });
     }));
 
     it("puts an environment on the scope", function() {
         expect($scope.environment).toBeDefined();
+    });
+
+    it("puts a repositoryTypeEnabled function on the scope", function() {
+        expect($scope.repositoryTypeEnabled).toBeDefined();
     });
 
     it("should provide ability to save an environment and return a promise", function() {

--- a/engines/bastion_katello/test/products/details/repositories/new/new-repository.controller.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/new/new-repository.controller.test.js
@@ -4,7 +4,8 @@ describe('Controller: NewRepositoryController', function() {
         Notification,
         DownloadPolicy,
         OstreeUpstreamSyncPolicy,
-        $httpBackend;
+        $httpBackend,
+        RepositoryTypesService;
 
     beforeEach(module('Bastion.repositories', 'Bastion.test-mocks'));
 
@@ -28,9 +29,9 @@ describe('Controller: NewRepositoryController', function() {
         $scope.$stateParams = {productId: 1};
         $scope.repositoryForm = $injector.get('MockForm');
 
-        Repository.repositoryTypes = function (data, func) {
-            $scope.repositoryTypesTestData = data;
-            $scope.repositoryTypesTestCalled = true;
+        RepositoryTypesService = {};
+        RepositoryTypesService.creatable = function () {
+            return [{name: 'yum', name: 'puppet'}]
         };
 
         Setting.get = function (data, succ, err) {
@@ -45,7 +46,8 @@ describe('Controller: NewRepositoryController', function() {
             ContentCredential: ContentCredential,
             Architecture: Architecture,
             Notification: Notification,
-            Setting: Setting
+            Setting: Setting,
+            RepositoryTypesService: RepositoryTypesService
         });
     }));
 
@@ -53,10 +55,6 @@ describe('Controller: NewRepositoryController', function() {
         expect($scope.repository).toBeDefined();
     });
 
-    it('should define a set of repository types', function() {
-        expect($scope.repositoryTypesTestCalled).toBe(true);
-        expect($scope.repositoryTypesTestData["creatable"]).toBeDefined();
-    });
 
     it('should fetch available Content Credentials', function() {
         expect($scope.contentCredentials).toBeDefined();

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |gem|
 
   # UI
   gem.add_dependency "deface", '>= 1.0.2', '< 2.0.0'
-  gem.add_dependency "bastion", ">= 6.1.2", "< 7.0.0"
+  gem.add_dependency "bastion", ">= 6.1.9", "< 7.0.0"
 
   # Testing
   gem.add_development_dependency "factory_bot_rails", "~> 4.5"

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -1,4 +1,5 @@
 require 'katello/permission_creator'
+require 'katello/repository_types.rb'
 
 # rubocop:disable Metrics/BlockLength
 Foreman::Plugin.register :katello do
@@ -89,68 +90,82 @@ Foreman::Plugin.register :katello do
 
     divider :top_menu, :caption => N_('Content Types'), :parent => :content_menu
 
-    menu :top_menu,
-         :debs,
-         :caption => N_('Deb Packages'),
-         :url => '/debs',
-         :url_hash => {:controller => 'katello/api/v2/debs',
-                       :action => 'index'},
-         :engine => Katello::Engine,
-         :turbolinks => false
+    if ::Katello::RepositoryTypeManager.enabled?(::Katello::Repository::DEB_TYPE)
+      menu :top_menu,
+           :debs,
+           :caption => N_('Deb Packages'),
+           :url => '/debs',
+           :url_hash => {:controller => 'katello/api/v2/debs',
+                         :action => 'index'},
+           :engine => Katello::Engine,
+           :turbolinks => false
+    end
 
-    menu :top_menu,
-         :docker_tags,
-         :caption => N_('Docker Tags'),
-         :url => '/docker_tags',
-         :url_hash => {:controller => 'katello/api/v2/docker_tags',
-                       :action => 'index'},
-         :engine => Katello::Engine,
-         :turbolinks => false
+    if ::Katello::RepositoryTypeManager.enabled?(::Katello::Repository::DOCKER_TYPE)
+      menu :top_menu,
+           :docker_tags,
+           :caption => N_('Docker Tags'),
+           :url => '/docker_tags',
+           :url_hash => {:controller => 'katello/api/v2/docker_tags',
+                         :action => 'index'},
+           :engine => Katello::Engine,
+           :turbolinks => false
+    end
 
-    menu :top_menu,
-         :errata,
-         :caption => N_('Errata'),
-         :url => '/errata',
-         :url_hash => {:controller => 'katello/api/v2/errata',
-                       :action => 'index'},
-         :engine => Katello::Engine,
-         :turbolinks => false
+    if ::Katello::RepositoryTypeManager.enabled?(::Katello::Repository::YUM_TYPE)
+      menu :top_menu,
+           :errata,
+           :caption => N_('Errata'),
+           :url => '/errata',
+           :url_hash => {:controller => 'katello/api/v2/errata',
+                         :action => 'index'},
+           :engine => Katello::Engine,
+           :turbolinks => false
+    end
 
-    menu :top_menu,
-         :files,
-         :caption => N_('Files'),
-         :url => '/files',
-         :url_hash => {:controller => 'katello/api/v2/file_units',
-                       :action => 'index'},
-         :engine => Katello::Engine,
-         :turbolinks => false
+    if ::Katello::RepositoryTypeManager.enabled?(::Katello::Repository::FILE_TYPE)
+      menu :top_menu,
+           :files,
+           :caption => N_('Files'),
+           :url => '/files',
+           :url_hash => {:controller => 'katello/api/v2/file_units',
+                         :action => 'index'},
+           :engine => Katello::Engine,
+           :turbolinks => false
+    end
 
-    menu :top_menu,
-         :ostree_branches,
-         :caption => N_('OSTree Branches'),
-         :url => '/ostree_branches',
-         :url_hash => {:controller => 'katello/api/v2/ostree_branches',
-                       :action => 'index'},
-         :engine => Katello::Engine,
-         :turbolinks => false
+    if ::Katello::RepositoryTypeManager.enabled?(::Katello::Repository::OSTREE_TYPE)
+      menu :top_menu,
+           :ostree_branches,
+           :caption => N_('OSTree Branches'),
+           :url => '/ostree_branches',
+           :url_hash => {:controller => 'katello/api/v2/ostree_branches',
+                         :action => 'index'},
+           :engine => Katello::Engine,
+           :turbolinks => false
+    end
 
-    menu :top_menu,
-         :packages,
-         :caption => N_('Packages'),
-         :url => '/packages',
-         :url_hash => {:controller => 'katello/api/v2/packages',
-                       :action => 'index'},
-         :engine => Katello::Engine,
-         :turbolinks => false
+    if ::Katello::RepositoryTypeManager.enabled?(::Katello::Repository::YUM_TYPE)
+      menu :top_menu,
+           :packages,
+           :caption => N_('Packages'),
+           :url => '/packages',
+           :url_hash => {:controller => 'katello/api/v2/packages',
+                         :action => 'index'},
+           :engine => Katello::Engine,
+           :turbolinks => false
+    end
 
-    menu :top_menu,
-         :puppet_modules,
-         :caption => N_('Puppet Modules'),
-         :url => '/puppet_modules',
-         :url_hash => {:controller => 'katello/api/v2/puppet_modules',
-                       :action => 'index'},
-         :engine => Katello::Engine,
-         :turbolinks => false
+    if ::Katello::RepositoryTypeManager.enabled?(::Katello::Repository::PUPPET_TYPE)
+      menu :top_menu,
+           :puppet_modules,
+           :caption => N_('Puppet Modules'),
+           :url => '/puppet_modules',
+           :url_hash => {:controller => 'katello/api/v2/puppet_modules',
+                         :action => 'index'},
+           :engine => Katello::Engine,
+           :turbolinks => false
+    end
   end
 
   menu :top_menu,


### PR DESCRIPTION
This adds more awareness around what repo types are
enabled, on the lifecycle env page, the main navigation,
and updates detection on the new repo page