### PR TITLE
Fixes #23111 - Add API to update upstream entitlement quantities

### DIFF
--- a/app/lib/actions/katello/upstream_subscriptions/update_entitlement.rb
+++ b/app/lib/actions/katello/upstream_subscriptions/update_entitlement.rb
@@ -1,0 +1,23 @@
+module Actions
+  module Katello
+    module UpstreamSubscriptions
+      class UpdateEntitlement < Actions::Base
+        middleware.use Actions::Middleware::KeepCurrentTaxonomies
+        middleware.use Actions::Middleware::PropagateCandlepinErrors
+
+        input_format do
+          param :entitlement_id
+          param :quantity
+        end
+
+        def run
+          output[:response] = ::Katello::Resources::Candlepin::UpstreamEntitlement.update(input[:entitlement_id], input[:quantity])
+        end
+
+        def run_progress_weight
+          0.01
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/upstream_subscriptions/update_entitlements.rb
+++ b/app/lib/actions/katello/upstream_subscriptions/update_entitlements.rb
@@ -1,0 +1,37 @@
+module Actions
+  module Katello
+    module UpstreamSubscriptions
+      class UpdateEntitlements < Actions::Base
+        middleware.use Actions::Middleware::KeepCurrentTaxonomies
+
+        def plan(pools = [])
+          fail _("No pools were provided.") if pools.blank?
+          fail _("Current organization is not set.") unless ::Organization.current
+
+          sequence do
+            concurrence do
+              pools.each do |p|
+                pool = ::Katello::Pool.find(p[:id])
+
+                fail _("Provided pool with id %s has no upstream entitlement" % p[:id]) if pool.upstream_entitlement_id.nil?
+                plan_action(::Actions::Katello::UpstreamSubscriptions::UpdateEntitlement,
+                            entitlement_id: pool.upstream_entitlement_id,
+                            quantity: p[:quantity])
+              end
+            end
+
+            plan_action(::Actions::Katello::Organization::ManifestRefresh, ::Organization.current)
+          end
+        end
+
+        def humanized_name
+          N_("Update Upstream Subscription")
+        end
+
+        def rescue_strategy
+          Dynflow::Action::Rescue::Skip
+        end
+      end
+    end
+  end
+end

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -76,6 +76,8 @@ module Katello
         self.prefix = '/subscription'
 
         class << self
