### PR TITLE
Fixes #23338 - Use local pool IDs for upstream subs list

### DIFF
--- a/app/controllers/katello/api/v2/upstream_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/upstream_subscriptions_controller.rb
@@ -18,7 +18,7 @@ module Katello
       N_("List available subscriptions from Red Hat Subscription Management")
     param :organization_id, :number, :desc => N_("Organization ID"), :required => true
     param_group :cp_search
-    param :pool_ids, Array, desc: N_("List of pool ids to fetch")
+    param :pool_ids, Array, desc: N_("Return only the upstream pools which map to the given local pool IDs")
     param :quantities_only, :bool, desc: N_("Only returns id and quantity fields")
     param :attachable, :bool, desc: N_("Return only subscriptions which can be attached to the upstream allocation")
     def index

--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -9,7 +9,7 @@ module Katello
         lazy_accessor :pool_facts, :initializer => lambda { |_s| self.import_lazy_attributes }
         lazy_accessor :subscription_facts, :initializer => lambda { |_s| self.subscription ? self.subscription.attributes : {} }
 
-        lazy_accessor :pool_derived, :owner, :source_pool_id, :virt_limit, :arch, :description,
+        lazy_accessor :pool_derived, :owner, :source_pool_id, :virt_limit, :arch, :description, :upstream_pool_id,
           :product_family, :variant, :suggested_quantity, :support_type, :product_id, :type, :upstream_entitlement_id,
           :initializer => :pool_facts
 
@@ -63,8 +63,8 @@ module Katello
         end
 
         json["product_id"] = json["productId"] if json["productId"]
-
         json["upstream_entitlement_id"] = json["upstreamEntitlementId"]
+        json["upstream_pool_id"] = json["upstreamPoolId"]
 
         if self.subscription
           subscription.backend_data["product"]["attributes"].map { |attr| json[attr["name"].underscore.to_sym] = attr["value"] }

--- a/app/services/katello/candlepin/pool_service.rb
+++ b/app/services/katello/candlepin/pool_service.rb
@@ -1,0 +1,17 @@
+module Katello
+  module Candlepin
+    class PoolService
+      def self.local_to_upstream_ids(local_pool_ids)
+        pools = Katello::Pool.find(local_pool_ids)
+        id_map = Hash.new { |hash, key| hash[key] = [] }
+
+        pools.each do |pool|
+          fail 'No upstream pool ID was found for Katello::Pool with ID: %s' % pool.id unless pool.upstream_pool_id
+          id_map[pool.upstream_pool_id] << pool.id
+        end
+
+        id_map
+      end
+    end
+  end
+end

--- a/app/views/katello/api/v2/upstream_subscriptions/base.json.rabl
+++ b/app/views/katello/api/v2/upstream_subscriptions/base.json.rabl
@@ -10,3 +10,7 @@ attributes :consumed
 attributes :product_name
 attributes :product_id
 attributes :subscription_id
+
+if params[:pool_ids]
+  attributes :local_pool_ids
+end

--- a/test/services/katello/candlepin/pool_service_test.rb
+++ b/test/services/katello/candlepin/pool_service_test.rb
@@ -1,0 +1,30 @@
+require 'katello_test_helper'
+
+module Katello
+  module Service
+    class PoolServiceTest < ActiveSupport::TestCase
+      def setup
+        @pool_one = katello_pools(:pool_one)
+        @pool_two = katello_pools(:pool_two)
+      end
+
+      def test_local_to_upstream_ids
+        Katello::Pool.expects(:find).returns([@pool_one, @pool_two])
+        @pool_one.expects(:upstream_pool_id).returns('pool_one_upstream_id').twice
+        @pool_two.expects(:upstream_pool_id).returns('pool_two_upstream_id').twice
+
+        result = Katello::Candlepin::PoolService.local_to_upstream_ids([@pool_two.id, @pool_two.id])
+
+        assert_equal [@pool_one.id], result['pool_one_upstream_id']
+        assert_equal [@pool_two.id], result['pool_two_upstream_id']
+      end
+
+      def test_local_to_upstream_ids_no_upstream
+        Katello::Pool.any_instance.expects(:upstream_pool_id).returns(nil)
+
+        error = proc { Katello::Candlepin::PoolService.local_to_upstream_ids([@pool_one.id]) }.must_raise RuntimeError
+        error.message.must_match(/No upstream pool ID/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We need an efficient way for users to interact with GET /upstream_subscriptions when using the pool_ids param. It's much easier if they do not have to know the upstream pool ID, and can instead use local pool IDS.

First iteration involved adding upstream_pool_id to the /subscriptions index but since that calls to backend Candlepin it is not a good idea.