### PR TITLE
fixes #18964 - lifecycle environment container image name

### DIFF
--- a/app/lib/actions/katello/content_view/capsule_sync.rb
+++ b/app/lib/actions/katello/content_view/capsule_sync.rb
@@ -1,7 +1,7 @@
 module Actions
   module Katello
     module ContentView
-      class CapsuleGenerateAndSync < Actions::Base
+      class CapsuleSync < Actions::Base
         def humanized_name
           _("Sync Content View on Smart Proxy(ies)")
         end

--- a/app/lib/actions/katello/content_view/promote_to_environment.rb
+++ b/app/lib/actions/katello/content_view/promote_to_environment.rb
@@ -45,7 +45,7 @@ module Actions
         def run
           environment = ::Katello::KTEnvironment.find(input[:environment_id])
           if ::Katello::CapsuleContent.sync_needed?(environment)
-            ForemanTasks.async_task(ContentView::CapsuleGenerateAndSync,
+            ForemanTasks.async_task(ContentView::CapsuleSync,
                                     ::Katello::ContentView.find(input[:content_view_id]),
                                     environment)
           end

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -90,7 +90,7 @@ module Actions
           end
 
           if ::Katello::CapsuleContent.sync_needed?(environment)
-            ForemanTasks.async_task(ContentView::CapsuleGenerateAndSync,
+            ForemanTasks.async_task(ContentView::CapsuleSync,
                                     view,
                                     environment)
           end

--- a/app/lib/actions/katello/environment/publish_repositories.rb
+++ b/app/lib/actions/katello/environment/publish_repositories.rb
@@ -1,0 +1,41 @@
+module Actions
+  module Katello
+    module Environment
+      class PublishRepositories < Actions::EntryAction
+        middleware.use ::Actions::Middleware::RemoteAction
+
+        input_format do
+          param :id
+          param :name
+        end
+
+        def plan(env, options = {})
+          repositories = options[:content_type] ? env.repositories.where(content_type: options[:content_type]) : env.repositories
+          action_subject(env)
+          concurrence do
+            repositories.each do |repository|
+              sequence do
+                plan_action(::Actions::Katello::Repository::Update, repository, container_repository_name: repository.container_repository_name)
+                plan_action(::Actions::Katello::Repository::CapsuleSync, repository)
+              end
+            end
+
+            plan_self
+          end
+        end
+
+        def rescue_strategy
+          Dynflow::Action::Rescue::Skip
+        end
+
+        def humanized_name
+          _("Publish Lifecycle Environment Repositories")
+        end
+
+        def humanized_input
+          input['kt_environment'].nil? ? super : ["'#{input['kt_environment']['name']}'"] + super
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/repository/capsule_sync.rb
+++ b/app/lib/actions/katello/repository/capsule_sync.rb
@@ -1,7 +1,7 @@
 module Actions
   module Katello
     module Repository
-      class CapsuleGenerateAndSync < Actions::Base
+      class CapsuleSync < Actions::Base
         def humanized_name
           _("Sync Repository on Smart Proxy(ies)")
         end

--- a/app/lib/actions/katello/repository/import_upload.rb
+++ b/app/lib/actions/katello/repository/import_upload.rb
@@ -39,7 +39,7 @@ module Actions
         def run
           repository = ::Katello::Repository.find(input[:repository_id])
           if input[:sync_capsule]
-            ForemanTasks.async_task(Katello::Repository::CapsuleGenerateAndSync, repository)
+            ForemanTasks.async_task(Katello::Repository::CapsuleSync, repository)
           end
           output[:upload_results] = results_to_json(input[:upload_results])
         rescue ::Katello::Errors::CapsuleCannotBeReached # skip any capsules that cannot be connected to

--- a/app/lib/actions/katello/repository/remove_content.rb
+++ b/app/lib/actions/katello/repository/remove_content.rb
@@ -38,7 +38,7 @@ module Actions
                                      :clauses => {:association => {'unit_id' => {'$in' => uuids}}
             })
             plan_self
-            plan_action(CapsuleGenerateAndSync, repository) if sync_capsule
+            plan_action(CapsuleSync, repository) if sync_capsule
           end
         end
 

--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -63,7 +63,7 @@ module Actions
         end
 
         def run
-          ForemanTasks.async_task(Repository::CapsuleGenerateAndSync, ::Katello::Repository.find(input[:id]))
+          ForemanTasks.async_task(Repository::CapsuleSync, ::Katello::Repository.find(input[:id]))
         rescue ::Katello::Errors::CapsuleCannotBeReached # skip any capsules that cannot be connected to
         end
 

--- a/app/lib/actions/katello/repository/update.rb
+++ b/app/lib/actions/katello/repository/update.rb
@@ -3,6 +3,7 @@ module Actions
     module Repository
       class Update < Actions::EntryAction
         middleware.use Actions::Middleware::KeepCurrentUser
+        # rubocop:disable MethodLength
         def plan(repository, repo_params)
           action_subject repository
           repository = repository.reload
@@ -37,10 +38,12 @@ module Actions
           end
 
           if SETTINGS[:katello][:use_pulp] && (repository.previous_changes.key?('unprotected') ||
-              repository.previous_changes.key?('checksum_type'))
+              repository.previous_changes.key?('checksum_type') ||
+              repository.previous_changes.key?('container_repository_name'))
             plan_self(:repository_id => repository.id)
           end
         end
