### PR TITLE
Fixes #23150 - Katello task page 404 error and refresh issue

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/task.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/task.factory.js
@@ -19,15 +19,12 @@
  */
 
 angular.module('Bastion.tasks').factory('Task',
-    ['BastionResource', '$timeout', '$log', '$q', 'CurrentOrganization',
-    function (BastionResource, $timeout, $log, $q, CurrentOrganization) {
+    ['BastionResource', '$timeout', '$log', '$q',
+    function (BastionResource, $timeout, $log, $q) {
         var bulkSearchRunning = false, searchIdGenerator = 0,
             searchParamsById = {}, callbackById = {}, pollCount = 0, maxPollInterval = 10000;
 
-        var resource = BastionResource('katello/api/v2/tasks/:id/:action',
-            {id: '@id', 'organization_id': CurrentOrganization}, {});
-
-        var foremanTasksResource = BastionResource('foreman_tasks/api/tasks/:id/:action',
+        var resource = BastionResource('foreman_tasks/api/tasks/:id/:action',
             {},
             {
                 bulkSearch: {method: 'POST', isArray: true, params: { action: 'bulk_search'}}
@@ -65,7 +62,7 @@ angular.module('Bastion.tasks').factory('Task',
                 bulkSearchRunning = false;
                 return;
             }
-            foremanTasksResource.bulkSearch(bulkSearchParams(), function (response) {
+            resource.bulkSearch(bulkSearchParams(), function (response) {
                 try {
                     _.each(response, function (tasksSearch) {
                         var searchId = tasksSearch['search_params']['search_id'];

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/tasks-nutupane.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/tasks-nutupane.factory.js
@@ -14,8 +14,13 @@ angular.module('Bastion.tasks').factory('TasksNutupane',
     ['Task', 'Nutupane', function (Task, Nutupane) {
         var TasksNutupane = function () {
             var self = this;
+            var nutupaneParams = {
+                'disableAutoLoad': true
+            };
 
-            Nutupane.call(self, Task, {});
+
+            Nutupane.call(self, Task, {}, undefined, nutupaneParams);
+            self.table.working = true;
 
             self.existingTasks = {};
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/tasks-table.directive.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/tasks-table.directive.js
@@ -79,9 +79,12 @@ angular.module('Bastion.tasks').directive('tasksTable',
                     }
                 });
 
-                scope.$watch('all', function () {
-                    scope.tasksNutupane.registerSearch({ 'type': 'all',
-                                                         'active_only': scope.activeOnly });
+                scope.$watch('all', function (all) {
+                    if (all) {
+                        scope.tasksNutupane.registerSearch({ 'type': 'all',
+                                                            'active_only': scope.activeOnly });
+
+                    }
                 });
 
                 element.bind('$destroy', function () {

--- a/engines/bastion_katello/test/tasks/task.factory.test.js
+++ b/engines/bastion_katello/test/tasks/task.factory.test.js
@@ -28,11 +28,11 @@ describe('Factory: Task', function() {
     });
 
     it('provides a way to get a list of tasks', function() {
-        $httpBackend.expectGET('katello/api/v2/tasks?full_result=true&organization_id=ACME')
-                    .respond(tasks);
+        $httpBackend.expectPOST('foreman_tasks/api/tasks/bulk_search')
+                    .respond(tasks.records);
 
-        Task.queryUnpaged(function(tasks) {
-            expect(tasks.records.length).toBe(1);
+        Task.bulkSearch(function(tasks) {
+            expect(tasks.length).toBe(1);
         });
     });
 


### PR DESCRIPTION
### Creating this PR against 2 issues:
1. http://projects.theforeman.org/issues/23150
2. http://projects.theforeman.org/issues/23264
****
#### Steps to reproduce [23150](http://projects.theforeman.org/issues/23150)
1. Go to any Katello Resource > Task page (ex: Product>task , CV> Task etc.)
2. A 404 error is reported in the logs due to a call made to endpoint /katello/api/v2/tasks which doesn't exist.
****
#### Steps to reproduce [23264](http://projects.theforeman.org/issues/23264)
1. Go to any katello resource > Task [Ex: Product > Tasks]
2. Do a browser refresh
3. All tasks (returned by foreman_tasks bulk search) are displayed.

