### PR TITLE
Fixes #22917 - use a download policy if default is not set

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -117,7 +117,7 @@ module Katello
       end
 
       def set_default_download_policy
-        self.download_policy ||= ::Setting[:default_proxy_download_policy]
+        self.download_policy ||= ::Setting[:default_proxy_download_policy] || ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND
       end
 
       def associate_lifecycle_environments


### PR DESCRIPTION
This allows foreman tests to run with katello enabled without the default Setting set.  Foreman fixtures end up blowing this away, causing any smart proxy save to fail. 