### PR TITLE
Fixes #23182 - Add param to limit upstream subs index to attachable ones

### DIFF
--- a/app/controllers/katello/api/v2/upstream_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/upstream_subscriptions_controller.rb
@@ -20,6 +20,7 @@ module Katello
     param_group :cp_search
     param :pool_ids, Array, desc: N_("List of pool ids to fetch")
     param :quantities_only, :bool, desc: N_("Only returns id and quantity fields")
+    param :attachable, :bool, desc: N_("Return only subscriptions which can be attached to the upstream allocation")
     def index
       pools = UpstreamPool.fetch_pools(upstream_pool_params.to_h)
       collection = scoped_search_results(
@@ -52,7 +53,7 @@ module Katello
     private
 
     def upstream_pool_params
-      params.permit(:page, :per_page, :order, :sort_by, :quantities_only, pool_ids: [])
+      params.permit(:page, :per_page, :order, :sort_by, :quantities_only, :attachable, pool_ids: [])
     end
 
     def bind_entitlements_params

--- a/app/models/katello/upstream_pool.rb
+++ b/app/models/katello/upstream_pool.rb
@@ -4,10 +4,10 @@ module Katello
 
     class << self
       def fetch_pools(params)
-        quantities_only = ::Foreman::Cast.to_bool(params.delete("quantities_only"))
+        quantities_only = ::Foreman::Cast.to_bool(params.delete(:quantities_only))
         cp_params = request_params(
-          base_params: params,
-          extra_params: pool_id_params(params.delete("pool_ids")),
+          base_params: base_params(params),
+          extra_params: pool_id_params(params.delete(:pool_ids)),
           included_fields: included_field_params(quantities_only)
         )
 
@@ -18,6 +18,16 @@ module Katello
           pools: pools,
           total: response.headers[total_count_header] || pools.count
         }
+      end
+
+      def base_params(params)
+        attachable = ::Foreman::Cast.to_bool(params.delete(:attachable))
+        params[:consumer] = upstream_consumer_id if attachable
+        params
+      end
+
+      def upstream_consumer_id
+        CP_POOL.upstream_consumer_id
       end
 
       def response_to_pools(response)

--- a/test/models/upstream_pool_test.rb
+++ b/test/models/upstream_pool_test.rb
@@ -19,9 +19,9 @@ module Katello
       }]
     end
 
-    def stub_fetch_pools(response, extra_params: [], included_fields: UpstreamPool.all_fields)
+    def stub_fetch_pools(response, base_params: {}, extra_params: [], included_fields: UpstreamPool.all_fields)
       Katello::UpstreamPool.expects(:request_params)
-                           .with(base_params: {},
+                           .with(base_params: base_params,
                                  extra_params: extra_params,
                                  included_fields: included_fields)
 
@@ -85,6 +85,17 @@ module Katello
       pools = UpstreamPool.fetch_pools(
         {pool_ids: ["pool_id"] }.with_indifferent_access
       )
+      assert_equal 1, pools[:total]
+    end
+
+    def test_fetch_pools_attachable
+      @response.expects(:to_str).returns(@raw_pool.to_json)
+      @response.expects(:headers).returns({})
+      stub_fetch_pools(@response, base_params: {consumer: :foo_id})
+      Resources::Candlepin::UpstreamPool.expects(:upstream_consumer_id).returns(:foo_id)
+
+      params = {attachable: true}
+      pools = UpstreamPool.fetch_pools(params)
       assert_equal 1, pools[:total]
     end
 


### PR DESCRIPTION
Pretty sure we need to do this for the UI when we go to attach subs