### PR TITLE
Fixes #23033 - Remove force_post_sync_actions

### DIFF
--- a/app/lib/actions/middleware/execute_if_contents_changed.rb
+++ b/app/lib/actions/middleware/execute_if_contents_changed.rb
@@ -12,7 +12,7 @@ module Actions
       private
 
       def execute?
-        if action.input.keys.include?('contents_changed') && !action.input['contents_changed'] && !Setting[:force_post_sync_actions]
+        if action.input.keys.include?('contents_changed') && !action.input['contents_changed']
           self.action.output[:post_sync_skipped] = true
           false
         else

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -46,8 +46,6 @@ class Setting::Content < Setting
                  false, N_('Restrict Composite Content View promotion')),
         self.set('check_services_before_actions', N_("Whether or not to check the status of backend services such as pulp and candlepin prior to performing some actions."),
                  true, N_('Check services before actions')),
-        self.set('force_post_sync_actions', N_("Force post sync actions such as indexing and email even if no content was available."),
-                 false, N_('Force post-sync actions')),
         self.set('default_download_policy', N_("Default download policy for repositories (either 'immediate', 'on_demand', or 'background')"), "on_demand",
                  N_('Default Repository download policy'), nil, :collection => download_policies),
         self.set('default_proxy_download_policy', N_("Default download policy for Smart Proxy syncs (either 'inherit', immediate', 'on_demand', or 'background')"), "on_demand",

--- a/db/migrate/20180402160223_clean_up_force_post_sync_action_setting.rb
+++ b/db/migrate/20180402160223_clean_up_force_post_sync_action_setting.rb
@@ -1,0 +1,5 @@
+class CleanUpForcePostSyncActionSetting < ActiveRecord::Migration[5.1]
+  def change
+    Setting.where(:name => 'force_post_sync_actions', :category => 'Setting::Content').delete_all
+  end
+end


### PR DESCRIPTION
Removing force_post_sync Settings option.

This can be achieved using Hammer flag skip-metadata-check and on the UI using complete sync.