### PR TITLE
fixes #22951 - support docker v2 api

### DIFF
--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -1,0 +1,423 @@
+module Katello
+  class Api::Registry::RegistryProxiesController < Api::V2::ApiController
+    before_action :disable_strong_params
+    before_action :confirm_settings
+    skip_before_action :authorize, except: [:token]
+    before_action :registry_authorize, except: [:token]
+    before_action :authorize_repository_read, only: [:pull_manifest, :tags_list]
+    before_action :authorize_repository_write, only: [:push_manifest]
+    skip_before_action :check_content_type, :only => [:start_upload_blob, :upload_blob, :finish_upload_blob,
+                                                      :chunk_upload_blob, :push_manifest]
+    skip_after_action :log_response_body, :only => [:pull_blob]
+
+    wrap_parameters false
+
+    around_action :repackage_message
+
+    def repackage_message
+      yield
+    ensure
+      response.headers['Docker-Distribution-API-Version'] = 'registry/2.0'
+    end
+
+    rescue_from RestClient::Exception do |e|
+      Rails.logger.error pp_exception(e)
+      if request_from_katello_cli?
+        render json: { errors: [e.http_body] }, status: e.http_code
+      else
+        render plain: e.http_body, status: e.http_code
+      end
+    end
+
+    def redirect_authorization_headers
+      response.headers['Docker-Distribution-API-Version'] = 'registry/2.0'
+      response.headers['Www-Authenticate'] = "Bearer realm=\"#{request_url}/v2/token\"," \
+                                             "service=\"#{request.host}\"," \
+                                             "scope=\"repository:registry:pull,push\""
+    end
+
+    def registry_authorize
+      token = request.headers['Authorization']
+      if token
+        token_type, token = token.split
+        if token_type == 'Bearer' && token
+          personal_token = PersonalAccessToken.find_by_token(token)
+          if personal_token && !personal_token.expired?
+            User.current = User.unscoped.find(personal_token.user_id)
+            return true if User.current
+          end
+        elsif token_type == 'Basic' && token
+          return true if authorize
+          redirect_authorization_headers
+          return false
+        end
+      end
+      redirect_authorization_headers
+      render_error('unauthorized', :status => :unauthorized)
+      return false
+    end
+
+    def authorize_repository_write
+      @repository = Repository.syncable.find_by_container_repository_name(params[:repository])
+      unless @repository
+        not_found params[:repository]
+        return false
+      end
+      true
+    end
+
+    # Reduce visible repos to include lifecycle env permissions
+    # http://projects.theforeman.org/issues/22914
+    def readable_repositories
+      table_name = Repository.table_name
+      in_products = Repository.where(:product_id => Katello::Product.authorized(:view_products)).select(:id)
+      in_environments = Repository.where(:environment_id => Katello::KTEnvironment.authorized(:view_lifecycle_environments)).select(:id)
+      in_content_views = Repository.joins(:content_view_repositories).where("#{ContentViewRepository.table_name}.content_view_id" => Katello::ContentView.readable).select(:id)
+      in_versions = Repository.joins(:content_view_version).where("#{Katello::ContentViewVersion.table_name}.content_view_id" => Katello::ContentView.readable).select(:id)
+      Repository.where("#{table_name}.id in (?) or #{table_name}.id in (?) or #{table_name}.id in (?) or #{table_name}.id in (?)", in_products, in_content_views, in_versions, in_environments)
+    end
+
+    def find_repository
+      readable_repositories.find_by_container_repository_name(params[:repository])
+    end
+
+    def authorize_repository_read
+      @repository = find_repository
+      unless @repository
+        not_found params[:repository]
+        return false
+      end
+
+      if params[:tag]
+        if params[:tag][0..6] == 'sha256:'
+          manifest = Katello::DockerManifestList.where(digest: params[:tag]).first || Katello::DockerManifest.where(digest: params[:tag]).first
+          not_found params[:tag] unless manifest
+        else
+          tag = DockerMetaTag.where(repository_id: @repository.id, name: params[:tag]).first
+          not_found params[:tag] unless tag
+        end
+      end
+
+      true
+    end
+
+    def token
+      personal_token = PersonalAccessToken.where(user_id: User.current.id, name: 'registry').first
+      if personal_token.nil?
+        personal_token = PersonalAccessToken.new(user: User.current, name: 'registry', expires_at: 6.minutes.from_now)
+        personal_token.generate_token
+        personal_token.save!
+      else
+        personal_token.expires_at = 6.minutes.from_now
+        personal_token.save!
+      end
+      response.headers['Docker-Distribution-API-Version'] = 'registry/2.0'
+      render json: { token: personal_token.token, expires_at: personal_token.expires_at, issued_at: personal_token.created_at }
+    end
+
+    def pull_manifest
+      headers = {}
+      env = request.env.select do |key, _value|
+        key.match("^HTTP.*")
+      end
+      env.each do |header|
+        headers[header[0].split('_')[1..-1].join('-')] = header[1]
+      end
+
+      r = Resources::Registry::Proxy.get(@_request.fullpath, headers)
+      logger.debug r
+      response = JSON.parse(r)
+      render json: response, content_type: response['mediaType']
+    end
+
+    def check_blob
+      begin
+        r = Resources::Registry::Proxy.get(@_request.fullpath, 'Accept' => request.headers['Accept'])
+        response.header['Content-Length'] = "#{r.body.size}"
+      rescue RestClient::NotFound
+        digest_file = tmp_file("#{params[:digest][7..-1]}.tar")
+        raise unless File.exist? digest_file
+        response.header['Content-Length'] = "#{File.size digest_file}"
+      end
+      render json: {}
+    end
+
+    def pull_blob
+      r = Resources::Registry::Proxy.get(@_request.fullpath, 'Accept' => request.headers['Accept'])
+      render json: r
+    end
+
+    def push_manifest
+      repository = params[:repository]
+      tag = params[:tag]
+
+      manifest = create_manifest
+      return if manifest.nil?
+
+      begin
+        files = get_manifest_files(repository, manifest)
+        return if files.nil?
+
+        tar_file = create_tar_file(files, repository, tag)
+        return if tar_file.nil?
+
+        digest = upload_manifest(tar_file)
+        return if digest.nil?
+
+        tag = upload_tag(digest, tag)
+        return if tag.nil?
+      ensure
+        File.delete(tmp_file('manifest.json')) if File.exist? tmp_file('manifest.json')
+      end
+
+      render json: {}
+    end
+
+    def pulp_content
+      Katello.pulp_server.resources.content
+    end
+
+    def start_upload_blob
+      uuid = SecureRandom.hex(16)
+      response.header['Location'] = "#{request_url}/v2/#{params[:repository]}/blobs/uploads/#{uuid}"
+      response.header['Docker-Upload-UUID'] = uuid
+      response.header['Range'] = '0-0'
+      head 202
+    end
+
+    def status_upload_blob
+      response.header['Location'] = "#{request_url}/v2/#{params[:repository]}/blobs/uploads/#{params[:uuid]}"
+      response.header['Range'] = "123"
+      response.header['Docker-Upload-UUID'] = "123"
+      render plain: '', status: 204
+    end
+
+    def chunk_upload_blob
+      response.header['Location'] = "#{request_url}/v2/#{params[:repository]}/blobs/uploads/#{params[:uuid]}"
+      render plain: '', status: 202
+    end
+
+    def upload_blob
+      File.open(tmp_file("#{params[:uuid]}.tar"), 'ab', 0600) do |file|
+        file.write request.body.read
+      end
+
+      # ???? true chunked data?
+      if request.headers['Content-Range']
+        render_error 'unprocessable_entity', :status => :unprocessable_entity
+      end
+
+      response.header['Location'] = "#{request_url}/v2/#{params[:repository]}/blobs/uploads/#{params[:uuid]}"
+      response.header['Range'] = "1-#{request.body.size}"
+      response.header['Docker-Upload-UUID'] = params[:uuid]
+      head 204
+    end
+
+    def finish_upload_blob
+      # error by client if no params[:digest]
+
+      uuid_file = tmp_file("#{params[:uuid]}.tar")
+      digest_file = tmp_file("#{params[:digest][7..-1]}.tar")
+
+      File.delete(digest_file) if File.exist? digest_file
+      File.rename(uuid_file, digest_file)
+
+      response.header['Location'] = "#{request_url}/v2/#{params[:repository]}/blobs/#{params[:digest]}"
+      response.header['Docker-Content-Digest'] = params[:digest]
+      response.header['Content-Range'] = "1-#{File.size(digest_file)}"
+      response.header['Content-Length'] = "0"
+      response.header['Docker-Upload-UUID'] = params[:uuid]
+      head 201
+    end
+
+    def cancel_upload_blob
+      render plain: '', status: 200
+    end
+
+    def ping
+      response.headers['Docker-Distribution-API-Version'] = 'registry/2.0'
+      render json: {}, status: 200
+    end
+
+    def v1_ping
+      head 200
+    end
+
+    def v1_search
+      options = {
+        resource_class: Katello::Repository
+      }
+      params[:per_page] = params[:n] || 25
+      params[:search] = params[:q]
+      search_results = scoped_search(readable_repositories.where(content_type: 'docker').distinct,
+                                   :container_repository_name, :asc, options)
+      results = {
+        num_results: search_results[:subtotal],
+        query: params[:search]
+      }
+      results[:results] = search_results[:results].collect do |repository|
+        { name: repository[:container_repository_name], description: repository[:description] }
+      end
+      render json: results, status: 200
+    end
+
+    def catalog
+      repositories = readable_repositories.where(content_type: 'docker').collect do |repository|
+        repository.container_repository_name
+      end
+      render json: { repositories: repositories }
+    end
+
+    def tags_list
+      tags = @repository.docker_tags.collect do |tag|
+        tag.name
+      end
+      tags.uniq!
+      tags.sort!
+      render json: {
+        name: @repository.container_repository_name,
+        tags: tags
+      }
+    end
+
+    def create_manifest
+      filename = tmp_file('manifest.json')
+      if File.exist? filename
+        render_error('custom_error', :status => :unprocessable_entity,
+                     :locals => { :message => "Upload already in progress" })
+        return nil
+      end
+      manifest = request.body.read
+      File.open(tmp_file('manifest.json'), 'wb', 0600) do |file|
+        file.write manifest
+      end
+      manifest = JSON.parse(manifest)
+    rescue
+      File.delete(tmp_file('manifest.json')) if File.exist? tmp_file('manifest.json')
+    end
+
+    def get_manifest_files(repository, manifest)
+      files = ['manifest.json']
+      if manifest['schemaVersion'] == 1
+        if manifest['fsLayers']
+          files += manifest['fsLayers'].collect do |layer|
+            layerfile = "#{layer['blobSum'][7..-1]}.tar"
+            force_include_layer(repository, layer['blobSum'], layerfile)
+            layerfile
+          end
+        end
+      elsif manifest['schemaVersion'] == 2
+        if manifest['layers']
+          files += manifest['layers'].collect do |layer|
+            layerfile = "#{layer['digest'][7..-1]}.tar"
+            force_include_layer(repository, layer['digest'], layerfile)
+            layerfile
+          end
+        end
+        files << "#{manifest['config']['digest'][7..-1]}.tar"
+      else
+        render_error 'custom_error', :status => :internal_server_error,
+                             :locals => { :message => "Unsupported schema #{manifest['schemaVersion']}" }
+        return nil
+      end
+      files
+    end
+
+    def create_tar_file(files, repository, tag)
+      tar_file = "#{repository}_#{tag}.tar"
+      `/usr/bin/tar cf #{tmp_file(tar_file)} -C #{tmp_dir} #{files.join(' ')}`
+
+      files.each do |file|
+        filename = tmp_file(file)
+        File.delete(filename) if File.exist? filename
+      end
+      tar_file
+    end
+
+    def upload_manifest(tar_file)
+      upload_id = pulp_content.create_upload_request['upload_id']
+      filename = tmp_file(tar_file)
+      File.open(filename, 'rb') do |file|
+        pulp_content.upload_bits(upload_id, 0, file.read)
+
+        file.rewind
+        content = file.read
+        unit_keys = [{
+          name: filename,
+          size: file.size,
+          checksum: Digest::SHA256.hexdigest(content)
+        }]
+        unit_type_id = 'docker_manifest'
+        task = sync_task(::Actions::Katello::Repository::ImportUpload,
+                         @repository, [upload_id], :unit_type_id => unit_type_id,
+                         :unit_keys => unit_keys,
+                         :generate_metadata => true, :sync_capsule => true)
+        digest = task.output['upload_results'][0]['digest']
+
+        File.delete(filename)
+
+        digest
+      end
+    ensure
+      pulp_content.delete_upload_request(upload_id) if upload_id
+    end
+
+    def upload_tag(digest, tag)
+      upload_id = pulp_content.create_upload_request['upload_id']
+      unit_keys = [{
+        name: tag,
+        digest: digest
+      }]
+      unit_type_id = 'docker_tag'
+      sync_task(::Actions::Katello::Repository::ImportUpload,
+                       @repository, [upload_id], :unit_type_id => unit_type_id,
+                       :unit_keys => unit_keys,
+                       :generate_metadata => true, :sync_capsule => true)
+
+      tag
+    ensure
+      pulp_content.delete_upload_request(upload_id) if upload_id
+    end
+
+    def tmp_dir
+      "#{Rails.root}/tmp"
+    end
+
+    def tmp_file(filename)
+      File.join(tmp_dir, filename)
+    end
+
+    # TODO: Until pulp supports optional upload of layers, include all layers
+    # https://pulp.plan.io/issues/3497
+    def force_include_layer(repository, digest, layer)
+      unless File.exist? tmp_file(layer)
+        logger.debug "Getting blob #{digest} to write to #{layer}"
+        fullpath = "/v2/#{repository}/blobs/#{digest}"
+        request = Resources::Registry::Proxy.get(fullpath)
+        File.open(tmp_file(layer), 'wb', 0600) do |file|
+          file.write request.body
+        end
+        logger.debug "Wrote blob #{digest} to #{layer}"
+      end
+    end
+
+    def disable_strong_params
+      params.permit!
+    end
+
+    def confirm_settings
+      return true if SETTINGS[:katello][:registry]
+      render_error('custom_error', :status => :not_found,
+                   :locals => { :message => "Registry not configured" })
+      false
+    end
+
+    def request_url
+      request.protocol + request.host_with_port
+    end
+
+    def logger
+      ::Foreman::Logging.logger('katello/registry_proxy')
+    end
+  end
+end