+        # rubocop:enable MethodLength
 
         def run
           repository = ::Katello::Repository.find(input[:repository_id])

--- a/app/lib/katello/validators/container_image_name_validator.rb
+++ b/app/lib/katello/validators/container_image_name_validator.rb
@@ -1,0 +1,18 @@
+module Katello
+  module Validators
+    class ContainerImageNameValidator < ActiveModel::EachValidator
+      def validate_each(record, attribute, value)
+        if value && !ContainerImageNameValidator.validate_name(value)
+          record.errors[attribute] << N_("invalid container image name")
+        end
+      end
+
+      def self.validate_name(name)
+        if name.empty? || name.length > 255 || !/\A([a-z0-9]+[a-z0-9\-\_\.]*)+(\/[a-z0-9]+[a-z0-9\-\_\.]*)*\z/.match?(name)
+          return false
+        end
+        true
+      end
+    end
+  end
+end

--- a/app/lib/katello/validators/environment_docker_repositories_validator.rb
+++ b/app/lib/katello/validators/environment_docker_repositories_validator.rb
@@ -1,0 +1,71 @@
+module Katello
+  module Validators
+    class EnvironmentDockerRepositoriesValidator < ActiveModel::Validator
+      def validate(environment)
+        return true if environment.registry_name_pattern.empty?
+
+        unless ContainerImageNameValidator.validate_name(Katello::Repository.safe_render_container_name(test_repository, environment.registry_name_pattern))
+          environment.errors.add(:registry_name_pattern, N_("Registry name pattern will result in invalid container image name of member repositories"))
+          return false
+        end
+
+        error_messages = EnvironmentDockerRepositoriesValidator.validate_repositories(environment.registry_name_pattern, environment.repositories.docker_type)
+        return true if error_messages.empty?
+
+        error_messages.each do |message|
+          environment.errors.add(:registry_name_pattern, message)
+        end
+        false
+      end
+
+      def self.validate_repositories(registry_name_pattern, repositories)
+        error_messages = []
+        names = []
+        repositories.each do |repository|
+          name = Katello::Repository.safe_render_container_name(repository, registry_name_pattern)
+
+          unless ContainerImageNameValidator.validate_name(name)
+            error_messages << N_("Registry name pattern results in invalid container image name of member repository '%{name}'") % {name: repository.name}
+            return error_messages
+          end
+          names << name
+        end
+
+        if names.length != names.uniq.length
+          error_messages << N_("Registry name pattern results in duplicate container image names")
+          return error_messages
+        end
+
+        []
+      end
+
+      def test_repository
+        Katello::Validators::EnvironmentDockerRepositoriesValidator::RepositoryOpenStruct.new(
+            name: "bad name!", label: "good_label", docker_upstream_name: "image/name", url: "https://registry.example.com",
+            organization: SafeOpenStruct.new(name: "bad name!", label: "good_label"),
+            product: SafeOpenStruct.new(name: "bad name!", label: "good_label"),
+            environment: SafeOpenStruct.new(name: "bad name!", label: "good_label"),
+            content_view_version: OpenStruct.new(content_view: ContentViewOpenStruct.new(name: "bad name!", label: "good_label", version: "1.2"))
+        )
+      end
+
+      class RepositoryOpenStruct < OpenStruct
+        class Jail < ::Safemode::Jail
+          allow :name, :label, :version, :docker_upstream_name, :url
+        end
+      end
+
+      class ContentViewOpenStruct < OpenStruct
+        class Jail < ::Safemode::Jail
+          allow :name, :label, :version
+        end
+      end
+
+      class SafeOpenStruct < OpenStruct
+        class Jail < ::Safemode::Jail
+          allow :name, :label
+        end
+      end
+    end
+  end
+end

