### PR TITLE
Fixes #23724 - Port robottelo tests - hostgroups

### DIFF
--- a/test/controllers/api/v2/hostgroups_controller_test.rb
+++ b/test/controllers/api/v2/hostgroups_controller_test.rb
@@ -11,19 +11,42 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
     @hostgroup = hostgroups(:common)
   end
 
+  test_attributes :pid => '70fe5df8-8917-4a46-b37a-708f449fe749'
+  def test_show_content_attributes
+    content_fields = %w[
+      content_source_id
+      content_source_name
+      content_view_id
+      content_view_name
+      lifecycle_environment_id
+      lifecycle_environment_name
+    ].sort
+    get :show, params: { :id => hostgroups(:common).to_param }
+    assert_response :success
+    assert_template 'katello/api/v2/hostgroups_extensions/show'
+    response = JSON.parse(@response.body)
+    assert_equal content_fields, response.keys.select { |key| content_fields.include?(key) }.sort
+  end
+
+  test_attributes :pid => '39a6273e-8301-449a-a9d3-e3b61cda1e81'
   def test_create
-    post :create, params: { :hostgroup => {:name => 'New Hostgroup'} }
+    content_source_id = smart_proxies(:four).id
+    post :create, params: { :hostgroup => { :name => 'New Hostgroup', :content_source_id => content_source_id } }
 
     assert_response :success
     assert_template 'api/v2/hostgroups/create'
-    assert_equal assigns[:hostgroup].name, 'New Hostgroup'
+    assert_equal 'New Hostgroup', assigns[:hostgroup].name
+    assert_equal content_source_id, assigns[:hostgroup].content_source_id
   end
 
+  test_attributes :pid => '02ef1340-a21e-41b7-8aa7-d6fdea196c16'
   def test_update
-    put :update, params: { :id => @hostgroup.id, :hostgroup => {:name => 'New Name'} }
+    content_source_id = smart_proxies(:four).id
+    put :update, params: { :id => @hostgroup.id, :hostgroup => { :name => 'New Name', :content_source_id => content_source_id } }
 
     assert_response :success
     assert_template 'api/v2/hostgroups/update'
-    assert_equal assigns[:hostgroup].name, 'New Name'
+    assert_equal 'New Name', assigns[:hostgroup].name
+    assert_equal content_source_id, assigns[:hostgroup].content_source_id
   end
 end

--- a/test/models/concerns/hostgroup_extensions_test.rb
+++ b/test/models/concerns/hostgroup_extensions_test.rb
@@ -13,6 +13,21 @@ module Katello
       @puppet_env = smart_proxies(:puppetmaster)
     end
 
+    def test_create_with_content_source
+      content_source = smart_proxies(:four)
+      host_group = Hostgroup.new(:name => 'new_hostgroup', :content_source => content_source)
+      assert_valid host_group
+      assert_equal content_source, host_group.content_source
+    end
+
+    def test_update_content_source
+      content_source = smart_proxies(:four)
+      host_group = Hostgroup.create!(:name => 'new_hostgroup')
+      host_group.content_source = content_source
+      assert_valid host_group
+      assert_equal content_source, host_group.content_source
+    end
+
     def inherited_content_source_id_with_ancestry
       @root.content_source =
         @root.save!


### PR DESCRIPTION
Port robottelo tier1 tests for hostgroups

Related Robottelo issue: https://github.com/SatelliteQE/robottelo/issues/5937

part of robottelo minitest port project: https://github.com/SatelliteQE/robottelo/projects/1

Related foreman PR for hostgroup port : https://github.com/theforeman/foreman/pull/5503
