### PR TITLE
Fixes #23650 - Lists no sub repos on RH repos page

### DIFF
--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepository.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepository.js
@@ -114,13 +114,14 @@ class RepositorySetRepository extends Component {
 RepositorySetRepository.propTypes = {
   contentId: PropTypes.number.isRequired,
   productId: PropTypes.number.isRequired,
-  arch: PropTypes.string.isRequired,
+  arch: PropTypes.string,
   releasever: PropTypes.string,
   setRepositoryEnabled: PropTypes.func.isRequired,
 };
 
 RepositorySetRepository.defaultProps = {
   releasever: '',
+  arch: __('Unspecified'),
 };
 
 export default connect(null, { setRepositoryEnabled })(RepositorySetRepository);


### PR DESCRIPTION
The new RH Repos page made the assumption that all repos had an arch
available. However there are many repos that do not have an arch or
release version defined as a substitution. This commit addresses that by
marking the arch as "Unspecified" if no substitution is available for
basearch.