### PR TITLE
Fixes #22909 - Remove subscriptions from upstream allocation

### DIFF
--- a/app/controllers/katello/api/v2/upstream_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/upstream_subscriptions_controller.rb
@@ -1,5 +1,3 @@
-require 'katello/resources/candlepin'
-
 module Katello
   class Api::V2::UpstreamSubscriptionsController < Api::V2::ApiController
     before_action :check_disconnected
@@ -25,6 +23,15 @@ module Katello
       collection = scoped_search_results(
         pools, pools.count, nil, params[:page], params[:per_page], nil)
       respond(collection: collection)
+    end
+
+    api :DELETE, "/organizations/:organization_id/upstream_subscriptions",
+      N_("Remove one or more subscriptions from an upstream subscription allocation")
+    param :organization_id, :number, :desc => N_("Organization ID"), :required => true
+    param :pool_ids, Array, desc: N_("Array of local pool IDs. Only pools originating upstream (non-custom) are accepted."), required: true
+    def destroy
+      task = async_task(::Actions::Katello::UpstreamSubscriptions::RemoveEntitlements, params[:pool_ids])
+      respond_for_async :resource => task
     end
 
     private

--- a/app/lib/actions/katello/upstream_subscriptions/remove_entitlement.rb
+++ b/app/lib/actions/katello/upstream_subscriptions/remove_entitlement.rb
@@ -1,0 +1,22 @@
+module Actions
+  module Katello
+    module UpstreamSubscriptions
+      class RemoveEntitlement < Actions::Base
+        middleware.use Actions::Middleware::KeepCurrentTaxonomies
+        middleware.use Actions::Middleware::PropagateCandlepinErrors
+
+        input_format do
+          param :entitlement_id
+        end
+
+        def run
+          output[:response] = ::Katello::Resources::Candlepin::UpstreamConsumer.remove_entitlement(input[:entitlement_id])
+        end
+
+        def run_progress_weight
+          0.01
+        end
+      end
+    end
+  end
+end

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -128,6 +128,11 @@ module Katello
                                     )
           end
 
+          def json_resource(url = self.site + self.path, client_cert = self.client_cert, client_key = self.client_key, ca_file = nil, options = {})
+            options.deep_merge!(headers: self.default_headers)
+            resource(url, client_cert, client_key, ca_file, options)
+          end
+
           def rest_client(_http_type = nil, method = :get, path = self.path)
             # No oauth upstream
             self.consumer_secret = nil

--- a/app/lib/katello/resources/candlepin/consumer.rb
+++ b/app/lib/katello/resources/candlepin/consumer.rb
@@ -214,6 +214,12 @@ module Katello
             super(id)
           end
 
+          def remove_entitlement(entitlement_id)
+            fail ArgumentError, "No entitlement ID given to remove." if entitlement_id.blank?
+
+            self["entitlements/#{entitlement_id}"].delete
+          end
+
           def export(url, client_cert, client_key, ca_file)
             logger.debug "Sending GET request to upstream Candlepin: #{url}"
             return resource(url, client_cert, client_key, ca_file).get
@@ -233,6 +239,8 @@ module Katello
           ensure
             RestClient.proxy = ""
           end
+
+          delegate :[], to: :json_resource
         end
       end
     end # Candlepin

--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -10,7 +10,7 @@ module Katello
         lazy_accessor :subscription_facts, :initializer => lambda { |_s| self.subscription ? self.subscription.attributes : {} }
 
         lazy_accessor :pool_derived, :owner, :source_pool_id, :virt_limit, :arch, :description,
-          :product_family, :variant, :suggested_quantity, :support_type, :product_id, :type,
+          :product_family, :variant, :suggested_quantity, :support_type, :product_id, :type, :upstream_entitlement_id,
           :initializer => :pool_facts
 
         lazy_accessor :name, :support_level, :org, :sockets, :cores, :stacking_id, :instance_multiplier,
@@ -63,6 +63,8 @@ module Katello
         end
 
         json["product_id"] = json["productId"] if json["productId"]
+
+        json["upstream_entitlement_id"] = json["upstreamEntitlementId"]
 
         if self.subscription
           subscription.backend_data["product"]["attributes"].map { |attr| json[attr["name"].underscore.to_sym] = attr["value"] }

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -317,7 +317,11 @@ Katello::Engine.routes.draw do
               put :refresh_manifest
             end
           end
