### PR TITLE
Fixes #23604 - Speed up manifest import perf

### DIFF
--- a/app/models/katello/glue/candlepin/candlepin_object.rb
+++ b/app/models/katello/glue/candlepin/candlepin_object.rb
@@ -32,7 +32,7 @@ module Katello
         where("#{self.table_name}.id = (?) or #{self.table_name}.cp_id = (?)", id_integers, ids)
       end
 
-      def import_all(organization = nil)
+      def import_all(organization = nil, import_managed_associations = true)
         organizations = organization ? [organization] : Organization.all
 
         organizations.each do |org|
@@ -42,7 +42,7 @@ module Katello
           objects.each do |item|
             if candlepin_ids.include?(item.cp_id)
               item.import_data
-              item.import_managed_associations if item.respond_to?(:import_managed_associations)
+              item.import_managed_associations if import_managed_associations && item.respond_to?(:import_managed_associations)
             else
               item.destroy
             end

--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -92,7 +92,7 @@ module Katello
       end
 
       # rubocop:disable MethodLength
-      def import_data(index_hosts = false)
+      def import_data(index_hosts_and_activation_keys = false)
         pool_attributes = {}.with_indifferent_access
         pool_json = self.backend_data
 
@@ -141,9 +141,9 @@ module Katello
         exceptions = pool_attributes.keys.map(&:to_sym) - self.attribute_names.map(&:to_sym)
         self.update_attributes(pool_attributes.except!(*exceptions))
         self.save!
-        self.create_activation_key_associations
+        self.create_activation_key_associations if index_hosts_and_activation_keys
         self.create_product_associations
-        self.import_hosts if index_hosts
+        self.import_hosts if index_hosts_and_activation_keys
       end
 
       def create_product_associations
@@ -183,6 +183,7 @@ module Katello
 
       def import_managed_associations
         import_hosts
+        create_activation_key_associations
       end
 
       def hosts

--- a/app/models/katello/glue/provider.rb
+++ b/app/models/katello/glue/provider.rb
@@ -144,7 +144,7 @@ module Katello
 
       def index_subscriptions(organization = nil)
         Katello::Subscription.import_all(organization)
-        Katello::Pool.import_all(organization)
+        Katello::Pool.import_all(organization, false)
       end
 
       def rules_source

--- a/test/models/pool_test.rb
+++ b/test/models/pool_test.rb
@@ -90,6 +90,24 @@ module Katello
       assert_equal @pool_one.quantity_available, 9
     end
 
+    def test_import_all_default
+      org = get_organization
+      Pool.expects(:import_candlepin_ids).with(org).returns([@pool_one.cp_id])
+      Pool.expects(:in_organization).with(org).returns([@pool_one])
+      @pool_one.expects(:import_data).once
+      @pool_one.expects(:import_managed_associations).once
+      Pool.import_all(org)
+    end
+
+    def test_import_all_no_managed_association
+      org = get_organization
+      Pool.expects(:import_candlepin_ids).with(org).returns([@pool_one.cp_id])
+      Pool.expects(:in_organization).with(org).returns([@pool_one])
+      @pool_one.expects(:import_data).once
+      @pool_one.expects(:import_managed_associations).never
+      Pool.import_all(org, false)
+    end
+
     def test_quantity_available_unlimited
       pool = FactoryBot.build(:katello_pool, quantity: -1, consumed: 3)
       assert_equal(-1, pool.quantity_available)


### PR DESCRIPTION
This commit intends to speed up the performance of the manifest import
by cutting down unnecessary operations during the Pool indexing stage.

Before
```
timer { Katello::Pool.find(446).import_data }
=> 12.708098227
```
After
```
> timer { Katello::Pool.find(446).import_data }
=> 0.029546651
```