### PR TITLE
Fixes #23639 - Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,12 @@ See the [annotation docs](./test/scenarios/README.md) for more information.
 ## Contact & Resources
 
  * [theforeman.org](https://theforeman.org/plugins/katello)
- * [Foreman User Mailing List](https://groups.google.com/forum/?fromgroups#!forum/foreman-users)
- * [Foreman Developer mailing list](https://groups.google.com/forum/?fromgroups#!forum/foreman-dev)
- * [IRC Freenode](http://freenode.net/using_the_network.shtml): #theforeman-dev
+ * [Discourse Forum](https://community.theforeman.org/)
+    * Archived mailing lists: 
+        * [Foreman User Mailing List](https://groups.google.com/forum/?fromgroups#!forum/foreman-users)
+        * [Foreman Developer mailing list](https://groups.google.com/forum/?fromgroups#!forum/foreman-dev)
+ * [IRC Freenode](https://kiwiirc.com/client/irc.freenode.net/?#theforeman-dev): #theforeman-dev
+ * [IRC Freenode](https://kiwiirc.com/client/irc.freenode.net/?#theforeman): #theforeman
 
 ## Documentation
 


### PR DESCRIPTION
The IRC link was broken, decided to link directly to the kiwiirc links. Added #theforeman. Also called out The mailing lists as archived and provided the Discourse Forum as the new way to communicate with the community.