### PR TITLE
Fixes #22853: Allow add entitlements to manifest

### DIFF
--- a/app/lib/actions/katello/upstream_subscriptions/bind_entitlement.rb
+++ b/app/lib/actions/katello/upstream_subscriptions/bind_entitlement.rb
@@ -1,0 +1,31 @@
+module Actions
+  module Katello
+    module UpstreamSubscriptions
+      class BindEntitlement < Actions::Base
+        middleware.use Actions::Middleware::KeepCurrentTaxonomies
+
+        def run
+          output[:response] = ::Katello::Resources::Candlepin::UpstreamConsumer
+            .bind_entitlement(pool)
+        end
+
+        def humanized_name
+          N_("Bind an entitlement to an allocation")
+        end
+
+        def rescue_strategy
+          Dynflow::Action::Rescue::Skip
+        end
+
+        private
+
+        def pool
+          {
+            pool: input[:pool],
+            quantity: input[:quantity]
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/upstream_subscriptions/bind_entitlements.rb
+++ b/app/lib/actions/katello/upstream_subscriptions/bind_entitlements.rb
@@ -1,0 +1,28 @@
+module Actions
+  module Katello
+    module UpstreamSubscriptions
+      class BindEntitlements < Actions::Base
+        middleware.use Actions::Middleware::KeepCurrentTaxonomies
+
+        def plan(pools = [])
+          fail _("No pools were provided.") unless pools.any?
+          fail _("Current organization is not set.") unless ::Organization.current
+          input[:pools] = pools
+
+          sequence do
+            concurrence do
+              pools.each do |pool|
+                plan_action(Katello::UpstreamSubscriptions::BindEntitlement, pool)
+              end
+            end
+            plan_action(Katello::Organization::ManifestRefresh, ::Organization.current)
+          end
+        end
+
+        def humanized_name
+          N_("Bind entitlements to an allocation")
+        end
+      end
+    end
+  end
+end

--- a/app/lib/katello/resources/candlepin/upstream_consumer.rb
+++ b/app/lib/katello/resources/candlepin/upstream_consumer.rb
@@ -35,6 +35,10 @@ module Katello
             RestClient.proxy = ""
           end
 
+          def bind_entitlement(**pool)
+            JSON.parse(self['entitlements'].post(nil, params: pool))
+          end
+
           delegate :[], to: :json_resource
         end
       end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -317,7 +317,7 @@ Katello::Engine.routes.draw do
               put :refresh_manifest
             end
           end
-          api_resources :upstream_subscriptions, only: :index do
+          api_resources :upstream_subscriptions, only: [:index, :create] do
             collection do
               delete :destroy
             end

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -351,7 +351,7 @@ module Katello
                          :resource_type => 'Katello::Subscription'
       @plugin.permission :manage_subscription_allocations,
                          {
-                           'katello/api/v2/upstream_subscriptions' => [:index, :destroy]
+                           'katello/api/v2/upstream_subscriptions' => [:index, :create, :destroy]
                          },
                          :resource_type => 'Katello::Subscription'
     end

--- a/test/actions/katello/upstream_subscriptions/bind_entitlement_test.rb
+++ b/test/actions/katello/upstream_subscriptions/bind_entitlement_test.rb
@@ -1,0 +1,21 @@
+require 'katello_test_helper'
+
+describe ::Actions::Katello::UpstreamSubscriptions::BindEntitlement do
+  include Dynflow::Testing
+
+  subject { described_class }
+
+  before do
+    @org = FactoryBot.build(:katello_organization)
+    Organization.stubs(:current).returns(@org)
+    @pool = {pool: "abcd1234", quantity: 3}
+    @action = create_and_plan_action(subject, @pool)
+    Organization.unscoped.class.any_instance.expects(:find).with(@org.id).returns(@org)
+  end
+
+  it 'runs' do
+    ::Katello::Resources::Candlepin::UpstreamConsumer.expects(:bind_entitlement).with(@pool)
+
+    @action = run_action(@action)
+  end
+end

--- a/test/actions/katello/upstream_subscriptions/bind_entitlements_test.rb
+++ b/test/actions/katello/upstream_subscriptions/bind_entitlements_test.rb
@@ -1,0 +1,38 @@
+require 'katello_test_helper'
+
+describe ::Actions::Katello::UpstreamSubscriptions::BindEntitlements do
+  include Dynflow::Testing
+
+  subject { described_class }
+
+  before :all do
+    @org = FactoryBot.build(:katello_organization)
+    @action = create_action(subject)
+    @manifest_action_class = ::Actions::Katello::Organization::ManifestRefresh
+  end
+
+  it 'plans' do
+    Organization.stubs(:current).returns(@org)
+
+    pools = [{"poolId" => "abcd1234", "quantity" => 3}]
+
+    plan_action(@action, pools)
+
+    pools.each do |pool|
+      assert_action_planned_with(@action, ::Actions::Katello::UpstreamSubscriptions::BindEntitlement, pool)
+    end
+
+    assert_action_planned_with(@action, @manifest_action_class, @org)
+  end
+
+  it 'raises an error when given no pools' do
+    error = proc { plan_action(@action, []) }.must_raise RuntimeError
+    error.message.must_match(/No pools were provided/)
+  end
+
+  it 'raises an error when organization is set' do
+    set_organization(nil)
+    error = proc { plan_action(@action, [{}]) }.must_raise RuntimeError
+    error.message.must_match(/Current organization is not set/)
+  end
+end


### PR DESCRIPTION
Allow adding entitlements to your manifest from Katello!

```js
POST katello/api/v2/organizations/1/upstream_subscriptions
{
  [
    {
      "id": "8a85f98c60c4fc0e0160c50f7eea0411",
      "quantity": 1
    },
    ...
  ]
{
```

~WIP for:~

- [x] tests
- [x] ForemanTasks

Requires https://github.com/theforeman/foreman-tasks/pull/324