### PR TITLE
Fixes #23639 - Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,11 @@ See the [annotation docs](./test/scenarios/README.md) for more information.
 ## Contact & Resources
 
  * [theforeman.org](https://theforeman.org/plugins/katello)
- * [Foreman User Mailing List](https://groups.google.com/forum/?fromgroups#!forum/foreman-users)
- * [Foreman Developer mailing list](https://groups.google.com/forum/?fromgroups#!forum/foreman-dev)
- * [IRC Freenode](http://freenode.net/using_the_network.shtml): #theforeman-dev
+ * [Discourse Forum](https://theforeman.org/support.html#DiscourseForum)
+ * Archived mailing lists:
+    * [Foreman User Mailing List](https://groups.google.com/forum/?fromgroups#!forum/foreman-users)
+    * [Foreman Developer mailing list](https://groups.google.com/forum/?fromgroups#!forum/foreman-dev)
+ * [IRC Freenode](https://theforeman.org/support.html#IRClivechat): #theforeman-dev, #theforeman
 
 ## Documentation
 


### PR DESCRIPTION
I made a couple of changes to the contacts and resources section of the README. The IRC link was broken, so I decided to link directly to the kiwiirc links. I also added #theforeman, as I believe others who aren't interested in development may stumble upon the GitHub page and wish to connect with others.

I also called out The mailing lists as archived and provided the Discourse Forum as the new way to communicate with the community.