-          api_resources :upstream_subscriptions, only: :index
+          api_resources :upstream_subscriptions, only: :index do
+            collection do
+              delete :destroy
+            end
+          end
         end
 
         api_resources :host_collections

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -351,7 +351,7 @@ module Katello
                          :resource_type => 'Katello::Subscription'
       @plugin.permission :manage_subscription_allocations,
                          {
-                           'katello/api/v2/upstream_subscriptions' => [:index]
+                           'katello/api/v2/upstream_subscriptions' => [:index, :destroy]
                          },
                          :resource_type => 'Katello::Subscription'
     end

--- a/test/actions/katello/upstream_subscriptions/remove_entitlement_test.rb
+++ b/test/actions/katello/upstream_subscriptions/remove_entitlement_test.rb
@@ -1,0 +1,18 @@
+require 'katello_test_helper'
+
+describe ::Actions::Katello::UpstreamSubscriptions::RemoveEntitlement do
+  include Dynflow::Testing
+
+  subject { described_class }
+
+  before :all do
+    @org = FactoryBot.create(:katello_organization)
+    set_organization(@org)
+    @planned_action = create_and_plan_action(subject, org_id: @org.id, entitlement_id: 'foo')
+  end
+
+  it 'runs' do
+    ::Katello::Resources::Candlepin::UpstreamConsumer.expects(:remove_entitlement).with('foo')
+    run_action @planned_action
+  end
+end

--- a/test/actions/katello/upstream_subscriptions/remove_entitlements_test.rb
+++ b/test/actions/katello/upstream_subscriptions/remove_entitlements_test.rb
@@ -1,0 +1,52 @@
+require 'katello_test_helper'
+
+describe ::Actions::Katello::UpstreamSubscriptions::RemoveEntitlements do
+  include Dynflow::Testing
+
+  subject { described_class }
+
+  before :all do
+    @org = FactoryBot.build(:katello_organization)
+    set_organization(@org)
+    @action = create_action(subject)
+    @remove_action_class = ::Actions::Katello::UpstreamSubscriptions::RemoveEntitlement
+    @manifest_action_class = ::Actions::Katello::Organization::ManifestRefresh
+  end
+
+  it 'plans' do
+    pool1 = katello_pools(:pool_one)
+    pool2 = katello_pools(:pool_two)
+
+    pool1.expects(:upstream_entitlement_id).returns('a').twice
+    pool2.expects(:upstream_entitlement_id).returns('b').twice
+
+    ::Katello::Pool.expects(:find).with(pool1.id).returns(pool1)
+    ::Katello::Pool.expects(:find).with(pool2.id).returns(pool2)
+
+    plan_action(@action, [pool1.id, pool2.id])
+
+    assert_action_planned_with(@action, @remove_action_class, entitlement_id: 'a')
+    assert_action_planned_with(@action, @remove_action_class, entitlement_id: 'b')
+    assert_action_planned_with(@action, @manifest_action_class, @org)
+  end
+
+  it 'raises an error when the pool has no upstream entitlement' do
+    pool1 = katello_pools(:pool_one)
+    pool1.expects(:upstream_entitlement_id).returns(nil)
+    ::Katello::Pool.expects(:find).with(pool1.id).returns(pool1)
+
+    error = proc { plan_action(@action, [pool1.id]) }.must_raise RuntimeError
+    error.message.must_match(/upstream/)
+  end
+
+  it 'raises an error when given no entitlement ids' do
+    error = proc { plan_action(@action, []) }.must_raise RuntimeError
+    error.message.must_match(/provided/)
+  end
+
+  it 'raises an error when organization is set' do
+    set_organization(nil)
+    error = proc { plan_action(@action, [:foo]) }.must_raise RuntimeError
+    error.message.must_match(/is not set/)
+  end
+end

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -191,6 +191,10 @@ class ActiveSupport::TestCase
     User.current = user
   end
 
+  def set_organization(org)
+    Organization.current = org
+  end
+
   def get_organization(org = nil)
     saved_user = User.current
     User.current = User.unscoped.find(users(:admin).id)


### PR DESCRIPTION
API may be invoked as follows: 

`DELETE /katello/api/v2/organizations/:id/upstream_subscriptions`

With a body:

```
{
  "pool_ids: ["a", "b", "c"]
}
```

The pool ids given must have an upstream_entitlement_id