### PR TITLE
Fixes #23172 - Swap link descriptions on package details tab

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/views/package-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/details/views/package-info.html
@@ -18,14 +18,14 @@
       <dt translate>Applicable To</dt>
       <dd>
         <a href="{{ '/content_hosts?search=' + createSearchString('applicable_rpms') }}" translate>
-          {{ package.hosts_available_count }} Host(s)
+          {{ package.hosts_applicable_count }} Host(s)
         </a>
       </dd>
 
       <dt translate>Upgradable For</dt>
       <dd>
         <a href="{{ '/content_hosts?search=' + createSearchString('upgradable_rpms') }}" translate>
-          {{ package.hosts_applicable_count }} Host(s)
+          {{ package.hosts_available_count }} Host(s)
         </a>
       </dd>
 


### PR DESCRIPTION
The link descriptions for the links next to "Applicable To" and "Upgradable
For" on the details tab for package overview pages need to be swapped.