### PR TITLE
Fixes #22502: Wait for product.$resolved b4 using

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/views/product-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/views/product-repositories.html
@@ -4,7 +4,7 @@
   <div data-block="list-actions">
     <button type="button" class="btn btn-default"
             ui-sref="product.repositories.new({productId: product.id})"
-            ng-hide="denied('edit_products', product) || product.redhat">
+            ng-hide="!product.$resolved || denied('edit_products', product) || product.redhat">
       <span translate>New Repository</span>
     </button>
 
@@ -17,7 +17,7 @@
 
     <button type="button" class="btn btn-default"
             ng-click="openModal()"
-            ng-show="canRemoveRepositories(product)"
+            ng-show="product.$resolved && canRemoveRepositories(product)"
             ng-disabled="removingRepositories || table.numSelected == 0">
       <span ng-show="removingRepositories">
         <i class="fa fa-spinner inline-icon fa-spin"></i>


### PR DESCRIPTION
Don't use buttons that hide/show conditionally on product state without
first checking that the product promise is $resolved.