--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -194,6 +194,10 @@ module Katello
           end
           users.pluck(:id)
         end
+
+        class Jail < ::Safemode::Jail
+          allow :name, :label
+        end
       end
     end
   end

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -554,6 +554,23 @@ module Katello
       fail _("User must be logged in.") if ::User.current.nil?
       fail _("Cannot publish default content view") if default?
       check_composite_action_allowed!(organization.library)
+      check_docker_repository_names!([organization.library])
+      true
+    end
+
+    def check_docker_repository_names!(environments)
+      environments.each do |environment|
+        repositories = []
+        publish_repositories do |all_repositories|
+          repositories += all_repositories.keep_if { |repository| repository.content_type == Katello::Repository::DOCKER_TYPE }
+        end
+        next if repositories.empty?
+
+        error_messages = ::Katello::Validators::EnvironmentDockerRepositoriesValidator.validate_repositories(environment.registry_name_pattern, repositories)
+        unless error_messages.empty?
+          fail _("Content View publish to environment %{name} will result in invalid container image name of member repositories") % {name: environment.name}
+        end
+      end
       true
     end
 
@@ -733,6 +750,10 @@ module Katello
 
     def related_resources
       self.organization
+    end
+
+    class Jail < ::Safemode::Jail
+      allow :name, :label
     end
   end
 end

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -333,6 +333,7 @@ module Katello
     def check_ready_to_promote!(to_env)
       fail _("Default content view versions cannot be promoted") if default?
       content_view.check_composite_action_allowed!(to_env)
+      content_view.check_docker_repository_names!(to_env)
     end
 
     def validate_destroyable!(skip_environment_check = false)
@@ -370,6 +371,10 @@ module Katello
 
     def related_resources
       [self.content_view]
+    end
+
+    class Jail < ::Safemode::Jail
+      allow :name, :label, :version
     end
   end
 end

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -445,7 +445,7 @@ module Katello
       def pulp_update_needed?
         changeable_attributes = %w(url unprotected checksum_type docker_upstream_name download_policy mirror_on_sync verify_ssl_on_sync
                                    upstream_username upstream_password ostree_upstream_sync_policy ostree_upstream_sync_depth ignore_global_proxy ignorable_content)
-        changeable_attributes << "name" if docker?
+        changeable_attributes += %w(name container_repository_name) if docker?
         changeable_attributes += %w(deb_releases deb_components deb_architectures) if deb?
         changeable_attributes.any? { |key| previous_changes.key?(key) }
       end

