### PR TITLE
Fixes #22944: Use current org for rhsm candlepin

### DIFF
--- a/app/controllers/katello/api/v2/upstream_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/upstream_subscriptions_controller.rb
@@ -2,7 +2,6 @@ require 'katello/resources/candlepin'
 
 module Katello
   class Api::V2::UpstreamSubscriptionsController < Api::V2::ApiController
-    before_action :find_organization
     before_action :check_disconnected
 
     resource_description do
@@ -17,12 +16,11 @@ module Katello
       param :sort_by, String, :desc => N_("The field to sort the data by. Defaults to the created date.")
     end
 
-    api :GET, "/organizations/:organization_id/upstream_subscriptions",
+    api :GET, "/upstream_subscriptions",
       N_("List available subscriptions from Red Hat Subscription Management")
-    param :organization_id, :number, :desc => N_("Organization ID"), :required => true
     param_group :cp_search
     def index
-      pools = UpstreamPool.fetch_pools(@organization, upstream_pool_params)
+      pools = UpstreamPool.fetch_pools(upstream_pool_params.to_h)
       collection = scoped_search_results(
         pools, pools.count, nil, params[:page], params[:per_page], nil)
       respond(collection: collection)
@@ -31,7 +29,7 @@ module Katello
     private
 
     def upstream_pool_params
-      params.permit(:page, :per_page, :order, :sort_by, :organization_id)
+      params.permit(:page, :per_page, :order, :sort_by)
     end
   end
 end

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -115,8 +115,6 @@ module Katello
         self.prefix = '/subscription'
 
         class << self
-          attr_accessor :organization
-
           def resource(url = self.site + self.path, client_cert = self.client_cert, client_key = self.client_key, ca_file = nil, options = {})
             RestClient.proxy = self.proxy_uri
             RestClient::Resource.new(url,
@@ -174,12 +172,11 @@ module Katello
           end
 
           def upstream_consumer
-            @organization ||= Organization.current
-            fail _("Current organization not set.") unless @organization
-            @upstream_consumer = @organization.owner_details['upstreamConsumer']
-            fail _("Current organization has no manifest imported.") unless @upstream_consumer
+            fail _("Current organization not set.") unless Organization.current
+            upstream_consumer = Organization.current.owner_details['upstreamConsumer']
+            fail _("Current organization has no manifest imported.") unless upstream_consumer
 
-            @upstream_consumer
+            upstream_consumer
           end
         end # class << self
       end # UpstreamCandlepinResource

--- a/app/models/katello/glue/candlepin/owner.rb
+++ b/app/models/katello/glue/candlepin/owner.rb
@@ -21,9 +21,10 @@ module Katello
       end
 
       def owner_details
-        details = Resources::Candlepin::Owner.find self.label
-        details['virt_who'] = self.subscriptions.using_virt_who.any?
-        details
+        @owner_details ||= Resources::Candlepin::Owner.find self.label
+        @owner_details['virt_who'] ||= self.subscriptions.using_virt_who.any?
+
+        @owner_details
       end
 
       def service_level

--- a/app/models/katello/upstream_pool.rb
+++ b/app/models/katello/upstream_pool.rb
@@ -5,12 +5,9 @@ module Katello
     CP_POOL = Resources::Candlepin::UpstreamPool
 
     class << self
-      def fetch_pools(organization, params)
-        CP_POOL.organization = organization
+      def fetch_pools(params)
         pools = JSON.parse(CP_POOL.get(params: cp_request_params.deep_merge(params)))
         pools.map { |pool| self.new(map_attributes(pool)) }
-      ensure
-        CP_POOL.organization = nil
       end
 
       def map_attributes(pool)

--- a/app/views/katello/api/v2/upstream_subscriptions/index.json.rabl
+++ b/app/views/katello/api/v2/upstream_subscriptions/index.json.rabl
@@ -2,8 +2,6 @@ object false
 
 extends "katello/api/v2/common/metadata"
 
-node(:organization_id) { @organization.id }
-
 child @collection[:results] => :results do
   extends "katello/api/v2/upstream_subscriptions/base"
 end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -291,6 +291,8 @@ Katello::Engine.routes.draw do
           end
         end
 
+        api_resources :upstream_subscriptions, only: :index
+
         ##############################
         ##############################
 
@@ -317,8 +319,6 @@ Katello::Engine.routes.draw do
               put :refresh_manifest
             end
           end
-
-          api_resources :upstream_subscriptions, only: :index
         end
 
         api_resources :host_collections

--- a/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
@@ -22,9 +22,9 @@ module Katello
     end
 
     def test_index
-      params = { organization_id: @organization.id, page: '3', per_page: '7' }
+      params = { page: '3', per_page: '7' }
       Api::V2::UpstreamSubscriptionsController.any_instance.stubs(:upstream_pool_params).returns(params)
-      UpstreamPool.expects(:fetch_pools).with(@organization, params).returns([{}])
+      UpstreamPool.expects(:fetch_pools).with(params).returns([{}])
       get :index, params: params
 
       assert_response :success
@@ -34,8 +34,8 @@ module Katello
       allowed_perms = [permission]
       denied_perms = []
 
-      assert_protected_action(:index, allowed_perms, denied_perms, [@organization]) do
-        get :index, params: { :organization_id => @organization.id }
+      assert_protected_action(:index, allowed_perms, denied_perms, []) do
+        get :index, params: { }
       end
     end
 

--- a/test/lib/resources/candlepin_test.rb
+++ b/test/lib/resources/candlepin_test.rb
@@ -6,7 +6,7 @@ module Katello
     module Candlepin
       class UpstreamCandlepinResourceTest < ActiveSupport::TestCase
         def test_upstream_consumer_nil_current_organization
-          UpstreamCandlepinResource.organization = nil
+          Organization.stubs(:current).returns(nil)
           UpstreamCandlepinResource.upstream_consumer
           flunk("Failed to raise exception when current organization is nil.")
         rescue RuntimeError => e

--- a/test/models/upstream_pool_test.rb
+++ b/test/models/upstream_pool_test.rb
@@ -11,7 +11,7 @@ module Katello
       UpstreamPool::CP_POOL.expects(:get)
         .with(params: UpstreamPool.cp_request_params)
         .returns("[]")
-      assert UpstreamPool.fetch_pools(@organization, params).first.nil?
+      assert UpstreamPool.fetch_pools(params).first.nil?
     end
   end
 end


### PR DESCRIPTION
We were using a passed in organization (and thus API param organization_id), and it's not thread safe. Organization.current is thread safe, and its similar to how the local Candlepin connection works (User.current).

To test:

```
GET katello.example.com/organization/1/select
GET katello.example.com/katello/api/v2/upstream_subscriptions
```