### PR TITLE
Fixes #23400 - Port robottelo tests for activation_key

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -52,4 +52,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rubocop-checkstyle_formatter"
   gem.add_development_dependency "simplecov"
   gem.add_development_dependency "simplecov-rcov"
+  gem.add_development_dependency "robottelo_reporter"
 end

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -194,7 +194,6 @@ module Katello
 
     test_attributes :pid => '71b9b000-b978-4a95-b6f8-83c09ed39c01'
     def test_should_not_create_unlimited_and_invalid_max_hosts
-      # BZ: 1156555
       post :create, params: {
         :organization_id => @organization.id,
         :activation_key => {:name => 'limited Key', :unlimited_hosts => true, :max_hosts => 0}

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -6,6 +6,7 @@ require 'factory_bot_rails'
 require "webmock/minitest"
 require "mocha/setup"
 require 'set'
+require 'robottelo/reporter/attributes'
 
 SimpleCov.formatters = [
   SimpleCov::Formatter::RcovFormatter,
@@ -96,6 +97,7 @@ module FixtureTestCase
 end
 
 class ActionController::TestCase
+  extend Robottelo::Reporter::TestAttributes
   include LocaleHelperMethods
   include ControllerSupport
   include ForemanTasks::TestHelpers::WithInThreadExecutor

--- a/test/models/activation_key_test.rb
+++ b/test/models/activation_key_test.rb
@@ -10,6 +10,10 @@ module Katello
       @pool_one = katello_pools(:pool_one)
     end
 
+    should allow_values(*valid_name_list).for(:name)
+    should allow_values(*valid_name_list).for(:description)
+    should_not allow_values(-1, 0, 'foo').for(:max_hosts)
+
     test "can have content view" do
       @dev_key = katello_activation_keys(:dev_key)
       @dev_key.content_view = @dev_view


### PR DESCRIPTION
Port robottelo tier1 api tests for Activation Key part of robottelo minitest port project: https://github.com/SatelliteQE/robottelo/projects/1

Related Robottelo issue: https://github.com/SatelliteQE/robottelo/issues/5834

This also introduce the possibility to report marker test with test_attributtes and a pid attribute set to be selected for Polarion reporting using repbottelo_reporter plugin this is also related to this foreman PR https://github.com/theforeman/foreman/pull/5464. 