--- a/app/models/katello/kt_environment.rb
+++ b/app/models/katello/kt_environment.rb
@@ -54,6 +54,8 @@ module Katello
     validates_with Validators::PriorValidator
     validates_with Validators::PathDescendentsValidator
 
+    validates_with Katello::Validators::EnvironmentDockerRepositoriesValidator
+
     has_many :capsule_lifecycle_environments, :foreign_key => :lifecycle_environment_id,
                                               :dependent => :destroy, :inverse_of => :lifecycle_environment
 
@@ -253,6 +255,10 @@ module Katello
 
     def self.permission_name
       'lifecycle_environments'
+    end
+
+    class Jail < ::Safemode::Jail
+      allow :name, :label
     end
   end
 end

--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -270,5 +270,9 @@ module Katello
         id
       end
     end
+
+    class Jail < ::Safemode::Jail
+      allow :name, :label
+    end
   end
 end

--- a/app/views/katello/api/v2/environments/show.json.rabl
+++ b/app/views/katello/api/v2/environments/show.json.rabl
@@ -4,6 +4,7 @@ extends 'katello/api/v2/common/identifier'
 extends 'katello/api/v2/common/org_reference'
 
 attributes :library
+attributes :registry_name_pattern
 
 node :prior do |env|
   if env.prior

--- a/db/migrate/20180323175122_add_registry_name_pattern_to_environment.rb
+++ b/db/migrate/20180323175122_add_registry_name_pattern_to_environment.rb
@@ -1,0 +1,11 @@
+class AddRegistryNamePatternToEnvironment < ActiveRecord::Migration[5.1]
+  def up
+    add_column(:katello_environments, :registry_name_pattern, :string, limit: 255, null: true)
+    change_column(:katello_repositories, :container_repository_name, :string, unique: true)
+  end
+
+  def down
+    remove_column(:katello_environments, :registry_name_pattern)
+    change_column(:katello_repositories, :container_repository_name, :string, unique: false)
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-details.html
@@ -1,3 +1,5 @@
+<span page-title ng-model="environment">{{ 'Lifecycle Environment:' | translate }} {{ environment.name }}</span>
+
 <div data-extend-template="layouts/two-column-details.html">
   <div data-block="left-column">
     <h4 translate>Basic Information</h4>
@@ -11,6 +13,12 @@
 
       <dt translate>Label</dt>
       <dd>{{ environment.label }}</dd>
+
+      <dt translate>Registry Name Pattern</dt>
+      <dd bst-edit-textarea="environment.registry_name_pattern"
+          on-save="save(environment)"
+          readonly="denied('edit_lifecycle_environments', environment)">
+      </dd>
 
       <dt translate>Description</dt>
       <dd bst-edit-textarea="environment.description"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-docker.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-docker.html
@@ -23,9 +23,13 @@
 
     <tbody>
       <tr bst-table-row ng-repeat="dockerTag in table.rows">
-        <td bst-table-cell>{{ dockerTag.name }}</td>
-        <td bst-table-cell>{{ dockerTag.product.name }}</td>
-        <td bst-table-cell>{{ dockerTag.repository.name }}</td>
+        <td bst-table-cell>
+          <a ng-href="/docker_tags/{{ dockerTag.id }}">{{ dockerTag.name }}</a>
+        </td>
+        <td bst-table-cell>
+          <a ng-href="/products/{{ dockerTag.product.id }}/repositories/{{ dockerTag.repository.id }}">{{ dockerTag.product.name }}</a>
+        </td>
+        <td bst-table-cell>{{ dockerTag.repository.full_path }}</td>
       </tr>
     </tbody>
   </table>

--- a/test/actions/katello/content_view_test.rb
+++ b/test/actions/katello/content_view_test.rb
@@ -269,10 +269,10 @@ module ::Actions::Katello::ContentView
     end
   end
 
-  class CapsuleGenerateAndSyncTest < TestBase
+  class CapsuleSyncTest < TestBase
     include Support::CapsuleSupport
 
