### PR TITLE
Fixes #22956: Remove gpg key content length limit

### DIFF
--- a/app/models/katello/gpg_key.rb
+++ b/app/models/katello/gpg_key.rb
@@ -1,7 +1,6 @@
 module Katello
   class GpgKey < Katello::Model
     include Katello::Authorization::GpgKey
-    MAX_CONTENT_LENGTH = 100_000
     MAX_CONTENT_LINE_LENGTH = 65
 
     GPG_KEY_TYPE = 'gpg_key'.freeze
@@ -28,7 +27,7 @@ module Katello
                                                         :message => N_("has already been taken")}
     validates :content_type, :presence => true, :inclusion => { :in => [GPG_KEY_TYPE, CERT_TYPE],
                                                                 :message => N_("must be %{gpg_key} or %{cert}") % { :gpg_key => GPG_KEY_TYPE, :cert => CERT_TYPE} }
-    validates :content, :presence => true, :length => {:maximum => MAX_CONTENT_LENGTH}
+    validates :content, :presence => true
     validates :organization, :presence => true
     validates_with Validators::KatelloNameFormatValidator, :attributes => :name
     validates_with Validators::ContentValidator, :attributes => :content

--- a/spec/models/gpg_key_spec.rb
+++ b/spec/models/gpg_key_spec.rb
@@ -54,11 +54,6 @@ module Katello
         gpg_key = GpgKey.new(:name => "Gpg Key 1", :content => content, :organization => @organization)
         gpg_key.wont_be :valid?
       end
-
-      it "should be unsuccessful with a key longer than #{GpgKey::MAX_CONTENT_LENGTH} characters" do
-        gpg_key = GpgKey.new(:name => "Gpg Key 8", :content => ("abc123" * GpgKey::MAX_CONTENT_LENGTH), :organization => @organization)
-        gpg_key.wont_be :valid?
-      end
     end
   end
 end


### PR DESCRIPTION
Since we were using the :text data type in Postgres, we don't have to
change anything on the DB side! Yay! :D