### PR TITLE
Fixes #23639 - Update README

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -117,7 +117,7 @@ module Katello
       end
 
       def set_default_download_policy
-        self.download_policy ||= ::Setting[:default_proxy_download_policy]
+        self.download_policy ||= ::Setting[:default_proxy_download_policy] || ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND
       end
 
       def associate_lifecycle_environments


### PR DESCRIPTION
I made a couple of changes to the contacts and resources section of the README. The IRC link was broken, so I decided to link to support page. I also added #theforeman, as I believe others who aren't interested in development may stumble upon the GitHub page and wish to connect with others.

I also called out The mailing lists as archived and provided the Discourse Forum as the new way to communicate with the community.