### PR TITLE
Fixes #23082: fix remote action errata installation.

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -82,7 +82,7 @@ module Katello
     def hosts_available(org_id = nil)
       self.hosts_applicable(org_id).joins("INNER JOIN #{Katello::RepositoryErratum.table_name} on \
         #{Katello::RepositoryErratum.table_name}.erratum_id = #{self.id}").joins(:content_facet_repositories).
-        where("#{Katello::ContentFacetRepository.table_name}.repository_id = #{Katello::RepositoryErratum.table_name}.repository_id").uniq
+        where("#{Katello::ContentFacetRepository.table_name}.repository_id = #{Katello::RepositoryErratum.table_name}.repository_id")
     end
 
     def self.installable_for_hosts(hosts = nil)

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
@@ -2,6 +2,15 @@
   <h4 data-block="modal-header">Content Host Errata Management</h4>
 
   <div data-block="modal-body">
+    <form id="errataActionForm" name="errataActionForm" class="form" method="post" action="/katello/remote_execution">
+      <input type="hidden" name="name" ng-value="errataActionFormValues.errata"/>
+      <input type="hidden" name="remote_action" ng-value="errataActionFormValues.remoteAction"/>
+      <input type="hidden" name="scoped_search" ng-value="errataActionFormValues.search"/>
+      <input type="hidden" name="host_ids" ng-value="errataActionFormValues.hostIds"/>
+      <input type="hidden" name="authenticity_token" ng-value="errataActionFormValues.authenticityToken"/>
+      <input type="hidden" name="customize" ng-value="errataActionFormValues.customize"/>
+    </form>
+
     <div bst-alert="info" ng-show="showConfirm">
       <span translate>
         Are you sure you want to apply the {{ table.numSelected }} selected errata to the content hosts chosen?
@@ -44,6 +53,7 @@
                   type="button" id="use-remote-execution">
             <span class="caret"></span>
           </button>
+          
           <ul uib-dropdown-menu class="dropdown-menu-right" role="menu" aria-labelledby="use-remote-execution">
             <li role="presentation"><a ng-click="installErrataViaKatelloAgent()" role="menuitem" translate>via Katello agent</a></li>
             <li role="presentation"><a ng-click="installErrataViaRemoteExecution(false)" role="menuitem" translate>via remote execution</a></li>


### PR DESCRIPTION
We were sending the parameter as remoteAction instead of the
required remote_action.  This commit fixes the label of the remote
action value.

http://projects.theforeman.org/issues/23082