--- a/app/lib/katello/resources/registry.rb
+++ b/app/lib/katello/resources/registry.rb
@@ -1,0 +1,38 @@
+require 'katello/util/data'
+
+module Katello
+  module Resources
+    require 'rest_client'
+
+    module Registry
+      class Proxy
+        def self.logger
+          ::Foreman::Logging.logger('katello/registry_proxy')
+        end
+
+        def self.get(path, headers = {:accept => :json})
+          logger.debug "Sending GET request to Registry: #{path}"
+          client = RegistryResource.rest_client(Net::HTTP::Get, :get, path)
+          client.get(headers)
+        end
+      end
+
+      class RegistryResource < HttpResource
+        cfg = SETTINGS[:katello][:registry]
+        url = cfg[:url]
+        uri = URI.parse(url)
+        self.prefix = uri.path
+        self.site = "#{uri.scheme}://#{uri.host}:#{uri.port}"
+        self.ca_cert_file = cfg[:ca_cert_file]
+
+        class << self
+          def process_response(response)
+            debug_level = response.code >= 400 ? :error : :debug
+            logger.send(debug_level, "Registry request returned with code #{response.code}")
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -174,6 +174,7 @@ module Katello
     scoped_search :on => :distribution_uuid, :complete_value => true
     scoped_search :on => :ignore_global_proxy, :complete_value => true
     scoped_search :on => :redhat, :complete_value => { :true => true, :false => false }, :ext_method => :search_by_redhat
