### PR TITLE
Fixes #23464 - Installed Package list is empty

### DIFF
--- a/app/models/katello/installed_package.rb
+++ b/app/models/katello/installed_package.rb
@@ -5,5 +5,9 @@ module Katello
 
     scoped_search :on => :name, :complete_value => true
     scoped_search :on => :nvra
+
+    def nvrea
+      nvra
+    end
   end
 end


### PR DESCRIPTION
Steps to reproduce:
1. Go to Hosts> Content Host > Record > Installed packages

You should see the table with empty rows

This was caused by this [Pull Request](https://github.com/Katello/katello/pull/7269 )
Installed packages do not store the epoch information afaik. 