### PR TITLE
Fixes #21797 - handle various edge cases related to registration

### DIFF
--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -48,7 +48,7 @@ module Katello
     api :DELETE, "/hosts/:host_id/subscriptions/", N_("Unregister the host as a subscription consumer")
     param :host_id, Integer, :desc => N_("Id of the host"), :required => true
     def destroy
-      Katello::RegistrationManager.unregister_host(@host)
+      Katello::RegistrationManager.unregister_host(@host, :unregistering => true)
       @host.reload
       respond_for_destroy(:resource => @host)
     end

--- a/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb
@@ -18,7 +18,7 @@ module Katello
       included do
         prepend Overrides
         def destroy
-          sync_task(::Actions::Katello::Host::Destroy, @host)
+          Katello::RegistrationManager.unregister_host(@host, :unregistering => false)
           process_response(:object => @host)
         end
 

--- a/app/controllers/katello/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/hosts_controller_extensions.rb
@@ -19,7 +19,7 @@ module Katello
         prepend Overrides
 
         def destroy
-          sync_task(::Actions::Katello::Host::Destroy, @host)
+          Katello::RegistrationManager.unregister_host(@host, :unregistering => false)
           process_success
         rescue StandardError => ex
           process_error(:object => @host, :error_msg => ex.message, :redirect => saved_redirect_url_or(send("#{controller_name}_url")))

--- a/app/lib/actions/katello/host/destroy.rb
+++ b/app/lib/actions/katello/host/destroy.rb
@@ -6,11 +6,27 @@ module Actions
 
         def plan(host, options = {})
           action_subject(host)
-          ::Katello::RegistrationManager.unregister_host(host, options)
+          # normalize options before passing through to run phase
+          organization_destroy = options.fetch(:organization_destroy, false)
+          unregistering = options.fetch(:unregistering, false)
+          plan_self(:hostname => host.name, :host_id => host.id, :unregistering => unregistering,
+                    :organization_destroy => organization_destroy)
+        end
+
+        def run
+          host = ::Host.find(input[:host_id])
+          ::Katello::RegistrationManager.unregister_host(host, :unregistering => input[:unregistering],
+                                                         :organization_destroy => input[:organization_destroy])
+        rescue ActiveRecord::RecordNotFound
+          Rails.logger.warn("Attempted to delete host %s in action, but host is already gone. Continuing." % input[:host_id])
         end
 
         def humanized_name
-          _("Destroy Content Host")
+          if input.try(:[], :hostname)
+            _("Destroy Content Host %s") % input[:hostname]
+          else
+            _("Destroy Content Host")
+          end
         end
       end
     end

--- a/app/lib/actions/pulp/consumer/generate_applicability.rb
+++ b/app/lib/actions/pulp/consumer/generate_applicability.rb
@@ -8,7 +8,11 @@ module Actions
 
         def invoke_external_task
           if input[:uuids].length == 1
-            pulp_resources.consumer.regenerate_applicability_by_id(input[:uuids].first)
+            begin
+              pulp_resources.consumer.regenerate_applicability_by_id(input[:uuids].first)
+            rescue RestClient::ResourceNotFound
+              Rails.logger.warn("Pulp consumer %s not found." % input[:uuids].first)
+            end
           else
             pulp_extensions.consumer.regenerate_applicability_by_ids(input[:uuids])
           end

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -20,7 +20,7 @@ module Katello
       included do
         prepend Overrides
 
-        has_many :host_installed_packages, :class_name => "::Katello::HostInstalledPackage", :foreign_key => :host_id, :dependent => :destroy
+        has_many :host_installed_packages, :class_name => "::Katello::HostInstalledPackage", :foreign_key => :host_id, :dependent => :delete_all
         has_many :installed_packages, :class_name => "::Katello::InstalledPackage", :through => :host_installed_packages
         has_many :host_traces, :class_name => "::Katello::HostTracer", :foreign_key => :host_id, :dependent => :destroy
 

--- a/app/models/katello/host_installed_package.rb
+++ b/app/models/katello/host_installed_package.rb
@@ -1,5 +1,6 @@
 module Katello
   class HostInstalledPackage < Katello::Model
+    # Do not use active record callbacks in this join model.  Direct INSERTs and DELETEs are done
     belongs_to :host, :inverse_of => :host_installed_packages, :class_name => '::Host::Managed'
     belongs_to :installed_package, :inverse_of => :host_installed_packages, :class_name => 'Katello::InstalledPackage'
   end

--- a/app/services/katello/candlepin/message_handler.rb
+++ b/app/services/katello/candlepin/message_handler.rb
@@ -55,16 +55,19 @@ module Katello
       end
 
       def subscription_facet
+        return nil if self.consumer_uuid.nil?
         ::Katello::Host::SubscriptionFacet.where(uuid: self.consumer_uuid).first
       end
 
       def create_pool_on_host