-    let(:action_class) { ::Actions::Katello::ContentView::CapsuleGenerateAndSync }
+    let(:action_class) { ::Actions::Katello::ContentView::CapsuleSync }
     let(:content_view) do
       katello_content_views(:library_dev_view)
     end

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -160,7 +160,7 @@ module ::Actions::Katello::Repository
 
   class RemoveContentTest < TestBase
     let(:action_class) { ::Actions::Katello::Repository::RemoveContent }
-    let(:capsule_generate_action_class) { ::Actions::Katello::Repository::CapsuleGenerateAndSync }
+    let(:capsule_generate_action_class) { ::Actions::Katello::Repository::CapsuleSync }
 
     it 'plans' do
       to_remove = custom_repository.rpms
@@ -511,10 +511,10 @@ module ::Actions::Katello::Repository
     end
   end
 
-  class CapsuleGenerateAndSyncTest < TestBase
+  class CapsuleSyncTest < TestBase
     include Support::CapsuleSupport
 
-    let(:action_class) { ::Actions::Katello::Repository::CapsuleGenerateAndSync }
+    let(:action_class) { ::Actions::Katello::Repository::CapsuleSync }
 
     it 'plans' do
       capsule_content_1 = new_capsule_content(:three)

--- a/test/factories/content_view_environment_factory.rb
+++ b/test/factories/content_view_environment_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :katello_content_view_environment, :class => Katello::ContentViewEnvironment do
+    sequence(:name) { |n| "name#{n}" }
+    sequence(:label) { |n| "label#{n}" }
+  end
+end

--- a/test/factories/registry_factory.rb
+++ b/test/factories/registry_factory.rb
@@ -1,0 +1,144 @@
+FactoryBot.define do
+  factory :registry_organization, class: "Organization" do
+    type "Organization"
+    association :library, factory: :katello_library
+
+    trait :headquarters do
+      name "Headquarters, Ltd."
+      type "Organization"
+      description "This is the registry headquarters."
+      label "headquarters"
+    end
+
+    trait :fieldoffice do
+      name "Field Office"
+      type "Organization"
+      description "This is the registry field office."
+      label "fieldoffice"
+    end
+  end
+
+  factory :registry_environment, class: Katello::KTEnvironment do
+    after :build do |env|
+      if !env.library && !env.prior
+        env.priors = [env.organization.library]
+      end
+    end
+
+    trait :hq_env_dev do
+      name "Headquarters DEV"
+      description "Headquarters DEV environment"
+      label "hq_env_dev"
+      association :organization, factory: [:registry_organization, :headquarters]
+    end
+
+    trait :fo_env_dev do
+      name "Field Office DEV"
+      description "Field Office DEV environment"
+      label "fo_env_dev"
+      association :organization, factory: [:registry_organization, :fieldoffice]
+    end
+  end
+
+  factory :registry_content_view, class: Katello::ContentView do
+    trait :hq_cv_single_repo do
+      name "Headquarters Single Repo"
+      label "hq_cv_single_repo"
+      composite false
+      association :organization, factory: [:registry_organization, :headquarters]
+    end
+    trait :hq_cv_multi_repo do
+      name "Headquarters Multi Repo"
+      label "hq_cv_multi_repo"
+      composite false
+      association :organization, factory: [:registry_organization, :headquarters]
+    end
+
+    trait :fo_cv_single_repo do
+      name "Field Office Single Repo"
+      label "fo_cv_single_repo"
+      composite false
+      association :organization, factory: [:registry_organization, :fieldoffice]
+    end
+    trait :fo_cv_multi_repo do
+      name "Field Office Multi Repo"
+      label "fo_cv_multi_repo"
+      composite false
+      association :organization, factory: [:registry_organization, :fieldoffice]
+    end
+  end
+
+  factory :registry_content_view_version, :class => Katello::ContentViewVersion do
+    sequence(:major)
+
+    trait :hq_cvv_single_repo do
+      association :content_view, factory: [:registry_content_view, :hq_cv_single_repo]
+    end
+    trait :hq_cvv_multi_repo do
+      association :content_view, factory: [:registry_content_view, :hq_cv_multi_repo]
+    end
+
+    trait :fo_cvv_single_repo do
+      association :content_view, factory: [:registry_content_view, :fo_cv_single_repo]
+    end
+    trait :fo_cvv_multi_repo do
+      association :content_view, factory: [:registry_content_view, :fo_cv_multi_repo]
+    end
+  end
+
+  factory :registry_product, class: Katello::Product do
+    trait :hq_product do
+      name "Headquarters Product"
+      label "hq_product"
+    end
+
+    trait :fo_product do
+      name "Field Office Product"
+      label "fo_product"
+    end
+  end
+
+  factory :registry_repository, class: Katello::Repository do
+    sequence(:pulp_id) { |n| "pulp-#{n}" }
+    sequence(:content_id)
+    unprotected true
+
+    trait :hq_repo_alpha do
+      content_type "docker"
+      name "Alpha Image"
+      label "alpha_image"
+      relative_path "headquarters-hq_product-alpha_image"
+      download_policy ""
+      url "http://devel.example.com:5000/alpha"
+      docker_upstream_name "registry/alpha"
+    end
+    trait :hq_repo_beta do
+      content_type "docker"
+      name "Beta Image"
+      label "beta_image"
+      relative_path "headquarters-hq_product-beta_image"
+      download_policy ""
+      url "http://devel.example.com:5000/beta"
+      docker_upstream_name "registry/beta"
+    end
+
+    trait :fo_repo_alpha do
+      content_type "docker"
+      name "Alpha Image"
+      label "alpha_image"
+      relative_path "fieldoffice-fo_product-alpha_image"
+      download_policy ""
+      url "http://devel.example.com:5000/alpha"
+      docker_upstream_name "registry/alpha"
+    end
+    trait :fo_repo_beta do
+      content_type "docker"
+      name "Beta Image"
+      label "beta_image"
+      relative_path "fieldoffice-fo_product-beta_image"
+      download_policy ""
+      url "http://devel.example.com:5000/beta"
+      docker_upstream_name "registry/beta"
+    end
+  end
+end

