### PR TITLE
Refs #23034 - Show upstream_pool_id on subs

### DIFF
--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -9,7 +9,7 @@ module Katello
         lazy_accessor :pool_facts, :initializer => lambda { |_s| self.import_lazy_attributes }
         lazy_accessor :subscription_facts, :initializer => lambda { |_s| self.subscription ? self.subscription.attributes : {} }
 
-        lazy_accessor :pool_derived, :owner, :source_pool_id, :virt_limit, :arch, :description,
+        lazy_accessor :pool_derived, :owner, :source_pool_id, :virt_limit, :arch, :description, :upstream_pool_id,
           :product_family, :variant, :suggested_quantity, :support_type, :product_id, :type, :upstream_entitlement_id,
           :initializer => :pool_facts
 
@@ -63,8 +63,8 @@ module Katello
         end
 
         json["product_id"] = json["productId"] if json["productId"]
-
         json["upstream_entitlement_id"] = json["upstreamEntitlementId"]
+        json["upstream_pool_id"] = json["upstreamPoolId"]
 
         if self.subscription
           subscription.backend_data["product"]["attributes"].map { |attr| json[attr["name"].underscore.to_sym] = attr["value"] }

--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -63,10 +63,6 @@ module Katello
       self.subscription.products if self.subscription
     end
 
-    def upstream?
-      subscription.present? && subscription.redhat?
-    end
-
     private
 
     def default_sort

--- a/app/views/katello/api/v2/subscriptions/base.json.rabl
+++ b/app/views/katello/api/v2/subscriptions/base.json.rabl
@@ -16,7 +16,7 @@ attributes :name => :product_name
 attributes :unmapped_guest
 attributes :virt_only
 attributes :virt_who
-attributes :upstream? => :upstream
+attributes :upstream_pool_id
 
 node :hypervisor, :if => lambda { |sub| sub && sub.respond_to?(:hypervisor) && sub.hypervisor_id } do |subscription|
   {

--- a/test/fixtures/models/katello_pools.yml
+++ b/test/fixtures/models/katello_pools.yml
@@ -26,15 +26,3 @@ pool_two:
   start_date: "2011-10-11T04:00:00.000+0000"
   end_date: "2022-01-01T04:59:59.000+0000"
   consumed: 10
-
-custom_pool:
-  cp_id: "xyz1234"
-  created_at: <%= Time.now %>
-  updated_at: <%= Time.now %>
-  subscription_id: <%= ActiveRecord::FixtureSet.identify(:custom_subscription) %> 
-  account_number: "84390203"
-  contract_number: "38943940"
-  quantity: 100
-  start_date: "2011-10-11T04:00:00.000+0000"
-  end_date: "2022-01-01T04:59:59.000+0000"
-  consumed: 10

--- a/test/fixtures/models/katello_subscriptions.yml
+++ b/test/fixtures/models/katello_subscriptions.yml
@@ -18,11 +18,3 @@ other_subscription:
   cores: 4
   stacking_id: "stack8473"
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
-
-custom_subscription:
-  name: "custom subscription"
-  product_id: "empty_product"
-  support_level: "all hands on deck"
-  sockets: 3
-  cores: 4
-  organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>

--- a/test/models/pool_test.rb
+++ b/test/models/pool_test.rb
@@ -7,18 +7,7 @@ module Katello
       @view = katello_content_views(:library_dev_view)
       @pool_one = katello_pools(:pool_one)
       @pool_two = katello_pools(:pool_two)
-      @custom_pool = katello_pools(:custom_pool)
       @host_one = hosts(:one)
-    end
-
-    def test_upstream
-      assert_equal true,  @pool_one.upstream?
-      assert_equal false, @custom_pool.upstream?
-    end
-
-    def test_upstream_nil_subscription
-      @pool_one.subscription = nil
-      assert_equal false, @pool_one.upstream?
     end
 
     def test_active


### PR DESCRIPTION
The code removed here is from the first shot I took at this behavior. It wasn't very helpful because simply knowing that a subscription came from the upstream doesn't give one the ability to correlate it to the upstream entity.

Now, we show the upstream pool ID from which the subscription is derived. Sadly, this means that for each subscription we are calling back to Candlepin - so there is a performance impact. I would like to hear if others think we should import that info into Katello for speedy lookup.