### PR TITLE
Fixes #23680  - Content type selector on Red Hat Repos page is empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "axios": "^0.17.1",
     "axios-mock-adapter": "^1.10.0",
-    "bootstrap-select": "^1.12.2",
+    "bootstrap-select": "1.12.4",
     "classnames": "^2.2.5",
     "downshift": "^1.28.0",
     "jed": "^1.1.1",


### PR DESCRIPTION
Anything beyond version 1.12.4 causes css breakage because patternfly-sass is not up to date with the most current version of bootstrap-select.  The newest version of bootstrap-select adds some css class that aren't currently in patternfly-sass