### PR TITLE
fixes #22923 - remove yum from "yum actions" menu

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
@@ -108,7 +108,7 @@
         <ul uib-dropdown-menu>
           <li>
             <a ui-sref="content-host.packages.actions" translate>
-              Yum Actions
+              Actions
             </a>
           </li>
           <li>


### PR DESCRIPTION
DNF is the future, and we're also using Zypper now with SUSE, so it doesn't make sense to name the specific package manager IMHO.