--- a/test/lib/validators/environment_docker_repositories_validator_test.rb
+++ b/test/lib/validators/environment_docker_repositories_validator_test.rb
@@ -1,0 +1,110 @@
+require 'katello_test_helper'
+
+module Katello
+  class EnvironmentDockerRepositoriesValidatorTest < ActiveSupport::TestCase
+    def setup
+      @validator = Validators::EnvironmentDockerRepositoriesValidator.new({})
+
+      @org_hq = create(:registry_organization, :headquarters)
+      @org_fo = create(:registry_organization, :fieldoffice)
+      @hq_env_dev = create(:registry_environment, :hq_env_dev, organization: @org_hq)
+      @fo_env_dev = create(:registry_environment, :fo_env_dev, organization: @org_fo)
+      @hq_cv_single_repo = create(:registry_content_view, :hq_cv_single_repo, organization: @org_hq)
+      @hq_cv_multi_repo = create(:registry_content_view, :hq_cv_multi_repo, organization: @org_hq)
+      @fo_cv_single_repo = create(:registry_content_view, :fo_cv_single_repo, organization: @org_fo)
+      @fo_cv_multi_repo = create(:registry_content_view, :fo_cv_multi_repo, organization: @org_fo)
+
+      @hq_product = create(:registry_product, :hq_product, organization: @org_hq,
+                           provider: create(:katello_provider, organization: @org_hq))
+      @fo_product = create(:registry_product, :fo_product, organization: @org_fo,
+                           provider: create(:katello_provider, organization: @org_fo))
+    end
+
+    test "success empty pattern" do
+      hq_cvv_single_repo = create(:registry_content_view_version, :hq_cvv_single_repo,
+                                  content_view: @hq_cv_single_repo)
+      create(:registry_repository, :hq_repo_alpha,
+             environment: @hq_env_dev,
+             product: @hq_product,
+             content_view_version: hq_cvv_single_repo)
+
+      @validator.validate(@hq_env_dev)
+      assert_empty @hq_env_dev.errors[:base]
+    end
+
+    test "success static pattern for single repo" do
+      hq_cvv_single_repo = create(:registry_content_view_version, :hq_cvv_single_repo,
+                                  content_view: @hq_cv_single_repo)
+      create(:registry_repository, :hq_repo_alpha,
+             environment: @hq_env_dev,
+             product: @hq_product,
+             content_view_version: hq_cvv_single_repo)
+
+      @hq_env_dev.registry_name_pattern = "pattern"
+      @validator.validate(@hq_env_dev)
+      assert_empty @hq_env_dev.errors[:registry_name_pattern]
+    end
+
+    test "fails static pattern for multiple repos" do
+      hq_cvv_multi_repo = create(:registry_content_view_version, :hq_cvv_multi_repo,
+                                  content_view: @hq_cv_multi_repo)
+      create(:registry_repository, :hq_repo_alpha,
+                              environment: @hq_env_dev,
+                              product: @hq_product,
+                              content_view_version: hq_cvv_multi_repo)
+      create(:registry_repository, :hq_repo_beta,
+                              environment: @hq_env_dev,
+                              product: @hq_product,
+                              content_view_version: hq_cvv_multi_repo)
+
+      @hq_env_dev.registry_name_pattern = "pattern"
+      @validator.validate(@hq_env_dev)
+      assert_equal ["Registry name pattern results in duplicate container image names"],
+                   @hq_env_dev.errors[:registry_name_pattern]
+    end
+
+    test "passes good pattern for multiple repos" do
+      hq_cvv_multi_repo = create(:registry_content_view_version, :hq_cvv_multi_repo,
+                                  content_view: @hq_cv_multi_repo)
+      create(:registry_repository, :hq_repo_alpha,
+             environment: @hq_env_dev,
+             product: @hq_product,
+             content_view_version: hq_cvv_multi_repo)
+      create(:registry_repository, :hq_repo_beta,
+             environment: @hq_env_dev,
+             product: @hq_product,
+             content_view_version: hq_cvv_multi_repo)
+
+      @hq_env_dev.registry_name_pattern = "<%= organization.label %>/<%= repository.label %>"
+      @validator.validate(@hq_env_dev)
+      assert_equal [], @hq_env_dev.errors[:registry_name_pattern]
+    end
+
+    test "fails same name in two orgs" do
+      hq_cvv_single_repo = create(:registry_content_view_version, :hq_cvv_single_repo,
+                                  content_view: @hq_cv_single_repo)
+      hq_repo = create(:registry_repository, :hq_repo_alpha,
+             environment: @hq_env_dev,
+             product: @hq_product,
+             content_view_version: hq_cvv_single_repo)
+      hq_repo.save!
+
+      @fo_env_dev.registry_name_pattern = "<%= repository.label %>"
+      @fo_env_dev.save
+      fo_cvv_single_repo = create(:registry_content_view_version, :fo_cvv_single_repo,
+                                  content_view: @fo_cv_single_repo)
+      fo_repo = create(:registry_repository, :fo_repo_alpha,
+             environment: @fo_env_dev,
+             product: @fo_product,
+             content_view_version: fo_cvv_single_repo)
+
+      @hq_env_dev.registry_name_pattern = "<%= repository.label %>"
+      @validator.validate(@hq_env_dev)
+
+      assert fo_repo.save!
+      assert_raises(ActiveRecord::RecordInvalid) do
+        hq_repo.save!
+      end
+    end
+  end
+end