+    scoped_search :on => :container_repository_name, :complete_value => true
 
     def organization
       if self.environment

--- a/config/routes/api/registry.rb
+++ b/config/routes/api/registry.rb
@@ -1,0 +1,29 @@
+require 'katello/api/mapper_extensions'
+
+class ActionDispatch::Routing::Mapper
+  include Katello::Routing::MapperExtensions
+end
+
+Katello::Engine.routes.draw do
+  scope :module => :api do
+    scope :module => :registry, :constraints => { :tag => /[0-9a-zA-Z\-_.:]*/, :digest => /[0-9a-zA-Z:]*/ } do
+      match '/v2/token' => 'registry_proxies#token', :via => :get
+      match '/v2/token' => 'registry_proxies#token', :via => :post
+      match '/v2/:repository/manifests/:tag' => 'registry_proxies#pull_manifest', :via => :get
+      match '/v2/:repository/manifests/:tag' => 'registry_proxies#push_manifest', :via => :put
+      match '/v2/:repository/blobs/:digest' => 'registry_proxies#pull_blob', :via => :get
+      match '/v2/:repository/blobs/:digest' => 'registry_proxies#check_blob', :via => :head
+      match '/v2/:repository/blobs/uploads' => 'registry_proxies#start_upload_blob', :via => :post
+      match '/v2/:repository/blobs/uploads/:uuid' => 'registry_proxies#chunk_upload_blob', :via => :post
+      match '/v2/:repository/blobs/uploads/:uuid' => 'registry_proxies#finish_upload_blob', :via => :put
+      match '/v2/:repository/blobs/uploads/:uuid' => 'registry_proxies#upload_blob', :via => :patch
+      match '/v2/:repository/blobs/uploads/:uuid' => 'registry_proxies#status_upload_blob', :via => :get
+      match '/v2/:repository/blobs/uploads/:uuid' => 'registry_proxies#cancel_upload_blob', :via => :delete
+      match '/v2/_catalog' => 'registry_proxies#catalog', :via => :get
+      match '/v2/:repository/tags/list' => 'registry_proxies#tags_list', :via => :get
+      match '/v2' => 'registry_proxies#ping', :via => :get
+      match '/v1/_ping' => 'registry_proxies#v1_ping', :via => :get
+      match '/v1/search' => 'registry_proxies#v1_search', :via => :get
+    end
+  end
+end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -103,6 +103,7 @@ module Katello
     initializer "katello.paths", :before => :sooner_routes_load do |app|
       app.routes_reloader.paths << "#{Katello::Engine.root}/config/routes/api/v2.rb"
       app.routes_reloader.paths << "#{Katello::Engine.root}/config/routes/api/rhsm.rb"
