### PR TITLE
Fixes #23292 - make s390x ks repos bootable

### DIFF
--- a/lib/katello/tasks/upgrades/3.7/make_all_ks_repos_bootable.rake
+++ b/lib/katello/tasks/upgrades/3.7/make_all_ks_repos_bootable.rake
@@ -1,0 +1,11 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '3.7' do
+      task :make_all_ks_repos_bootable => ["environment"] do
+        User.current = User.anonymous_api_admin
+        puts _("Ensuring all Kickstart Repos are bootable")
+        Katello::Repository.import_distributions
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/Katello/katello/commit/715a11bd8eec7e08c8c6800449349ecfa6dd5fbe
makes newly created s390x repos 'bootable' but never migrated
any pre existing repos.