### PR TITLE
Fixes #23674 - Lists no sub KS repos on RH Repos

### DIFF
--- a/app/controllers/katello/api/v2/repository_sets_controller.rb
+++ b/app/controllers/katello/api/v2/repository_sets_controller.rb
@@ -40,7 +40,7 @@ module Katello
       repos = repos.select do |repo|
         if repo[:path].include?('kickstart')
           variants = ['Server', 'Client', 'ComputeNode', 'Workstation']
-          has_variant = variants.any? { |v| repo[:substitutions][:releasever].include?(v) }
+          has_variant = variants.any? { |v| repo[:substitutions][:releasever].try(:include?, v) }
           has_variant ? repo[:enabled] : true
         else
           true


### PR DESCRIPTION
The new RH Repos page made the assumption that all KS repositories had a
release version set. Turns out that some kickstart repositories do not.
Examples include
Red Hat Enterprise Linux 7 Server Beta (Kickstart)
Red Hat Enterprise Linux 7 for IBM Power LE Beta (Kickstart)

This commit properly handles the case of KS repos that do not have a
release version set.