### PR TITLE
Fixes #23221 - Humanized name for notification jobs

### DIFF
--- a/app/jobs/create_pulp_disk_space_notifications.rb
+++ b/app/jobs/create_pulp_disk_space_notifications.rb
@@ -6,4 +6,8 @@ class CreatePulpDiskSpaceNotifications < ApplicationJob
   def perform
     Katello::UINotifications::Pulp::ProxyDiskSpace.deliver!
   end
+
+  def humanized_name
+    _('Pulp disk space notification')
+  end
 end

--- a/app/jobs/send_expire_soon_notifications.rb
+++ b/app/jobs/send_expire_soon_notifications.rb
@@ -6,4 +6,8 @@ class SendExpireSoonNotifications < ApplicationJob
   def perform
     Katello::UINotifications::Subscriptions::ExpireSoon.deliver!
   end
+
+  def humanized_name
+    _('Subscription expiration notification')
+  end
 end


### PR DESCRIPTION
Redmine is down now, whenever it's back I will create an issue number.

This PR allows to show the notifications in the Tasks page  https://github.com/theforeman/foreman-tasks/pull/238 - without the `humanized_name` method, it'll just display the class name.

![screenshot from 2018-04-11 11-41-14](https://user-images.githubusercontent.com/598891/38609009-440b129a-3d7d-11e8-987f-47d56e59d8cb.png)

Can be merged at any time, it's harmless even if https://github.com/theforeman/foreman-tasks/pull/238 isn't merged yet