### PR TITLE
Fixes #23084 - activation-key copy fix

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -97,7 +97,7 @@ module Katello
       @activation_key.pools.each do |pool|
         @new_activation_key.subscribe(pool[:id])
       end
-      @new_activation_key.set_content_overrides(@activation_key.content_overrides)
+      @new_activation_key.set_content_overrides(@activation_key.content_overrides) unless @activation_key.content_overrides.blank?
       respond_for_show(:resource => @new_activation_key)
     end
 

--- a/app/lib/katello/resources/candlepin/activation_key.rb
+++ b/app/lib/katello/resources/candlepin/activation_key.rb
@@ -88,7 +88,7 @@ module Katello
               client.options[:payload] = attrs_to_delete.to_json
               result = client.delete({:accept => :json, :content_type => :json}.merge(User.cp_oauth_header))
             end
-            ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result))
+            ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result || '{}'))
           end
 
           def path(id = nil)

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -173,7 +173,7 @@ module Katello
         assert_equal activation_key_params[:auto_attach], @activation_key.auto_attach
       end
       content_overrides = [::Katello::ContentOverride.new("foo", :enabled => 1), ::Katello::ContentOverride.new("bar", :enabled => nil)]
-      @activation_key.expects(:content_overrides).returns(content_overrides)
+      @activation_key.expects(:content_overrides).at_least_once.returns(content_overrides)
 
       ::Katello::Resources::Candlepin::ActivationKey.expects(:update_content_overrides).with do |id, hash|
         id.wont_equal(@activation_key.cp_id)


### PR DESCRIPTION
Activation-key copy fails with "no implicit conversion of nil into String"