### PR TITLE
Fixes #23148 - Promote option for CV version does not work

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
@@ -99,7 +99,15 @@
                 <span class="sr-only">Toggle Dropdown</span>
               </button>
               <ul class="dropdown-menu">
-                <li><a href="#">Promote</a></li>
+                <li>
+                  <a href="#"
+                     ng-click="$state.go('content-view.promotion', {contentViewId: contentView.id, versionId: version.id})"
+                     ng-hide="denied('promote_or_remove_content_views', contentView)"
+                     ng-disabled="taskInProgress(version) || taskFailed(version) || pendingVersionTask"
+                     translate>
+                     Promote
+                  </a>
+                </li>
                 <li>
                   <a href="#"
                      ng-click="regenerateRepositories(version)"


### PR DESCRIPTION
### Description of problem:
"Promote" option from the dropdown list (next to Promote button) for the CV version does not work
****
#### Steps to Reproduce:
1. Create and publish one CV 
2. For the version 1.0 in the Actions column, we can see "Promote" button and the drop-down arrow 
3. When we click on the drop-down arrow and click on "Promote" it does not promote the CV.
****
#### Approach:
We are enabling the Promote option in in the drop down.
 
***Alternatively, we could also remove the option as it already exists as a button on the same page.***