### PR TITLE
fixes #23733 - bypass foreman mismatches on manifest refresh

### DIFF
--- a/app/lib/actions/katello/organization/manifest_refresh.rb
+++ b/app/lib/actions/katello/organization/manifest_refresh.rb
@@ -46,9 +46,9 @@ module Actions
 
         def finalize
           organization = ::Organization.find(input[:organization][:id])
-          organization.update_attributes!(
-            :manifest_refreshed_at => Time.now,
-            :audit_comment => _('Manifest refreshed'))
+          organization.manifest_refreshed_at = Time.now
+          organization.audit_comment = _('Manifest refreshed')
+          organization.save(validate: false)
         end
       end
     end


### PR DESCRIPTION
When Foreman organizations become invalid due to mismatches, the finalize step in manifest refresh will fail due to update_attributes triggering rails validations.  :disappointed:  Taxonomy validity is a tricky thing, and very often users have inconsistencies. Until that situation is improved, I don't think we should fail manifest import just because we can't update a timestamp and audit message.

