### PR TITLE
Fixes #22931 - Stop communication w/ RH portal while disconnected

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -187,5 +187,11 @@ module Katello
       @host = resource_finder(::Host::Managed.authorized(permission, ::Host::Managed), id)
       fail HttpErrors::BadRequest, _("Host has not been registered with subscription-manager") if @host.subscription_facet.nil?
     end
+
+    def check_disconnected
+      msg = "You are currently operating in disconnected mode where access to Red Hat Subcription Management " \
+            "is prohibited. If you would like to change this, please update the content setting 'Disconnected mode'."
+      fail HttpErrors::BadRequest, _(msg) if Setting[:content_disconnected]
+    end
   end
 end

--- a/app/controllers/katello/api/v2/subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/subscriptions_controller.rb
@@ -7,6 +7,7 @@ module Katello
     before_action :find_optional_organization, :only => [:index, :available, :show]
     before_action :find_organization, :only => [:upload, :delete_manifest,
                                                 :refresh_manifest, :manifest_history]
+    before_action :check_disconnected, only: [:refresh_manifest]
     before_action :find_provider
     before_action :deprecated, :only => [:create, :destroy]
 

--- a/app/controllers/katello/api/v2/upstream_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/upstream_subscriptions_controller.rb
@@ -3,6 +3,7 @@ require 'katello/resources/candlepin'
 module Katello
   class Api::V2::UpstreamSubscriptionsController < Api::V2::ApiController
     before_action :find_organization
+    before_action :check_disconnected
 
     resource_description do
       description "Red Hat subscriptions management platform."

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/manifest-import.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/manifest-import.controller.js
@@ -7,15 +7,16 @@
  * @requires translate
  * @requires CurrentOrganization
  * @requires Organization
- * @requires Subscription
  * @requires Task
+ * @requires Subscription
+ * @requires contentDisconnected
  *
  * @description
  *   Controls the import of a manifest.
  */
 angular.module('Bastion.subscriptions').controller('ManifestImportController',
-    ['$scope', '$q', 'translate', 'CurrentOrganization', 'Organization', 'Task', 'Subscription', 'Notification',
-    function ($scope, $q, translate, CurrentOrganization, Organization, Task, Subscription, Notification) {
+    ['$scope', '$q', 'translate', 'CurrentOrganization', 'Organization', 'Task', 'Subscription', 'Notification', 'contentDisconnected',
+    function ($scope, $q, translate, CurrentOrganization, Organization, Task, Subscription, Notification, contentDisconnected) {
 
         function buildManifestLink(upstream) {
             var url = upstream.webUrl,
@@ -248,5 +249,13 @@ angular.module('Bastion.subscriptions').controller('ManifestImportController',
                 $scope.showHistoryMoreLink = $scope.isTruncated($scope.statuses, results);
             });
         });
+
+        $scope.manifestRefreshDisabled = function () {
+          return $scope.isTaskPending() ||
+                 !$scope.upstream ||
+                 !$scope.upstream.idCert ||
+                 !$scope.upstream.idCert.cert ||
+                 contentDisconnected
+        }
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/views/manifest-import.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/manifest/views/manifest-import.html
@@ -43,7 +43,7 @@
          <span bst-modal="deleteManifest()" template-url="subscriptions/manifest/views/manifest-delete-modal.html"></span>
           <span translate>Delete Manifest</span>
       </button>
-      <button type="button" class="btn btn-default" ng-disabled="isTaskPending() || upstream.idCert == undefined || upstream.idCert.cert == undefined"
+      <button type="button" class="btn btn-default" ng-disabled="manifestRefreshDisabled()"
         ng-click="refreshManifest()">
           <span translate>Refresh Manifest</span>
       </button>

--- a/test/controllers/api/v2/subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/subscriptions_controller_test.rb
@@ -101,6 +101,12 @@ module Katello
       end
     end
 
+    def test_refresh_disconnected
+      Setting["content_disconnected"] = true
+      put :refresh_manifest, params: { :organization_id => @organization.id }
+      assert_response :bad_request
+    end
+
     def test_delete_manifest
       assert_async_task(::Actions::Katello::Organization::ManifestDelete) do |org|
         assert_equal @organization, org

--- a/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
@@ -38,5 +38,11 @@ module Katello
         get :index, params: { :organization_id => @organization.id }
       end
     end
+
+    def test_index_disconnected
+      Setting["content_disconnected"] = true
+      get :index, params: { organization_id: @organization.id }
+      assert_response :bad_request
+    end
   end
 end


### PR DESCRIPTION
Example of a response from a server where `content_disconnected` setting is true 

```
[vagrant@cinnamon foreman{develop}]$ curl -X PUT -k -u admin:changeme -H "Content-Type: application/json"  localhost:3000/katello/api/v2//organizations/1/subscriptions/refresh_manifest

{"displayMessage":"You are currently operating in disconnected mode where access to Red Hat Subcription Management is prohibited. If you would like to change this, please update the content setting 'Disconnected mode'.","errors":["You are currently operating in disconnected mode where access to Red Hat Subcription Management is prohibited. If you would like to change this, please update the content setting 'Disconnected mode'."]}
```