### PR TITLE
Fixes #23706 - CV/LE show the right value on Host form

### DIFF
--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -14,27 +14,11 @@ module Katello
       %(<option data-id="#{inherited_value}" value="">#{blank_or_inherit_f(f, attr)}</option>)
     end
 
-    def content_view(host)
-      if host.is_a?(Hostgroup)
-        host.content_view
-      else
-        host.content_facet.try(:content_view)
-      end
-    end
-
     def organizations(host)
       if host.is_a?(Hostgroup)
         host.organizations
       else
         host.organization ? [host.organization] : []
-      end
-    end
-
-    def lifecycle_environment(host)
-      if host.is_a?(Hostgroup)
-        host.lifecycle_environment
-      else
-        host.content_facet.try(:lifecycle_environment)
       end
     end
 
@@ -77,20 +61,19 @@ module Katello
     end
 
     def fetch_lifecycle_environment(host, options = {})
+      return host.lifecycle_environment if host.lifecycle_environment.present?
       selected_host_group = options.fetch(:selected_host_group, nil)
-      return lifecycle_environment(selected_host_group) if selected_host_group.present?
-      selected_env = lifecycle_environment(host)
-      return selected_env if selected_env.present?
+      return selected_host_group.lifecycle_environment if selected_host_group.present?
     end
 
     def fetch_content_view(host, options = {})
+      return host.content_view if host.content_view.present?
       selected_host_group = options.fetch(:selected_host_group, nil)
-      return content_view(selected_host_group) if selected_host_group.present?
-      content_view(host)
+      return selected_host_group.content_view if selected_host_group.present?
     end
 
     def accessible_lifecycle_environments(org, host)
-      selected = lifecycle_environment(host)
+      selected = host.lifecycle_environment
       envs = org.kt_environments.readable
       envs |= [selected] if selected.present? && org == selected.organization
       envs

--- a/test/helpers/hosts_and_hostgroups_helper_test.rb
+++ b/test/helpers/hosts_and_hostgroups_helper_test.rb
@@ -12,9 +12,12 @@ class HostAndHostGroupsHelperLifecycleEnvironmentTests < HostsAndHostGroupsHelpe
     User.current = User.anonymous_api_admin
 
     @library = katello_environments(:library)
-    @host =  FactoryBot.build(:host, :with_content, :with_subscription,
-                               :content_view => katello_content_views(:library_dev_view),
-                               :lifecycle_environment => katello_environments(:library), :id => 343)
+    @host =  FactoryBot.build(:host, :with_content, :with_subscription, :id => 343)
+    content_facet = Katello::Host::ContentFacet.new(
+      :content_view => katello_content_views(:library_dev_view),
+      :lifecycle_environment => katello_environments(:library)
+    )
+    @host.content_facet = content_facet
     @host.organization = taxonomies(:organization1)
     @group = FactoryBot.build(:hostgroup)
     @smart_proxy = FactoryBot.create(:smart_proxy, :features => [FactoryBot.create(:feature, name: 'Pulp')])
@@ -26,6 +29,8 @@ class HostAndHostGroupsHelperLifecycleEnvironmentTests < HostsAndHostGroupsHelpe
   end
 
   def test_accessible_lifecycle_environments_limited
+    @host.save
+    @host.reload
     User.current = FactoryBot.create(:user)
     envs = accessible_lifecycle_environments(@library.organization, @host)
     assert_equal([@host.content_facet.lifecycle_environment], envs)


### PR DESCRIPTION
Before this patch, the following situation could happen:

1. Host A is part of a Host Group 'test'. Host A inherits LE/CV 'test'
coming from Host Group 'test'

2. We decide to change the LE/CV of Host A to 'production', either
through the API or the UI.

3. The next time we decide to check the UI, the helper was wrong (this
patch fixes it) and showed the LE/CV from the Host Group 'test'. This is
very confusing and may even cause you to change the LE/CV to from
'production' to 'test' by accident.

In my opinion this should be backported to 3.6 at least

:movie_camera: 

Before: https://webmshare.com/q5g6Q
After: https://webmshare.com/mPa3D