### PR TITLE
Fixes #23121 - Include default paging params for upstream subs list

### DIFF
--- a/app/models/katello/upstream_pool.rb
+++ b/app/models/katello/upstream_pool.rb
@@ -16,7 +16,8 @@ module Katello
 
         {
           pools: pools,
-          total: response.headers[total_count_header] || pools.count
+          total: response.headers[total_count_header] || pools.count,
+          subtotal: pools.count
         }
       end
 

--- a/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
@@ -25,8 +25,26 @@ module Katello
 
     def test_index
       params = { page: '3', per_page: '7', organization_id: @organization.id }
-      Api::V2::UpstreamSubscriptionsController.any_instance.stubs(:upstream_pool_params).returns(params)
-      UpstreamPool.expects(:fetch_pools).with(params).returns(pools: [{}], total: nil)
+      UpstreamPool.expects(:fetch_pools).with('page' => '3', 'per_page' => '7').returns(pools: [{}], total: nil)
+      get :index, params: params
+
+      assert_response :success
+    end
+
+    def test_index_full_result
+      params = {full_result: 'true', page: '3', per_page: '7', organization_id: @organization.id}
+      # omit page and per_page params for candlepin
+      UpstreamPool.expects(:fetch_pools).with({}).returns({})
+
+      get :index, params: params
+
+      assert_response :success
+    end
+
+    def test_index_no_per_page
+      params = {page: '3', organization_id: @organization.id }
+      UpstreamPool.expects(:fetch_pools).with('page' => '3', 'per_page' => Setting[:entries_per_page]).returns({})
+
       get :index, params: params
 
       assert_response :success

--- a/test/models/upstream_pool_test.rb
+++ b/test/models/upstream_pool_test.rb
@@ -54,6 +54,9 @@ module Katello
       @raw_pool.first.each_value do |value|
         assert_equal value, pool[value].to_sym
       end
+
+      assert_equal 1, pools[:total]
+      assert_equal 1, pools[:subtotal]
     end
 
     def test_fetch_pools_total


### PR DESCRIPTION
This wasn't respecting the default page size setting like ordinary APIs which use scoped search