+      app.routes_reloader.paths << "#{Katello::Engine.root}/config/routes/api/registry.rb"
       app.routes_reloader.paths.unshift("#{Katello::Engine.root}/config/routes/overrides.rb")
     end
 

--- a/lib/katello/permissions/registry_permissions.rb
+++ b/lib/katello/permissions/registry_permissions.rb
@@ -1,0 +1,20 @@
+require 'katello/plugin.rb'
+
+Foreman::AccessControl.permission(:create_personal_access_tokens).actions.concat [
+  'katello/api/registry/registry_proxies/token',
+  'katello/api/registry/registry_proxies/v1_ping',
+  'katello/api/registry/registry_proxies/ping',
+  'katello/api/registry/registry_proxies/v1_search',
+  'katello/api/registry/registry_proxies/catalog',
+  'katello/api/registry/registry_proxies/tags_list',
+  'katello/api/registry/registry_proxies/pull_manifest',
+  'katello/api/registry/registry_proxies/push_manifest',
+  'katello/api/registry/registry_proxies/pull_blob',
+  'katello/api/registry/registry_proxies/check_blob',
+  'katello/api/registry/registry_proxies/start_upload_blob',
+  'katello/api/registry/registry_proxies/upload_blob',
+  'katello/api/registry/registry_proxies/chunk_upload_blob',
+  'katello/api/registry/registry_proxies/finish_upload_blob',
+  'katello/api/registry/registry_proxies/status_upload_blob',
+  'katello/api/registry/registry_proxies/cancel_upload_blob'
+]

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -223,6 +223,7 @@ Foreman::Plugin.register :katello do
   logger :cp_proxy, :enabled => true
   logger :action, :enabled => true
   logger :manifest_import_logger, :enabled => true
