### PR TITLE
fixes #23636 - add default hook methods

### DIFF
--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -358,6 +358,20 @@ module Katello
       true
     end
 
+    def before_promote_hooks
+      run_callbacks :sync do
+        logger.debug "custom hook before_promote on #{name} will be executed if defined."
+        true
+      end
+    end
+
+    def after_promote_hooks
+      run_callbacks :sync do
+        logger.debug "custom hook after_promote on #{name} will be executed if defined."
+        true
+      end
+    end
+
     def rabl_path
       "katello/api/v2/#{self.class.to_s.demodulize.tableize}/show"
     end


### PR DESCRIPTION
This corrects if foreman-hook plugin not present, an error is thrown during cv promote.