+        return if self.subscription_facet.nil?
         pool = self.pool_by_reference_id
         ::Katello::SubscriptionFacetPool.where(subscription_facet_id: self.subscription_facet.id,
                                                pool_id: pool.id).first_or_create
       end
 
       def remove_pool_from_host
+        return if self.subscription_facet.nil?
         pool = self.pool_by_reference_id
         ::Katello::SubscriptionFacetPool.where(subscription_facet_id: self.subscription_facet.id,
                                                pool_id: pool.id).destroy_all

--- a/test/actions/katello/host/destroy_test.rb
+++ b/test/actions/katello/host/destroy_test.rb
@@ -21,27 +21,44 @@ module Katello::Host
         action = create_action action_class
         action.stubs(:action_subject).with(@host)
 
-        ::Katello::RegistrationManager.expects(:unregister_host).with(@host, {})
+        ::Host.expects(:find).returns(@host)
+        ::Katello::RegistrationManager.expects(:unregister_host).with(@host, :unregistering => false, :organization_destroy => false)
 
         plan_action action, @host
+        run_action action
+      end
+
+      it 'plans and host has since been deleted' do
+        action = create_action action_class
+        action.stubs(:action_subject).with(@host)
+
+        ::Host.expects(:find).raises(ActiveRecord::RecordNotFound)
+        ::Katello::RegistrationManager.expects(:unregister_host).never
+
+        plan_action action, @host
+        run_action action
       end
 
       it 'plans with unregistering true' do
         action = create_action action_class
         action.stubs(:action_subject).with(@host)
 
-        ::Katello::RegistrationManager.expects(:unregister_host).with(@host, :unregistering => true)
+        ::Host.expects(:find).returns(@host)
+        ::Katello::RegistrationManager.expects(:unregister_host).with(@host, :unregistering => true, :organization_destroy => false)
 
         plan_action action, @host, :unregistering => true
+        run_action action
       end
 
       it 'plans with organization_destroy true' do
         action = create_action action_class
         action.stubs(:action_subject).with(@host)
 
-        ::Katello::RegistrationManager.expects(:unregister_host).with(@host, :organization_destroy => true)
+        ::Host.expects(:find).returns(@host)
+        ::Katello::RegistrationManager.expects(:unregister_host).with(@host, :unregistering => false, :organization_destroy => true)
 
         plan_action action, @host, :organization_destroy => true
+        run_action action
       end
     end
   end

--- a/test/controllers/api/v2/host_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/host_subscriptions_controller_test.rb
@@ -294,7 +294,8 @@ module Katello
     end
 
     def test_destroy
-      ::Katello::RegistrationManager.expects(:unregister_host).with(@host)
+      ::Katello::RegistrationManager.expects(:unregister_host).with(@host, :unregistering => true)
+
       delete :destroy, params: { :host_id => @host.id }
 
       assert_response :success

--- a/test/services/candlepin/message_handler_test.rb
+++ b/test/services/candlepin/message_handler_test.rb
@@ -57,6 +57,17 @@ module Katello
                                                     pool_id: @pool.id).count == 0
     end
 
+    def test_create_pool_on_nonexistant_host
+      @message_handler.expects(:subscription_facet).returns(nil).at_least_once
+      @message_handler.expects(:reference_id).returns(@pool.cp_id).never
+
+      @message_handler.create_pool_on_host
+      ::Katello::SubscriptionFacetPool.expects(:where).never
+
+      @message_handler.remove_pool_from_host
+      ::Katello::SubscriptionFacetPool.expects(:where).never
+    end
+
     def test_import_pool
       pool = ::Katello::Pool.first
       ::Katello::Pool.expects(:import_pool).with(pool.id, true).returns(true).once

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -91,6 +91,7 @@ module Katello
         @host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @content_view,
                                    :lifecycle_environment => @library, :organization => @content_view.organization)
 
+        ::Host.expects(:find).returns(@host)
         ::Katello::Resources::Candlepin::Consumer.expects(:destroy)
         ::Runcible::Extensions::Consumer.any_instance.expects(:delete)
 
@@ -142,7 +143,8 @@ module Katello
       def test_registration_dead_candlepin
         new_host = ::Host::Managed.new(:name => 'foobar', :managed => false, :organization => @library.organization)
 
-        new_host.expects(:destroy!)
+        ::Host.expects(:find).returns(new_host)
+        new_host.expects(:destroy)
         ::Katello::Resources::Candlepin::Consumer.expects(:create).with(@content_view_environment.cp_id, rhsm_params, []).raises("uhoh!")
         ::Runcible::Extensions::Consumer.any_instance.expects(:create).with('fake-uuid', :display_name => 'foobar').never
 


### PR DESCRIPTION
This commit fixes various edge cases and errors related to
registration and hosts unregistering before actions complete.

This is tied closely to #21703.