+  logger :registry_proxy, :enabled => true
 
   widget 'errata_widget', :name => 'Latest Errata', :sizey => 1, :sizex => 6
   widget 'content_views_widget', :name => 'Content Views', :sizey => 1, :sizex => 6

--- a/test/controllers/api/registry/registry_proxies_controller_test.rb
+++ b/test/controllers/api/registry/registry_proxies_controller_test.rb
@@ -1,0 +1,294 @@
+require "katello_test_helper"
+
+module Katello
+  describe Api::Registry::RegistryProxiesController do
+    include Support::ForemanTasks::Task
+
+    def setup_models
+      @docker_repo = katello_repositories(:busybox)
+      @organization = @docker_repo.product.organization
+      @docker_env_repo = katello_repositories(:busybox_view1)
+      @rpm_repo = katello_repositories(:fedora_17_x86_64)
+      @tag = katello_docker_tags(:one)
+    end
+
+    def setup_permissions
+      @read_permission = :view_products
+      @create_permission = :create_products
+      @update_permission = :edit_products
+      @destroy_permission = :destroy_products
+      @sync_permission = :sync_products
+    end
+
+    before do
+      setup_models
+      setup_permissions
+      setup_controller_defaults_api
+
+      SETTINGS[:katello][:registry] = {url: 'https://localhost:5000', ca_cert_file: '/etc/pki/katello/certs/katello-default-ca.crt'}
+
+      File.delete("#{Rails.root}/tmp/manifest.json") if File.exist?("#{Rails.root}/tmp/manifest.json")
+    end
+
+    describe "registry config" do
+      it "ping - unconfigured" do
+        SETTINGS[:katello].except!(:registry)
+        response = get :ping
+        body = JSON.parse(response.body)
+        assert_response 404
+        assert_equal('Registry not configured', body['error']['message'])
+      end
+    end
+
+    describe "docker login" do
+      it "ping - unauthorized" do
+        User.current = nil
+        session[:user] = nil
+        reset_api_credentials
+
+        get :ping
+        assert_response 401
+        assert_equal 'registry/2.0', response.headers['Docker-Distribution-API-Version']
+        assert_equal "Bearer realm=\"http://test.host/v2/token\"," \
+                     "service=\"test.host\"," \
+                     "scope=\"repository:registry:pull,push\"",
+                     response.headers['Www-Authenticate']
+      end
+
+      it "ping - basic unauthorized" do
+        User.current = nil
+        session[:user] = nil
+        reset_api_credentials
+
+        get :ping
+        assert_response 401
+        assert_equal 'registry/2.0', response.headers['Docker-Distribution-API-Version']
+        assert_equal "Bearer realm=\"http://test.host/v2/token\"," \
+                     "service=\"test.host\"," \
+                     "scope=\"repository:registry:pull,push\"",
+                     response.headers['Www-Authenticate']
+      end
+
+      it "ping - bearer bad token" do
+        User.current = nil
+        session[:user] = nil
+        @request.env['HTTP_AUTHORIZATION'] = "Bearer 12345"
+
+        get :ping
+        assert_response 401
+        assert_equal 'registry/2.0', response.headers['Docker-Distribution-API-Version']
+        assert_equal "Bearer realm=\"http://test.host/v2/token\"," \
+                     "service=\"test.host\"," \
+                     "scope=\"repository:registry:pull,push\"",
+                     response.headers['Www-Authenticate']
+      end
+
+      it "ping - bearer expired" do
+        User.current = nil
+        session[:user] = nil
+        @request.env['HTTP_AUTHORIZATION'] = "Bearer 12345"
+
+        token = mock('token')
+        token.stubs('expired?').returns(true)
+        PersonalAccessToken.expects(:find_by_token).with("12345").returns(token)
+
+        get :ping
+        assert_response 401
+        assert_equal 'registry/2.0', response.headers['Docker-Distribution-API-Version']
+        assert_equal "Bearer realm=\"http://test.host/v2/token\"," \
+                     "service=\"test.host\"," \
+                     "scope=\"repository:registry:pull,push\"",
+                     response.headers['Www-Authenticate']
+      end
+
+      it "ping - bearer authorized" do
+        user = User.current
+        User.current = nil
+        session[:user] = nil
+        @request.env['HTTP_AUTHORIZATION'] = "Bearer 12345"
+
+        token = mock('token')
+        token.stubs('expired?').returns(false)
+        token.stubs(:user_id).returns(user.id)
+        PersonalAccessToken.expects(:find_by_token).with("12345").returns(token)
+
+        get :ping
+        assert_response 200
+        assert_equal 'registry/2.0', response.headers['Docker-Distribution-API-Version']
+        assert_nil response.headers['Www-Authenticate']
+      end
+
+      it "ping - basic authorized" do
+        get :ping
+        assert_response 200
+        assert_equal 'registry/2.0', response.headers['Docker-Distribution-API-Version']
+        assert_nil response.headers['Www-Authenticate']
+      end
+
+      it "token - no 'registry' token yet" do
+        PersonalAccessToken.expects(:where)
+                           .with(user_id: User.current.id, name: 'registry')
+                           .returns([])
+        expiration = Time.now
+        token = mock('token')
+        token.stubs(:token).returns("12345")
+        token.stubs(:generate_token).returns("12345")
+        token.stubs(:user_id).returns(User.current.id)
+        token.stubs(:expires_at).returns("#{expiration}")
+        token.stubs(:created_at).returns("#{expiration}")
+        token.stubs('save!').returns(true)
+        PersonalAccessToken.expects(:new).returns(token)
+
+        get :token
+        assert_response 200
+        assert_equal 'registry/2.0', response.headers['Docker-Distribution-API-Version']
+        body = JSON.parse(response.body)
+        assert_equal "12345", body['token']
+        assert_equal "#{expiration}", body['expires_at']
+        assert_equal "#{expiration}", body['issued_at']
+      end
+
+      it "token - has 'registry' token" do
+        expiration = Time.now
+        token = mock('token')
+        token.stubs(:token).returns("12345")
+        token.stubs(:generate_token).returns("12345")
+        token.stubs(:user_id).returns(User.current.id)
+        token.stubs(:expires_at).returns("#{expiration}")
+        token.stubs(:created_at).returns("#{expiration}")
+        token.stubs('save!').returns(true)
+        token.expects('expires_at=').returns(true)
+        PersonalAccessToken.expects(:where)
+                           .with(user_id: User.current.id, name: 'registry')
+                           .returns([token])
+        PersonalAccessToken.expects(:new).never
+
+        get :token
+        assert_response 200
+        assert_equal 'registry/2.0', response.headers['Docker-Distribution-API-Version']
+        body = JSON.parse(response.body)
+        assert_equal "12345", body['token']
+        assert_equal "#{expiration}", body['expires_at']
+        assert_equal "#{expiration}", body['issued_at']
+      end
+    end
+
+    describe "docker search" do
+      it "search" do
+        @docker_repo.set_container_repository_name
+        @docker_env_repo.set_container_repository_name
+        per_page = 25
+        scoped_results = {
+          total: 100,
+          subtotal: 2,
+          page: 1,
+          per_page: per_page,
+          results: [@docker_repo, @docker_env_repo]
+        }
+        @controller.stubs(:scoped_search).returns(scoped_results)
+        get :v1_search, params: { q: "abc", n: 2 }
+        assert_response 200
+        body = JSON.parse(response.body)
+        assert_equal(body,
+                      "num_results" => 2,
+                      "query" => "abc",
+                      "results" => [{ "name" => "puppet_product-busybox", "description" => nil },
+                                    { "name" => "published_library_view-1_0-puppet_product-busybox", "description" => nil }]
+                    )
+      end
+    end
+
+    describe "docker pull" do
+      it "pull manifest - protected" do
+        @controller.stubs(:registry_authorize).returns(true)
+        @controller.stubs(:find_repository).returns(@docker_repo)
+        Resources::Registry::Proxy.stubs(:get).returns(stubbed: true)
+        DockerMetaTag.stubs(:where).with(repository_id: @docker_repo.id, name: @tag.name).returns([@tag])
+
+        allowed_perms = [:create_personal_access_tokens]
+        denied_perms = []
+        assert_protected_action(:pull_manifest, allowed_perms, denied_perms, [@organization]) do
+          get :pull_manifest, params: { repository: @docker_repo.name, tag: @tag.name }
+        end
+      end
+
+      it "pull manifest - success" do
+        manifest = '{"mediaType":"MEDIATYPE"}'
+        @controller.stubs(:registry_authorize).returns(true)
+        @controller.stubs(:find_repository).returns(@docker_repo)
+        Resources::Registry::Proxy.stubs(:get).returns(manifest)
+        DockerMetaTag.stubs(:where).with(repository_id: @docker_repo.id, name: @tag.name).returns([@tag])
+
+        get :pull_manifest, params: { repository: @docker_repo.name, tag: @tag.name }
+        assert_response 200
+        assert_equal(manifest, response.body)
+        assert response.header['Content-Type'] =~ /MEDIATYPE/
+      end
+    end
+
+    describe "docker push" do
+      it "push manifest - error" do
+        @controller.stubs(:authorize_repository_write).returns(true)
+        put :push_manifest, params: { repository: 'repository', tag: 'tag' }
+        assert_response 500
+        body = JSON.parse(response.body)
+        assert_equal "Unsupported schema ", body['error']['message']
+      end
+
+      it "push manifest - manifest.json exists" do
+        File.open("#{Rails.root}/tmp/manifest.json", 'wb', 0600) do |file|
+          file.write "empty manifest"
+        end
+
+        @controller.stubs(:authorize_repository_write).returns(true)
+        put :push_manifest, params: { repository: 'repository', tag: 'tag' }
+        assert_response 422
+        body = JSON.parse(response.body)
+        assert_equal "Upload already in progress", body['error']['message']
+      end
+
+      it "push manifest - success" do
+        @repository = katello_repositories(:busybox)
+        mock_pulp_server([
+                           { name: :create_upload_request, result: { 'upload_id' => 123 }, count: 2 },
+                           { name: :delete_upload_request, result: true, count: 2 },
+                           { name: :upload_bits, result: true, count: 1 }
+                         ])
+        @controller.expects(:sync_task)
+          .times(2)
+          .returns(stub('task', :output => {'upload_results' => [{ 'digest' => 'sha256:1234' }]}), true)
+          .with do |action_class, repository, upload_ids, params|
+            assert_equal ::Actions::Katello::Repository::ImportUpload, action_class
+            assert_equal @repository, repository
+            assert_equal [123], upload_ids
+            if params[:unit_type_id] == 'docker_manifest'
+              assert_equal [:checksum, :name, :size], params[:unit_keys][0].keys.sort
+            elsif params[:unit_type_id] == 'docker_tag'
+              assert_equal [{name: 'tag', digest: 'sha256:1234'}], params[:unit_keys]
+            else
+              assert_equal "unknown unit_type_id", params[:unit_type_id]
+            end
+            assert_equal true, params[:generate_metadata]
+            assert_equal true, params[:sync_capsule]
+          end
+
+        manifest = {
+          schemaVersion: 1
+        }
+        @controller.stubs(:authorize_repository_write).returns(true)
+        @controller.instance_variable_set('@repository', @repository)
+        put :push_manifest, params: { repository: 'repository', tag: 'tag' },
+            body: manifest.to_json
+        assert_response 200
+      end
+    end
+
+    def mock_pulp_server(content_hash)
+      content = mock
+      content_hash.each do |method|
+        content.stubs(method[:name]).times(method[:count]).returns(method[:result])
+      end
+      @controller.stubs(:pulp_content).returns(content)
+    end
+  end
+end


