### PR TITLE
Fixes #22156 - Repo discovery table showing empty rows

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.controller.js
@@ -21,7 +21,7 @@
 angular.module('Bastion.products').controller('ProductsController',
     ['$scope', '$state', '$sce', '$location', '$uibModal', 'translate', 'Nutupane', 'Product', 'ProductBulkAction', 'CurrentOrganization', 'Notification',
     function ($scope, $state, $sce, $location, $uibModal, translate, Nutupane, Product, ProductBulkAction, CurrentOrganization, Notification) {
-        var nutupane, taskUrl, taskLink, getBulkParams, bulkError, params;
+        var nutupane, nutupaneParams, taskUrl, taskLink, getBulkParams, bulkError, params;
 
         getBulkParams = function () {
             return {
@@ -47,10 +47,16 @@ angular.module('Bastion.products').controller('ProductsController',
             'paged': true
         };
 
-        nutupane = new Nutupane(Product, params);
+        nutupaneParams = {
+            'disableAutoLoad': true
+        };
+        $scope.disableRepoDiscovery = true;
+        nutupane = new Nutupane(Product, params, undefined, nutupaneParams);
         $scope.controllerName = 'katello_products';
         nutupane.masterOnly = true;
-
+        nutupane.refresh().then(function () {
+            $scope.disableRepoDiscovery = false;
+        });
         $scope.table = nutupane.table;
 
         $scope.$on('productDelete', function (event, taskId) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/views/products.html
@@ -17,7 +17,8 @@
     <button type="button" class="btn btn-default"
             ng-click="goToDiscoveries()"
             bst-feature-flag="custom_products"
-            ng-show="permitted('edit_products')">
+            ng-show="permitted('edit_products')"
+            ng-disabled = "disableRepoDiscovery">
       <span translate>Repo Discovery</span>
     </button>
 

--- a/engines/bastion_katello/test/products/products.controller.test.js
+++ b/engines/bastion_katello/test/products/products.controller.test.js
@@ -7,23 +7,38 @@ describe('Controller: ProductsController', function() {
 
     beforeEach(module('Bastion.products', 'Bastion.test-mocks'));
 
-    beforeEach(function() {
-        Nutupane = function() {
+    beforeEach(function () {
+        Nutupane = function () {
             this.table = {
-                showColumns: function() {},
+                showColumns: function () {},
                 getSelected: function () {
                     return [{id: 1}, {id: 2}, {id: 3}];
-                }
+                },
+                rows: [{dummy: 1}, {dummy: 2}, {dummy: 3}],
+                resource: {
+                    results: [1,2,3],
+                    total: 3,
+                    subtotal: 3
+                },
+
+                numSelected: 0
             };
-            this.get = function() {};
+            this.get = function () {};
             this.invalidate = function () {};
+            this.refresh = function () {
+                var deferred = $q.defer();
+                return {
+                    $promise: deferred.promise,
+                    then : function () {}
+                }
+            }
         };
         ProductBulkAction = {
-            removeProducts: function() {
+            removeProducts: function () {
                 var deferred = $q.defer();
                 return {$promise: deferred.promise};
             },
-            syncProducts: function() {
+            syncProducts: function () {
                 var deferred = $q.defer();
                 return {$promise: deferred.promise};
             }
@@ -34,14 +49,14 @@ describe('Controller: ProductsController', function() {
             open: function () {
                 return {
                     closed: {
-                        then: function() {}
+                        then: function () {}
                     }
                 }
             }
         };
     });
 
-    beforeEach(inject(function(_Notification_, $controller, $rootScope, $location) {
+    beforeEach(inject(function (_Notification_, $controller, $rootScope, $location) {
         $scope = $rootScope.$new();
         Notification = _Notification_;
 
@@ -57,10 +72,10 @@ describe('Controller: ProductsController', function() {
         });
     }));
 
-    it('attaches the nutupane table to the scope', function() {
+    it('attaches the nutupane table to the scope', function () {
         expect($scope.table).toBeDefined();
     });
-    
+
     it('properly detects most important sync state error', function () {
         var product = {
             'sync_summary': {
@@ -91,7 +106,7 @@ describe('Controller: ProductsController', function() {
         expect($scope.mostImportantSyncState(product)).toBe('success');
     });
 
-    it("can remove multiple products", function() {
+    it("can remove multiple products", function () {
         spyOn(ProductBulkAction, 'removeProducts').and.callThrough();
 
         $scope.removeProducts();
@@ -100,7 +115,7 @@ describe('Controller: ProductsController', function() {
             jasmine.any(Function), jasmine.any(Function));
     });
 
-    it("can sync products", function() {
+    it("can sync products", function () {
         spyOn(ProductBulkAction, 'syncProducts').and.callThrough();
         $scope.syncProducts();
 
@@ -118,6 +133,18 @@ describe('Controller: ProductsController', function() {
 
         expect(result.templateUrl).toContain('products-bulk-sync-plan-modal.html');
         expect(result.controller).toBe('ProductsBulkSyncPlanModalController');
+    });
+
+    it("can disable repo discovery before refresh", function () {
+        expect($scope.disableRepoDiscovery).toBe(true);
+    });
+
+    it("can refresh table on repo discovery", function () {
+        $scope.goToDiscoveries();
+        expect($scope.table.rows).toEqual([]);
+        expect($scope.table.resource.total).toBe(0);
+        expect($scope.table.resource.subtotal).toBe(0);
+        expect($scope.table.resource.results).toEqual([]);
     });
 });
 


### PR DESCRIPTION
### Description of problem:

Sometimes the Repo discovery page has table with empty rows. 

****
### Steps to Reproduce: 
1. Navigate to Content > Products
2. Click on Repo Discovery.
3. Chances are that you will see a table of empty rows (Number of empty rows being equal to number of products)

##### If unable to reproduce with above steps:
1. Go to Content > Product
2. Click on any product in the table.
3. Click on Product link on Breadcrumb
4. Before the Product table loads, click on Repo Discovery.

