### PR TITLE
Fixes #22743 - ensure proper ordering on registering reload paths

### DIFF
--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -11,7 +11,7 @@ module Katello
       )
     end
 
-    initializer 'katello.mount_engine', :after => :build_middleware_stack do |app|
+    initializer 'katello.mount_engine', :before => :sooner_routes_load, :after => :build_middleware_stack do |app|
       app.routes_reloader.paths << "#{Katello::Engine.root}/config/routes/mount_engine.rb"
     end
 
@@ -100,7 +100,7 @@ module Katello
       app.config.autoload_paths += Dir["#{config.root}/app/views/foreman"]
     end
 
-    initializer "katello.paths" do |app|
+    initializer "katello.paths", :before => :sooner_routes_load do |app|
       app.routes_reloader.paths << "#{Katello::Engine.root}/config/routes/api/v2.rb"
       app.routes_reloader.paths << "#{Katello::Engine.root}/config/routes/api/rhsm.rb"
       app.routes_reloader.paths.unshift("#{Katello::Engine.root}/config/routes/overrides.rb")


### PR DESCRIPTION
In some cases, the initializers were running in wrong order (running
'katello.paths' after 'sooner_routes_load', which lead to `can't modify
frozen Array`.

Being explicit about the ordering should help making sure we don't run
into the issue.

This was not reproduced locally, was proved at the user the patch
resolved the issue.