### PR TITLE
Refs #23635 - Stop relying on facter

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -278,7 +278,7 @@ module Katello
     def get_parent_host(headers)
       hostnames = headers["HTTP_X_FORWARDED_SERVER"]
       host = hostnames.split(",")[0] if hostnames
-      host || Facter.value(:fqdn) || SETTINGS[:fqdn]
+      host || SETTINGS[:fqdn]
     end
 
     private

--- a/app/models/katello/glue/candlepin/repository.rb
+++ b/app/models/katello/glue/candlepin/repository.rb
@@ -18,7 +18,7 @@ module Katello
       def yum_gpg_key_url
         # if the repo has a gpg key return a url to access it
         if (gpg_key && gpg_key.content.present?)
-          host = Facter.value(:fqdn) || SETTINGS[:fqdn]
+          host = SETTINGS[:fqdn]
           gpg_key_content_api_repository_url(self, :host => host + "/katello", :protocol => 'https')
         end
       end

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -379,7 +379,7 @@ module Katello
 
         assert_equal @controller.get_parent_host(host_and_capsule), "#{capsule}"
         assert_equal @controller.get_parent_host(just_capsule), "#{capsule}"
-        assert_includes [Facter.value(:fqdn), SETTINGS[:fqdn]], @controller.get_parent_host(nil_host)
+        assert_equal SETTINGS[:fqdn], @controller.get_parent_host(nil_host)
       end
     end
   end


### PR DESCRIPTION
The inclusion of facter is technically optional since it's a bundler group. In practice there are direct calls to it.

This change relies on a change in Foreman core to ensure SETTINGS[:fqdn] is set: https://github.com/theforeman/foreman/pull/5589

The benefit is that you can explicitly set the FQDN in your settings file and avoid the use of the host FQDN altogether. This has the benefit of decoupling from the actual host you run Foreman on.