### PR TITLE
Fixes #23667: Allow nil task, xfer date from CVV

### DIFF
--- a/app/views/katello/api/v2/content_view_histories/show.json.rabl
+++ b/app/views/katello/api/v2/content_view_histories/show.json.rabl
@@ -1,6 +1,6 @@
 object @resource
 
-attributes :user, :status, :description
+attributes :user, :status, :description, :action
 
 child :environment => :environment do |_h|
   attributes :id, :name

--- a/db/migrate/20161014133811_move_content_view_version_description_to_histories.rb
+++ b/db/migrate/20161014133811_move_content_view_version_description_to_histories.rb
@@ -25,7 +25,8 @@ class MoveContentViewVersionDescriptionToHistories < ActiveRecord::Migration[4.2
       publish_history ||= CVHistory.create!(action: CVHistory.actions[:publish],
                                             katello_content_view_version_id: version.id,
                                             status: 'successful',
-                                            user: ''
+                                            user: '',
+                                            created_at: version.created_at
                                            )
 
       publish_history.update_attributes!(notes: version[:description])

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-versions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-versions.controller.js
@@ -149,7 +149,7 @@ angular.module('Bastion.content-views').controller('ContentViewVersionsControlle
 
         $scope.historyText = function (version) {
             var taskTypes = $scope.taskTypes,
-                taskType = version['last_event'].task.label,
+                taskType = version['last_event'].task ? version['last_event'].task.label : taskTypes[version['last_event'].action],
                 message = "";
 
             if (taskType === taskTypes.deletion) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/histories/content-view-history.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/histories/content-view-history.controller.js
@@ -26,8 +26,8 @@ angular.module('Bastion.content-views').controller('ContentViewHistoryController
 
         $scope.actionText = function (history) {
             var message,
-                taskType = history.task.label,
-                taskTypes = $scope.taskTypes;
+                taskTypes = $scope.taskTypes,
+                taskType = history.task ? history.task.label : taskTypes[history.action];
 
             if (taskType === taskTypes.deletion) {
                 message = translate("Deleted from %s").replace('%s', history.environment.name);


### PR DESCRIPTION
1. Add `action` to the content_view_histories show API
2. Use `history.action` when `history.task` is nil
3. Tranfer the created_at date to the new history record during
migration from the ContentViewVersion created_at date

You can easily reproduce this by deleting the task of a recently published CV's history:

```rb
Katello::ContentViewHistory.last.task.destroy
```