### PR TITLE
fixes #23735 - only show cv tabs if repo type is enabled

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-details.html
@@ -61,8 +61,7 @@
 
       <li uib-dropdown
           ng-class="{active: stateIncludes('content-view.repositories.yum') || stateIncludes('content-view.yum.filters')}"
-          ng-hide="contentView.composite"
-          ng-show="repositoryTypeEnabled('yum')">
+          ng-hide="contentView.composite || !repositoryTypeEnabled('yum')">
 
         <a uib-dropdown-toggle>
           <span translate>Yum Content</span>
@@ -83,24 +82,21 @@
       </li>
 
       <li ng-class="{active: stateIncludes('content-view.repositories.deb')}"
-          ng-hide="contentView.composite"
-          ng-show="repositoryTypeEnabled('deb')">
+          ng-hide="contentView.composite || !repositoryTypeEnabled('deb')">
         <a ui-sref="content-view.repositories.deb.list" translate>
           Apt Repositories
         </a>
       </li>
 
       <li ng-class="{active: stateIncludes('content-view.repositories.file')}"
-          ng-hide="contentView.composite"
-          ng-show="repositoryTypeEnabled('file')">
+          ng-hide="contentView.composite || !repositoryTypeEnabled('file')">
         <a ui-sref="content-view.repositories.file.list" translate>
           File Repositories
         </a>
       </li>
 
       <li ng-class="{active: stateIncludes('content-view.puppet-modules')}"
-          ng-hide="contentView.composite"
-          ng-show="repositoryTypeEnabled('puppet')">
+          ng-hide="contentView.composite || !repositoryTypeEnabled('puppet')">
         <a ui-sref="content-view.puppet-modules.list" translate>
           Puppet Modules
         </a>
@@ -108,8 +104,7 @@
 
       <li uib-dropdown
           ng-class="{active: stateIncludes('content-view.repositories.docker') || stateIncludes('content-view.docker.filters')}"
-          ng-hide="contentView.composite"
-          ng-show="repositoryTypeEnabled('docker')">
+          ng-hide="contentView.composite || !repositoryTypeEnabled('docker')">
         <a uib-dropdown-toggle>
           <span translate>Container Images</span>
           <i class="fa fa-chevron-down"></i>
@@ -129,8 +124,7 @@
       </li>
 
       <li ng-class="{active: stateIncludes('content-view.repositories.ostree')}"
-          ng-hide="contentView.composite"
-          ng-show="repositoryTypeEnabled('ostree')">
+          ng-hide="contentView.composite || !repositoryTypeEnabled('ostree')">
         <a ui-sref="content-view.repositories.ostree.list" translate>
           OSTree Content
         </a>


### PR DESCRIPTION
With 'deb' repo types disabled, the tab still shows up on CV page. Source of the problem seems to be having ng-hide and show on same element:

```
ng-hide="contentView.composite" 
ng-show="repositoryTypeEnabled('deb')"
```
changing to just ng-hide makes it work:

```
ng-hide="contentView.composite || !repositoryTypeEnabled('deb')"
```
