### PR TITLE
Fixes #22760 - Search repository sets by name

### DIFF
--- a/app/controllers/katello/api/v2/repository_sets_controller.rb
+++ b/app/controllers/katello/api/v2/repository_sets_controller.rb
@@ -82,7 +82,7 @@ module Katello
     end
 
     def default_sort
-      lambda { |relation| relation.joins(:content).order("#{Katello::Content.table_name}.name asc") }
+      lambda { |relation| relation.order("#{Katello::Content.table_name}.name asc") }
     end
 
     def index_relation
@@ -93,7 +93,7 @@ module Katello
       end
 
       relation = relation.enabled(@organization) if ::Foreman::Cast.to_bool(params[:enabled])
-      relation = relation.joins(:content).where(:name => params[:name]) if params[:name].present?
+      relation = relation.where(Katello::Content.table_name => {:name => params[:name]}) if params[:name].present?
       relation.redhat
     end
 

--- a/test/controllers/api/v2/repository_sets_controller_test.rb
+++ b/test/controllers/api/v2/repository_sets_controller_test.rb
@@ -34,6 +34,18 @@ module Katello
     def test_index_product
       get :index, params: { :product_id => @product.id }
 
+      body = JSON.parse(response.body)
+
+      assert_empty body['error']
+      assert_response :success
+    end
+
+    def test_index_name
+      get :index, params: { :product_id => @product.id, :name => 'foo' }
+
+      body = JSON.parse(response.body)
+
+      assert_empty body['error']
       assert_response :success
     end
 
@@ -46,18 +58,27 @@ module Katello
     def test_index_org_enabled
       get :index, params: { :organization_id => @organization.id, :enabled => true }
 
+      body = JSON.parse(response.body)
+
+      assert_empty body['error']
       assert_response :success
     end
 
     def test_index_org
       get :index, params: { :organization_id => @organization.id}
 
+      body = JSON.parse(response.body)
+
+      assert_empty body['error']
       assert_response :success
     end
 
     def test_index_org_id
       get :index, params: { :organization_id => @organization.id}
 
+      body = JSON.parse(response.body)
+
+      assert_empty body['error']
       assert_response :success
     end
 


### PR DESCRIPTION
Couldn't search repository sets by name: katello/api/v2/products/1/repository_sets?name=foo

Removed redundant joins (on default scope) and search by name on the correct table. Also added some more stringent checks on `index` tests