### PR TITLE
Fixes #22998 - Docker Tags link on repository details page

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-manage-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-manage-content.controller.js
@@ -13,6 +13,7 @@
  * @requires PuppetModule
  * @requires DockerManifest
  * @requires DockerManifestList
+ * @requires DockerTag
  * @requires OstreeBranch
  * @requires File
  * @requires Deb
@@ -21,8 +22,8 @@
  *   Provides the functionality for the repository details pane.
  */
 angular.module('Bastion.repositories').controller('RepositoryManageContentController',
-    ['$scope', '$state', 'translate', 'Notification', 'Nutupane', 'Repository', 'Package', 'PackageGroup', 'PuppetModule', 'DockerManifest', 'DockerManifestList', 'OstreeBranch', 'File', 'Deb',
-    function ($scope, $state, translate, Notification, Nutupane, Repository, Package, PackageGroup, PuppetModule, DockerManifest, DockerManifestList, OstreeBranch, File, Deb) {
+    ['$scope', '$state', 'translate', 'Notification', 'Nutupane', 'Repository', 'Package', 'PackageGroup', 'PuppetModule', 'DockerManifest', 'DockerManifestList', 'DockerTag', 'OstreeBranch', 'File', 'Deb',
+    function ($scope, $state, translate, Notification, Nutupane, Repository, Package, PackageGroup, PuppetModule, DockerManifest, DockerManifestList, DockerTag, OstreeBranch, File, Deb) {
         var contentTypes;
 
         function success(response, selected) {
@@ -57,6 +58,7 @@ angular.module('Bastion.repositories').controller('RepositoryManageContentContro
             'puppet-modules': { type: PuppetModule },
             'docker-manifests': { type: DockerManifest },
             'docker-manifest-lists': { type: DockerManifestList },
+            'docker-tags': {type: DockerTag},
             'ostree-branches': { type: OstreeBranch },
             'files': { type: File },
             'debs': { type: Deb }
@@ -97,6 +99,17 @@ angular.module('Bastion.repositories').controller('RepositoryManageContentContro
                 item.unselectable = true;
             }
             return item;
+        };
+        $scope.availableSchemaVersions = function (tag) {
+            var versions = [];
+            if (tag.manifest_schema1) {
+                versions.push(1);
+            }
+
+            if (tag.manifest_schema2) {
+                versions.push(2);
+            }
+            return versions.join(", ");
         };
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -312,7 +312,7 @@
         <tr ng-show="repository.content_type === 'docker'">
           <td translate>Docker Tags</td>
           <td class="align-center">
-            <a ui-sref="product.repository.manage-content.docker-manifests({productId: product.id, repositoryId: repository.id})">
+            <a ui-sref="product.repository.manage-content.docker-tags({productId: product.id, repositoryId: repository.id})">
               {{ repository.content_counts.docker_tag || 0 }}
             </a>
           </td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-manage-docker-tags.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-manage-docker-tags.html
@@ -1,0 +1,47 @@
+<span page-title ng-model="repository">{{ 'View Docker Tags for Repository:' | translate }} {{ repository.name }}</span>
+
+<div data-block="messages">
+    <div bst-alert="success" ng-hide="generationTaskId === undefined">
+        <button type="button" class="close" ng-click="clearTaskId()">&times;</button>
+        <p translate>
+            Docker metadata generation has been initiated in the background.  Click
+            <a ng-href="{{ taskUrl() }}">Here</a> to monitor the progress.
+        </p>
+    </div>
+</div>
+
+<div data-extend-template="layouts/partials/table.html">
+
+    <div data-block="table">
+        <table class="table table-striped table-bordered" >
+
+            <thead>
+            <tr bst-table-head>
+                <th bst-table-column="name">{{ "Name" | translate }}</th>
+                <th bst-table-column="schema_version">{{ "Available Schema Versions" | translate }}</th>
+                <th bst-table-column="product">{{ "Product Name" | translate }}</th>
+                <th bst-table-column="repository">{{ "Repository Name" | translate }}</th>
+            </tr>
+            </thead>
+
+            <tbody>
+            <tr bst-table-row ng-repeat="tag in table.rows">
+                <td bst-table-cell>
+                    <a ui-sref="docker-tag.info({tagId: tag.id})">
+                        {{ tag.name }}
+                    </a>
+                </td>
+                <td bst-table-cell>
+                    {{ availableSchemaVersions(tag) }}
+                </td>
+                <td bst-table-cell>
+                    {{ tag.product.name }}
+                </td>
+                <td bst-table-cell>
+                    {{ tag.repository.name }}
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repositories.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repositories.routes.js
@@ -108,6 +108,15 @@
                 parent: 'product.repository.info'
             }
         })
+        .state('product.repository.manage-content.docker-tags', {
+            url: '/content/docker_tags',
+            permission: 'view_products',
+            templateUrl: 'products/details/repositories/details/views/repository-manage-docker-tags.html',
+            ncyBreadcrumb: {
+                label: "{{'Docker Tags' | translate }}",
+                parent: 'product.repository.info'
+            }
+        })
         .state('product.repository.manage-content.docker-manifest-lists', {
             url: '/content/docker_manifest_lists',
             permission: 'view_products',

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/views/product-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/views/product-repositories.html
@@ -146,7 +146,7 @@
                 </a>
               </div>
               <div>
-                <a ui-sref="product.repository.manage-content.docker-manifests({productId: product.id, repositoryId: repository.id})" translate>
+                <a ui-sref="product.repository.manage-content.docker-tags({productId: product.id, repositoryId: repository.id})" translate>
                   {{ repository.content_counts.docker_tag || 0 }} Docker Tags
                 </a>
               </div>


### PR DESCRIPTION
### Steps to Reproduce:
* Create and sync a docker repository with some tags.
* Navigate to the repository link and click the link (number) next to Docker Tags

#### Actual results:
Points to docker manifests page

#### Expected results:
Should list docker tags associated with the repo