### PR TITLE
fixes #23022 - lookup candlepin owner from facts

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -345,7 +345,8 @@ module Katello
       organization = nil
 
       if params.key?(key)
-        organization = Organization.find_by(:label => params[key])
+        label = params[key].is_a?(ActionController::Parameters) ? params[key]['key'] : params[key]
+        organization = Organization.find_by(:label => label)
       end
 
       if organization.nil?


### PR DESCRIPTION
When updating facts by a PUT to /rhsm/consumers, owner is not the label, but rather a ActiveController::Parameters hash containing keys like id, key, etc.  The label is stored in "key"