+          delegate :[], to: :json_resource
+
           def resource(url = self.site + self.path, client_cert = self.client_cert, client_key = self.client_key, ca_file = nil, options = {})
             RestClient::Resource.new(url,
                                      :ssl_client_cert => OpenSSL::X509::Certificate.new(client_cert),

--- a/app/lib/katello/resources/candlepin/upstream_consumer.rb
+++ b/app/lib/katello/resources/candlepin/upstream_consumer.rb
@@ -34,8 +34,6 @@ module Katello
           def bind_entitlement(**pool)
             JSON.parse(self['entitlements'].post(nil, params: pool))
           end
-
-          delegate :[], to: :json_resource
         end
       end
     end

--- a/app/lib/katello/resources/candlepin/upstream_entitlement.rb
+++ b/app/lib/katello/resources/candlepin/upstream_entitlement.rb
@@ -1,0 +1,19 @@
+module Katello
+  module Resources
+    module Candlepin
+      class UpstreamEntitlement < UpstreamCandlepinResource
+        class << self
+          def path(id = nil)
+            "#{self.prefix}/entitlements/#{id}"
+          end
+
+          def update(entitlement_id, quantity)
+            body = {quantity: quantity}.to_json
+
+            self[entitlement_id].put(body)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/katello/resources/candlepin/upstream_pool.rb
+++ b/app/lib/katello/resources/candlepin/upstream_pool.rb
@@ -9,7 +9,6 @@ module Katello
             super(id, owner_label || upstream_owner_id)
           end
 
-          delegate :[], to: :resource
           delegate :get, to: :resource
         end
       end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -320,6 +320,7 @@ Katello::Engine.routes.draw do
           api_resources :upstream_subscriptions, only: [:index, :create] do
             collection do
               delete :destroy
+              put :update
             end
           end
         end

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -351,7 +351,7 @@ module Katello
                          :resource_type => 'Katello::Subscription'
       @plugin.permission :manage_subscription_allocations,
                          {
-                           'katello/api/v2/upstream_subscriptions' => [:index, :create, :destroy]
+                           'katello/api/v2/upstream_subscriptions' => [:index, :create, :destroy, :update]
                          },
                          :resource_type => 'Katello::Subscription'
     end

--- a/test/actions/katello/upstream_subscriptions/update_entitlement_test.rb
+++ b/test/actions/katello/upstream_subscriptions/update_entitlement_test.rb
@@ -1,0 +1,17 @@
+require 'katello_test_helper'
+
+describe ::Actions::Katello::UpstreamSubscriptions::UpdateEntitlement do
+  include Dynflow::Testing
+
+  subject { described_class }
+
+  before :all do
+    @org = get_organization
+    @planned_action = create_and_plan_action(subject, entitlement_id: 'foo', quantity: 5)
+  end
+
+  it 'runs' do
+    ::Katello::Resources::Candlepin::UpstreamEntitlement.expects(:update).with('foo', 5)
+    run_action @planned_action
+  end
+end

--- a/test/actions/katello/upstream_subscriptions/update_entitlements_test.rb
+++ b/test/actions/katello/upstream_subscriptions/update_entitlements_test.rb
@@ -1,0 +1,47 @@
+require 'katello_test_helper'
+
+describe ::Actions::Katello::UpstreamSubscriptions::UpdateEntitlements do
+  include Dynflow::Testing
+
+  subject { described_class }
+
+  before :all do
+    @org = FactoryBot.build(:katello_organization)
+    set_organization(@org)
+    @action = create_action(subject)
+    @update_action_class = ::Actions::Katello::UpstreamSubscriptions::UpdateEntitlement
+    @manifest_action_class = ::Actions::Katello::Organization::ManifestRefresh
+  end
+
+  it 'plans' do
+    pool = katello_pools(:pool_one)
+    pool.expects(:upstream_entitlement_id).returns(:foo).twice
+    ::Katello::Pool.expects(:find).with(pool.id).returns(pool)
+    pools = [{id: pool.id, quantity: 5}]
+
+    plan_action(@action, pools)
+
+    assert_action_planned_with(@action, @update_action_class, entitlement_id: :foo, quantity: 5)
+    assert_action_planned_with(@action, @manifest_action_class, @org)
+  end
+
+  it 'raises an error when given no pools' do
+    error = proc { plan_action(@action, []) }.must_raise RuntimeError
+    error.message.must_match(/provided/)
+  end
+
+  it 'raises an error when the pool has no upstream entitlement' do
+    pool1 = katello_pools(:pool_one)
+    pool1.expects(:upstream_entitlement_id).returns(nil)
+    ::Katello::Pool.expects(:find).with(pool1.id).returns(pool1)
+
+    error = proc { plan_action(@action, [{id: pool1.id, quantity: 1}]) }.must_raise RuntimeError
+    error.message.must_match(/upstream/)
+  end
+
+  it 'raises an error when no organization is set' do
+    set_organization(nil)
+    error = proc { plan_action(@action, [:foo]) }.must_raise RuntimeError
+    error.message.must_match(/is not set/)
+  end
+end

--- a/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
@@ -90,5 +90,26 @@ module Katello
                                 organization_id: @organization.id }
       end
     end
+
+    def test_update
+      pools = [{"id" => "12345", "quantity" => 5}]
+
+      assert_async_task ::Actions::Katello::UpstreamSubscriptions::UpdateEntitlements do |poolz|
+        poolz.must_equal pools
+      end
+
+      put :update, params: { organization_id: @organization.id, pools: pools }
+
+      assert_response :success
+    end
+
+    def test_update_protected
+      allowed_perms = [permission]
+      denied_perms = []
+
+      assert_protected_action(:update, allowed_perms, denied_perms, [@organization]) do
+        put :update, params: { organization_id: @organization.id, pools: [] }
+      end
+    end
   end
 end


### PR DESCRIPTION
Like the remove entitlements API, this one takes local pools which are derived from the org's manifest as input - otherwise an error will be raised

`PUT katello/api/v2/organizations/:id/upstream_subscriptions`

```
{
  "pools": [
    {
      "id": "56",
      "quantity": "2"
    }
  ]
}
```
```