### PR TITLE
Fixes #23432 - Many content View pages make 2 API calls to fetch results

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-deb-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-deb-repositories.controller.js
@@ -14,7 +14,9 @@
      *    Provides UI functionality add deb repositories to a content view
      */
     function ContentViewAvailableDebRepositoriesController($scope, Repository, Nutupane, CurrentOrganization, ContentViewRepositoriesUtil) {
-        var nutupane;
+        var nutupane, nutupaneParams = {
+            'disableAutoLoad': true
+        };
 
         ContentViewRepositoriesUtil($scope);
 
@@ -25,7 +27,7 @@
             'content_view_id': $scope.$stateParams.contentViewId,
             'available_for': 'content_view'
         },
-        'queryUnpaged');
+        'queryUnpaged', nutupaneParams);
         $scope.controllerName = 'katello_repositories';
 
         nutupane.load();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-docker-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-docker-repositories.controller.js
@@ -15,7 +15,9 @@ angular.module('Bastion.content-views').controller('ContentViewAvailableDockerRe
     ['$scope', 'Repository', 'Nutupane', 'CurrentOrganization', 'ContentViewRepositoriesUtil',
     function ($scope, Repository, Nutupane, CurrentOrganization, ContentViewRepositoriesUtil) {
 
-        var nutupane;
+        var nutupane, nutupaneParams = {
+            'disableAutoLoad': true
+        };
 
         ContentViewRepositoriesUtil($scope);
 
@@ -26,11 +28,11 @@ angular.module('Bastion.content-views').controller('ContentViewAvailableDockerRe
             'content_view_id': $scope.$stateParams.contentViewId,
             'available_for': 'content_view'
         },
-        'queryUnpaged');
+        'queryUnpaged', nutupaneParams);
         $scope.controllerName = 'katello_repositories';
 
         nutupane.masterOnly = true;
-
+        nutupane.load();
         $scope.table = nutupane.table;
 
         $scope.addRepositories = function (contentView) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-file-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-file-repositories.controller.js
@@ -14,7 +14,9 @@
      *    Provides UI functionality add file repositories to a content view
      */
     function ContentViewAvailableFileRepositoriesController($scope, Repository, Nutupane, CurrentOrganization, ContentViewRepositoriesUtil) {
-        var nutupane;
+        var nutupane, nutupaneParams = {
+            'disableAutoLoad': true
+        };
 
         ContentViewRepositoriesUtil($scope);
 
@@ -25,7 +27,7 @@
             'content_view_id': $scope.$stateParams.contentViewId,
             'available_for': 'content_view'
         },
-        'queryUnpaged');
+        'queryUnpaged', nutupaneParams);
         $scope.controllerName = 'katello_repositories';
 
         nutupane.load();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-ostree-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-ostree-repositories.controller.js
@@ -15,8 +15,9 @@ angular.module('Bastion.content-views').controller('ContentViewAvailableOstreeRe
     ['$scope', 'Repository', 'Nutupane', 'CurrentOrganization', 'ContentViewRepositoriesUtil',
     function ($scope, Repository, Nutupane, CurrentOrganization, ContentViewRepositoriesUtil) {
 
-        var nutupane;
-
+        var nutupane, nutupaneParams = {
+            'disableAutoLoad': true
+        };
         ContentViewRepositoriesUtil($scope);
 
         nutupane = new Nutupane(Repository, {
@@ -26,10 +27,11 @@ angular.module('Bastion.content-views').controller('ContentViewAvailableOstreeRe
             'content_view_id': $scope.$stateParams.contentViewId,
             'available_for': 'content_view'
         },
-        'queryUnpaged');
+        'queryUnpaged', nutupaneParams);
         $scope.controllerName = 'katello_repositories';
 
         nutupane.masterOnly = true;
+        nutupane.load();
 
         $scope.table = nutupane.table;
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-repositories.controller.js
@@ -17,7 +17,9 @@ angular.module('Bastion.content-views').controller('ContentViewAvailableReposito
     ['$scope', 'Repository', 'Nutupane', 'CurrentOrganization', 'ContentViewRepositoriesUtil',
     function ($scope, Repository, Nutupane, CurrentOrganization, ContentViewRepositoriesUtil) {
 
-        var nutupane;
+        var nutupane, nutupaneParams = {
+            'disableAutoLoad': true
+        };
 
         ContentViewRepositoriesUtil($scope);
 
@@ -28,7 +30,7 @@ angular.module('Bastion.content-views').controller('ContentViewAvailableReposito
             'content_view_id': $scope.$stateParams.contentViewId,
             'available_for': 'content_view'
         },
-        'queryUnpaged');
+        'queryUnpaged', nutupaneParams);
         $scope.controllerName = 'katello_repositories';
 
         nutupane.load();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-deb-repositories-list.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-deb-repositories-list.controller.js
@@ -14,7 +14,9 @@
      *    Provides UI functionality list/remove deb repositories from a content view
      */
     function ContentViewDebRepositoriesListController($scope, Repository, Nutupane, CurrentOrganization, ContentViewRepositoriesUtil) {
-        var nutupane;
+        var nutupane, nutupaneParams = {
+            'disableAutoLoad': true
+        };
 
         ContentViewRepositoriesUtil($scope);
 
@@ -23,7 +25,7 @@
             'content_view_id': $scope.$stateParams.contentViewId,
             'content_type': 'deb'
         },
-        'queryUnpaged');
+        'queryUnpaged', nutupaneParams);
         $scope.controllerName = 'katello_repositories';
 
         nutupane.load();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-docker-repositories-list.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-docker-repositories-list.controller.js
@@ -14,7 +14,9 @@
      *    Provides UI functionality list/remove docker repositories from a content view
      */
     function ContentViewDockerRepositoriesListController($scope, Repository, Nutupane, CurrentOrganization, ContentViewRepositoriesUtil) {
-        var nutupane;
+        var nutupane, nutupaneParams = {
+            'disableAutoLoad': true
+        };
 
         ContentViewRepositoriesUtil($scope);
 
@@ -23,7 +25,7 @@
             'content_view_id': $scope.$stateParams.contentViewId,
             'content_type': 'docker'
         },
-        'queryUnpaged');
+        'queryUnpaged', nutupaneParams);
         $scope.controllerName = 'katello_repositories';
 
         nutupane.masterOnly = true;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-file-repositories-list.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-file-repositories-list.controller.js
