### PR TITLE
Fixes #22731 - Add delete button to subscriptions page 

### DIFF
--- a/webpack/move_to_foreman/common/helpers.js
+++ b/webpack/move_to_foreman/common/helpers.js
@@ -1,3 +1,6 @@
+import React from 'react';
+import { Table } from 'patternfly-react';
+
 export default {
   urlBuilder(controller, action, id = undefined) {
     return `/${controller}/${id ? `${id}/` : ''}${action}`;
@@ -9,3 +12,25 @@ export const KEY_CODES = {
   ENTER_KEY: 13,
   ESCAPE_KEY: 27,
 };
+
+export const selectionFormatter = (selectionController, label) => (
+  <Table.SelectionHeading aria-label={label}>
+    <Table.Checkbox
+      id="selectAll"
+      label={label}
+      checked={selectionController.allRowsSelected()}
+      onChange={() => selectionController.selectAllRows()}
+    />
+  </Table.SelectionHeading>
+);
+
+export const selectionCellFormatter = (selectionController, value, additionalData) => (
+  <Table.SelectionCell>
+    <Table.Checkbox
+      id={`select${additionalData.rowIndex}`}
+      label={__('Select row')}
+      checked={selectionController.isSelected(additionalData)}
+      onChange={() => selectionController.selectRow(additionalData)}
+    />
+  </Table.SelectionCell>
+);

--- a/webpack/move_to_foreman/components/common/table/index.js
+++ b/webpack/move_to_foreman/components/common/table/index.js
@@ -49,7 +49,6 @@ export class Table extends React.Component {
     return this.props.rows.length === 0 && this.props.bodyMessage === undefined;
   }
 
-
   render() {
     const { columns, rows, emptyState, bodyMessage, children, itemCount, pagination, onPaginationChange, ...otherProps } = this.props;
 
@@ -84,6 +83,18 @@ export class Table extends React.Component {
           bordered
           hover
           columns={columns}
+          components={{
+            header: {
+              cell: cellProps =>
+                this.customHeaderFormatters({
+                  cellProps,
+                  columns,
+                  sortingColumns,
+                  rows: rows,
+                  onSelectAllRows: this.onSelectAllRows
+                })
+            }
+          }}
           {...otherProps}
         >
           {table}

--- a/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
+++ b/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Col, Tabs, Tab, Form, FormGroup, FormControl, ControlLabel } from 'react-bootstrap';
 import { bindMethods, Alert, Button, Icon, Modal, ProgressBar, Spinner, OverlayTrigger, Tooltip } from 'patternfly-react';
-
 import { Table } from '../../../move_to_foreman/components/common/table';
 import { columns } from './ManifestHistoryTableSchema';
 

--- a/webpack/scenes/Subscriptions/SubscriptionActions.js
+++ b/webpack/scenes/Subscriptions/SubscriptionActions.js
@@ -11,6 +11,9 @@ import {
   UPDATE_QUANTITY_REQUEST,
   UPDATE_QUANTITY_SUCCESS,
   UPDATE_QUANTITY_FAILURE,
+  DELETE_SUBSCRIPTIONS_REQUEST,
+  DELETE_SUBSCRIPTIONS_SUCCESS,
+  DELETE_SUBSCRIPTIONS_FAILURE,
 } from './SubscriptionConstants';
 import { filterRHSubscriptions } from './SubscriptionHelpers.js';
 
@@ -91,5 +94,29 @@ export const updateQuantity = (quantities = {}) => (dispatch) => {
       });
     });
 };
+
+export const deleteSubscriptions = poolIds => (dispatch) => {
+  dispatch({ type: DELETE_SUBSCRIPTIONS_REQUEST });
+
+  const params = {
+    pool_ids: poolIds,
+  };
+
+  return api
+    .delete(`/organizations/${orgId}/upstream_subscriptions`, {}, params)
+    .then(({ data }) => {
+      dispatch({
+        type: DELETE_SUBSCRIPTIONS_SUCCESS,
+        response: data,
+      });
+    })
+    .catch((result) => {
+      dispatch({
+        type: DELETE_SUBSCRIPTIONS_FAILURE,
+        result,
+      });
+    });
+};
+
 
 export default loadSubscriptions;

