### PR TITLE
Fixes #23324 - add notifications to manifest related jobs

### DIFF
--- a/app/lib/actions/helpers/notifications.rb
+++ b/app/lib/actions/helpers/notifications.rb
@@ -1,0 +1,35 @@
+module Actions
+  module Helpers
+    module Notifications
+      def self.included(base)
+        base.execution_plan_hooks.use :send_notification, :on => [:stopped]
+      end
+
+      def send_notification(plan)
+        if plan_failed?(plan)
+          failure_notification(plan)
+        else
+          success_notification(plan)
+        end
+      end
+
+      def success_notification(plan)
+      end
+
+      def failure_notification(plan)
+      end
+
+      def plan_failed?(plan)
+        [:error, :warning, :cancelled].include?(plan.result)
+      end
+
+      def subject_organization
+        @organization ||= ::Organization.find(input[:organization][:id])
+      end
+
+      def get_foreman_task(plan)
+        ::ForemanTasks::Task::DynflowTask.where(:external_id => plan.id).first
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/organization/manifest_import.rb
+++ b/app/lib/actions/katello/organization/manifest_import.rb
@@ -4,6 +4,8 @@ module Actions
       class ManifestImport < Actions::AbstractAsyncTask
         middleware.use Actions::Middleware::PropagateCandlepinErrors
 
+        include Helpers::Notifications
+
         def plan(organization, path, force)
           action_subject organization
           manifest_update = organization.products.redhat.any?
@@ -24,13 +26,25 @@ module Actions
           end
         end
 
+        def failure_notification(plan)
+          ::Katello::UINotifications::Subscriptions::ManifestImportError.deliver!(
+            :subject => subject_organization,
+            :task => get_foreman_task(plan)
+          )
+        end
+
+        def success_notification(_plan)
+          ::Katello::UINotifications::Subscriptions::ManifestImportSuccess.deliver!(
+            subject_organization
+          )
+        end
+
         def humanized_name
           _("Import Manifest")
         end
 
         def finalize
