### PR TITLE
Fixes #23363 - Use ActiveSupport::Digest when available

### DIFF
--- a/app/lib/katello/util/data.rb
+++ b/app/lib/katello/util/data.rb
@@ -5,10 +5,8 @@ module Katello
         variable.map { |x| x.with_indifferent_access }
       end
 
-      def self.md5hash(string)
-        md5 = Digest::MD5.new
-        md5.update(string)
-        md5.hexdigest
+      def self.hexdigest(string)
+        defined?(ActiveSupport::Digest) ? ActiveSupport::Digest.hexdigest(string) : Digest::MD5.hexdigest(string)
       end
 
       def self.ostructize(obj, options = {})

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -635,7 +635,7 @@ module Katello
       # for a default view, the same candlepin environment will be referenced
       # by the kt_environment and content_view_environment.
       value = self.default ? env.organization.label.to_s : [env.organization.label, env.label, self.label].join('-')
-      Katello::Util::Data.md5hash(value)
+      Katello::Util::Data.hexdigest(value)
     end
 
     def confirm_not_promoted

--- a/app/models/katello/content_view_environment.rb
+++ b/app/models/katello/content_view_environment.rb
@@ -44,10 +44,10 @@ module Katello
 
       if content_view.default?
         self.label ||= environment.label
-        self.cp_id ||= Katello::Util::Data.md5hash(environment.organization.label)
+        self.cp_id ||= Katello::Util::Data.hexdigest(environment.organization.label)
       else
         self.label ||= [environment.label, content_view.label].join('/')
-        self.cp_id ||= Katello::Util::Data.md5hash([environment.id, content_view.id].join('-'))
+        self.cp_id ||= Katello::Util::Data.hexdigest([environment.id, content_view.id].join('-'))
       end
     end
   end


### PR DESCRIPTION
In Rails 5.2 and later ActiveSupport::Digest is an abstraction used to generate hash digests. When FIPS compliance is required It can be configured to use SHA512 (or others) instead of MD5.