### PR TITLE
fixes #21951 - don't allow export of on-demand repos

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -82,6 +82,10 @@ module Katello
         fail HttpErrors::BadRequest, _("ISO export must be enabled when specifying ISO size")
       end
 
+      if (repos = @version.content_view.on_demand_repositories).any?
+        fail HttpErrors::BadRequest, _("This content view has on demand repositories that cannot be exported: %{repos}" % {repos: repos.pluck(:label).join(", ")})
+      end
+
       if params[:since].present?
         begin
           params[:since].to_datetime

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -250,6 +250,8 @@ module Katello
 
       fail HttpErrors::BadRequest, _("Repository content type must be 'yum' to export.") unless @repository.content_type == 'yum'
 
+      fail HttpErrors::BadRequest, _("On demand repositories cannot be exported.") if @repository.download_policy == ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND
+
       task = async_task(::Actions::Katello::Repository::Export, [@repository],
                         ::Foreman::Cast.to_bool(params[:export_to_iso]),
                         params[:since].try(:to_datetime),

--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -606,6 +606,10 @@ module Katello
       content_view_versions.count
     end
 
+    def on_demand_repositories
+      repositories.where(download_policy: ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND)
+    end
+
     protected
 
     def remove_repository(repository)

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -127,6 +127,13 @@ module Katello
       assert_response :success
     end
 
+    def test_export_fails_on_demand
+      ContentView.any_instance.stubs(:on_demand_repositories).returns([katello_repositories(:fedora_17_x86_64)])
+      version = @library_dev_staging_view.versions.first
+      post :export, params: { :id => version.id }
+      assert_response :bad_request
+    end
+
     def test_export_bad_date
       version = @library_dev_staging_view.versions.first
       post :export, params: { :id => version.id, :since => "a really bad date" }

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -16,6 +16,7 @@ module Katello
       @environment = katello_environments(:dev)
       @content_view_version = katello_content_view_versions(:library_view_version_1)
       @fedora_dev = katello_repositories(:fedora_17_x86_64_dev)
+      @on_demand_repo = katello_repositories(:fedora_17_x86_64)
       @puppet_repo = katello_repositories(:p_forge)
       @docker_repo = katello_repositories(:busybox)
     end
@@ -972,6 +973,12 @@ module Katello
 
     def test_export_wrong_type
       post :export, params: { :id => @puppet_repo.id }
+      assert_response 400
+    end
+
+    def test_export_on_demand
+      Setting['pulp_export_destination'] = '/tmp'
+      post :export, params: { :id => @on_demand_repo.id }
       assert_response 400
     end
 

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -363,7 +363,7 @@ fedora_17_unpublished:
   gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
   url:                  "http://www.pleaseack.com"
-  download_policy: on_demand
+  download_policy:      immediate
 
 fedora_17_unpublished_2:
   name:                 Fedora 17 x86_64 2

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -171,6 +171,25 @@ module Katello
       assert_empty view.repositories
     end
 
+    def test_on_demand_repositories
+      product = create(:katello_product, provider: @organization.anonymous_provider, organization: @organization)
+      repo1 = create(:katello_repository,
+                     content_view_version: @organization.default_content_view.versions.first,
+                     download_policy: ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND,
+                     product: product)
+      view1 = create(:katello_content_view, organization: @organization)
+      view1.repositories << repo1
+      assert view1.on_demand_repositories.include?(repo1)
+
+      repo2 = create(:katello_repository,
+                     content_view_version: @organization.default_content_view.versions.first,
+                     download_policy: ::Runcible::Models::YumImporter::DOWNLOAD_IMMEDIATE,
+                     product: product)
+      view2 = create(:katello_content_view, organization: @organization)
+      view2.repositories << repo2
+      refute view2.on_demand_repositories.include?(repo2)
+    end
+
     def test_content_view_components
       assert_raises(ActiveRecord::RecordInvalid) do
         @library_dev_view.update_attributes!(:component_ids => [@library_view.versions.first.id])


### PR DESCRIPTION
Prevents exporting content views with on demand repositories:

```
[root@centos7-devel ~]# hammer -s https://$HOSTNAME content-view version export --id 9
[Foreman] Password for admin: 
Could not export the content view:
  Content views with on-demand repositories cannot be exported.
```