### PR TITLE
Fixes #22981 - Not able to attach a subscription to a host with hammer

### DIFF
--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -126,7 +126,7 @@ module Katello
     end
     def add_subscriptions
       pools_with_quantities = params.require(:subscriptions).map do |sub_params|
-        PoolWithQuantities.new(Pool.with_identifier(sub_params['id']), sub_params['quantity'])
+        PoolWithQuantities.new(Pool.with_identifier(sub_params['id']), sub_params['quantity'].to_i)
       end
 
       sync_task(::Actions::Katello::Host::AttachSubscriptions, @host, pools_with_quantities)


### PR DESCRIPTION
Converting string to number in API will resolve the issue from both API and hammer