### PR TITLE
Fixes #23139 - Composite CV add page makes 2 API calls to get CVs

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/components/content-view-composite-available-content-views.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/components/content-view-composite-available-content-views.controller.js
@@ -14,7 +14,7 @@
 angular.module('Bastion.content-views').controller('ContentViewCompositeAvailableContentViewsController',
     ['$scope', 'Nutupane', 'CurrentOrganization', 'ContentView', 'ContentViewComponent',
         function ($scope, Nutupane, CurrentOrganization, ContentView, ContentViewComponent) {
-            var nutupane, params;
+            var nutupane, params, nutupaneParams;
 
             params = {
                 'full_result': true,
@@ -23,10 +23,13 @@ angular.module('Bastion.content-views').controller('ContentViewCompositeAvailabl
                 'organization_id': CurrentOrganization
             };
 
-            nutupane = new Nutupane(ContentView, params);
+            nutupaneParams = {
+                'disableAutoLoad': true
+            };
+
+            nutupane = new Nutupane(ContentView, params,undefined,nutupaneParams);
             $scope.controllerName = 'katello_content_views';
             nutupane.masterOnly = true;
-            nutupane.table.initialLoad = false;
             $scope.table = nutupane.table;
 
             $scope.contentView.$promise.then(function (contentView) {
@@ -41,7 +44,7 @@ angular.module('Bastion.content-views').controller('ContentViewCompositeAvailabl
                 params['without[]'] = filterIds;
 
                 nutupane.setParams(params);
-                nutupane.load(true);
+                nutupane.refresh();
             });
 
             $scope.addContentViews = function () {


### PR DESCRIPTION
## Steps to Reproduce:
1. Go to an existing Composite Content view (Or create a new one)
2. Go to Content Views Page
3. Go to Add
4. 2 API calls made from UI (to: /katello/api/v2/content_views?...)