### PR TITLE
Fixes #23552 - add keys to table and fix select row formatters

### DIFF
--- a/webpack/move_to_foreman/common/helpers.js
+++ b/webpack/move_to_foreman/common/helpers.js
@@ -13,7 +13,7 @@ export const KEY_CODES = {
   ESCAPE_KEY: 27,
 };
 
-export const selectionFormatter = (selectionController, label) => (
+export const selectionHeaderCellFormatter = (selectionController, label) => (
   <Table.SelectionHeading aria-label={label}>
     <Table.Checkbox
       id="selectAll"

--- a/webpack/move_to_foreman/components/common/table/index.js
+++ b/webpack/move_to_foreman/components/common/table/index.js
@@ -1,12 +1,9 @@
 /* eslint-disable */
-import { Table as PfTable, customHeaderFormattersDefinition } from 'patternfly-react';
+import { Table as PfTable } from 'patternfly-react';
 import React from 'react';
 import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
 import EmptyState from '../emptyState';
 import PaginationRow from '../../../../components/PaginationRow/index';
-
-export const selectionCellFormatter = PfTable.selectionCellFormatter;
-export const selectionHeaderCellFormatter = PfTable.selectionHeaderCellFormatter;
 
 export const headerFormat = value => <PfTable.Heading>{value}</PfTable.Heading>;
 export const cellFormat = value => <PfTable.Cell>{value}</PfTable.Cell>;
@@ -39,12 +36,6 @@ export const TableBody = (props) => {
 };
 
 export class Table extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.customHeaderFormatters = customHeaderFormattersDefinition;
-  }
-
   isEmpty() {
     return this.props.rows.length === 0 && this.props.bodyMessage === undefined;
   }
@@ -72,8 +63,8 @@ export class Table extends React.Component {
     const table = (children !== undefined)
       ? children
       : [
-        <PfTable.Header />,
-        <TableBody columns={columns} rows={rows} message={bodyMessage} rowKey="id" />,
+        <PfTable.Header key="header" />,
+        <TableBody key="body" columns={columns} rows={rows} message={bodyMessage} rowKey="id" />,
       ];
 
     sortingColumns = sortingColumns || {};
@@ -86,18 +77,6 @@ export class Table extends React.Component {
           bordered
           hover
           columns={columns}
-          components={{
-            header: {
-              cell: cellProps =>
-                this.customHeaderFormatters({
-                  cellProps,
-                  columns,
-                  sortingColumns,
-                  rows: rows,
-                  onSelectAllRows: this.onSelectAllRows
-                })
-            }
-          }}
           {...otherProps}
         >
           {table}

--- a/webpack/scenes/Subscriptions/SubscriptionsTableSchema.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsTableSchema.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Icon } from 'patternfly-react';
-import helpers, { selectionFormatter, selectionCellFormatter } from '../../move_to_foreman/common/helpers';
+import helpers, { selectionHeaderCellFormatter, selectionCellFormatter } from '../../move_to_foreman/common/helpers';
 import { entitlementsInlineEditFormatter } from './EntitlementsInlineEditFormatter';
 import { headerFormat, cellFormat } from '../../move_to_foreman/components/common/table';
 
@@ -9,10 +9,7 @@ export const columns = (inlineEditController, selectionController) => [
     property: 'select',
     header: {
       label: __('Select all rows'),
-      props: {
-        index: 0,
-      },
-      formatters: [label => selectionFormatter(selectionController, label)],
+      formatters: [label => selectionHeaderCellFormatter(selectionController, label)],
     },
     cell: {
       formatters: [(value, additionalData) =>
@@ -24,9 +21,6 @@ export const columns = (inlineEditController, selectionController) => [
     header: {
       label: __('Name'),
       formatters: [headerFormat],
-      props: {
-        index: 1,
-      },
     },
     cell: {
       formatters: [
@@ -45,9 +39,6 @@ export const columns = (inlineEditController, selectionController) => [
     header: {
       label: __('SKU'),
       formatters: [headerFormat],
-      props: {
-        index: 2,
-      },
     },
     cell: {
       formatters: [cellFormat],
@@ -58,9 +49,6 @@ export const columns = (inlineEditController, selectionController) => [
     header: {
       label: __('Contract'),
       formatters: [headerFormat],
-      props: {
-        index: 3,
-      },
     },
     cell: {
       formatters: [cellFormat],
@@ -71,9 +59,6 @@ export const columns = (inlineEditController, selectionController) => [
     header: {
       label: __('Start Date'),
       formatters: [headerFormat],
-      props: {
-        index: 4,
-      },
     },
     cell: {
       formatters: [cellFormat],
@@ -84,9 +69,6 @@ export const columns = (inlineEditController, selectionController) => [
     header: {
       label: __('End Date'),
       formatters: [headerFormat],
-      props: {
-        index: 5,
-      },
     },
     cell: {
       formatters: [cellFormat],
@@ -97,9 +79,6 @@ export const columns = (inlineEditController, selectionController) => [
     header: {
       label: __('Requires Virt-Who'),
       formatters: [headerFormat],
-      props: {
-        index: 6,
-      },
     },
     cell: {
       formatters: [
@@ -116,9 +95,6 @@ export const columns = (inlineEditController, selectionController) => [
     header: {
       label: __('Consumed'),
       formatters: [headerFormat],
-      props: {
-        index: 7,
-      },
     },
     cell: {
       formatters: [cellFormat],
@@ -129,9 +105,6 @@ export const columns = (inlineEditController, selectionController) => [
     header: {
       label: __('Entitlements'),
       formatters: [headerFormat],
-      props: {
-        index: 8,
-      },
     },
     cell: {
       formatters: [

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsTableSchema.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsTableSchema.js
@@ -1,35 +1,21 @@
 import React from 'react';
 import { FormGroup, FormControl, ControlLabel } from 'react-bootstrap';
-import helpers from '../../../move_to_foreman/common/helpers';
+import helpers, { selectionHeaderCellFormatter, selectionCellFormatter } from '../../../move_to_foreman/common/helpers';
 import {
   headerFormat,
   cellFormat,
-  selectionHeaderCellFormatter,
-  selectionCellFormatter,
 } from '../../../move_to_foreman/components/common/table';
 
-export const columns = controller => [
+export const columns = (controller, selectionController) => [
   {
     property: 'select',
     header: {
-      label: 'Select all rows',
-      props: {
-        index: 0,
-        rowSpan: 1,
-        colSpan: 1,
-      },
-      customFormatters: [selectionHeaderCellFormatter],
+      label: __('Select all rows'),
+      formatters: [label => selectionHeaderCellFormatter(selectionController, label)],
     },
     cell: {
-      props: {
-        index: 0,
-      },
-      formatters: [
-        (value, { rowData, rowIndex }) => selectionCellFormatter(
-          { rowData, rowIndex },
-          controller.onSelectRow,
-        ),
-      ],
+      formatters: [(value, additionalData) =>
+        selectionCellFormatter(selectionController, value, additionalData)],
     },
   },
   {
@@ -37,9 +23,6 @@ export const columns = controller => [
     header: {
       label: __('Subscription Name'),
       formatters: [headerFormat],
-      props: {
-        index: 1,
-      },
     },
     cell: {
       formatters: [
@@ -58,9 +41,6 @@ export const columns = controller => [
     header: {
       label: __('Contract'),
       formatters: [headerFormat],
-      props: {
-        index: 2,
-      },
     },
     cell: {
       formatters: [cellFormat],
@@ -72,9 +52,6 @@ export const columns = controller => [
     header: {
       label: __('Start Date'),
       formatters: [headerFormat],
-      props: {
-        index: 3,
-      },
     },
     cell: {
       formatters: [cellFormat],
@@ -85,9 +62,6 @@ export const columns = controller => [
     header: {
       label: __('End Date'),
       formatters: [headerFormat],
-      props: {
-        index: 4,
-      },
     },
     cell: {
       formatters: [cellFormat],
@@ -98,9 +72,6 @@ export const columns = controller => [
     header: {
       label: __('Available Entitlements'),
       formatters: [headerFormat],
-      props: {
-        index: 5,
-      },
     },
     cell: {
       formatters: [
@@ -117,9 +88,6 @@ export const columns = controller => [
     header: {
       label: __('Quantity to Allocate'),
       formatters: [headerFormat],
-      props: {
-        index: 6,
-      },
     },
     cell: {
       formatters: [

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/__snapshots__/UpstreamSubscriptionsPage.test.js.snap
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/__snapshots__/UpstreamSubscriptionsPage.test.js.snap
@@ -33,20 +33,12 @@ exports[`upstream subscriptions page should render 1`] = `
                   "formatters": Array [
                     [Function],
                   ],
-                  "props": Object {
-                    "index": 0,
-                  },
                 },
                 "header": Object {
-                  "customFormatters": Array [
+                  "formatters": Array [
                     [Function],
                   ],
                   "label": "Select all rows",
-                  "props": Object {
-                    "colSpan": 1,
-                    "index": 0,
-                    "rowSpan": 1,
-                  },
                 },
                 "property": "select",
               },
@@ -61,9 +53,6 @@ exports[`upstream subscriptions page should render 1`] = `
                     [Function],
                   ],
                   "label": "Subscription Name",
-                  "props": Object {
-                    "index": 1,
-                  },
                 },
                 "property": "id",
               },
@@ -78,9 +67,6 @@ exports[`upstream subscriptions page should render 1`] = `
                     [Function],
                   ],
                   "label": "Contract",
-                  "props": Object {
-                    "index": 2,
-                  },
                 },
                 "property": "contract_number",
               },
@@ -95,9 +81,6 @@ exports[`upstream subscriptions page should render 1`] = `
                     [Function],
                   ],
                   "label": "Start Date",
-                  "props": Object {
-                    "index": 3,
-                  },
                 },
                 "property": "start_date",
               },
@@ -112,9 +95,6 @@ exports[`upstream subscriptions page should render 1`] = `
                     [Function],
                   ],
                   "label": "End Date",
-                  "props": Object {
-                    "index": 4,
-                  },
                 },
                 "property": "end_date",
               },
@@ -129,9 +109,6 @@ exports[`upstream subscriptions page should render 1`] = `
                     [Function],
                   ],
                   "label": "Available Entitlements",
-                  "props": Object {
-                    "index": 5,
-                  },
                 },
                 "property": "quantity",
               },
@@ -146,20 +123,10 @@ exports[`upstream subscriptions page should render 1`] = `
                     [Function],
                   ],
                   "label": "Quantity to Allocate",
-                  "props": Object {
-                    "index": 6,
-                  },
                 },
                 "property": "consumed",
               },
             ]
-          }
-          components={
-            Object {
-              "header": Object {
-                "cell": [Function],
-              },
-            }
           }
           emptyState={
             Object {


### PR DESCRIPTION
- Replaces patternfly-react custom formatters with our selection formatters in the upstream subscription table
- Renames `selectionFormatter` to more obvious `selectionHeaderCellFormatter`
- Removes `{props: {index}}` from column definitions (they're no longer needed)
- Fixes `Warning: Each child in an array or iterator should have a unique "key" prop.`