### PR TITLE
Fixes #23141 - Package search not showing CV

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/package-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/package-repositories.controller.js
@@ -36,6 +36,9 @@ angular.module('Bastion.packages').controller('PackageRepositoriesController',
 
         contentView = ContentView.queryUnpaged(function (response) {
             $scope.contentViews = response.results;
+            _.each($scope.contentViews, function(cv) {
+                cv.environment_ids = _.map(cv.environments, "id");
+            });
             $scope.contentViewFilter = _.find($scope.contentViews, {'default': true});
         });
 
@@ -47,10 +50,20 @@ angular.module('Bastion.packages').controller('PackageRepositoriesController',
 
         $scope.filterPackages = function () {
             params['environment_id'] = $scope.environmentFilter;
-            params['content_view_version_id'] = $scope.contentViewFilter;
 
             if ($scope.contentViewFilter) {
-                params['content_view_version_id'] = _.map($scope.contentViewFilter.versions, 'id');
+                version = _.find($scope.contentViewFilter.versions, function(version) {
+                    // Find the version belonging to the environment specified by the enviroment filter
+                    env = _.find(version.environment_ids, function(env_id) {
+                        return env_id === $scope.environmentFilter;
+                    });
+
+                    return !angular.isUndefined(env);
+                });
+
+                if (!angular.isUndefined(version)) {
+                    params['content_view_version_id'] = version.id;
+                }
             }
 
             repositoriesNutupane.setParams = (params);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/views/package-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/views/package-repositories.html
@@ -15,7 +15,7 @@
     <select class="form-control"
             ng-disabled="!contentViews || filteredCVs.length === 0"
             ng-model="contentViewFilter"
-            ng-options="cv as cv.name for cv in filteredCVs = (contentViews | filter:{environments: environmentFilter})"
+            ng-options="cv as cv.name for cv in filteredCVs = (contentViews | filter:{environment_ids: environmentFilter})"
             ng-change="filterPackages()">
     </select>
     <p class="help-block" translate ng-show="filteredCVs.length === 0">


### PR DESCRIPTION
Addressing 2 issues in this commit both dealing with the same page.

1) A filter issue in the Package Details -> Repository
page. The environment filter searches based on a id value for the
content view while the list it is searching against is a bunch of
content_view objects instead of id. This causes the filter to
always fail and return nil.

2) Also fixes the search query sent to the backend server when one is
filtering the objects. The search query previously did not the
environment into account when passing a content view version id matching
an environment. This commit tries to address that.