### PR TITLE
Fixes #23096 - Improve SubFacetPool indexing perf

### DIFF
--- a/app/models/katello/glue/candlepin/candlepin_object.rb
+++ b/app/models/katello/glue/candlepin/candlepin_object.rb
@@ -42,6 +42,7 @@ module Katello
           objects.uniq.each do |item|
             if candlepin_ids.include?(item.cp_id)
               item.import_data
+              item.import_managed_associations if item.respond_to?(:import_managed_associations)
             else
               item.destroy
             end

--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -10,7 +10,7 @@ module Katello
       has_many :subscription_facet_activation_keys, :class_name => "Katello::SubscriptionFacetActivationKey", :dependent => :destroy, :inverse_of => :subscription_facet
       has_many :activation_keys, :through => :subscription_facet_activation_keys, :class_name => "Katello::ActivationKey"
 
-      has_many :subscription_facet_pools, :class_name => "Katello::SubscriptionFacetPool", :dependent => :destroy, :inverse_of => :subscription_facet
+      has_many :subscription_facet_pools, :class_name => "Katello::SubscriptionFacetPool", :dependent => :delete_all, :inverse_of => :subscription_facet
       has_many :pools, :through => :subscription_facet_pools, :class_name => "Katello::Pool"
 
       has_many :subscription_facet_installed_products, :class_name => "Katello::SubscriptionFacetInstalledProduct", :dependent => :destroy, :inverse_of => :subscription_facet

--- a/app/models/katello/subscription_facet_pool.rb
+++ b/app/models/katello/subscription_facet_pool.rb
@@ -1,5 +1,7 @@
 module Katello
   class SubscriptionFacetPool < Katello::Model
+    # Note: Do not use active record call backs or dependent references on this class
+    # Direct deletes are made in Pool#import_hosts (instead of destroys).
     belongs_to :subscription_facet, :inverse_of => :subscription_facet_pools, :class_name => 'Katello::Host::SubscriptionFacet'
     belongs_to :pool, :inverse_of => :subscription_facet_pools, :class_name => 'Katello::Pool'
   end


### PR DESCRIPTION
This commit intends to improve the performance of the import hosts
method used while indexing Pools. It reduces the number of queries made
on SubscriptionFacetPool to determine what needs to be added or removed
from it. In some high volume consumers this could mean reductions from
50K sql queries to 4 (depending on the number of consumers in a pool).