--- a/test/models/content_view_docker_filter_test.rb
+++ b/test/models/content_view_docker_filter_test.rb
@@ -60,9 +60,13 @@ module Katello
     end
 
     # rubocop:disable MethodLength
+    # rubocop:disable Metrics/AbcSize
     def test_repo_intersection_clause
       #create repo1 with tag goo
       repo1 = Repository.find(katello_repositories(:busybox).id)
+      repo1.stubs(:container_repository_name).returns('repo1')
+      repo1.stubs(:set_container_repository_name).returns('repo1')
+      repo1.save!
       schema1_repo1 = create(:docker_tag, :with_uuid, :repository => repo1, :name => "latest")
       schema2_repo1 = create(:docker_tag, :with_uuid, :schema1, :repository => repo1, :name => "latest")
 
@@ -86,6 +90,9 @@ module Katello
       # same manifests
       # but different tagW as in No goo
       repo2 = Repository.find(katello_repositories(:busybox2).id)
+      repo2.stubs(:container_repository_name).returns('repo2')
+      repo2.stubs(:set_container_repository_name).returns('repo2')
+      repo2.save!
       schema1_repo2 = create(:docker_tag, :with_uuid, :repository => repo1, :name => "latest")
       schema2_repo2 = create(:docker_tag, :with_uuid, :schema1, :repository => repo1, :name => "latest")
 

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -86,6 +86,7 @@ module Katello
                   thisisareallylongbutstillvalidname
                   soisthis/thisisareallylongbutstillvalidname
                   single/slash