--- a/webpack/scenes/Subscriptions/SubscriptionConstants.js
+++ b/webpack/scenes/Subscriptions/SubscriptionConstants.js
@@ -10,12 +10,17 @@ export const SUBSCRIPTIONS_QUANTITIES_REQUEST = 'SUBSCRIPTIONS_QUANTITIES_REQUES
 export const SUBSCRIPTIONS_QUANTITIES_SUCCESS = 'SUBSCRIPTIONS_QUANTITIES_SUCCESS';
 export const SUBSCRIPTIONS_QUANTITIES_FAILURE = 'SUBSCRIPTIONS_QUANTITIES_FAILURE';
 
+export const DELETE_SUBSCRIPTIONS_REQUEST = 'DELETE_SUBSCRIPTIONS_REQUEST';
+export const DELETE_SUBSCRIPTIONS_SUCCESS = 'DELETE_SUBSCRIPTIONS_SUCCESS';
+export const DELETE_SUBSCRIPTIONS_FAILURE = 'DELETE_SUBSCRIPTIONS_FAILURE';
+
 export const BLOCKING_FOREMAN_TASK_TYPES = [
   'Actions::Katello::Organization::ManifestImport',
   'Actions::Katello::Organization::ManifestRefresh',
   'Actions::Katello::Organization::ManifestDelete',
   'Actions::Katello::UpstreamSubscriptions::BindEntitlements',
   'Actions::Katello::UpstreamSubscriptions::UpdateEntitlement',
+  'Actions::Katello::UpstreamSubscriptions::RemoveEntitlements',
 ];
 
 export const MANIFEST_TASKS_BULK_SEARCH_ID = 'activeManifestTasksSearch';

--- a/webpack/scenes/Subscriptions/SubscriptionReducer.js
+++ b/webpack/scenes/Subscriptions/SubscriptionReducer.js
@@ -13,6 +13,9 @@ import {
   UPDATE_QUANTITY_REQUEST,
   UPDATE_QUANTITY_SUCCESS,
   UPDATE_QUANTITY_FAILURE,
+  DELETE_SUBSCRIPTIONS_REQUEST,
+  DELETE_SUBSCRIPTIONS_SUCCESS,
+  DELETE_SUBSCRIPTIONS_FAILURE,
   MANIFEST_TASKS_BULK_SEARCH_ID,
 } from './SubscriptionConstants';
 
