### PR TITLE
Fixes #22802 - Enables ignorable units in yum repo

### DIFF
--- a/app/lib/actions/katello/repository/create.rb
+++ b/app/lib/actions/katello/repository/create.rb
@@ -37,7 +37,8 @@ module Actions
                                         upstream_username: repository.upstream_username,
                                         upstream_password: repository.upstream_password,
                                         repo_registry_id: repository.container_repository_name,
-                                        proxy_host: repository.proxy_host_value)
+                                        proxy_host: repository.proxy_host_value,
+                                        ignorable_content: repository.ignorable_content)
 
             return if create_action.error
 

--- a/app/lib/actions/pulp/repository/create.rb
+++ b/app/lib/actions/pulp/repository/create.rb
@@ -28,6 +28,7 @@ module Actions
           param :deb_releases
           param :deb_architectures
           param :deb_components
+          param :ignorable_content
         end
 
         def run
@@ -75,6 +76,7 @@ module Actions
           importer.remove_missing  = input[:mirror_on_sync] if input[:content_type] == ::Katello::Repository::YUM_TYPE
           importer.basic_auth_username = input[:upstream_username] if input[:upstream_username].present?
           importer.basic_auth_password = input[:upstream_password] if input[:upstream_password].present?
+          importer.type_skip_list = input[:ignorable_content] if input[:ignorable_content]
           importer
         end
 
@@ -157,6 +159,7 @@ module Actions
           yum_dist_options = { protected: true,
                                id: input[:pulp_id],
                                auto_publish: true }
+          yum_dist_options[:skip] = input[:ignorable_content] if input[:ignorable_content]
           yum_dist_options[:checksum_type] = input[:checksum_type] if input[:checksum_type]
           Runcible::Models::YumDistributor.new(input[:path],
                                                input[:unprotected] || false,

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -227,6 +227,7 @@ module Katello
           :download_policy => new_download_policy,
           :remove_missing => capsule.default_capsule? ? self.mirror_on_sync? : true
         }
+        config[:type_skip_list] = ignorable_content if ignorable_content
         config.merge(importer_connection_options(capsule))
       end
 
@@ -296,6 +297,7 @@ module Katello
         when Repository::YUM_TYPE
           yum_dist_id = self.pulp_id
           yum_dist_options = {:protected => true, :id => yum_dist_id, :auto_publish => true}
+          yum_dist_options[:skip] = ignorable_content if ignorable_content
           #check the instance variable, as we do not want to go to pulp
           yum_dist_options['checksum_type'] = self.checksum_type
           yum_dist = Runcible::Models::YumDistributor.new(self.relative_path, self.unprotected, true,
@@ -442,7 +444,7 @@ module Katello
 
       def pulp_update_needed?
         changeable_attributes = %w(url unprotected checksum_type docker_upstream_name download_policy mirror_on_sync verify_ssl_on_sync
-                                   upstream_username upstream_password ostree_upstream_sync_policy ostree_upstream_sync_depth ignore_global_proxy)
+                                   upstream_username upstream_password ostree_upstream_sync_policy ostree_upstream_sync_depth ignore_global_proxy ignorable_content)
         changeable_attributes << "name" if docker?
         changeable_attributes += %w(deb_releases deb_components deb_architectures) if deb?
         changeable_attributes.any? { |key| previous_changes.key?(key) }

--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -24,6 +24,7 @@ attributes :upstream_username
 attributes :ostree_upstream_sync_policy, :ostree_upstream_sync_depth, :compute_ostree_upstream_sync_depth => :computed_ostree_upstream_sync_depth
 attributes :deb_releases, :deb_components, :deb_architectures
 attributes :ignore_global_proxy
+attributes :ignorable_content
 
 if @resource.is_a?(Katello::Repository)
   if @resource.distribution_version || @resource.distribution_arch || @resource.distribution_family || @resource.distribution_variant

--- a/db/migrate/20180417031215_add_ignorable_content_to_repository.rb
+++ b/db/migrate/20180417031215_add_ignorable_content_to_repository.rb
@@ -1,0 +1,5 @@
+class AddIgnorableContentToRepository < ActiveRecord::Migration[5.1]
+  def change
+    add_column :katello_repositories, :ignorable_content, :text, :null => true
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
@@ -12,13 +12,14 @@
  * @requires DownloadPolicy
  * @requires OstreeUpstreamSyncPolicy
  * @requires Architecture
