### PR TITLE
Fixes #23688 - Error in Subscription Add/List when location is selected

### DIFF
--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -201,7 +201,8 @@ module Katello
       end
 
       def hypervisor
-        ::Host.find_by(id: self.hypervisor_id) if self.hypervisor_id
+        host = ::Host.unscoped.find_by(id: self.hypervisor_id) if self.hypervisor_id
+        return host if (host && host.authorized?(:view_hosts))
       end
     end
   end

--- a/app/views/katello/api/v2/subscriptions/base.json.rabl
+++ b/app/views/katello/api/v2/subscriptions/base.json.rabl
@@ -18,7 +18,7 @@ attributes :virt_only
 attributes :virt_who
 attributes :upstream? => :upstream
 
-node :hypervisor, :if => lambda { |sub| sub && sub.respond_to?(:hypervisor) && sub.hypervisor_id } do |subscription|
+node :hypervisor, :if => lambda { |sub| sub && sub.try(:hypervisor) && sub.hypervisor_id } do |subscription|
   {
     id: subscription.hypervisor.id,
     name: subscription.hypervisor.name


### PR DESCRIPTION
#### Steps to Reproduce:
The reproducer system has 1 Organization and multiple Locations. 
Select location and navigate to:
Activation Keys -> activation key -> Subscriptions -> List/Remove

You cannot see any attached Subscriptions even those which are attached to currently selected Location, but you can see Add list

When you select different Location, you can see List/Remove list, but not Add list.
*************