### PR TITLE
Fixes #23069 - use org scoped api for upstream subs

### DIFF
--- a/app/controllers/katello/api/v2/upstream_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/upstream_subscriptions_controller.rb
@@ -16,8 +16,9 @@ module Katello
       param :sort_by, String, :desc => N_("The field to sort the data by. Defaults to the created date.")
     end
 
-    api :GET, "/upstream_subscriptions",
+    api :GET, "/organizations/:organization_id/upstream_subscriptions",
       N_("List available subscriptions from Red Hat Subscription Management")
+    param :organization_id, :number, :desc => N_("Organization ID"), :required => true
     param_group :cp_search
     def index
       pools = UpstreamPool.fetch_pools(upstream_pool_params.to_h)

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -291,8 +291,6 @@ Katello::Engine.routes.draw do
           end
         end
 
-        api_resources :upstream_subscriptions, only: :index
-
         ##############################
         ##############################
 
@@ -319,6 +317,7 @@ Katello::Engine.routes.draw do
               put :refresh_manifest
             end
           end
+          api_resources :upstream_subscriptions, only: :index
         end
 
         api_resources :host_collections

--- a/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
@@ -22,7 +22,7 @@ module Katello
     end
 
     def test_index
-      params = { page: '3', per_page: '7' }
+      params = { page: '3', per_page: '7', organization_id: @organization.id }
       Api::V2::UpstreamSubscriptionsController.any_instance.stubs(:upstream_pool_params).returns(params)
       UpstreamPool.expects(:fetch_pools).with(params).returns([{}])
       get :index, params: params
@@ -34,8 +34,8 @@ module Katello
       allowed_perms = [permission]
       denied_perms = []
 
-      assert_protected_action(:index, allowed_perms, denied_perms, []) do
-        get :index, params: { }
+      assert_protected_action(:index, allowed_perms, denied_perms, [@organization]) do
+        get :index, params: { organization_id: @organization.id }
       end
     end
 


### PR DESCRIPTION
the set_taxonomies is called automatically and Organization.current should be set 
based on the organization_id param