+ * @requires YumContentUnits
  *
  * @description
  *   Provides the functionality for the repository details info page.
  */
 angular.module('Bastion.repositories').controller('RepositoryDetailsInfoController',
-    ['$scope', '$q', 'translate', 'Notification', 'ContentCredential', 'CurrentOrganization', 'Checksum', 'DownloadPolicy', 'OstreeUpstreamSyncPolicy', 'Architecture',
-    function ($scope, $q, translate, Notification, ContentCredential, CurrentOrganization, Checksum, DownloadPolicy, OstreeUpstreamSyncPolicy, Architecture) {
+    ['$scope', '$q', 'translate', 'Notification', 'ContentCredential', 'CurrentOrganization', 'Checksum', 'DownloadPolicy', 'YumContentUnits', 'OstreeUpstreamSyncPolicy', 'Architecture',
+    function ($scope, $q, translate, Notification, ContentCredential, CurrentOrganization, Checksum, DownloadPolicy, YumContentUnits, OstreeUpstreamSyncPolicy, Architecture) {
         $scope.organization = CurrentOrganization;
 
         $scope.progress = {uploading: false};
@@ -140,6 +141,7 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
         $scope.checksums = Checksum.checksums;
         $scope.downloadPolicies = DownloadPolicy.downloadPolicies;
         $scope.ostreeUpstreamSyncPolicies = OstreeUpstreamSyncPolicy.syncPolicies;
+        $scope.ignorableYumContentUnits = YumContentUnits.units;
 
         $scope.checksumTypeDisplay = function (checksum) {
             return Checksum.checksumType(checksum);
@@ -147,14 +149,6 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
 
         $scope.downloadPolicyDisplay = function (downloadPolicy) {
             return DownloadPolicy.downloadPolicyName(downloadPolicy);
-        };
-
-        $scope.ostreeUpstreamSyncPolicyDisplay = function (repository) {
-            var policy = repository["ostree_upstream_sync_policy"];
-            if ( policy === "custom") {
-                return OstreeUpstreamSyncPolicy.syncPolicyName(policy, repository["ostree_upstream_sync_depth"]);
-            }
-            return OstreeUpstreamSyncPolicy.syncPolicyName(policy);
         };
 
         $scope.clearUpstreamPassword = function () {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.filter.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.filter.js
@@ -4,6 +4,7 @@
  *
  * @requires translate
  * @requires OstreeUpstreamSyncPolicy
+ * @requires YumContentUnits
  *
  * @description
  *   Provides the Ostree Upstream Sync policy filter functionality for the repository details info page.
@@ -25,5 +26,20 @@ angular.module('Bastion.components.formatters').filter('upstreamPasswordFilter',
             return "******";
         }
         return null;
+    };
+}]);
+
+angular.module('Bastion.components.formatters').filter('yumIgnorableContentFilter', ['YumContentUnits', function (YumContentUnits) {
+    return function (displayValue, repository) {
+        var names;
+        if (_.isEmpty(repository["ignorable_content"])) {
+            return null;
+        }
+
+        names = _.map(repository["ignorable_content"], function (key) {
+            return YumContentUnits.unitName(key);
+        });
+
+        return names.join(", ");
     };
 }]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -123,6 +123,23 @@
         </dd>
       </span>
 
+      <span ng-if="repository.content_type === 'yum'">
+        <dt translate>Ignorable Content</dt>
+        <dd bst-edit-custom="repository.ignorable_content"
+            readonly="denied('edit_products', product)"
+            on-save="save(repository)"
+            formatter="yumIgnorableContentFilter"
+            formatter-options="repository"
+            >
+            <select id="ignorable_content"
+                    name="ignorable_content"
+                    multiple="true"
+                    ng-model="repository.ignorable_content"
+                    ng-options="id as name for (id, name) in ignorableYumContentUnits">
+            </select>
+        </dd>
+      </span>
+
       <dt translate>Publish via HTTPS</dt>
       <dd translate>Yes</dd>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/new-repository.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/new-repository.controller.js
@@ -16,13 +16,14 @@
  * @requires OstreeUpstreamSyncPolicy
  * @requires Architecture
  * @requires RepositoryTypesService
+ * @requires YumContentUnits
  *
  * @description
  *   Controls the creation of an empty Repository object for use by sub-controllers.
  */
 angular.module('Bastion.repositories').controller('NewRepositoryController',
-    ['$scope', 'Repository', 'Product', 'ContentCredential', 'FormUtils', 'translate', 'Notification', 'ApiErrorHandler', 'BastionConfig', 'Checksum', 'DownloadPolicy', 'OstreeUpstreamSyncPolicy', 'Architecture', 'RepositoryTypesService',
-    function ($scope, Repository, Product, ContentCredential, FormUtils, translate, Notification, ApiErrorHandler, BastionConfig, Checksum, DownloadPolicy, OstreeUpstreamSyncPolicy, Architecture, RepositoryTypesService) {
+    ['$scope', 'Repository', 'Product', 'ContentCredential', 'FormUtils', 'translate', 'Notification', 'ApiErrorHandler', 'BastionConfig', 'Checksum', 'YumContentUnits', 'DownloadPolicy', 'OstreeUpstreamSyncPolicy', 'Architecture', 'RepositoryTypesService',
+    function ($scope, Repository, Product, ContentCredential, FormUtils, translate, Notification, ApiErrorHandler, BastionConfig, Checksum, YumContentUnits, DownloadPolicy, OstreeUpstreamSyncPolicy, Architecture, RepositoryTypesService) {
 
         function success() {
             Notification.setSuccessMessage(translate('Repository %s successfully created.').replace('%s', $scope.repository.name));
@@ -76,6 +77,7 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
         $scope.checksums = Checksum.checksums;
         $scope.downloadPolicies = DownloadPolicy.downloadPolicies;
         $scope.ostreeUpstreamSyncPolicies = OstreeUpstreamSyncPolicy.syncPolicies;
+        $scope.ignorableYumContentUnits = YumContentUnits.units;
 
         $scope.$watch('repository.name', function () {
             if ($scope.repositoryForm && $scope.repositoryForm.name) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -113,6 +113,19 @@
 
       </div>
 
+      <div bst-form-group label="{{ 'Ignorable Content' | translate }}"  ng-show="repository.content_type === 'yum'">
+        <select id="ignorable_content"
+                name="ignorable_content"
+                multiple="true"
+                ng-model="repository.ignorable_content"
+                ng-options="id as name for (id, name) in ignorableYumContentUnits">
+        </select>
+
+        <h6 translate>
+          Select content units to ignore while synchronizing this repository.
+        </h6>
+      </div>
+
       <div class="checkbox">
         <label>
           <input id="verify_ssl_on_sync" name="verify_ssl_on_sync" ng-model="repository.verify_ssl_on_sync" type="checkbox"/>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/yum-content-units.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/yum-content-units.service.js
@@ -1,0 +1,24 @@
+/**
+ * @ngdoc service
+ * @name  Bastion.repository.service:YumContentUnits
+ *
+ * @requires translate
+ *
+ * @description
+ *   Provides content type units for yum
+ */
+angular.module('Bastion.repositories').service('YumContentUnits',
+    ['translate', function (translate) {
+        this.units = {
+            'rpm': translate('RPM'),
+            'drpm': translate('Delta RPM'),
+            'srpm': translate('Source RPM'),
+            'erratum': translate('Errata'),
+            'distribution': translate('Distribution')
+        };
+
+        this.unitName = function (unit) {
+            return this.units[unit];
+        };
+    }]
+);

--- a/engines/bastion_katello/test/products/details/repositories/details/repository-details-info.controller.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/details/repository-details-info.controller.test.js
@@ -1,5 +1,5 @@
 describe('Controller: RepositoryDetailsInfoController', function() {
-    var $scope, $state, translate, Notification, repository, DownloadPolicy, OstreeUpstreamSyncPolicy;
+    var $scope, $state, translate, Notification, repository, DownloadPolicy, OstreeUpstreamSyncPolicy, YumContentUnits;
 
     beforeEach(module(
         'Bastion.repositories',
@@ -15,6 +15,7 @@ describe('Controller: RepositoryDetailsInfoController', function() {
         repository = new Repository();
         DownloadPolicy = $injector.get("DownloadPolicy");
         OstreeUpstreamSyncPolicy = $injector.get("OstreeUpstreamSyncPolicy");
+        YumContentUnits = $injector.get("YumContentUnits");
         $scope = $injector.get('$rootScope').$new();
         $state = $injector.get('$state');
 
@@ -133,6 +134,10 @@ describe('Controller: RepositoryDetailsInfoController', function() {
 
     it ('should set ostree upstream sync policies', function() {
        expect($scope.ostreeUpstreamSyncPolicies).toBe(OstreeUpstreamSyncPolicy.syncPolicies);
+    });
+
+    it ('should set yum content units', function() {
+       expect($scope.ignorableYumContentUnits).toBe(YumContentUnits.units);
     });
 
     it('should set the upload status to success and refresh the repository if a file upload status is success', function() {

--- a/engines/bastion_katello/test/products/details/repositories/new/new-repository.controller.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/new/new-repository.controller.test.js
@@ -4,6 +4,7 @@ describe('Controller: NewRepositoryController', function() {
         Notification,
         DownloadPolicy,
         OstreeUpstreamSyncPolicy,
+        YumContentUnits,
         $httpBackend,
         RepositoryTypesService;
 
@@ -20,6 +21,7 @@ describe('Controller: NewRepositoryController', function() {
 
         DownloadPolicy = $injector.get('DownloadPolicy');
         OstreeUpstreamSyncPolicy = $injector.get('OstreeUpstreamSyncPolicy');
+        YumContentUnits = $injector.get('YumContentUnits');
         $scope = $injector.get('$rootScope').$new();
         $httpBackend = $injector.get('$httpBackend');
         FormUtils = $injector.get('FormUtils');
@@ -105,4 +107,9 @@ describe('Controller: NewRepositoryController', function() {
     it ('should set ostree upstream sync policies', function() {
        expect($scope.ostreeUpstreamSyncPolicies).toBe(OstreeUpstreamSyncPolicy.syncPolicies);
     });
+
+    it ('should set yum content units', function() {
+       expect($scope.ignorableYumContentUnits).toBe(YumContentUnits.units);
+    });
+
 });

--- a/engines/bastion_katello/test/products/details/repositories/yum-content-units.service.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/yum-content-units.service.test.js
@@ -1,0 +1,18 @@
+describe('Service: YumContentUnits', function() {
+    var YumContentUnits;
+
+    beforeEach(module('Bastion.repositories'));
+
+    beforeEach(module(function ($provide) {
+        $provide.value('translate', function (string) { return string; });
+    }));
+
+    beforeEach(inject(function($injector) {
+        YumContentUnits = $injector.get('YumContentUnits');
+    }));
+
+    it("provides a method to convert a YumContentUnits policy to a human readable version", function() {
+        expect(YumContentUnits.unitName('rpm')).toBe('RPM');
+        expect(YumContentUnits.unitName('srpm')).toBe('Source RPM');
+    });
+});

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -354,6 +354,26 @@ module Katello
       version.components << katello_content_view_versions(:library_view_version_2)
       assert version_archive_repo.master?
     end
+
+    def test_yum_ignorable_content
+      @repo.url = "http://foo.com"
+      @repo.ignorable_content = nil
+      assert @repo.valid?
+      @repo.ignorable_content = ["srpm", "erratum"]
+      assert @repo.valid?
+      @repo.ignorable_content = ["boo"]
+      refute @repo.valid?
+      assert @repo.errors.include?(:ignorable_content)
+
+      @repo.ignorable_content = ["srpm"]
+      @repo.content_type = Repository::PUPPET_TYPE
+      @repo.download_policy = nil
+      refute @repo.valid?
+      assert @repo.errors.include?(:ignorable_content)
+
+      @repo.ignorable_content = nil
+      assert @repo.valid?
+    end
   end
 
   class RepositoryGeneratedIdsTest < RepositoryTestBase


### PR DESCRIPTION
This commit facilitates the ability to ignore certain content units in a
Yum repo. For example one would be able to say "ignore srpms while
syncing this repo". This commit largely feeds of the pulp 'skip' list
feature.
Ignorable content units would be rpm, drpm, srpm, distribution and
erratum
This commit adds the UI and api bindings to make this work.