-          organization = ::Organization.find(input[:organization][:id])
-          organization.update_attributes!(
+          subject_organization.update_attributes!(
             :manifest_refreshed_at => Time.now,
             :audit_comment => _('Manifest imported'))
         end

--- a/app/services/katello/ui_notifications/abstract_notification.rb
+++ b/app/services/katello/ui_notifications/abstract_notification.rb
@@ -1,0 +1,29 @@
+module Katello
+  module UINotifications
+    class AbstractNotification < ::UINotifications::Base
+      protected
+
+      def create
+        Notification.create!(
+          subject: subject,
+          initiator: initiator,
+          audience: audience,
+          notification_blueprint: blueprint,
+          actions: actions
+        )
+      end
+
+      def audience
+        ::Notification::AUDIENCE_SUBJECT
+      end
+
+      def actions
+        []
+      end
+
+      def blueprint
+        fail(Foreman::Exception, "must define blueprint in #{self.class} successors")
+      end
+    end
+  end
+end

--- a/app/services/katello/ui_notifications/subscriptions/manifest_delete_error.rb
+++ b/app/services/katello/ui_notifications/subscriptions/manifest_delete_error.rb
@@ -1,0 +1,13 @@
+module Katello
+  module UINotifications
+    module Subscriptions
+      class ManifestDeleteError < UINotifications::TaskNotification
+        private
+
+        def blueprint
+          @blueprint ||= NotificationBlueprint.find_by(name: 'manifest_delete_error')
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/ui_notifications/subscriptions/manifest_delete_success.rb
+++ b/app/services/katello/ui_notifications/subscriptions/manifest_delete_success.rb
@@ -1,0 +1,13 @@
+module Katello
+  module UINotifications
+    module Subscriptions
+      class ManifestDeleteSuccess < UINotifications::AbstractNotification
+        private
+
+        def blueprint
+          @blueprint ||= NotificationBlueprint.find_by(name: 'manifest_delete_success')
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/ui_notifications/subscriptions/manifest_import_error.rb
+++ b/app/services/katello/ui_notifications/subscriptions/manifest_import_error.rb
@@ -1,0 +1,13 @@
+module Katello
+  module UINotifications
+    module Subscriptions
+      class ManifestImportError < UINotifications::TaskNotification
+        private
+
+        def blueprint
+          @blueprint ||= NotificationBlueprint.find_by(name: 'manifest_import_error')
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/ui_notifications/subscriptions/manifest_import_success.rb
+++ b/app/services/katello/ui_notifications/subscriptions/manifest_import_success.rb
@@ -1,0 +1,13 @@
+module Katello
+  module UINotifications
+    module Subscriptions
+      class ManifestImportSuccess < UINotifications::AbstractNotification
+        private
+
+        def blueprint
+          @blueprint ||= NotificationBlueprint.find_by(name: 'manifest_import_success')
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/ui_notifications/subscriptions/manifest_refresh_error.rb
+++ b/app/services/katello/ui_notifications/subscriptions/manifest_refresh_error.rb
@@ -1,0 +1,13 @@
+module Katello
+  module UINotifications
+    module Subscriptions
+      class ManifestRefreshError < UINotifications::TaskNotification
+        private
+
+        def blueprint
+          @blueprint ||= NotificationBlueprint.find_by(name: 'manifest_refresh_error')
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/ui_notifications/subscriptions/manifest_refresh_success.rb
+++ b/app/services/katello/ui_notifications/subscriptions/manifest_refresh_success.rb
@@ -1,0 +1,13 @@
+module Katello
+  module UINotifications
+    module Subscriptions
+      class ManifestRefreshSuccess < UINotifications::AbstractNotification
+        private
+
+        def blueprint
+          @blueprint ||= NotificationBlueprint.find_by(name: 'manifest_refresh_success')
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/ui_notifications/task_notification.rb
+++ b/app/services/katello/ui_notifications/task_notification.rb
@@ -1,0 +1,26 @@
+module Katello
+  module UINotifications
+    class TaskNotification < AbstractNotification
+      def initialize(options)
+        @subject = options[:subject]
+        @task = options[:task]
+        fail(Foreman::Exception, 'must provide notification subject') if @subject.nil?
+        fail(Foreman::Exception, 'must provide related task') if @task.nil?
+      end
+
+      protected
+
+      def actions
+        ::UINotifications::URLResolver.new(
+          @task,
+          :links => [
+            {
+              :path_method => :foreman_tasks_task_path,
+              :title => _('Task detail')
+            }
+          ]
+        ).actions
+      end
+    end
+  end
+end

--- a/db/seeds.d/109-katello-notification-blueprints.rb
+++ b/db/seeds.d/109-katello-notification-blueprints.rb
@@ -18,6 +18,42 @@ blueprints = [
     name: 'subs_expire_soon',
     message: N_('%{expiring_subs} subscriptions in %{subject} are going to expire in less than %{days} days. Please renew them before they expire to guarantee your hosts will continue receiving content.'),
     level: 'warning'
+  },
+  {
+    group: N_('Subscriptions'),
+    name: 'manifest_import_success',
+    message: N_('Manifest in \'%{subject}\' imported.'),
+    level: 'info'
+  },
+  {
+    group: N_('Subscriptions'),
+    name: 'manifest_import_error',
+    message: N_('Importing manifest into \'%{subject}\' failed.'),
+    level: 'error'
+  },
+  {
+    group: N_('Subscriptions'),
+    name: 'manifest_refresh_success',
+    message: N_('Manifest in \'%{subject}\' refreshed.'),
+    level: 'info'
+  },
+  {
+    group: N_('Subscriptions'),
+    name: 'manifest_refresh_error',
+    message: N_('Manifest in \'%{subject}\' failed to refresh.'),
+    level: 'error'
+  },
+  {
+    group: N_('Subscriptions'),
+    name: 'manifest_delete_success',
+    message: N_('Manifest in \'%{subject}\' deleted.'),
+    level: 'info'
+  },
+  {
+    group: N_('Subscriptions'),
+    name: 'manifest_delete_error',
+    message: N_('Deleting manifest in \'%{subject}\' failed.'),
+    level: 'error'
   }
 ]
 


### PR DESCRIPTION
Adds success and failure notifications to import, refresh and delete manifest tasks. The failure notifications contain link to the detail page of the related task.

