### PR TITLE
Refs #22909 - use correct messaging format

### DIFF
--- a/app/lib/actions/katello/upstream_subscriptions/remove_entitlements.rb
+++ b/app/lib/actions/katello/upstream_subscriptions/remove_entitlements.rb
@@ -13,7 +13,7 @@ module Actions
             ids.each do |pid|
               pool = ::Katello::Pool.find(pid)
 
-              fail("Provided pool with id #{pid} has no upstream entitlement") if pool.upstream_entitlement_id.nil?
+              fail _("Provided pool with id %s has no upstream entitlement" % pid) if pool.upstream_entitlement_id.nil?
 
               plan_action(::Actions::Katello::UpstreamSubscriptions::RemoveEntitlement, entitlement_id: pool.upstream_entitlement_id)
             end

--- a/test/actions/katello/upstream_subscriptions/remove_entitlements_test.rb
+++ b/test/actions/katello/upstream_subscriptions/remove_entitlements_test.rb
@@ -39,12 +39,12 @@ describe ::Actions::Katello::UpstreamSubscriptions::RemoveEntitlements do
     error.message.must_match(/upstream/)
   end
 
-  it 'raises an error when given no entitlement ids' do
+  it 'raises an error when given no pool ids' do
     error = proc { plan_action(@action, []) }.must_raise RuntimeError
     error.message.must_match(/provided/)
   end
 
-  it 'raises an error when organization is set' do
+  it 'raises an error when no organization is set' do
     set_organization(nil)
     error = proc { plan_action(@action, [:foo]) }.must_raise RuntimeError
     error.message.must_match(/is not set/)


### PR DESCRIPTION
I've seen issues with interpolation and gettext in the past, for example, when variable names change. This will keep things working.