### PR TITLE
Fixes #22825: fix repository type icon tests after upgrade.

### DIFF
--- a/webpack/scenes/RedHatRepositories/components/__tests__/__snapshots__/RepositoryTypeIcon.test.js.snap
+++ b/webpack/scenes/RedHatRepositories/components/__tests__/__snapshots__/RepositoryTypeIcon.test.js.snap
@@ -23,8 +23,6 @@ exports[`RepositoryTypeIcon component rendering it should get rendered correctly
 >
   <ListViewIcon
     name="fa-2x fa fa-question"
-    size="sm"
-    type="fa"
   />
 </OverlayTrigger>
 `;
@@ -52,8 +50,6 @@ exports[`RepositoryTypeIcon component rendering it should get rendered correctly
 >
   <ListViewIcon
     name="fa-2x pficon-bundle"
-    size="sm"
-    type="fa"
   />
 </OverlayTrigger>
 `;


### PR DESCRIPTION
Fix RepositoryTypeIcon.test.js after patternfly-react upgrade.

http://projects.theforeman.org/issues/22825