+                  multiple/slash/es abc/def/valid
                   )
       valid << 'a' * 255
       valid.each do |name|
@@ -97,7 +98,6 @@ module Katello
                     $ymbols $tuff.th@t.m!ght.h@ve.w%!rd.r#g#x.m*anings()
                     /startingslash trailingslash/
                     abcd/.-_
-                    multiple/slash/es abc/def/invalid
                     )
       invalid << 'a' * 256
       invalid.each do |name|
@@ -464,6 +464,22 @@ module Katello
       repo.container_repository_name = nil
       repo.set_container_repository_name
       assert_equal 'empty_organization-puppet_product-test', repo.container_repository_name
+    end
+
+    def test_container_repository_name_pattern
+      repo = katello_repositories(:busybox)
+
+      labels = [
+        ['test', '<%= repository.label %>', 'test'],
+        ['test', '<%= organization.label %> <%= repository.label %>', 'empty_organization_test'],
+        ['test', ' <%= organization.label %>   <%= repository.label %> ', 'empty_organization_test']
+      ]
+
+      labels.each do |label, pattern, result|
+        repo.label = label
+        rendered = Repository.safe_render_container_name(repo, pattern)
+        assert_equal rendered, result
+      end
     end
   end
 


### PR DESCRIPTION
This feature allows a lifecycle environment to specify a image name pattern (erb) to
use instead of the default ($org-$prod-$env-$cv-$name).

For example "<%= organization.label %>/<%= docker_upstream_name %>"

The pattern, on the lifecycle UI details page, is used for container image repositories. These repos have a name and label but in pulp they also have a "registry name". This registry name is what users use when referencing the repo for "docker pull" or "skopeo copy".

Prior to this PR, the registry name was hard coded based on a combination of organization, product, content view, life cycle, and repo labels. This style of auto-naming remains if the life cycle pattern is left blank.

The pattern is ERB format. This allows a rich flexibility in the resulting names. In the simplest, and likely the most common, is to simply use the repository's original container image name as the pattern.
```
<%= repository.docker_upstream_name %>
```

It is important to remember that the results of running a repository through a life cycle's pattern must be unique across all repos in all orgs. Thus the same pattern should be reused in multiple life cycle's with care.

Variables available in ERB:
```
organization.name
organization.label
repository.name
repository.label
repository.docker_upstream_name
repository.url
content_view.label
content_view.name
content_view.version
product.name
product.label
lifecycle_environment.name
lifecycle_environment.label
```