### PR TITLE
Fixes #21689 - Validate content source in facet

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -20,6 +20,7 @@ module Katello
 
       validates :content_view, :presence => true, :allow_blank => false
       validates :lifecycle_environment, :presence => true, :allow_blank => false
+      validates_with Validators::AssociationExistsValidator, attributes: [:content_source]
       validates :host, :presence => true, :allow_blank => false
       validates_with Validators::ContentViewEnvironmentValidator
 


### PR DESCRIPTION
This change should check that the content source exists in the
database only if a content_source_id is given for a host.

Requires https://github.com/theforeman/foreman/pull/5405