### PR TITLE
Fixes #22748 - API for Selectable columns for Subs

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -7,7 +7,7 @@ module Katello
 
     # support for session (thread-local) variables must be the last filter in this class
     include Foreman::ThreadSession::Cleaner
-
+    helper_method :resource_class
     skip_before_action :setup_has_many_params # TODO: get this working #8862
 
     resource_description do

--- a/app/views/katello/api/v2/common/_metadata.json.rabl
+++ b/app/views/katello/api/v2/common/_metadata.json.rabl
@@ -12,3 +12,13 @@ node(:sort) do
     :order => params[:sort_order]
   }
 end
+
+if User.current && ::ColumnRegistry::Manager.resources.include?(resource_class.name)
+  node(:table_configuration) do
+    {
+      :resource => resource_class.name,
+      :columns => ::UserColumn.collate(resource_class.name,
+                   User.current.user_columns.resource(resource_class.name).first.try(:columns))
+    }
+  end
+end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -230,6 +230,32 @@ Foreman::Plugin.register :katello do
   widget 'subscription_status_widget', :name => 'Subscription Status', :sizey => 1, :sizex => 6
   widget 'host_collection_widget', :name => 'Host Collections', :sizey => 1, :sizex => 6
 
+  column_resource ::Katello::Pool.name do |resource|
+    resource.column 'name', :description => N_("Name"),
+                            :path => "name",
+                            :default_enabled => true
+
+    resource.column 'account', :description => N_("Account"),
+                               :path => "account_number",
+                               :default_enabled => true
+
+    resource.column 'contract', :description => N_("Contract"),
+                                :path => "contract_number",
+                                :default_enabled => true
+
+    resource.column 'start_date', :description => N_("Start Date"),
+                                  :path => "start_date",
+                                  :default_enabled => true
+
+    resource.column 'end_date', :description => N_("End Date"),
+                                :path => "end_date",
+                                :default_enabled => true
+
+    resource.column 'entitlements', :description => N_("Entitlements"),
+                                    :path => "consumed",
+                                    :default_enabled => true
+  end
+
   extend_page("smart_proxies/show") do |context|
     context.add_pagelet :main_tabs,
       :name => _("Content"),


### PR DESCRIPTION
This commit adds the initial API bindings for selectable columns for
subscriptions. We basically massage the API returned by the index call
to include columns that could be displayed and their values.