### PR TITLE
Fixes #23257 - Check if the delayed plans have expected interface

### DIFF
--- a/lib/katello/scheduled_jobs.rb
+++ b/lib/katello/scheduled_jobs.rb
@@ -4,12 +4,12 @@
   scheduled_pulp_job = pending_jobs.select do |job|
     delayed_plan = world.persistence.load_delayed_plan job.id
     next if delayed_plan.blank?
-    delayed_plan.to_hash[:serialized_args].first["job_class"] == 'CreatePulpDiskSpaceNotifications'
+    delayed_plan.to_hash[:serialized_args].first.try(:[], 'job_class') == 'CreatePulpDiskSpaceNotifications'
   end
   scheduled_subs_expiration_job = pending_jobs.select do |job|
     delayed_plan = world.persistence.load_delayed_plan job.id
     next if delayed_plan.blank?
-    delayed_plan.to_hash[:serialized_args].first["job_class"] == 'SendExpireSoonNotifications'
+    delayed_plan.to_hash[:serialized_args].first.try(:[], 'job_class') == 'SendExpireSoonNotifications'
   end
 
   # Only create notifications if there isn't a scheduled job


### PR DESCRIPTION
Not all delayed plan records have 'job_class' key in first element
in serialized_args.