### PR TITLE
fixes #23612 - robottelo test port content credentials (gpg_keys)

### DIFF
--- a/test/models/gpg_keys_test.rb
+++ b/test/models/gpg_keys_test.rb
@@ -1,0 +1,9 @@
+require 'katello_test_helper'
+
+module Katello
+  class GpgKeyTest < ActiveSupport::TestCase
+    should allow_values(*valid_name_list).for(:name)
+    should_not allow_values(*invalid_name_list).for(:name)
+    should_not allow_values('', ' ', "\t", *RFauxFactory.gen_strings(247).values).for(:content)
+  end
+end


### PR DESCRIPTION
Port robottelo tier1 api tests for GPG Key 
part of robottelo minitest port project: https://github.com/SatelliteQE/robottelo/projects/1

Related Robottelo issue: SatelliteQE/robottelo#5870

```
rake test:katello TEST=../katello/test/controllers/api/v2/content_credentials_controller_test.rb
[snip]

# Running:

..........

Finished in 4.736510s, 2.1113 runs/s, 5.7004 assertions/s.
10 runs, 27 assertions, 0 failures, 0 errors, 0 skips

```