### PR DESCRIPTION
This feature is not enabled unless the following is in _config/settings.plugins.d/katello.yml_
```
:katello:
   :registry:
     :url: https://devel.example.com:5000
     :ca_cert_file: /etc/pki/katello/certs/katello-default-ca.crt
```

To test, create a docker repository. The source url and upstream name can be garbage values since this is just a placeholder repo to push new images to. In my example I made a repo with label "builds" in org with label "examplecorp". Some commands I ran during devel are below.

To test permission scoping, users must have personal access token permissions (view_personal_access_tokens, create_personal_access_tokens, revoke_personal_access_tokens). Limiting the user to a specific lifecycle environment will also reduce their scope of search and pulling images.

```

sudo yum install -y skopeo

# Copy an image from remote registry to foreman
skopeo copy --dest-creds admin:changeme docker://registry-1.docker.io/alpine:latest docker://devel.example.com/examplecorp-builds-alpine:latest

# Get image info
skopeo inspect --creds admin:changeme docker://devel.example.com/examplecorp-builds-alpine

# Copy image from foreman to local docker daemon
sudo skopeo copy --src-creds admin:changeme docker://devel.example.com/examplecorp-builds-alpine:latest docker-daemon:pulled-alpine:latest

# Copy image from foreman to foreman
sudo skopeo copy --src-creds admin:changeme --dest-creds admin:changeme docker://devel.example.com/examplecorp-builds-alpine:latest docker://devel.example.com/examplecorp-builds-alpine:pushed

# Docker commands
docker login -u admin -p changeme devel.example.com
docker search devel.example.com/builds

```