### PR TITLE
fixes #23676 - port robottelo CV tests

### DIFF
--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -124,10 +124,12 @@ module Katello
     end
 
     def test_update
-      params = { :name => "My View" }
+      params = { :name => "My View", :description => "New description" }
       assert_sync_task(::Actions::Katello::ContentView::Update) do |_content_view, content_view_params|
         content_view_params.key?(:name).must_equal true
         content_view_params[:name].must_equal params[:name]
+        content_view_params.key?(:description).must_equal true
+        content_view_params[:description].must_equal params[:description]
       end
       put :update, params: { :id => @library_dev_staging_view.id, :content_view => params }
 

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -63,6 +63,9 @@ module Katello
     end
     # rubocop:enable Metrics/MethodLength
 
+    should_not allow_values(*invalid_name_list).for(:name)
+    should_not allow_values(*invalid_name_list).for(:label)
+
     def test_create
       assert ContentView.create(FactoryBot.attributes_for(:katello_content_view))
     end


### PR DESCRIPTION
Port robottelo tier1 api tests for content views
part of robottelo minitest port project: https://github.com/SatelliteQE/robottelo/projects/1

Related Robottelo issue:

https://github.com/SatelliteQE/robottelo/issues/5843

```
rake test:katello TEST=../katello/test/models/content_view_test.rb 
 
# Running:

.S.........S.........S...S................S...

Finished in 17.613607s, 2.6116 runs/s, 6.3019 assertions/s.
46 runs, 111 assertions, 0 failures, 0 errors, 5 skips
```

```
rake test:katello TEST=../katello/test/controllers/api/v2/content_views_controller_test.rb TESTOPTS="-ntest-update"

# Running:

.................................

Finished in 28.965637s, 1.1393 runs/s, 4.8678 assertions/s.
33 runs, 141 assertions, 0 failures, 0 errors, 0 skips
```