@@ -39,6 +42,7 @@ export default (state = initialState, action) => {
   switch (action.type) {
     case SUBSCRIPTIONS_REQUEST:
     case UPDATE_QUANTITY_REQUEST:
+    case DELETE_SUBSCRIPTIONS_REQUEST:
       return state.set('loading', true).set('tasks', []);
 
     case SUBSCRIPTIONS_SUCCESS: {
@@ -60,11 +64,15 @@ export default (state = initialState, action) => {
       });
     }
 
+    case DELETE_SUBSCRIPTIONS_SUCCESS:
+      return state.set('loading', false);
+
     case UPDATE_QUANTITY_SUCCESS:
       return state.set('loading', false);
 
     case SUBSCRIPTIONS_FAILURE:
     case UPDATE_QUANTITY_FAILURE:
+    case DELETE_SUBSCRIPTIONS_FAILURE:
       return state.merge({
         error: action.error,
         loading: false,

--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -18,6 +18,8 @@ class SubscriptionsPage extends Component {
     super(props);
     this.state = {
       manifestModalOpen: false,
+      subscriptionDeleteModalOpen: false,
+      disableDeleteButton: true,
     };
   }
 
@@ -55,8 +57,25 @@ class SubscriptionsPage extends Component {
       this.setState({ manifestModalOpen: true });
     };
 
-    const onModalClose = () => {
+    const onManageManifestModalClose = () => {
       this.setState({ manifestModalOpen: false });
+    };
+
+    const showSubscriptionDeleteModal = () => {
+      this.setState({ subscriptionDeleteModalOpen: true });
+    };
+
+    const onSubscriptionDeleteModalClose = () => {
+      this.setState({ subscriptionDeleteModalOpen: false });
+    };
+
+    const onDeleteSubscriptions = (selectedRows) => {
+      this.props.deleteSubscriptions(selectedRows);
+      onSubscriptionDeleteModalClose();
+    };
+
+    const toggleDeleteButton = (rowsSelected) => {
+      this.setState({ disableDeleteButton: !rowsSelected });
     };
 
     return (
@@ -88,7 +107,11 @@ class SubscriptionsPage extends Component {
                         {__('Export CSV')}
                       </Button>
 
-                      <Button disabled={taskInProgress}>
+                      <Button
+                        bsStyle="danger"
+                        onClick={showSubscriptionDeleteModal}
+                        disabled={taskInProgress || this.state.disableDeleteButton}
+                      >
                         {__('Delete')}
                       </Button>
                     </FormGroup>
@@ -96,11 +119,18 @@ class SubscriptionsPage extends Component {
                 </Form>
               </Col>
             </Row>
-            <ManageManifestModal showModal={this.state.manifestModalOpen} onClose={onModalClose} />
+            <ManageManifestModal
+              showModal={this.state.manifestModalOpen}
+              onClose={onManageManifestModalClose}
+            />
             <SubscriptionsTable
               loadSubscriptions={this.props.loadSubscriptions}
               updateQuantity={this.props.updateQuantity}
               subscriptions={this.props.subscriptions}
+              subscriptionDeleteModalOpen={this.state.subscriptionDeleteModalOpen}
+              onSubscriptionDeleteModalClose={onSubscriptionDeleteModalClose}
+              onDeleteSubscriptions={onDeleteSubscriptions}
+              toggleDeleteButton={toggleDeleteButton}
             />
           </Col>
         </Row>
@@ -115,6 +145,7 @@ SubscriptionsPage.propTypes = {
   subscriptions: PropTypes.shape({}).isRequired,
   pollBulkSearch: PropTypes.func.isRequired,
   tasks: PropTypes.arrayOf(PropTypes.shape({})),
+  deleteSubscriptions: PropTypes.func.isRequired,
 };
 
 SubscriptionsPage.defaultProps = {

--- a/webpack/scenes/Subscriptions/SubscriptionsTableSchema.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsTableSchema.js
@@ -1,10 +1,24 @@
 import React from 'react';
 import { Icon } from 'patternfly-react';
-import helpers from '../../move_to_foreman/common/helpers';
-import { headerFormat, cellFormat } from '../../move_to_foreman/components/common/table';
+import helpers, { selectionFormatter, selectionCellFormatter } from '../../move_to_foreman/common/helpers';
 import { entitlementsInlineEditFormatter } from './EntitlementsInlineEditFormatter';
+import { headerFormat, cellFormat } from '../../move_to_foreman/components/common/table';
 
-export const columns = inlineEditController => [
+export const columns = (inlineEditController, selectionController) => [
+  {
+    property: 'select',
+    header: {
+      label: __('Select all rows'),
+      props: {
+        index: 0,
+      },
+      formatters: [label => selectionFormatter(selectionController, label)],
+    },
+    cell: {
+      formatters: [(value, additionalData) =>
+        selectionCellFormatter(selectionController, value, additionalData)],
+    },
+  },
   {
     property: 'id',
     header: {
@@ -51,8 +65,7 @@ export const columns = inlineEditController => [
     cell: {
       formatters: [cellFormat],
     },
-  },
-  // TODO: use date formatter from tomas' PR
+  }, // TODO: use date formatter from tomas' PR
   {
     property: 'start_date',
     header: {

--- a/webpack/scenes/Subscriptions/__tests__/SubscriptionsPage.test.js
+++ b/webpack/scenes/Subscriptions/__tests__/SubscriptionsPage.test.js
@@ -14,6 +14,7 @@ describe('subscriptions page', () => {
       loadSubscriptions={loadSubscriptions}
       updateQuantity={updateQuantity}
       pollBulkSearch={pollBulkSearch}
+      deleteSubscriptions={() => {}}
     />);
     expect(toJson(page)).toMatchSnapshot();
   });

--- a/webpack/scenes/Subscriptions/__tests__/SubscriptionsTable.test.js
+++ b/webpack/scenes/Subscriptions/__tests__/SubscriptionsTable.test.js
@@ -11,6 +11,10 @@ describe('subscriptions table', () => {
       subscriptions={successState}
       loadSubscriptions={loadSubscriptions}
       updateQuantity={updateQuantity}
+      subscriptionDeleteModalOpen={false}
+      onSubscriptionDeleteModalClose={() => { }}
+      onDeleteSubscriptions={() => {}}
+      toggleDeleteButton={() => {}}
     />);
     expect(toJson(page)).toMatchSnapshot();
   });
@@ -20,6 +24,10 @@ describe('subscriptions table', () => {
       subscriptions={emptyState}
       loadSubscriptions={loadSubscriptions}
       updateQuantity={updateQuantity}
+      subscriptionDeleteModalOpen={false}
+      onSubscriptionDeleteModalClose={() => { }}
+      onDeleteSubscriptions={() => {}}
+      toggleDeleteButton={() => {}}
     />);
     expect(toJson(page)).toMatchSnapshot();
   });
@@ -29,6 +37,10 @@ describe('subscriptions table', () => {
       subscriptions={loadingState}
       loadSubscriptions={loadSubscriptions}
       updateQuantity={updateQuantity}
+      subscriptionDeleteModalOpen={false}
+      onSubscriptionDeleteModalClose={() => { }}
+      onDeleteSubscriptions={() => {}}
+      toggleDeleteButton={() => {}}
     />);
     expect(toJson(page)).toMatchSnapshot();
   });

--- a/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsPage.test.js.snap
+++ b/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsPage.test.js.snap
@@ -90,8 +90,9 @@ exports[`subscriptions page should render 1`] = `
                   active={false}
                   block={false}
                   bsClass="btn"
-                  bsStyle="default"
-                  disabled={false}
+                  bsStyle="danger"
+                  disabled={true}
+                  onClick={[Function]}
                 >
                   Delete
                 </Button>
@@ -106,6 +107,9 @@ exports[`subscriptions page should render 1`] = `
       />
       <SubscriptionsTable
         loadSubscriptions={[Function]}
+        onDeleteSubscriptions={[Function]}
+        onSubscriptionDeleteModalClose={[Function]}
+        subscriptionDeleteModalOpen={false}
         subscriptions={
           Object {
             "availableQuantities": Object {},
@@ -174,6 +178,7 @@ exports[`subscriptions page should render 1`] = `
             "searchIsActive": false,
           }
         }
+        toggleDeleteButton={[Function]}
         updateQuantity={[Function]}
       />
     </Col>

--- a/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
+++ b/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
@@ -18,6 +18,21 @@ Array [
           class=""
         >
           <th
+            aria-label="Select all rows"
+            class="table-view-pf-select"
+          >
+            <label
+              class="control-label sr-only"
+              for="selectAll"
+            >
+              Select all rows
+            </label>
+            <input
+              id="selectAll"
+              type="checkbox"
+            />
+          </th>
+          <th
             class=""
           >
             Name
@@ -61,6 +76,20 @@ Array [
       </thead>
       <tbody>
         <tr>
+          <td
+            class="table-view-pf-select"
+          >
+            <label
+              class="control-label sr-only"
+              for="select0"
+            >
+              Select row
+            </label>
+            <input
+              id="select0"
+              type="checkbox"
+            />
+          </td>
           <td>
             <a
               href="/subscriptions/3/"
@@ -102,6 +131,20 @@ Array [
           </td>
         </tr>
         <tr>
+          <td
+            class="table-view-pf-select"
+          >
+            <label
+              class="control-label sr-only"
+              for="select1"
+            >
+              Select row
+            </label>
+            <input
+              id="select1"
+              type="checkbox"
+            />
+          </td>
           <td>
             <a
               href="/subscriptions/4/"

--- a/webpack/services/api/index.js
+++ b/webpack/services/api/index.js
@@ -47,9 +47,10 @@ class Api {
     });
   }
 
-  delete(url, headers = {}) {
+  delete(url, headers = {}, data = {}) {
     return axios.delete(this.getApiUrl(url), {
       headers,
+      data,
     });
   }
 


### PR DESCRIPTION
 This adds the capability to delete subscriptions upstream (in RHSM) and trigger a manifest refresh.

Depends on https://github.com/Katello/katello/pull/7317, my changes are in a separate commit to make things easier to review.

To do:
- [x] rebase once https://github.com/Katello/katello/pull/7317 is merged
- [x] update tests