### PR TITLE
fixes #22835 - support deleting pools from sub-man

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -492,9 +492,9 @@ module Katello
         (User.consumer? || ::User.current.can?(:view_organizations, self))
       when "rhsm_proxy_consumer_certificates_path", "rhsm_proxy_consumer_releases_path", "rhsm_proxy_certificate_serials_path",
            "rhsm_proxy_consumer_entitlements_path", "rhsm_proxy_consumer_entitlements_post_path",
-           "rhsm_proxy_consumer_entitlements_delete_path", "rhsm_proxy_consumer_certificates_put_path",
-           "rhsm_proxy_consumer_dryrun_path", "rhsm_proxy_consumer_owners_path",
-           "rhsm_proxy_consumer_compliance_path"
+           "rhsm_proxy_consumer_entitlements_delete_path", "rhsm_proxy_consumer_entitlements_pool_delete_path",
+           "rhsm_proxy_consumer_certificates_put_path", "rhsm_proxy_consumer_dryrun_path",
+           "rhsm_proxy_consumer_owners_path", "rhsm_proxy_consumer_compliance_path"
         User.consumer? && current_user.uuid == params[:id]
       when "rhsm_proxy_consumer_certificates_delete_path"
         User.consumer? && current_user.uuid == params[:consumer_id]

--- a/config/routes/api/rhsm.rb
+++ b/config/routes/api/rhsm.rb
@@ -33,6 +33,7 @@ Katello::Engine.routes.draw do
       match '/consumers/:id/entitlements' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_entitlements_path
       match '/consumers/:id/entitlements' => 'candlepin_proxies#post', :via => :post, :as => :proxy_consumer_entitlements_post_path
       match '/consumers/:id/entitlements' => 'candlepin_proxies#delete', :via => :delete, :as => :proxy_consumer_entitlements_delete_path
+      match '/consumers/:id/entitlements/pool/:poolId' => 'candlepin_proxies#delete', :via => :delete, :as => :proxy_consumer_entitlements_pool_delete_path
       match '/consumers/:id/entitlements/dry-run' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_dryrun_path
       match '/consumers/:id/owner' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_owners_path
       match '/consumers/:consumer_id/certificates/:id' => 'candlepin_proxies#delete', :via => :delete, :as => :proxy_consumer_certificates_delete_path


### PR DESCRIPTION
To test, add a subscription to a host and try removing it via sub-man.  Without this PR you'll get an error that no route matches, with this PR it will succeed:

```
[root@centos7 ~]# subscription-manager unsubscribe --pool 4028f9f8635f741601635fc75d150001
The entitlement server successfully removed these pools:
   4028f9f8635f741601635fc75d150001
```
