### PR TITLE
Fixes #22734 - Add ability to edit RH Subscription entitlements 

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "jed": "^1.1.1",
     "lodash": "^4.17.5",
     "patternfly": "^3.41.1",
-    "patternfly-react": "^1.11.0",
+    "patternfly-react": "^2.1.0",
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
     "react-bootstrap": "^0.31.5",

--- a/webpack/containers/Application/overrides.scss
+++ b/webpack/containers/Application/overrides.scss
@@ -13,3 +13,10 @@ html .pagination-pf-pagesize.btn-group {
 .table + .table-view-pf-pagination {
   margin-top: -6px !important;
 }
+
+// override foreman's .editable styles, that are conflicting with the patternfly ones
+.pf-table-inline-edit {
+  .editable {
+    background: none;
+  }
+}

--- a/webpack/mockRequest.js
+++ b/webpack/mockRequest.js
@@ -10,6 +10,8 @@ const methods = {
   DELETE: 'onDelete',
 };
 
+const errorResponse = msg => ({ displayMessage: msg });
+
 export const mockRequest = ({
   method = 'GET',
   url,
@@ -17,5 +19,14 @@ export const mockRequest = ({
   status = 200,
   response = null,
 }) => mock[methods[method]](url, data).reply(status, response);
+
+export const mockErrorRequest = ({
+  status = 500,
+  ...options
+}) => mockRequest({
+  response: errorResponse(`Request failed with status code ${status}`),
+  status,
+  ...options,
+});
 
 export const mockReset = () => mock.reset();

--- a/webpack/move_to_foreman/common/helpers.js
+++ b/webpack/move_to_foreman/common/helpers.js
@@ -3,3 +3,9 @@ export default {
     return `/${controller}/${id ? `${id}/` : ''}${action}`;
   },
 };
+
+export const KEY_CODES = {
+  TAB_KEY: 9,
+  ENTER_KEY: 13,
+  ESCAPE_KEY: 27,
+};

--- a/webpack/move_to_foreman/components/common/ConfirmDialog/ConfirmDialog.js
+++ b/webpack/move_to_foreman/components/common/ConfirmDialog/ConfirmDialog.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button } from 'patternfly-react';
+import Dialog from '../Dialog';
+
+const ConfirmDialog = (props) => {
+  const {
+    onCancel, cancelLabel, onConfirm, confirmLabel, ...otherProps
+  } = props;
+
+  const buttons = [
+    <Button
+      key="cancel"
+      bsStyle="default"
+      className="btn-cancel"
+      onClick={onCancel}
+    >
+      {cancelLabel}
+    </Button>,
+    <Button
+      key="confirm"
+      bsStyle="primary"
+      onClick={onConfirm}
+    >
+      {confirmLabel}
+    </Button>,
+  ];
+
+  return (
+    <Dialog buttons={buttons} onCancel={onCancel} {...otherProps} />
+  );
+};
+
+ConfirmDialog.propTypes = {
+  ...Button.propTypes,
+  onConfirm: PropTypes.func.isRequired,
+  confirmLabel: PropTypes.string,
+};
+
+ConfirmDialog.defaultProps = {
+  ...Button.defaultProps,
+  confirmLabel: __('Save'),
+  cancelLabel: __('Cancel'),
+  dangerouslySetInnerHTML: undefined,
+  message: undefined,
+};
+
+export default ConfirmDialog;

--- a/webpack/move_to_foreman/components/common/ConfirmDialog/__tests__/ConfirmDialog.test.js
+++ b/webpack/move_to_foreman/components/common/ConfirmDialog/__tests__/ConfirmDialog.test.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import ConfirmDialog from '../ConfirmDialog';
+
+describe('ConfirmDialog', () => {
+  const props = {
+    show: true,
+    onConfirm: () => {},
+    onCancel: () => {},
+    title: 'Please Confirm',
+  };
+  const message = 'Proceed with this action?';
+
+  it('renders a confirm dialog', async () => {
+    const dialog = shallow(<ConfirmDialog
+      {...props}
+      {...{ message }}
+    />);
+    expect(toJson(dialog)).toMatchSnapshot();
+  });
+
+  it('enables to override button labels', async () => {
+    const dialog = shallow(<ConfirmDialog
+      {...props}
+      {...{ message }}
+      confirmLabel="Custom confirm"
+      cancelLabel="Custom cancel"
+    />);
+    expect(toJson(dialog)).toMatchSnapshot();
+  });
+
+  it('enables to set inner html', async () => {
+    const dialog = shallow(<ConfirmDialog
+      {...props}
+      dangerouslySetInnerHTML={{ _html: '<b>Custom</b> html content' }}
+    />);
+    expect(toJson(dialog)).toMatchSnapshot();
+  });
+});

--- a/webpack/move_to_foreman/components/common/ConfirmDialog/__tests__/__snapshots__/ConfirmDialog.test.js.snap
+++ b/webpack/move_to_foreman/components/common/ConfirmDialog/__tests__/__snapshots__/ConfirmDialog.test.js.snap
@@ -1,0 +1,125 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConfirmDialog enables to override button labels 1`] = `
+<Dialog
+  active={false}
+  block={false}
+  bsClass="btn"
+  bsStyle="default"
+  buttons={
+    Array [
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
+        bsStyle="default"
+        className="btn-cancel"
+        disabled={false}
+        onClick={[Function]}
+      >
+        Custom cancel
+      </Button>,
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
+        bsStyle="primary"
+        disabled={false}
+        onClick={[Function]}
+      >
+        Custom confirm
+      </Button>,
+    ]
+  }
+  cancelLabel="Ok"
+  disabled={false}
+  message="Proceed with this action?"
+  onCancel={[Function]}
+  show={true}
+  title="Please Confirm"
+/>
+`;
+
+exports[`ConfirmDialog enables to set inner html 1`] = `
+<Dialog
+  active={false}
+  block={false}
+  bsClass="btn"
+  bsStyle="default"
+  buttons={
+    Array [
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
+        bsStyle="default"
+        className="btn-cancel"
+        disabled={false}
+        onClick={[Function]}
+      >
+        Cancel
+      </Button>,
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
+        bsStyle="primary"
+        disabled={false}
+        onClick={[Function]}
+      >
+        Save
+      </Button>,
+    ]
+  }
+  cancelLabel="Ok"
+  dangerouslySetInnerHTML={
+    Object {
+      "_html": "<b>Custom</b> html content",
+    }
+  }
+  disabled={false}
+  onCancel={[Function]}
+  show={true}
+  title="Please Confirm"
+/>
+`;
+
+exports[`ConfirmDialog renders a confirm dialog 1`] = `
+<Dialog
+  active={false}
+  block={false}
+  bsClass="btn"
+  bsStyle="default"
+  buttons={
+    Array [
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
+        bsStyle="default"
+        className="btn-cancel"
+        disabled={false}
+        onClick={[Function]}
+      >
+        Cancel
+      </Button>,
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
+        bsStyle="primary"
+        disabled={false}
+        onClick={[Function]}
+      >
+        Save
+      </Button>,
+    ]
+  }
+  cancelLabel="Ok"
+  disabled={false}
+  message="Proceed with this action?"
+  onCancel={[Function]}
+  show={true}
+  title="Please Confirm"
+/>
+`;

--- a/webpack/move_to_foreman/components/common/ConfirmDialog/index.js
+++ b/webpack/move_to_foreman/components/common/ConfirmDialog/index.js
@@ -1,0 +1,3 @@
+import ConfirmDialog from './ConfirmDialog';
+
+export default ConfirmDialog;

--- a/webpack/move_to_foreman/components/common/Dialog/Dialog.js
+++ b/webpack/move_to_foreman/components/common/Dialog/Dialog.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, Modal, Icon } from 'patternfly-react';
+
+const Dialog = (props) => {
+  const buttons = (props.buttons)
+    ? props.buttons
+    : (
+      <Button
+        key="cancel"
+        bsStyle="default"
+        className="btn-cancel"
+        onClick={props.onCancel}
+      >
+        {props.cancelLabel}
+      </Button>
+    );
+  return (
+    <Modal show={props.show}>
+      <Modal.Header>
+        <Button
+          className="close"
+          onClick={props.onCancel}
+          aria-hidden="true"
+          aria-label={props.cancelLabel}
+        >
+          <Icon type="pf" name="close" />
+        </Button>
+        <Modal.Title>{props.title}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {/* eslint-disable react/no-danger */}
+        <p dangerouslySetInnerHTML={props.dangerouslySetInnerHTML}>
+          {props.message}
+        </p>
+        {/* eslint-enable react/no-danger */}
+      </Modal.Body>
+      <Modal.Footer>
+        {buttons}
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+Dialog.propTypes = {
+  show: PropTypes.bool.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  message: PropTypes.string,
+  title: PropTypes.string.isRequired,
+  cancelLabel: PropTypes.string,
+  dangerouslySetInnerHTML: PropTypes.shape({}),
+  buttons: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
+};
+
+Dialog.defaultProps = {
+  cancelLabel: __('Ok'),
+  dangerouslySetInnerHTML: undefined,
+  message: undefined,
+  buttons: undefined,
+};
+
+export default Dialog;

--- a/webpack/move_to_foreman/components/common/Dialog/__tests__/Dialog.test.js
+++ b/webpack/move_to_foreman/components/common/Dialog/__tests__/Dialog.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import { Button } from 'patternfly-react';
+import Dialog from '../Dialog';
+
+describe('Dialog', () => {
+  const props = {
+    show: true,
+    onCancel: () => {},
+    title: 'Message dialog',
+  };
+  const message = 'Some important message';
+
+  it('renders a message dialog', async () => {
+    const dialog = shallow(<Dialog
+      {...props}
+      {...{ message }}
+    />);
+    expect(toJson(dialog)).toMatchSnapshot();
+  });
+
+  it('enables to override cancel button label', async () => {
+    const dialog = shallow(<Dialog
+      {...props}
+      {...{ message }}
+      cancelLabel="Custom cancel"
+    />);
+    expect(toJson(dialog)).toMatchSnapshot();
+  });
+
+  it('enables to set inner html', async () => {
+    const dialog = shallow(<Dialog
+      {...props}
+      dangerouslySetInnerHTML={{ _html: '<b>Custom</b> html content' }}
+    />);
+    expect(toJson(dialog)).toMatchSnapshot();
+  });
+
+  it("passes onCancel to the default OK button's onClick", () => {
+    const onCancel = jest.fn();
+    const dialog = shallow(<Dialog
+      {...props}
+      {...{ onCancel }}
+    />);
+    expect(dialog.find('ModalFooter > Button[bsStyle="default"]').props().onClick).toBe(onCancel);
+    expect(dialog.find('ModalHeader > Button').props().onClick).toBe(onCancel);
+  });
+
+  it('enables to define custom buttons', async () => {
+    const dialog = shallow(<Dialog
+      {...props}
+      buttons={[
+        <Button key="btn1">Button 1</Button>,
+        <Button key="btn2">Button 2</Button>,
+        <Button key="btn3">Button 3</Button>,
+      ]}
+    />);
+    expect(toJson(dialog)).toMatchSnapshot();
+  });
+});

--- a/webpack/move_to_foreman/components/common/Dialog/__tests__/__snapshots__/Dialog.test.js.snap
+++ b/webpack/move_to_foreman/components/common/Dialog/__tests__/__snapshots__/Dialog.test.js.snap
@@ -1,0 +1,349 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Dialog enables to define custom buttons 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onHide={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={false}
+    closeLabel="Close"
+  >
+    <Button
+      active={false}
+      aria-hidden="true"
+      aria-label="Ok"
+      block={false}
+      bsClass="btn"
+      bsStyle="default"
+      className="close"
+      disabled={false}
+      onClick={[Function]}
+    >
+      <Icon
+        name="close"
+        type="pf"
+      />
+    </Button>
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h4"
+    >
+      Message dialog
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body"
+    componentClass="div"
+  >
+    <p />
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <Button
+      active={false}
+      block={false}
+      bsClass="btn"
+      bsStyle="default"
+      disabled={false}
+      key="btn1"
+    >
+      Button 1
+    </Button>
+    <Button
+      active={false}
+      block={false}
+      bsClass="btn"
+      bsStyle="default"
+      disabled={false}
+      key="btn2"
+    >
+      Button 2
+    </Button>
+    <Button
+      active={false}
+      block={false}
+      bsClass="btn"
+      bsStyle="default"
+      disabled={false}
+      key="btn3"
+    >
+      Button 3
+    </Button>
+  </ModalFooter>
+</Modal>
+`;
+
+exports[`Dialog enables to override cancel button label 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onHide={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={false}
+    closeLabel="Close"
+  >
+    <Button
+      active={false}
+      aria-hidden="true"
+      aria-label="Custom cancel"
+      block={false}
+      bsClass="btn"
+      bsStyle="default"
+      className="close"
+      disabled={false}
+      onClick={[Function]}
+    >
+      <Icon
+        name="close"
+        type="pf"
+      />
+    </Button>
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h4"
+    >
+      Message dialog
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body"
+    componentClass="div"
+  >
+    <p>
+      Some important message
+    </p>
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <Button
+      active={false}
+      block={false}
+      bsClass="btn"
+      bsStyle="default"
+      className="btn-cancel"
+      disabled={false}
+      key="cancel"
+      onClick={[Function]}
+    >
+      Custom cancel
+    </Button>
+  </ModalFooter>
+</Modal>
+`;
+
+exports[`Dialog enables to set inner html 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onHide={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={false}
+    closeLabel="Close"
+  >
+    <Button
+      active={false}
+      aria-hidden="true"
+      aria-label="Ok"
+      block={false}
+      bsClass="btn"
+      bsStyle="default"
+      className="close"
+      disabled={false}
+      onClick={[Function]}
+    >
+      <Icon
+        name="close"
+        type="pf"
+      />
+    </Button>
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h4"
+    >
+      Message dialog
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body"
+    componentClass="div"
+  >
+    <p
+      dangerouslySetInnerHTML={
+        Object {
+          "_html": "<b>Custom</b> html content",
+        }
+      }
+    />
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <Button
+      active={false}
+      block={false}
+      bsClass="btn"
+      bsStyle="default"
+      className="btn-cancel"
+      disabled={false}
+      key="cancel"
+      onClick={[Function]}
+    >
+      Ok
+    </Button>
+  </ModalFooter>
+</Modal>
+`;
+
+exports[`Dialog renders a message dialog 1`] = `
+<Modal
+  animation={true}
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onHide={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  show={true}
+>
+  <ModalHeader
+    bsClass="modal-header"
+    closeButton={false}
+    closeLabel="Close"
+  >
+    <Button
+      active={false}
+      aria-hidden="true"
+      aria-label="Ok"
+      block={false}
+      bsClass="btn"
+      bsStyle="default"
+      className="close"
+      disabled={false}
+      onClick={[Function]}
+    >
+      <Icon
+        name="close"
+        type="pf"
+      />
+    </Button>
+    <ModalTitle
+      bsClass="modal-title"
+      componentClass="h4"
+    >
+      Message dialog
+    </ModalTitle>
+  </ModalHeader>
+  <ModalBody
+    bsClass="modal-body"
+    componentClass="div"
+  >
+    <p>
+      Some important message
+    </p>
+  </ModalBody>
+  <ModalFooter
+    bsClass="modal-footer"
+    componentClass="div"
+  >
+    <Button
+      active={false}
+      block={false}
+      bsClass="btn"
+      bsStyle="default"
+      className="btn-cancel"
+      disabled={false}
+      key="cancel"
+      onClick={[Function]}
+    >
+      Ok
+    </Button>
+  </ModalFooter>
+</Modal>
+`;

--- a/webpack/move_to_foreman/components/common/Dialog/index.js
+++ b/webpack/move_to_foreman/components/common/Dialog/index.js
@@ -1,0 +1,3 @@
+import Dialog from './Dialog';
+
+export default Dialog;

--- a/webpack/move_to_foreman/components/common/emptyState/index.js
+++ b/webpack/move_to_foreman/components/common/emptyState/index.js
@@ -8,29 +8,32 @@ const EmptyState = (props) => {
     header,
     description,
     customDocumentation,
-    documentationLabel = 'For more information please see',
-    documentationButton = 'Documentation',
+    documentationLabel = __('For more information please see'),
+    documentationButton = __('Documentation'),
     docUrl,
     action,
     secondayActions,
   } = props;
-  const defaultDocumantion = __(`${documentationLabel} <a href=${docUrl}>${documentationButton}</a>`);
+  const defaultDocumantion = `${documentationLabel} <a href=${docUrl}>${documentationButton}</a>`;
+  const showDocsLink = !!(docUrl || customDocumentation);
 
   return (
     <PfEmptyState>
       <PfEmptyState.Icon type="pf" name={icon} />
       <PfEmptyState.Title>{header}</PfEmptyState.Title>
       <PfEmptyState.Info>{description}</PfEmptyState.Info>
-      <PfEmptyState.Help>
-        {customDocumentation || <span dangerouslySetInnerHTML={{ __html: defaultDocumantion }} />}
-      </PfEmptyState.Help>
-      <PfEmptyState.Action>
-        {action && (
+      {showDocsLink && (
+        <PfEmptyState.Help>
+          {customDocumentation || <span dangerouslySetInnerHTML={{ __html: defaultDocumantion }} />}
+        </PfEmptyState.Help>
+      )}
+      {action && (
+        <PfEmptyState.Action>
           <Button href={action.url} bsStyle="primary" bsSize="large">
             {action.title}
           </Button>
-        )}
-      </PfEmptyState.Action>
+        </PfEmptyState.Action>
+      )}
       {secondayActions && (
         <PfEmptyState.Action secondary>
           {secondayActions.map(item => (

--- a/webpack/move_to_foreman/components/common/table/index.js
+++ b/webpack/move_to_foreman/components/common/table/index.js
@@ -3,11 +3,14 @@ import { Table as PfTable, customHeaderFormattersDefinition } from 'patternfly-r
 import React from 'react';
 import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
 import EmptyState from '../emptyState';
+import PaginationRow from '../../../../components/PaginationRow/index';
 
 export const selectionCellFormatter = PfTable.selectionCellFormatter;
 export const selectionHeaderCellFormatter = PfTable.selectionHeaderCellFormatter;
+
 export const headerFormat = value => <PfTable.Heading>{value}</PfTable.Heading>;
 export const cellFormat = value => <PfTable.Cell>{value}</PfTable.Cell>;
+
 export const ellipsisFormat = value => (
   <PfTable.Cell>
     <EllipsisWithTooltip>{value}</EllipsisWithTooltip>
@@ -29,13 +32,13 @@ export const TableBody = (props) => {
 
   return (
     <PfTable.Body
-     rows={rows}
-     rowKey={({ rowIndex }) => rowIndex}
+      rows={rows}
+      rowKey={({ rowIndex }) => rowIndex}
     />
-  )
-}
+  );
+};
 
-class Table extends React.Component {
+export class Table extends React.Component {
   constructor(props) {
     super(props);
 
@@ -48,35 +51,45 @@ class Table extends React.Component {
 
 
   render() {
-    const { columns, rows, emptyState, bodyMessage } = this.props;
-    const sortingColumns = {};
+    const { columns, rows, emptyState, bodyMessage, children, itemCount, pagination, onPaginationChange, ...otherProps } = this.props;
 
-    return this.isEmpty() ? (
-      <EmptyState {...emptyState} />
-    ) : (
-      <PfTable.PfProvider
-        className="table-fixed"
-        striped
-        bordered
-        hover
-        columns={columns}
-        components={{
-          header: {
-            cell: cellProps =>
-              this.customHeaderFormatters({
-                cellProps,
-                columns,
-                sortingColumns,
-                rows: rows,
-                onSelectAllRows: this.props.onSelectAllRows
-              })
-          }
-        }}
-      >
-        <PfTable.Header />
-        <TableBody columns={columns} rows={rows} message={bodyMessage} />
-      </PfTable.PfProvider>
+    let paginationComponent;
+    if (itemCount && pagination) {
+      paginationComponent = (
+        <PaginationRow
+          viewType="table"
+          itemCount={itemCount}
+          pagination={pagination}
+          onChange={onPaginationChange}
+        />
+      );
+    }
+
+    if (this.isEmpty()) {
+      return (<EmptyState {...emptyState} />);
+    }
+
+    const table = (children !== undefined)
+      ? children
+      : [
+        <PfTable.Header />,
+        <TableBody columns={columns} rows={rows} message={bodyMessage} rowKey="id" />,
+      ];
+
+    return (
+      <div>
+        <PfTable.PfProvider
+          className="table-fixed"
+          striped
+          bordered
+          hover
+          columns={columns}
+          {...otherProps}
+        >
+          {table}
+        </PfTable.PfProvider>
+        {paginationComponent}
+      </div>
     );
   }
 }
-export default Table;

--- a/webpack/scenes/Subscriptions/EntitlementsInlineEditFormatter.js
+++ b/webpack/scenes/Subscriptions/EntitlementsInlineEditFormatter.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import { Table, FormControl, FormGroup, HelpBlock, Spinner } from 'patternfly-react';
+import { validateQuantity } from './SubscriptionValidations';
+import { KEY_CODES } from '../../move_to_foreman/common/helpers';
+
+export const entitlementsInlineEditFormatter =
+  inlineEditController => Table.inlineEditFormatterFactory({
+    isEditing: additionalData =>
+      inlineEditController.isEditing(additionalData),
+    renderValue: (value, additionalData) => {
+      const { rowData } = additionalData;
+      if (rowData.available < 0) {
+        return (
+          <td>{__('Unlimited')}</td>
+        );
+      }
+      return (
+        <td className="editable">
+          <div
+            onClick={() => inlineEditController.onActivate(additionalData)}
+            onKeyPress={(e) => {
+              if (e.keyCode === KEY_CODES.ENTER_KEY) {
+                inlineEditController.onActivate(additionalData);
+              }
+            }}
+            className="input"
+            role="textbox"
+            tabIndex={0}
+          >
+            {value}
+          </div>
+        </td>
+      );
+    },
+    renderEdit: (value, additionalData) => {
+      const { availableQuantity } = additionalData.rowData;
+
+      const className = inlineEditController.hasChanged(additionalData)
+        ? 'editable editing changed'
+        : 'editable editing';
+
+      const maxMessage = [
+        __('Max'),
+        availableQuantity,
+      ].join(' ');
+
+      const validation = validateQuantity(value, availableQuantity);
+
+      const formGroup = (
+        // We have to block editing until available quantities are loaded.
+        // Otherwise changes that user typed prior to update would be deleted,
+        // because we save them onBlur. Unfortunately onChange can't be used
+        // because reactabular always creates new component instances
+        // in re-render.
+        // The same issue prevents from correct switching inputs on TAB.
+        // See the reactabular code for details:
+        // https://github.com/reactabular/reactabular/blob/master/packages/reactabular-table/src/body-row.js#L58
+        <Spinner loading={!availableQuantity} size="xs">
+          <FormGroup
+            validationState={validation.state}
+          >
+            <FormControl
+              type="text"
+              defaultValue={value}
+              onBlur={e =>
+                inlineEditController.onChange(e.target.value, additionalData)
+              }
+            />
+            <HelpBlock>
+              {maxMessage}
+              <div className="validationMessages">
+                {validation.message}
+              </div>
+            </HelpBlock>
+          </FormGroup>
+        </Spinner>
+      );
+
+      return (
+        <td className={className}>
+          {formGroup}
+        </td>
+      );
+    },
+  });
+
+export default entitlementsInlineEditFormatter;

--- a/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
+++ b/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Col, Tabs, Tab, Form, FormGroup, FormControl, ControlLabel } from 'react-bootstrap';
 import { bindMethods, Alert, Button, Icon, Modal, ProgressBar, Spinner, OverlayTrigger, Tooltip } from 'patternfly-react';
 
-import Table from '../../../move_to_foreman/components/common/table';
+import { Table } from '../../../move_to_foreman/components/common/table';
 import { columns } from './ManifestHistoryTableSchema';
 
 class ManageManifestModal extends Component {

--- a/webpack/scenes/Subscriptions/SubscriptionActions.js
+++ b/webpack/scenes/Subscriptions/SubscriptionActions.js
@@ -5,7 +5,40 @@ import {
   SUBSCRIPTIONS_REQUEST,
   SUBSCRIPTIONS_SUCCESS,
   SUBSCRIPTIONS_FAILURE,
+  SUBSCRIPTIONS_QUANTITIES_REQUEST,
+  SUBSCRIPTIONS_QUANTITIES_SUCCESS,
+  SUBSCRIPTIONS_QUANTITIES_FAILURE,
+  UPDATE_QUANTITY_REQUEST,
+  UPDATE_QUANTITY_SUCCESS,
+  UPDATE_QUANTITY_FAILURE,
 } from './SubscriptionConstants';
+import { filterRHSubscriptions } from './SubscriptionHelpers.js';
+
+const getResponseError = ({ data }) => data && (data.displayMessage || data.error);
+
+export const loadAvailableQuantities = (extendedParams = {}) => (dispatch) => {
+  dispatch({ type: SUBSCRIPTIONS_QUANTITIES_REQUEST });
+
+  const params = {
+    ...{ organization_id: orgId },
+    ...propsToSnakeCase(extendedParams),
+  };
+
+  return api
+    .get(`/organizations/${orgId}/upstream_subscriptions`, {}, params)
+    .then(({ data }) => {
+      dispatch({
+        type: SUBSCRIPTIONS_QUANTITIES_SUCCESS,
+        response: data,
+      });
+    })
+    .catch((result) => {
+      dispatch({
+        type: SUBSCRIPTIONS_QUANTITIES_FAILURE,
+        error: getResponseError(result.response),
+      });
+    });
+};
 
 export const loadSubscriptions = (extendedParams = {}) => (dispatch) => {
   dispatch({ type: SUBSCRIPTIONS_REQUEST });
@@ -23,11 +56,38 @@ export const loadSubscriptions = (extendedParams = {}) => (dispatch) => {
         response: data,
         search: extendedParams.search,
       });
+      const poolIds = filterRHSubscriptions(data.results).map(subs => subs.id);
+      if (poolIds.length > 0) {
+        dispatch(loadAvailableQuantities({ poolIds }));
+      }
     })
     .catch((result) => {
       dispatch({
         type: SUBSCRIPTIONS_FAILURE,
-        result,
+        error: getResponseError(result.response),
+      });
+    });
+};
+
+export const updateQuantity = (quantities = {}) => (dispatch) => {
+  dispatch({ type: UPDATE_QUANTITY_REQUEST, quantities });
+
+  const params = {
+    pools: quantities,
+  };
+
+  return api
+    .put(`/organizations/${orgId}/upstream_subscriptions`, params)
+    .then(({ data }) => {
+      dispatch({
+        type: UPDATE_QUANTITY_SUCCESS,
+        response: data,
+      });
+    })
+    .catch((result) => {
+      dispatch({
+        type: UPDATE_QUANTITY_FAILURE,
+        error: getResponseError(result.response),
       });
     });
 };

--- a/webpack/scenes/Subscriptions/SubscriptionConstants.js
+++ b/webpack/scenes/Subscriptions/SubscriptionConstants.js
@@ -2,11 +2,21 @@ export const SUBSCRIPTIONS_REQUEST = 'SUBSCRIPTIONS_REQUEST';
 export const SUBSCRIPTIONS_SUCCESS = 'SUBSCRIPTIONS_SUCCESS';
 export const SUBSCRIPTIONS_FAILURE = 'SUBSCRIPTIONS_FAILURE';
 
+export const UPDATE_QUANTITY_REQUEST = 'UPDATE_QUANTITY_REQUEST';
+export const UPDATE_QUANTITY_SUCCESS = 'UPDATE_QUANTITY_SUCCESS';
+export const UPDATE_QUANTITY_FAILURE = 'UPDATE_QUANTITY_FAILURE';
+
+export const SUBSCRIPTIONS_QUANTITIES_REQUEST = 'SUBSCRIPTIONS_QUANTITIES_REQUEST';
+export const SUBSCRIPTIONS_QUANTITIES_SUCCESS = 'SUBSCRIPTIONS_QUANTITIES_SUCCESS';
+export const SUBSCRIPTIONS_QUANTITIES_FAILURE = 'SUBSCRIPTIONS_QUANTITIES_FAILURE';
+
 export const BLOCKING_FOREMAN_TASK_TYPES = [
   'Actions::Katello::Organization::ManifestImport',
   'Actions::Katello::Organization::ManifestRefresh',
   'Actions::Katello::Organization::ManifestDelete',
   'Actions::Katello::UpstreamSubscriptions::BindEntitlements',
+  'Actions::Katello::UpstreamSubscriptions::UpdateEntitlement',
 ];
 
 export const MANIFEST_TASKS_BULK_SEARCH_ID = 'activeManifestTasksSearch';
+export const BULK_TASK_SEARCH_INTERVAL = 10000;

--- a/webpack/scenes/Subscriptions/SubscriptionHelpers.js
+++ b/webpack/scenes/Subscriptions/SubscriptionHelpers.js
@@ -1,0 +1,3 @@
+// eslint-disable-next-line import/prefer-default-export
+export const filterRHSubscriptions = subscriptions =>
+  subscriptions.filter(sub => sub.available >= 0);

--- a/webpack/scenes/Subscriptions/SubscriptionReducer.js
+++ b/webpack/scenes/Subscriptions/SubscriptionReducer.js
@@ -1,4 +1,5 @@
 import find from 'lodash/find';
+import Immutable from 'seamless-immutable';
 import { initialApiState } from '../../services/api';
 import { TASK_BULK_SEARCH_SUCCESS } from '../Tasks/TaskConstants';
 
@@ -6,14 +7,38 @@ import {
   SUBSCRIPTIONS_REQUEST,
   SUBSCRIPTIONS_SUCCESS,
   SUBSCRIPTIONS_FAILURE,
+  SUBSCRIPTIONS_QUANTITIES_REQUEST,
+  SUBSCRIPTIONS_QUANTITIES_SUCCESS,
+  SUBSCRIPTIONS_QUANTITIES_FAILURE,
+  UPDATE_QUANTITY_REQUEST,
+  UPDATE_QUANTITY_SUCCESS,
+  UPDATE_QUANTITY_FAILURE,
   MANIFEST_TASKS_BULK_SEARCH_ID,
 } from './SubscriptionConstants';
 
-const initialState = initialApiState;
+const initialState = Immutable({
+  ...initialApiState,
+  quantitiesLoading: false,
+  availableQuantities: {},
+});
+
+const mapQuantities = (pools) => {
+  const quantityMap = {};
+  pools.forEach(pool =>
+    pool.local_pool_ids && pool.local_pool_ids.forEach((localId) => {
+      if (quantityMap[localId]) {
+        quantityMap[localId] += pool.quantity;
+      } else {
+        quantityMap[localId] = pool.quantity;
+      }
+    }));
+  return quantityMap;
+};
 
 export default (state = initialState, action) => {
   switch (action.type) {
     case SUBSCRIPTIONS_REQUEST:
+    case UPDATE_QUANTITY_REQUEST:
       return state.set('loading', true).set('tasks', []);
 
     case SUBSCRIPTIONS_SUCCESS: {
@@ -35,11 +60,32 @@ export default (state = initialState, action) => {
       });
     }
 
+    case UPDATE_QUANTITY_SUCCESS:
+      return state.set('loading', false);
+
     case SUBSCRIPTIONS_FAILURE:
+    case UPDATE_QUANTITY_FAILURE:
       return state.merge({
         error: action.error,
         loading: false,
       });
+
+    case SUBSCRIPTIONS_QUANTITIES_REQUEST:
+      return state.set('quantitiesLoading', true);
+
+    case SUBSCRIPTIONS_QUANTITIES_SUCCESS: {
+      return state.merge({
+        quantitiesLoading: false,
+        availableQuantities: mapQuantities(action.response.results),
+      });
+    }
+
+    case SUBSCRIPTIONS_QUANTITIES_FAILURE: {
+      return state.merge({
+        quantitiesLoading: false,
+        quantitiesError: action.error,
+      });
+    }
 
     case TASK_BULK_SEARCH_SUCCESS: {
       let tasks = [];

--- a/webpack/scenes/Subscriptions/SubscriptionValidations.js
+++ b/webpack/scenes/Subscriptions/SubscriptionValidations.js
@@ -1,0 +1,25 @@
+import { filterRHSubscriptions } from './SubscriptionHelpers.js';
+
+export const validateQuantity = (quantity, availableQuantity) => {
+  let state;
+  let message;
+
+  const numberValue = Number(quantity);
+  if (Number.isNaN(numberValue)) {
+    state = 'error';
+    message = __('Not a number');
+  } else if (numberValue < 0) {
+    state = 'error';
+    message = __('Has to be > 0');
+  } else if (availableQuantity && availableQuantity >= 0 && numberValue > availableQuantity) {
+    state = 'error';
+    message = __('Exceeds available quantity');
+  }
+  return {
+    state,
+    message,
+  };
+};
+
+export const recordsValid = rows =>
+  filterRHSubscriptions(rows).every(row => validateQuantity(row.quantity, row.availableQuantity).state !== 'error');

--- a/webpack/scenes/Subscriptions/Subscriptions.scss
+++ b/webpack/scenes/Subscriptions/Subscriptions.scss
@@ -1,0 +1,14 @@
+@import '~patternfly/dist/sass/patternfly/variables';
+@import '~patternfly-react/dist/sass/inline-edit';
+
+.editable {
+  &.changed {
+    font-weight: bold;
+  }
+}
+
+.pf-table-inline-edit {
+  .form-group {
+    margin-bottom: 0;
+  }
+}

--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -2,19 +2,20 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Grid, Row, Col, Form, FormGroup } from 'react-bootstrap';
-import { Button, Spinner } from 'patternfly-react';
-import Table from '../../move_to_foreman/components/common/table';
-import PaginationRow from '../../components/PaginationRow/index';
+import { Button } from 'patternfly-react';
 import ManageManifestModal from './Manifest/';
-import { columns } from './SubscriptionsTableSchema';
+import SubscriptionsTable from './SubscriptionsTable';
 import Search from '../../components/Search/index';
 import { orgId } from '../../services/api';
-import { BLOCKING_FOREMAN_TASK_TYPES, MANIFEST_TASKS_BULK_SEARCH_ID } from './SubscriptionConstants';
+import {
+  BLOCKING_FOREMAN_TASK_TYPES,
+  MANIFEST_TASKS_BULK_SEARCH_ID,
+  BULK_TASK_SEARCH_INTERVAL,
+} from './SubscriptionConstants';
 
 class SubscriptionsPage extends Component {
   constructor(props) {
     super(props);
-
     this.state = {
       manifestModalOpen: false,
     };
@@ -30,53 +31,8 @@ class SubscriptionsPage extends Component {
       type: 'all',
       active_only: true,
       action_types: BLOCKING_FOREMAN_TASK_TYPES,
-    }, 10000);
+    }, BULK_TASK_SEARCH_INTERVAL);
     this.props.loadSubscriptions();
-  }
-
-  renderSubscriptionTable() {
-    const { subscriptions } = this.props;
-
-    const emptyStateData = () => ({
-      header: __('There are no Subscriptions to display'),
-      description: __('Add Subscriptions to this Allocation to manage your Entitlements.'),
-      documentation: {
-        title: __('Learn more about adding Subscriptions to Allocations'),
-        url: 'http://redhat.com',
-      },
-      action: {
-        title: __('Add Subscriptions'),
-        url: 'subscriptions/add',
-      },
-    });
-
-    const onPaginationChange = (pagination) => {
-      this.props.loadSubscriptions({
-        ...pagination,
-      });
-    };
-
-    let bodyMessage;
-    if (subscriptions.results.length === 0 && subscriptions.searchIsActive) {
-      bodyMessage = __('No subscriptions match your search criteria.');
-    }
-
-    return (
-      <Spinner loading={subscriptions.loading} className="small-spacer">
-        <Table
-          rows={subscriptions.results}
-          columns={columns}
-          emptyState={emptyStateData()}
-          bodyMessage={bodyMessage}
-        />
-        <PaginationRow
-          viewType="table"
-          itemCount={subscriptions.itemCount}
-          pagination={subscriptions.pagination}
-          onChange={onPaginationChange}
-        />
-      </Spinner>
-    );
   }
 
   render() {
@@ -140,10 +96,12 @@ class SubscriptionsPage extends Component {
                 </Form>
               </Col>
             </Row>
-
             <ManageManifestModal showModal={this.state.manifestModalOpen} onClose={onModalClose} />
-
-            { this.renderSubscriptionTable() }
+            <SubscriptionsTable
+              loadSubscriptions={this.props.loadSubscriptions}
+              updateQuantity={this.props.updateQuantity}
+              subscriptions={this.props.subscriptions}
+            />
           </Col>
         </Row>
       </Grid>
@@ -153,6 +111,7 @@ class SubscriptionsPage extends Component {
 
 SubscriptionsPage.propTypes = {
   loadSubscriptions: PropTypes.func.isRequired,
+  updateQuantity: PropTypes.func.isRequired,
   subscriptions: PropTypes.shape({}).isRequired,
   pollBulkSearch: PropTypes.func.isRequired,
   tasks: PropTypes.arrayOf(PropTypes.shape({})),

--- a/webpack/scenes/Subscriptions/SubscriptionsTable.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsTable.js
@@ -1,0 +1,275 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { sprintf } from 'jed';
+import { cloneDeep, findIndex } from 'lodash';
+import { Spinner, Table, Alert } from 'patternfly-react';
+import { Table as ForemanTable, TableBody as ForemanTableBody } from '../../move_to_foreman/components/common/table';
+import ConfirmDialog from '../../move_to_foreman/components/common/ConfirmDialog';
+import Dialog from '../../move_to_foreman/components/common/Dialog';
+import { columns } from './SubscriptionsTableSchema';
+import { recordsValid } from './SubscriptionValidations';
+
+const emptyStateData = {
+  header: __('There are no Subscriptions to display'),
+  description: __('Add Subscriptions to this Allocation to manage your Entitlements.'),
+  documentation: {
+    title: __('Learn more about adding Subscriptions to Allocations'),
+    url: 'http://redhat.com',
+  },
+  action: {
+    title: __('Add Subscriptions'),
+    url: 'subscriptions/add',
+  },
+};
+
+const ErrorAlerts = ({ errors }) => {
+  const alerts = errors.filter(Boolean).map(e => (
+    <Alert type={Alert.ALERT_TYPE_ERROR} key={e}>
+      <span>{e}</span>
+    </Alert>
+  ));
+
+  return (
+    <div>
+      {alerts}
+    </div>
+  );
+};
+ErrorAlerts.propTypes = {
+  errors: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+const buildTableRows = (subscriptions, updatedQuantity) =>
+  subscriptions.results.map((subs) => {
+    if (updatedQuantity[subs.id]) {
+      return {
+        ...subs,
+        entitlementsChanged: true,
+        quantity: updatedQuantity[subs.id],
+        availableQuantity: subscriptions.availableQuantities[subs.id],
+      };
+    }
+    return {
+      ...subs,
+      availableQuantity: subscriptions.availableQuantities[subs.id],
+    };
+  });
+
+const buildPools = updatedQuantity =>
+  Object.entries(updatedQuantity)
+    .map(([id, quantity]) => ({
+      id,
+      quantity,
+    }));
+
+class SubscriptionsTable extends Component {
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.subscriptions !== undefined) {
+      return {
+        rows: buildTableRows(
+          nextProps.subscriptions,
+          prevState.updatedQuantity,
+        ),
+      };
+    }
+    return null;
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      updatedQuantity: {},
+      editing: false,
+      rows: props.subscriptions.results,
+      showUpdateConfirmDialog: false,
+      showCancelConfirmDialog: false,
+      showErrorDialog: false,
+    };
+  }
+
+  enableEditing(editingState) {
+    this.setState({
+      updatedQuantity: {},
+      editing: editingState,
+    });
+  }
+
+  updateRows(updatedQuantity) {
+    const rows = buildTableRows(
+      this.props.subscriptions,
+      updatedQuantity,
+    );
+    this.setState({ rows, updatedQuantity });
+  }
+
+  showUpdateConfirm(show) {
+    this.setState({
+      showUpdateConfirmDialog: show,
+    });
+  }
+
+  showCancelConfirm(show) {
+    this.setState({
+      showCancelConfirmDialog: show,
+    });
+  }
+
+  showErrorDialog(show) {
+    this.setState({
+      showErrorDialog: show,
+    });
+  }
+
+  confirmEdit() {
+    this.showUpdateConfirm(false);
+    if (Object.keys(this.state.updatedQuantity).length > 0) {
+      this.props.updateQuantity(buildPools(this.state.updatedQuantity));
+    }
+    this.enableEditing(false);
+  }
+
+  cancelEdit() {
+    this.showCancelConfirm(false);
+    this.enableEditing(false);
+    this.updateRows({});
+  }
+
+  hasQuantityChanged(rowData, editedValue) {
+    if (editedValue !== undefined) {
+      const originalRows = this.props.subscriptions.results;
+      const index = findIndex(originalRows, row => (row.id === rowData.id));
+      const currentValue = originalRows[index].quantity;
+
+      return (`${editedValue}` !== `${currentValue}`);
+    }
+    return false;
+  }
+
+  render() {
+    const { subscriptions } = this.props;
+
+    const inlineEditController = {
+      isEditing: ({ rowData }) => (this.state.editing && rowData.available >= 0),
+      hasChanged: ({ rowData }) => {
+        const editedValue = this.state.updatedQuantity[rowData.id];
+        return this.hasQuantityChanged(rowData, editedValue);
+      },
+      onActivate: () => {
+        this.enableEditing(true);
+      },
+      onConfirm: () => {
+        if (recordsValid(this.state.rows)) {
+          this.showUpdateConfirm(true);
+        } else {
+          this.showErrorDialog(true);
+        }
+      },
+      onCancel: () => {
+        this.showCancelConfirm(true);
+      },
+      onChange: (value, { rowData }) => {
+        const updatedQuantity = cloneDeep(this.state.updatedQuantity);
+
+        if (this.hasQuantityChanged(rowData, value)) {
+          updatedQuantity[rowData.id] = value;
+        } else {
+          delete updatedQuantity[rowData.id];
+        }
+
+        this.updateRows(updatedQuantity);
+      },
+    };
+
+    const onPaginationChange = (pagination) => {
+      this.props.loadSubscriptions({
+        ...pagination,
+      });
+    };
+
+    let bodyMessage;
+    if (subscriptions.results.length === 0 && subscriptions.searchIsActive) {
+      bodyMessage = __('No subscriptions match your search criteria.');
+    }
+
+    const columnsDefinition = columns(inlineEditController);
+
+    return (
+      <Spinner loading={subscriptions.loading} className="small-spacer">
+        <ErrorAlerts
+          errors={[
+            subscriptions.error,
+            subscriptions.quantitiesError,
+          ]}
+        />
+        <ForemanTable
+          columns={columnsDefinition}
+          emptyState={emptyStateData}
+          bodyMessage={bodyMessage}
+          rows={this.state.rows}
+          components={{
+            header: {
+              row: Table.TableInlineEditHeaderRow,
+            },
+          }}
+          itemCount={subscriptions.itemCount}
+          pagination={subscriptions.pagination}
+          onPaginationChange={onPaginationChange}
+          inlineEdit
+        >
+          <Table.Header
+            onRow={() => ({
+              role: 'row',
+              isEditing: () => this.state.editing,
+              onCancel: () => inlineEditController.onCancel(),
+              onConfirm: () => inlineEditController.onConfirm(),
+            })}
+          />
+          <ForemanTableBody
+            columns={columnsDefinition}
+            rows={this.state.rows}
+            rowKey="id"
+            message={bodyMessage}
+          />
+        </ForemanTable>
+        <ConfirmDialog
+          show={this.state.showUpdateConfirmDialog}
+          title={__('Editing Entitlements')}
+          dangerouslySetInnerHTML={{
+            __html: sprintf(
+              __("You're making changes to %(entitlementCount)s entitlement(s)"),
+              {
+                entitlementCount: `<b>${Object.keys(this.state.updatedQuantity).length}</b>`,
+              },
+            ),
+          }}
+          onConfirm={() => this.confirmEdit()}
+          onCancel={() => this.showUpdateConfirm(false)}
+        />
+        <ConfirmDialog
+          show={this.state.showCancelConfirmDialog}
+          title={__('Editing Entitlements')}
+          message={__('You have unsaved changes. Do you want to continue without saving your changes?')}
+          confirmLabel={__('Continue')}
+          onConfirm={() => this.cancelEdit()}
+          onCancel={() => this.showCancelConfirm(false)}
+        />
+        <Dialog
+          show={this.state.showErrorDialog}
+          title={__('Editing Entitlements')}
+          message={__('Some of your inputs contain errors. Please update them and save your changes again.')}
+          onCancel={() => this.showErrorDialog(false)}
+        />
+      </Spinner>
+    );
+  }
+}
+
+SubscriptionsTable.propTypes = {
+  loadSubscriptions: PropTypes.func.isRequired,
+  updateQuantity: PropTypes.func.isRequired,
+  subscriptions: PropTypes.shape({
+    results: PropTypes.array,
+  }).isRequired,
+};
+
+export default SubscriptionsTable;

--- a/webpack/scenes/Subscriptions/SubscriptionsTableSchema.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsTableSchema.js
@@ -1,37 +1,10 @@
 import React from 'react';
 import { Icon } from 'patternfly-react';
 import helpers from '../../move_to_foreman/common/helpers';
-import {
-  selectionHeaderCellFormatter,
-  selectionCellFormatter,
-  headerFormat,
-  cellFormat,
-} from '../../move_to_foreman/components/common/table';
+import { headerFormat, cellFormat } from '../../move_to_foreman/components/common/table';
+import { entitlementsInlineEditFormatter } from './EntitlementsInlineEditFormatter';
 
-export const columns = [
-  {
-    property: 'select',
-    header: {
-      label: 'Select all rows',
-      props: {
-        index: 0,
-        rowSpan: 1,
-        colSpan: 1,
-      },
-      customFormatters: [selectionHeaderCellFormatter],
-    },
-    cell: {
-      props: {
-        index: 0,
-      },
-      formatters: [
-        (value, { rowData, rowIndex }) => selectionCellFormatter(
-          { rowData, rowIndex },
-          () => {},
-        ),
-      ],
-    },
-  },
+export const columns = inlineEditController => [
   {
     property: 'id',
     header: {
@@ -139,7 +112,7 @@ export const columns = [
     },
   },
   {
-    property: 'entitlements',
+    property: 'quantity',
     header: {
       label: __('Entitlements'),
       formatters: [headerFormat],
@@ -149,11 +122,7 @@ export const columns = [
     },
     cell: {
       formatters: [
-        (value, { rowData }) => (
-          <td>
-            {rowData.available === -1 ? __('Unlimited') : rowData.consumed }
-          </td>
-        ),
+        entitlementsInlineEditFormatter(inlineEditController),
       ],
     },
   },

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsPage.js
@@ -4,11 +4,10 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Grid, Row, Col } from 'react-bootstrap';
-import { bindMethods, Button, Spinner } from 'patternfly-react';
-import Table from '../../../move_to_foreman/components/common/table';
+import { bindMethods, Button, Spinner, customHeaderFormattersDefinition } from 'patternfly-react';
 import { notify } from '../../../move_to_foreman/foreman_toast_notifications';
 import helpers from '../../../move_to_foreman/common/helpers';
-import PaginationRow from '../../../components/PaginationRow/index';
+import { Table } from '../../../move_to_foreman/components/common/table';
 import { columns } from './UpstreamSubscriptionsTableSchema';
 
 class UpstreamSubscriptionsPage extends Component {
@@ -216,6 +215,10 @@ class UpstreamSubscriptionsPage extends Component {
       },
     });
 
+    const tableColumns = columns(this);
+    const sortingColumns = {};
+    const rows = getSelectedUpstreamSubscriptions();
+
     return (
       <Grid bsClass="container-fluid">
         <h1>{__('Add Subscriptions')}</h1>
@@ -224,16 +227,25 @@ class UpstreamSubscriptionsPage extends Component {
           <Row>
             <Col sm={12}>
               <Table
-                rows={getSelectedUpstreamSubscriptions()}
-                columns={columns(this)}
+                rows={rows}
+                columns={tableColumns}
                 emptyState={emptyStateData()}
-                onSelectAllRows={this.onSelectAllRows}
-              />
-              <PaginationRow
-                viewType="table"
+                // TODO: should be replaced with custom formatters
+                components={{
+                  header: {
+                    cell: cellProps =>
+                      customHeaderFormattersDefinition({
+                        cellProps,
+                        columns: tableColumns,
+                        sortingColumns,
+                        rows,
+                        onSelectAllRows: this.onSelectAllRows,
+                      }),
+                  },
+                }}
                 itemCount={upstreamSubscriptions.itemCount}
                 pagination={upstreamSubscriptions.pagination}
-                onChange={onPaginationChange}
+                onPaginationChange={onPaginationChange}
               />
             </Col>
           </Row>

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/__snapshots__/UpstreamSubscriptionsPage.test.js.snap
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/__snapshots__/UpstreamSubscriptionsPage.test.js.snap
@@ -154,6 +154,13 @@ exports[`upstream subscriptions page should render 1`] = `
               },
             ]
           }
+          components={
+            Object {
+              "header": Object {
+                "cell": [Function],
+              },
+            }
+          }
           emptyState={
             Object {
               "action": Object {
@@ -169,7 +176,14 @@ exports[`upstream subscriptions page should render 1`] = `
               "header": "There are no Subscription Allocations to display",
             }
           }
-          onSelectAllRows={[Function]}
+          itemCount={2}
+          onPaginationChange={[Function]}
+          pagination={
+            Object {
+              "page": 1,
+              "perPage": 20,
+            }
+          }
           rows={
             Array [
               Object {
@@ -198,32 +212,6 @@ exports[`upstream subscriptions page should render 1`] = `
               },
             ]
           }
-        />
-        <PaginationRow
-          className=""
-          dropdownButtonId="pagination-row-dropdown"
-          itemCount={2}
-          messages={
-            Object {
-              "currentPage": "Current Page",
-              "firstPage": "First Page",
-              "lastPage": "Last Page",
-              "nextPage": "Next Page",
-              "of": "of",
-              "perPage": "per page",
-              "previousPage": "Previous Page",
-            }
-          }
-          onChange={[Function]}
-          onPageSet={[Function]}
-          onPerPageSelect={[Function]}
-          pagination={
-            Object {
-              "page": 1,
-              "perPage": 20,
-            }
-          }
-          viewType="table"
         />
       </Col>
     </Row>

--- a/webpack/scenes/Subscriptions/__tests__/SubscriptionValidations.test.js
+++ b/webpack/scenes/Subscriptions/__tests__/SubscriptionValidations.test.js
@@ -1,0 +1,66 @@
+import { validateQuantity, recordsValid } from '../SubscriptionValidations';
+
+describe('validateQuantity', () => {
+  const validResult = {
+    state: undefined,
+    message: undefined,
+  };
+  const validationError = message => ({
+    state: 'error',
+    message,
+  });
+
+  it('accepts a number', () => {
+    expect(validateQuantity('123', 500))
+      .toEqual(validResult);
+  });
+
+  it('accepts a string number', () => {
+    expect(validateQuantity(123, 500))
+      .toEqual(validResult);
+  });
+
+  it('detects not a number', () => {
+    expect(validateQuantity('123abc', 500))
+      .toEqual(validationError('Not a number'));
+  });
+
+  it('detects negative number', () => {
+    expect(validateQuantity('-1', 500))
+      .toEqual(validationError('Has to be > 0'));
+  });
+
+  it('detects too big quantity', () => {
+    expect(validateQuantity('501', 500))
+      .toEqual(validationError('Exceeds available quantity'));
+  });
+
+  it('skips quantity detection', () => {
+    expect(validateQuantity(100))
+      .toEqual(validResult);
+  });
+});
+
+describe('recordsValid', () => {
+  it('accepts empty array', () => {
+    expect(recordsValid([])).toBe(true);
+  });
+
+  it('accepts valid array', () => {
+    const rows = [
+      { quantity: 10, available: 10, availableQuantity: 100 },
+      { quantity: 10, available: 10, availableQuantity: -1 },
+      { quantity: -1, available: -1 },
+      { quantity: 10, available: 10 },
+    ];
+    expect(recordsValid(rows)).toBe(true);
+  });
+
+  it('detects invalid record', () => {
+    const rows = [
+      { quantity: 10, available: 10, availableQuantity: 100 },
+      { quantity: 10, available: 10, availableQuantity: 5 },
+    ];
+    expect(recordsValid(rows)).toBe(false);
+  });
+});

--- a/webpack/scenes/Subscriptions/__tests__/SubscriptionsActions.test.js
+++ b/webpack/scenes/Subscriptions/__tests__/SubscriptionsActions.test.js
@@ -1,10 +1,21 @@
 import thunk from 'redux-thunk';
 import Immutable from 'seamless-immutable';
 import configureMockStore from 'redux-mock-store';
-import { mockRequest, mockReset } from '../../../mockRequest';
-import { requestSuccessResponse, successActions, failureActions } from './subscriptions.fixtures';
-
-import { loadSubscriptions } from '../SubscriptionActions';
+import { mockRequest, mockErrorRequest, mockReset } from '../../../mockRequest';
+import {
+  requestSuccessResponse,
+  requestSuccessResponseWithRHSubscriptions,
+  successActions,
+  successActionsWithQuantityLoad,
+  failureActions,
+  updateQuantitySuccessActions,
+  updateQuantityFailureActions,
+  poolsUpdate,
+  loadQuantitiesFailureActions,
+  loadQuantitiesSuccessActions,
+  quantitiesRequestSuccessResponse,
+} from './subscriptions.fixtures';
+import { loadSubscriptions, updateQuantity, loadAvailableQuantities } from '../SubscriptionActions';
 
 const mockStore = configureMockStore([thunk]);
 const store = mockStore({ subscriptions: Immutable({}) });
@@ -15,26 +26,101 @@ afterEach(() => {
 });
 
 describe('subscription actions', () => {
-  it(
-    'creates SUBSCRIPTIONS_REQUEST and then fails with 422',
-    () => {
-      mockRequest({
-        url: '/katello/api/v2/subscriptions',
-        status: 422,
-      });
-      return store.dispatch(loadSubscriptions())
-        .then(() => expect(store.getActions()).toEqual(failureActions));
-    },
-  );
-  it(
-    'creates SUBSCRIPTIONS_REQUEST and ends with success',
-    () => {
-      mockRequest({
-        url: '/katello/api/v2/subscriptions',
-        response: requestSuccessResponse,
-      });
-      return store.dispatch(loadSubscriptions())
-        .then(() => expect(store.getActions()).toEqual(successActions));
-    },
-  );
+  describe('loadSubscriptions', () => {
+    it(
+      'creates SUBSCRIPTIONS_REQUEST and then fails with 422',
+      () => {
+        mockErrorRequest({
+          url: '/katello/api/v2/subscriptions',
+          status: 422,
+        });
+        return store.dispatch(loadSubscriptions())
+          .then(() => expect(store.getActions()).toEqual(failureActions));
+      },
+    );
+    it(
+      'creates SUBSCRIPTIONS_REQUEST and ends with success',
+      () => {
+        mockRequest({
+          url: '/katello/api/v2/subscriptions',
+          response: requestSuccessResponse,
+        });
+        return store.dispatch(loadSubscriptions())
+          .then(() => expect(store.getActions()).toEqual(successActions));
+      },
+    );
+    it(
+      'creates SUBSCRIPTIONS_REQUEST and triggers loadAvailableQuantities when there is some RH subscription',
+      () => {
+        mockRequest({
+          url: '/katello/api/v2/subscriptions',
+          response: requestSuccessResponseWithRHSubscriptions,
+        });
+        return store.dispatch(loadSubscriptions())
+          .then(() =>
+            expect(store.getActions())
+              .toEqual(successActionsWithQuantityLoad));
+      },
+    );
+  });
+
+  describe('updateQuantity', () => {
+    it(
+      'creates UPDATE_QUANTITY_REQUEST and then fails with 422',
+      () => {
+        mockErrorRequest({
+          method: 'PUT',
+          url: '/katello/api/v2/organizations/1/upstream_subscriptions',
+          data: { pools: poolsUpdate },
+          status: 422,
+        });
+        return store.dispatch(updateQuantity(poolsUpdate))
+          .then(() => expect(store.getActions()).toEqual(updateQuantityFailureActions));
+      },
+    );
+    it(
+      'creates UPDATE_QUANTITY_REQUEST and ends with success',
+      () => {
+        mockRequest({
+          method: 'PUT',
+          url: '/katello/api/v2/organizations/1/upstream_subscriptions',
+          data: { pools: poolsUpdate },
+          response: requestSuccessResponse,
+        });
+        return store.dispatch(updateQuantity(poolsUpdate))
+          .then(() => expect(store.getActions()).toEqual(updateQuantitySuccessActions));
+      },
+    );
+  });
+
+  describe('loadAvailableQuantities', () => {
+    const data = { pool_ids: [5] };
+
+    it(
+      'creates SUBSCRIPTIONS_QUANTITIES_REQUEST and then fails with 500',
+      () => {
+        mockErrorRequest({
+          method: 'GET',
+          url: '/katello/api/v2/organizations/1/upstream_subscriptions',
+          data,
+          status: 500,
+        });
+        return store.dispatch(loadAvailableQuantities())
+          .then(() => expect(store.getActions()).toEqual(loadQuantitiesFailureActions));
+      },
+    );
+    it(
+      'creates SUBSCRIPTIONS_QUANTITIES_REQUEST and ends with success',
+      () => {
+        mockRequest({
+          method: 'GET',
+          url: '/katello/api/v2/organizations/1/upstream_subscriptions',
+          data,
+          response: quantitiesRequestSuccessResponse,
+        });
+        return store.dispatch(loadAvailableQuantities())
+          .then(() => expect(store.getActions()).toEqual(loadQuantitiesSuccessActions));
+      },
+    );
+  });
 });

--- a/webpack/scenes/Subscriptions/__tests__/SubscriptionsPage.test.js
+++ b/webpack/scenes/Subscriptions/__tests__/SubscriptionsPage.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import SubscriptionsPage from '../SubscriptionsPage';
 import { successState } from './subscriptions.fixtures';
-import { loadSubscriptions } from '../SubscriptionActions';
+import { loadSubscriptions, updateQuantity } from '../SubscriptionActions';
 
 describe('subscriptions page', () => {
   const pollBulkSearch = () => {};
@@ -12,6 +12,7 @@ describe('subscriptions page', () => {
     const page = shallow(<SubscriptionsPage
       subscriptions={successState}
       loadSubscriptions={loadSubscriptions}
+      updateQuantity={updateQuantity}
       pollBulkSearch={pollBulkSearch}
     />);
     expect(toJson(page)).toMatchSnapshot();

--- a/webpack/scenes/Subscriptions/__tests__/SubscriptionsReducer.test.js
+++ b/webpack/scenes/Subscriptions/__tests__/SubscriptionsReducer.test.js
@@ -3,9 +3,13 @@ import * as types from '../SubscriptionConstants';
 import {
   initialState,
   loadingState,
+  loadingQuantitiesState,
   requestSuccessResponse,
+  quantitiesSuccessState,
+  quantitiesRequestSuccessResponse,
   successState,
   errorState,
+  quantitiesErrorState,
 } from './subscriptions.fixtures';
 import reducer from '../SubscriptionReducer';
 
@@ -32,5 +36,32 @@ describe('subscriptions reducer', () => {
       type: types.SUBSCRIPTIONS_FAILURE,
       error: 'Unable to process request.',
     })).toEqual(errorState);
+  });
+
+  it('should have error on UPDATE_QUANTITY_FAILURE', () => {
+    expect(reducer(initialState, {
+      type: types.UPDATE_QUANTITY_FAILURE,
+      error: 'Unable to process request.',
+    })).toEqual(errorState);
+  });
+
+  it('should flip quantitiesLoading on SUBSCRIPTIONS_QUANTITIES_REQUEST', () => {
+    expect(reducer(successState, {
+      type: types.SUBSCRIPTIONS_QUANTITIES_REQUEST,
+    })).toEqual(loadingQuantitiesState);
+  });
+
+  it('should flatten subscriptions response SUBSCRIPTIONS_QUANTITIES_SUCCESS', () => {
+    expect(reducer(loadingQuantitiesState, {
+      type: types.SUBSCRIPTIONS_QUANTITIES_SUCCESS,
+      response: quantitiesRequestSuccessResponse,
+    })).toEqual(quantitiesSuccessState);
+  });
+
+  it('should have error on SUBSCRIPTIONS_QUANTITIES_FAILURE', () => {
+    expect(reducer(successState, {
+      type: types.SUBSCRIPTIONS_QUANTITIES_FAILURE,
+      error: 'Unable to process request.',
+    })).toEqual(quantitiesErrorState);
   });
 });

--- a/webpack/scenes/Subscriptions/__tests__/SubscriptionsTable.test.js
+++ b/webpack/scenes/Subscriptions/__tests__/SubscriptionsTable.test.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import SubscriptionsTable from '../SubscriptionsTable';
+import { successState, loadingState, emptyState } from './subscriptions.fixtures';
+import { loadSubscriptions, updateQuantity } from '../SubscriptionActions';
+
+describe('subscriptions table', () => {
+  it('should render a table', async () => {
+    const page = render(<SubscriptionsTable
+      subscriptions={successState}
+      loadSubscriptions={loadSubscriptions}
+      updateQuantity={updateQuantity}
+    />);
+    expect(toJson(page)).toMatchSnapshot();
+  });
+
+  it('should render an empty state', async () => {
+    const page = render(<SubscriptionsTable
+      subscriptions={emptyState}
+      loadSubscriptions={loadSubscriptions}
+      updateQuantity={updateQuantity}
+    />);
+    expect(toJson(page)).toMatchSnapshot();
+  });
+
+  it('should render a loading state', async () => {
+    const page = render(<SubscriptionsTable
+      subscriptions={loadingState}
+      loadSubscriptions={loadSubscriptions}
+      updateQuantity={updateQuantity}
+    />);
+    expect(toJson(page)).toMatchSnapshot();
+  });
+});

--- a/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsPage.test.js.snap
+++ b/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsPage.test.js.snap
@@ -104,192 +104,19 @@ exports[`subscriptions page should render 1`] = `
         onClose={[Function]}
         showModal={false}
       />
-      <Spinner
-        className="small-spacer"
-        inline={false}
-        inverse={false}
-        loading={false}
-        size="md"
-      >
-        <Table
-          columns={
-            Array [
-              Object {
-                "cell": Object {
-                  "formatters": Array [
-                    [Function],
-                  ],
-                  "props": Object {
-                    "index": 0,
-                  },
-                },
-                "header": Object {
-                  "customFormatters": Array [
-                    [Function],
-                  ],
-                  "label": "Select all rows",
-                  "props": Object {
-                    "colSpan": 1,
-                    "index": 0,
-                    "rowSpan": 1,
-                  },
-                },
-                "property": "select",
-              },
-              Object {
-                "cell": Object {
-                  "formatters": Array [
-                    [Function],
-                  ],
-                },
-                "header": Object {
-                  "formatters": Array [
-                    [Function],
-                  ],
-                  "label": "Name",
-                  "props": Object {
-                    "index": 1,
-                  },
-                },
-                "property": "id",
-              },
-              Object {
-                "cell": Object {
-                  "formatters": Array [
-                    [Function],
-                  ],
-                },
-                "header": Object {
-                  "formatters": Array [
-                    [Function],
-                  ],
-                  "label": "SKU",
-                  "props": Object {
-                    "index": 2,
-                  },
-                },
-                "property": "product_id",
-              },
-              Object {
-                "cell": Object {
-                  "formatters": Array [
-                    [Function],
-                  ],
-                },
-                "header": Object {
-                  "formatters": Array [
-                    [Function],
-                  ],
-                  "label": "Contract",
-                  "props": Object {
-                    "index": 3,
-                  },
-                },
-                "property": "contract_number",
-              },
-              Object {
-                "cell": Object {
-                  "formatters": Array [
-                    [Function],
-                  ],
-                },
-                "header": Object {
-                  "formatters": Array [
-                    [Function],
-                  ],
-                  "label": "Start Date",
-                  "props": Object {
-                    "index": 4,
-                  },
-                },
-                "property": "start_date",
-              },
-              Object {
-                "cell": Object {
-                  "formatters": Array [
-                    [Function],
-                  ],
-                },
-                "header": Object {
-                  "formatters": Array [
-                    [Function],
-                  ],
-                  "label": "End Date",
-                  "props": Object {
-                    "index": 5,
-                  },
-                },
-                "property": "end_date",
-              },
-              Object {
-                "cell": Object {
-                  "formatters": Array [
-                    [Function],
-                  ],
-                },
-                "header": Object {
-                  "formatters": Array [
-                    [Function],
-                  ],
-                  "label": "Requires Virt-Who",
-                  "props": Object {
-                    "index": 6,
-                  },
-                },
-                "property": "virt_who",
-              },
-              Object {
-                "cell": Object {
-                  "formatters": Array [
-                    [Function],
-                  ],
-                },
-                "header": Object {
-                  "formatters": Array [
-                    [Function],
-                  ],
-                  "label": "Consumed",
-                  "props": Object {
-                    "index": 7,
-                  },
-                },
-                "property": "consumed",
-              },
-              Object {
-                "cell": Object {
-                  "formatters": Array [
-                    [Function],
-                  ],
-                },
-                "header": Object {
-                  "formatters": Array [
-                    [Function],
-                  ],
-                  "label": "Entitlements",
-                  "props": Object {
-                    "index": 8,
-                  },
-                },
-                "property": "entitlements",
-              },
-            ]
-          }
-          emptyState={
-            Object {
-              "action": Object {
-                "title": "Add Subscriptions",
-                "url": "subscriptions/add",
-              },
-              "description": "Add Subscriptions to this Allocation to manage your Entitlements.",
-              "documentation": Object {
-                "title": "Learn more about adding Subscriptions to Allocations",
-                "url": "http://redhat.com",
-              },
-              "header": "There are no Subscriptions to display",
-            }
-          }
-          rows={
-            Array [
+      <SubscriptionsTable
+        loadSubscriptions={[Function]}
+        subscriptions={
+          Object {
+            "availableQuantities": Object {},
+            "itemCount": 81,
+            "loading": false,
+            "pagination": Object {
+              "page": 1,
+              "perPage": 2,
+            },
+            "quantitiesLoading": false,
+            "results": Array [
               Object {
                 "account_number": null,
                 "available": -2,
@@ -342,36 +169,13 @@ exports[`subscriptions page should render 1`] = `
                 "virt_only": false,
                 "virt_who": false,
               },
-            ]
+            ],
+            "search": undefined,
+            "searchIsActive": false,
           }
-        />
-        <PaginationRow
-          className=""
-          dropdownButtonId="pagination-row-dropdown"
-          itemCount={81}
-          messages={
-            Object {
-              "currentPage": "Current Page",
-              "firstPage": "First Page",
-              "lastPage": "Last Page",
-              "nextPage": "Next Page",
-              "of": "of",
-              "perPage": "per page",
-              "previousPage": "Previous Page",
-            }
-          }
-          onChange={[Function]}
-          onPageSet={[Function]}
-          onPerPageSelect={[Function]}
-          pagination={
-            Object {
-              "page": 1,
-              "perPage": 2,
-            }
-          }
-          viewType="table"
-        />
-      </Spinner>
+        }
+        updateQuantity={[Function]}
+      />
     </Col>
   </Row>
 </Grid>

--- a/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
+++ b/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
@@ -1,0 +1,376 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`subscriptions table should render a loading state 1`] = `
+<div
+  class="small-spacer spinner spinner-md"
+/>
+`;
+
+exports[`subscriptions table should render a table 1`] = `
+Array [
+  <div />,
+  <div>
+    <table
+      class="table table-striped table-bordered table-hover pf-table-inline-edit table-fixed"
+    >
+      <thead>
+        <tr
+          class=""
+        >
+          <th
+            class=""
+          >
+            Name
+          </th>
+          <th
+            class=""
+          >
+            SKU
+          </th>
+          <th
+            class=""
+          >
+            Contract
+          </th>
+          <th
+            class=""
+          >
+            Start Date
+          </th>
+          <th
+            class=""
+          >
+            End Date
+          </th>
+          <th
+            class=""
+          >
+            Requires Virt-Who
+          </th>
+          <th
+            class=""
+          >
+            Consumed
+          </th>
+          <th
+            class=""
+          >
+            Entitlements
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <a
+              href="/subscriptions/3/"
+            >
+              zoo
+            </a>
+          </td>
+          <td
+            class=""
+          >
+            853987721546
+          </td>
+          <td
+            class=""
+          />
+          <td
+            class=""
+          >
+            2017-09-21 16:18:44 -0400
+          </td>
+          <td
+            class=""
+          >
+            2047-09-14 15:18:44 -0500
+          </td>
+          <td>
+            <span
+              aria-hidden="true"
+              class="fa fa-minus"
+            />
+          </td>
+          <td
+            class=""
+          >
+            1
+          </td>
+          <td>
+            Unlimited
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href="/subscriptions/4/"
+            >
+              hsdfhsdh
+            </a>
+          </td>
+          <td
+            class=""
+          >
+            947637693017
+          </td>
+          <td
+            class=""
+          />
+          <td
+            class=""
+          >
+            2017-09-25 17:54:36 -0400
+          </td>
+          <td
+            class=""
+          >
+            2047-09-18 16:54:36 -0500
+          </td>
+          <td>
+            <span
+              aria-hidden="true"
+              class="fa fa-minus"
+            />
+          </td>
+          <td
+            class=""
+          >
+            0
+          </td>
+          <td>
+            Unlimited
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <form
+      class="content-view-pf-pagination table-view-pf-pagination clearfix "
+    >
+      <div
+        class="form-group"
+      >
+        <div
+          class="dropup pagination-pf-pagesize btn-group"
+        >
+          <button
+            aria-expanded="false"
+            aria-haspopup="true"
+            class="dropdown-toggle btn btn-default"
+            id="pagination-row-dropdown"
+            role="button"
+            type="button"
+          >
+            2 
+            <span
+              class="caret"
+            />
+          </button>
+          <ul
+            aria-labelledby="pagination-row-dropdown"
+            class="dropdown-menu"
+            role="menu"
+          >
+            <li
+              class=""
+              role="presentation"
+            >
+              <a
+                href="#"
+                role="menuitem"
+                tabindex="-1"
+              >
+                5
+              </a>
+            </li>
+            <li
+              class=""
+              role="presentation"
+            >
+              <a
+                href="#"
+                role="menuitem"
+                tabindex="-1"
+              >
+                10
+              </a>
+            </li>
+            <li
+              class=""
+              role="presentation"
+            >
+              <a
+                href="#"
+                role="menuitem"
+                tabindex="-1"
+              >
+                15
+              </a>
+            </li>
+            <li
+              class=""
+              role="presentation"
+            >
+              <a
+                href="#"
+                role="menuitem"
+                tabindex="-1"
+              >
+                25
+              </a>
+            </li>
+            <li
+              class=""
+              role="presentation"
+            >
+              <a
+                href="#"
+                role="menuitem"
+                tabindex="-1"
+              >
+                50
+              </a>
+            </li>
+          </ul>
+        </div>
+        <span>
+          per page
+        </span>
+      </div>
+      <div
+        class="form-group"
+      >
+        <span>
+          <span
+            class="pagination-pf-items-current"
+          >
+            1-2
+          </span>
+           of 
+          <span
+            class="pagination-pf-items-total"
+          >
+            81
+          </span>
+        </span>
+        <ul
+          class="pagination pagination-pf-back"
+        >
+          <li
+            class="disabled"
+          >
+            <a
+              href="#"
+              title="First Page"
+            >
+              <span
+                aria-hidden="true"
+                class="fa fa-angle-double-left i"
+              />
+            </a>
+          </li>
+          <li
+            class="disabled"
+          >
+            <a
+              href="#"
+              title="Previous Page"
+            >
+              <span
+                aria-hidden="true"
+                class="fa fa-angle-left i"
+              />
+            </a>
+          </li>
+        </ul>
+        <label
+          class="sr-only control-label"
+        >
+          Current Page
+        </label>
+        <input
+          class="pagination-pf-page form-control"
+          type="text"
+          value="1"
+        />
+        <span>
+           of 
+          <span
+            class="pagination-pf-pages"
+          >
+            41
+          </span>
+        </span>
+        <ul
+          class="pagination pagination-pf-forward"
+        >
+          <li
+            class=""
+          >
+            <a
+              href="#"
+              title="Next Page"
+            >
+              <span
+                aria-hidden="true"
+                class="fa fa-angle-right i"
+              />
+            </a>
+          </li>
+          <li
+            class=""
+          >
+            <a
+              href="#"
+              title="Last Page"
+            >
+              <span
+                aria-hidden="true"
+                class="fa fa-angle-double-right i"
+              />
+            </a>
+          </li>
+        </ul>
+      </div>
+    </form>
+  </div>,
+]
+`;
+
+exports[`subscriptions table should render an empty state 1`] = `
+Array [
+  <div />,
+  <div
+    class="blank-slate-pf"
+  >
+    <div
+      class="blank-slate-pf-icon"
+    >
+      <span
+        aria-hidden="true"
+        class="pficon pficon-add-circle-o"
+      />
+    </div>
+    <h4
+      class="h1 blank-slate-pf-title"
+    >
+      There are no Subscriptions to display
+    </h4>
+    <p
+      class="blank-slate-pf-info"
+    >
+      Add Subscriptions to this Allocation to manage your Entitlements.
+    </p>
+    <div
+      class="blank-slate-pf-main-action"
+    >
+      <a
+        class="btn btn-lg btn-primary"
+        href="subscriptions/add"
+      >
+        Add Subscriptions
+      </a>
+    </div>
+  </div>,
+]
+`;

--- a/webpack/scenes/Subscriptions/__tests__/subscriptions.fixtures.js
+++ b/webpack/scenes/Subscriptions/__tests__/subscriptions.fixtures.js
@@ -8,17 +8,18 @@ export const initialState = Immutable({
     perPage: 20,
   },
   itemCount: 0,
+  quantitiesLoading: false,
+  availableQuantities: {},
 });
 
 export const loadingState = Immutable({
-  loading: true,
-  results: [],
-  pagination: {
-    page: 0,
-    perPage: 20,
-  },
-  itemCount: 0,
+  ...initialState,
   tasks: [],
+});
+
+export const emptyState = Immutable({
+  ...loadingState,
+  loading: false,
 });
 
 export const requestSuccessResponse = Immutable({
@@ -89,6 +90,92 @@ export const requestSuccessResponse = Immutable({
   ],
 });
 
+export const requestSuccessResponseWithRHSubscriptions = Immutable({
+  organization: {},
+  total: 81,
+  subtotal: 1,
+  page: 1,
+  per_page: 2,
+  error: null,
+  search: null,
+  sort: {
+    by: 'cp_id',
+    order: 'asc',
+  },
+  results: [
+    {
+      id: 4,
+      cp_id: '4028f95a62ce96190162cf435202005b',
+      subscription_id: 5,
+      name: 'Some RH Product',
+      start_date: '2013-02-28 18:00:00 -1100',
+      end_date: '2021-12-31 17:59:59 -1100',
+      available: 12,
+      quantity: 12,
+      consumed: 0,
+      account_number: 1000000,
+      contract_number: 20000000,
+      support_level: 'Self-Support',
+      product_id: 'Z3BRU11',
+      sockets: null,
+      cores: null,
+      ram: null,
+      instance_multiplier: 1,
+      stacking_id: null,
+      multi_entitlement: null,
+      type: 'NORMAL',
+      product_name: 'Some RH Product',
+      unmapped_guest: false,
+      virt_only: false,
+      virt_who: false,
+      upstream: true,
+    },
+  ],
+});
+
+export const quantitiesRequestSuccessResponse = Immutable({
+  results: [
+    {
+      pool_id: '9a95f981519abf020151ab082c5e0313',
+      quantity: 10000,
+      start_date: '2016-12-15T05:00:00+0000',
+      end_date: '2032-01-01T04:59:59+0000',
+      contract_number: '10880011',
+      consumed: 9469,
+      product_name: 'Some RH Product',
+      product_id: 'Z3BRU11',
+      subscription_id: '3802241',
+      local_pool_ids: [
+        4,
+        5,
+      ],
+    },
+    {
+      pool_id: '6b123381519abf020151ab082c5e4678',
+      quantity: 400,
+      start_date: '2016-12-15T05:00:00+0000',
+      end_date: '2032-01-01T04:59:59+0000',
+      contract_number: '10880011',
+      consumed: 9469,
+      product_name: 'Another RH Product',
+      product_id: 'ABIC300',
+      subscription_id: '3808964',
+      local_pool_ids: [
+        6,
+      ],
+    },
+  ],
+  page: 1,
+  per_page: 10,
+  search: null,
+  sort: {
+    by: 'cp_id',
+    order: 'asc',
+  },
+  subtotal: 3,
+  total: 3,
+});
+
 export const successState = Immutable({
   loading: false,
   results: [
@@ -152,6 +239,8 @@ export const successState = Immutable({
     perPage: 2,
   },
   itemCount: 81,
+  quantitiesLoading: false,
+  availableQuantities: {},
 });
 
 export const errorState = Immutable({
@@ -163,16 +252,53 @@ export const errorState = Immutable({
   },
   itemCount: 0,
   results: [],
+  quantitiesLoading: false,
+  availableQuantities: {},
 });
 
+export const quantitiesSuccessState = Immutable({
+  ...successState,
+  quantitiesLoading: false,
+  availableQuantities: {
+    4: 10000,
+    5: 10000,
+    6: 400,
+  },
+});
+
+export const loadingQuantitiesState = Immutable({
+  ...successState,
+  quantitiesLoading: true,
+});
+
+export const quantitiesErrorState = Immutable({
+  ...successState,
+  quantitiesLoading: false,
+  quantitiesError: 'Unable to process request.',
+});
 
 export const successActions = [
   {
     type: 'SUBSCRIPTIONS_REQUEST',
   },
   {
-    response: requestSuccessResponse,
     type: 'SUBSCRIPTIONS_SUCCESS',
+    response: requestSuccessResponse,
+    search: undefined,
+  },
+];
+
+export const successActionsWithQuantityLoad = [
+  {
+    type: 'SUBSCRIPTIONS_REQUEST',
+  },
+  {
+    type: 'SUBSCRIPTIONS_SUCCESS',
+    response: requestSuccessResponseWithRHSubscriptions,
+    search: undefined,
+  },
+  {
+    type: 'SUBSCRIPTIONS_QUANTITIES_REQUEST',
   },
 ];
 
@@ -181,7 +307,57 @@ export const failureActions = [
     type: 'SUBSCRIPTIONS_REQUEST',
   },
   {
-    result: new Error('Request failed with status code 422'),
+    error: 'Request failed with status code 422',
     type: 'SUBSCRIPTIONS_FAILURE',
+  },
+];
+
+export const poolsUpdate = [{
+  id: 1,
+  quantity: 32,
+}, {
+  id: 42,
+  quantity: 83,
+}];
+
+export const updateQuantitySuccessActions = [
+  {
+    type: 'UPDATE_QUANTITY_REQUEST',
+    quantities: poolsUpdate,
+  },
+  {
+    response: requestSuccessResponse,
+    type: 'UPDATE_QUANTITY_SUCCESS',
+  },
+];
+
+export const updateQuantityFailureActions = [
+  {
+    type: 'UPDATE_QUANTITY_REQUEST',
+    quantities: poolsUpdate,
+  },
+  {
+    error: 'Request failed with status code 422',
+    type: 'UPDATE_QUANTITY_FAILURE',
+  },
+];
+
+export const loadQuantitiesFailureActions = [
+  {
+    type: 'SUBSCRIPTIONS_QUANTITIES_REQUEST',
+  },
+  {
+    error: 'Request failed with status code 500',
+    type: 'SUBSCRIPTIONS_QUANTITIES_FAILURE',
+  },
+];
+
+export const loadQuantitiesSuccessActions = [
+  {
+    type: 'SUBSCRIPTIONS_QUANTITIES_REQUEST',
+  },
+  {
+    type: 'SUBSCRIPTIONS_QUANTITIES_SUCCESS',
+    response: quantitiesRequestSuccessResponse,
   },
 ];

--- a/webpack/scenes/Subscriptions/index.js
+++ b/webpack/scenes/Subscriptions/index.js
@@ -7,6 +7,7 @@ import * as taskActions from '../Tasks/TaskActions';
 import reducer from './SubscriptionReducer';
 
 import SubscriptionsPage from './SubscriptionsPage';
+import './Subscriptions.scss';
 
 // map state to props
 const mapStateToProps = state => ({


### PR DESCRIPTION
Contains also Walden's https://github.com/Katello/katello/commit/748a501fcecaf989fbd42c3621e9b62bef54f98d which will be removed eventually.

It requires https://github.com/patternfly/patternfly-react/pull/240#pullrequestreview-112958795 for the inline edit capabilities.

**TODO:**

- [x] Either add dependency to the latest patternfly-react or copy over the inline edit components (if the other PR doesn't get merged)
- [x] Confirm modal
- [ ] Add icon for changed inputs
- [x] Tests