### PR TITLE
Fixes #23381 - Add resorce switcher hide option to katello pages

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-register.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-register.controller.js
@@ -30,7 +30,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostRegisterControlle
             $scope.noCapsulesFound = _.isEmpty(data.results);
             $scope.selectedCapsule = _.isEmpty(defaultCapsule) ? data.results[0] : defaultCapsule[0];
         });
-
+        $scope.hideSwitcher = true;
 
         $scope.hostname = function (url) {
             if (url) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
@@ -32,7 +32,7 @@ angular.module('Bastion.products').controller('DiscoveryController',
             {id: "yum", name: "Yum Repositories"},
             {id: "docker", name: "Docker Images"}
         ];
-
+        $scope.hideSwitcher = true;
         if (!$scope.table) {
             $scope.table = {
                 rows: [],


### PR DESCRIPTION
Depends on PR: [Bastion : 228](https://github.com/Katello/bastion/pull/228) which adds the hideSwitcher option to Bastion pages.
*****
Identified 2 pages where hideSwitcher is to be used since we do not need resource switcher.
1. Product> Repo Discovery
2. Content Host> Register
*****
Can hide resource switcher on any other page using $scope.hideSwitcher.
