### PR TITLE
Fixes #22867 - Configurable 'expiring soon' days

### DIFF
--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -36,7 +36,6 @@ module Katello
 
     validates_lengths_from_database
 
-    DAYS_EXPIRING_SOON = 120
     DAYS_RECENTLY_EXPIRED = 30
 
     def active?
@@ -44,7 +43,7 @@ module Katello
     end
 
     def expiring_soon?
-      (end_date.to_date - Date.today) <= DAYS_EXPIRING_SOON
+      (end_date.to_date - Date.today) <= Setting[:expire_soon_days]
     end
 
     def recently_expired?

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -76,7 +76,9 @@ class Setting::Content < Setting
         self.set('default_location_puppet_content',
                  N_('Default Location where new Puppet content will be put upon Content View publish'),
                  nil, N_('Default Location Puppet content'), nil,
-                 :collection => proc { Hash[Location.unscoped.all.map { |loc| [loc[:title], loc[:title]] }] })
+                 :collection => proc { Hash[Location.unscoped.all.map { |loc| [loc[:title], loc[:title]] }] }),
+        self.set('expire_soon_days', N_('The number of days remaining in a subscription before you will be reminded about renewing it.'),
+                 120, N_('Expire soon days'))
       ].each { |s| self.create! s.update(:category => "Setting::Content") }
     end
     true

--- a/test/factories/pool_factory.rb
+++ b/test/factories/pool_factory.rb
@@ -20,11 +20,11 @@ FactoryBot.define do
     end
 
     trait :expiring_soon do
-      end_date Date.today + Katello::Pool::DAYS_EXPIRING_SOON
+      end_date Date.today + Setting[:expire_soon_days]
     end
 
     trait :not_expiring_soon do
-      end_date Date.today + Katello::Pool::DAYS_EXPIRING_SOON + 1
+      end_date Date.today + Setting[:expire_soon_days] + 1
     end
 
     trait :recently_expired do


### PR DESCRIPTION
The number of days before a subscription is counted as 'expires soon' is
120, hardcoded in pool.rb. Users should be able to configure this so
that they can get notifications when they think it's more appropriate.

To be tested with the subscriptions widget in the dashboard, the bookmark for 'expiring soon' in the subscriptions page, or https://github.com/Katello/katello/pull/6752

cc @jyejare