### PR TITLE
fixes #23712 - port robottelo test cv filter

### DIFF
--- a/test/models/content_view_filter_test.rb
+++ b/test/models/content_view_filter_test.rb
@@ -50,6 +50,14 @@ module Katello
       assert_equal ContentViewPackageFilter, ContentViewFilter.search_for("content_type = rpm").first.class
     end
 
+    def test_search_type_erratum
+      assert_equal ContentViewErratumFilter, ContentViewFilter.search_for("content_type = erratum").first.class
+    end
+
+    def test_search_type_package_group
+      assert_equal ContentViewPackageGroupFilter, ContentViewFilter.search_for("content_type = package_group").first.class
+    end
+
     def test_search_inclusion
       inclusion = @filter.inclusion ? 'include' : 'exclude'
       assert_includes ContentViewFilter.search_for("inclusion_type = #{inclusion}"), @filter


### PR DESCRIPTION
Port robottelo tier1 api tests for cv filters
part of robottelo minitest port project: https://github.com/SatelliteQE/robottelo/projects/1

Related Robottelo issue: SatelliteQE/robottelo#6008

```
rake test:katello TEST=../katello/test/models/content_view_filter_test.rb 
# Running:

......S......

Finished in 4.903350s, 2.6512 runs/s, 4.2828 assertions/s.
13 runs, 21 assertions, 0 failures, 0 errors, 1 skips
```