@@ -14,7 +14,9 @@
      *    Provides UI functionality list/remove file repositories from a content view
      */
     function ContentViewFileRepositoriesListController($scope, Repository, Nutupane, CurrentOrganization, ContentViewRepositoriesUtil) {
-        var nutupane;
+        var nutupane, nutupaneParams = {
+            'disableAutoLoad': true
+        };
 
         ContentViewRepositoriesUtil($scope);
 
@@ -23,7 +25,7 @@
             'content_view_id': $scope.$stateParams.contentViewId,
             'content_type': 'file'
         },
-        'queryUnpaged');
+        'queryUnpaged', nutupaneParams);
         $scope.controllerName = 'katello_repositories';
 
         nutupane.load();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-ostree-repositories-list.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-ostree-repositories-list.controller.js
@@ -14,7 +14,9 @@
      *    Provides UI functionality list/remove ostree repositories from a content view
      */
     function ContentViewOstreeRepositoriesListController($scope, Repository, Nutupane, CurrentOrganization, ContentViewRepositoriesUtil) {
-        var nutupane;
+        var nutupane, nutupaneParams = {
+            'disableAutoLoad': true
+        };
 
         ContentViewRepositoriesUtil($scope);
 
@@ -23,7 +25,7 @@
             'content_view_id': $scope.$stateParams.contentViewId,
             'content_type': 'ostree'
         },
-        'queryUnpaged');
+        'queryUnpaged', nutupaneParams);
         $scope.controllerName = 'katello_repositories';
 
         nutupane.masterOnly = true;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-repositories-list.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-repositories-list.controller.js
@@ -16,7 +16,9 @@
 angular.module('Bastion.content-views').controller('ContentViewRepositoriesListController',
     ['$scope', 'Repository', 'Nutupane', 'CurrentOrganization', 'ContentViewRepositoriesUtil',
     function ($scope, Repository, Nutupane, CurrentOrganization, ContentViewRepositoriesUtil) {
-        var nutupane;
+        var nutupane, nutupaneParams = {
+            'disableAutoLoad': true
+        };
 
         ContentViewRepositoriesUtil($scope);
 
@@ -25,7 +27,7 @@ angular.module('Bastion.content-views').controller('ContentViewRepositoriesListC
             'content_view_id': $scope.$stateParams.contentViewId,
             'content_type': 'yum'
         },
-        'queryUnpaged');
+        'queryUnpaged', nutupaneParams);
         $scope.controllerName = 'katello_repositories';
 
         nutupane.load();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-versions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-versions.controller.js
@@ -18,7 +18,9 @@
 angular.module('Bastion.content-views').controller('ContentViewVersionsController',
     ['$scope', 'translate', 'Nutupane', 'ContentViewVersion', 'AggregateTask', 'ApiErrorHandler', 'Notification',
     function ($scope, translate, Nutupane, ContentViewVersion, AggregateTask, ApiErrorHandler, Notification) {
-        var nutupane;
+        var nutupane, nutupaneParams = {
+            'disableAutoLoad': true
+        };
 
         function pluralSafe(count, strings) {
             if (count === 1) {
@@ -224,7 +226,7 @@ angular.module('Bastion.content-views').controller('ContentViewVersionsControlle
             loading: true
         };
 
-        nutupane = new Nutupane(ContentViewVersion, {'content_view_id': $scope.$stateParams.contentViewId});
+        nutupane = new Nutupane(ContentViewVersion, {'content_view_id': $scope.$stateParams.contentViewId}, undefined, nutupaneParams);
         $scope.controllerName = 'katello_content_views';
         nutupane.setSearchKey('contentViewVersionSearch');
         nutupane.masterOnly = true;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version-content.controller.js
@@ -87,7 +87,8 @@
         };
 
         params = contentTypes[currentState].params || {'content_view_version_id': $scope.$stateParams.versionId};
-        nutupane = new Nutupane(contentTypes[currentState].type, params, 'queryPaged');
+
+        nutupane = new Nutupane(contentTypes[currentState].type, params, 'queryPaged', { 'disableAutoLoad': true });
         nutupane.masterOnly = true;
 
         $scope.nutupane = nutupane;


### PR DESCRIPTION
## Description:
On the Content View Page, the following pages make multiple calls to the API when it should be making just one.
*****
## The following pages have this issue: 
**CV >** 
* Versions
* Yum Content -> Repositories
  * Add
  * Available
* Apt Repo
  * Add 
  * Available
* File Repo
  * Add 
  * Available
* Docker> Repo
  * Add 
  * Available
* OSTree
  * Add 
  * Available

**CV>Version>**
* Yum Repo
* RPM Package
* Errata
* Apt Repositories
* Deb Packages
***
## Steps to reproduce:
* Go to any of the pages above
* You can see that 2 calls are made to respective corresponding API endpoints.
