### PR TITLE
Fixes #23660 - Add/Update desc on Composite Content view

### DIFF
--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -208,9 +208,12 @@ module Katello
     end
 
     def view_params
-      attrs = [:name, :description, :force_puppet_environment, {:repository_ids => []}, {:component_ids => []}]
+      attrs = [:name, :description, :force_puppet_environment, {:component_ids => []}]
       attrs.push(:label, :composite) if action_name == "create"
-      attrs.push(:component_ids, :repository_ids, :auto_publish) # For deep_munge; Remove for Rails 5
+      attrs.push(:component_ids, :auto_publish) # For deep_munge; Remove for Rails 5
+      if (!@view || !@view.composite?)
+        attrs.push({:repository_ids => []}, :repository_ids)
+      end
       params.require(:content_view).permit(*attrs).to_h
     end
 

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -159,6 +159,7 @@ module Katello
       assert_sync_task(::Actions::Katello::ContentView::Update) do |_content_view, content_view_params|
         content_view_params.key?(:component_ids).must_equal true
         content_view_params[:component_ids].must_equal params[:component_ids]
+        content_view_params[:repository_ids].must_be_nil
       end
       put :update, params: { :id => composite.id, :content_view => params }
 


### PR DESCRIPTION
**Issue Description:**
Cannot update description or name on a composite content view
****
**Steps to reproduce**
1. Create/Go to a composite content view
2. Update the name/description and hit Save
3. Error : _"An error occurred updating the Content View: Cannot add repositories to a composite content view,Repositories from published Content Views are not allowed."_
****
