### PR TITLE
Fixes #22978 - Improve Event Queue db queries

### DIFF
--- a/app/models/katello/event.rb
+++ b/app/models/katello/event.rb
@@ -1,6 +1,8 @@
 module Katello
   class Event < Katello::Model
     validate :validate_event_type
+    # Note: Do not use active record call backs or dependent references on this class
+    # Direct deletes are made in EventQueue#clear_events (instead of destroys).
 
     def validate_event_type
       unless EventQueue.supported_event_types.include?(self.event_type)


### PR DESCRIPTION
The delete and update operations in the event queue were not quick
enough when there was a lot of data in the event queue (20K entries
with many duplicates etc.)
This commit addresses that issue by speeding up the delete and update
operations