### PR TITLE
Fixes #22732 - Add export CSV for RH repos and subs

### DIFF
--- a/test/controllers/api/v2/api_controller_test.rb
+++ b/test/controllers/api/v2/api_controller_test.rb
@@ -176,5 +176,16 @@ module Katello
       assert_nil results[:per_page]
       assert_equal error_message, results[:error]
     end
+
+    def test_scoped_search_csv_query
+      params = {}
+      @controller.stubs(:params).returns(params)
+
+      query = Pool.all
+      options = {resource_class: Katello::Pool, csv: true}
+
+      results = @controller.scoped_search(query, nil, nil, options)
+      assert_equal results.sort, query.sort
+    end
   end
 end

--- a/webpack/components/Search/index.js
+++ b/webpack/components/Search/index.js
@@ -43,6 +43,7 @@ class Search extends Component {
   }
 
   onSearch(search) {
+    if (this.props.updateSearchQuery) this.props.updateSearchQuery(search);
     this.props.onSearch(search);
   }
 
@@ -76,6 +77,10 @@ Search.propTypes = {
       }
   */
   getAutoCompleteParams: PropTypes.func.isRequired,
+  updateSearchQuery: PropTypes.func,
 };
 
+Search.defaultProps = {
+  updateSearchQuery: undefined,
+};
 export default Search;

--- a/webpack/redux/actions/RedHatRepositories/enabled.js
+++ b/webpack/redux/actions/RedHatRepositories/enabled.js
@@ -14,9 +14,7 @@ export const setRepositoryDisabled = repository => ({
   repository,
 });
 
-export const loadEnabledRepos = (extendedParams = {}) => (dispatch) => {
-  dispatch({ type: ENABLED_REPOSITORIES_REQUEST, params: extendedParams });
-
+export const createEnabledRepoParams = (extendedParams = {}) => {
   const searchParams = extendedParams.search || {};
   const search = joinSearchQueries([
     'redhat = true',
@@ -24,14 +22,21 @@ export const loadEnabledRepos = (extendedParams = {}) => (dispatch) => {
     searchParams.query,
   ]);
 
-  const params = {
+  const repoParams = {
     ...{ organization_id: orgId, enabled: 'true' },
     ...propsToSnakeCase(extendedParams),
     search,
   };
 
+  return { searchParams, repoParams };
+};
+
+export const loadEnabledRepos = (extendedParams = {}) => (dispatch) => {
+  dispatch({ type: ENABLED_REPOSITORIES_REQUEST, params: extendedParams });
+  const { searchParams, repoParams } = createEnabledRepoParams(extendedParams);
+
   api
-    .get('/repositories', {}, params)
+    .get('/repositories', {}, repoParams)
     .then(({ data }) => {
       dispatch({
         type: ENABLED_REPOSITORIES_SUCCESS,

--- a/webpack/scenes/RedHatRepositories/components/SearchBar.js
+++ b/webpack/scenes/RedHatRepositories/components/SearchBar.js
@@ -3,11 +3,13 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
+import { Button } from 'patternfly-react';
 import { Form, FormGroup } from 'react-bootstrap';
 
 import { loadEnabledRepos } from '../../../redux/actions/RedHatRepositories/enabled';
 import { loadRepositorySets } from '../../../redux/actions/RedHatRepositories/sets';
 
+import api from '../../../services/api';
 import Search from './Search';
 import MultiSelect from '../../../components/MultiSelect/index';
 
@@ -84,23 +86,32 @@ class SearchBar extends Component {
   }
 
   render() {
+    const { repoParams } = this.props;
+
     return (
       <Form className="toolbar-pf-actions">
         <FormGroup className="toolbar-pf-filter">
           <Search onSearch={this.onSearch} onSelectSearchList={this.onSelectSearchList} />
         </FormGroup>
 
-        <FormGroup className="toolbar-pf-filter">
-          <MultiSelect
-            value={this.state.filters}
-            options={filterOptions}
-            onChange={(e) => {
-              const values = [...e.target.options]
-                .filter(({ selected }) => selected)
-                .map(({ value }) => value);
-              this.onSelectFilterType(values);
-            }}
-          />
+        <MultiSelect
+          value={this.state.filters}
+          options={filterOptions}
+          onChange={(e) => {
+            const values = [...e.target.options]
+              .filter(({ selected }) => selected)
+              .map(({ value }) => value);
+            this.onSelectFilterType(values);
+          }}
+        />
+
+        <FormGroup>
+          <Button
+            className="export-csv-button"
+            onClick={() => { api.open('/repositories.csv', repoParams); }}
+          >
+            {__('Export Enabled as CSV')}
+          </Button>
         </FormGroup>
       </Form>
     );
@@ -110,6 +121,7 @@ class SearchBar extends Component {
 SearchBar.propTypes = {
   loadEnabledRepos: PropTypes.func.isRequired,
   loadRepositorySets: PropTypes.func.isRequired,
+  repoParams: PropTypes.shape({}).isRequired,
   enabledRepositories: PropTypes.shape({
     pagination: PropTypes.shape({
       perPage: PropTypes.number,

--- a/webpack/scenes/RedHatRepositories/index.js
+++ b/webpack/scenes/RedHatRepositories/index.js
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import { Grid, Row, Col } from 'react-bootstrap';
 import { Spinner } from 'patternfly-react';
 
-import { loadEnabledRepos } from '../../redux/actions/RedHatRepositories/enabled';
+import { createEnabledRepoParams, loadEnabledRepos } from '../../redux/actions/RedHatRepositories/enabled';
 import { loadRepositorySets } from '../../redux/actions/RedHatRepositories/sets';
 import SearchBar from './components/SearchBar';
 import { getSetsComponent, getEnabledComponent } from './helpers';
@@ -25,6 +25,7 @@ class RedHatRepositoriesPage extends Component {
 
   render() {
     const { enabledRepositories, repositorySets } = this.props;
+    const { repoParams } = createEnabledRepoParams(enabledRepositories);
 
     return (
       <Grid id="redhatRepositoriesPage" bsClass="container-fluid">
@@ -32,7 +33,7 @@ class RedHatRepositoriesPage extends Component {
 
         <Row className="toolbar-pf">
           <Col sm={12}>
-            <SearchBar />
+            <SearchBar repoParams={repoParams} />
           </Col>
         </Row>
 

--- a/webpack/scenes/RedHatRepositories/index.scss
+++ b/webpack/scenes/RedHatRepositories/index.scss
@@ -43,10 +43,6 @@
     margin-bottom: 20px;
   }
 
-  .toolbar-pf-filter {
-    margin-bottom: 7px;
-  }
-
   @media (min-width: 1280px) {
     .toolbar-pf-filter {
       width: 50%;

--- a/webpack/scenes/Subscriptions/SubscriptionActions.js
+++ b/webpack/scenes/Subscriptions/SubscriptionActions.js
@@ -19,14 +19,15 @@ import { filterRHSubscriptions } from './SubscriptionHelpers.js';
 
 const getResponseError = ({ data }) => data && (data.displayMessage || data.error);
 
+export const createSubscriptionParams = (extendedParams = {}) => ({
+  ...{ organization_id: orgId },
+  ...propsToSnakeCase(extendedParams),
+});
+
 export const loadAvailableQuantities = (extendedParams = {}) => (dispatch) => {
   dispatch({ type: SUBSCRIPTIONS_QUANTITIES_REQUEST });
 
-  const params = {
-    ...{ organization_id: orgId },
-    ...propsToSnakeCase(extendedParams),
-  };
-
+  const params = createSubscriptionParams(extendedParams);
   return api
     .get(`/organizations/${orgId}/upstream_subscriptions`, {}, params)
     .then(({ data }) => {
@@ -46,11 +47,7 @@ export const loadAvailableQuantities = (extendedParams = {}) => (dispatch) => {
 export const loadSubscriptions = (extendedParams = {}) => (dispatch) => {
   dispatch({ type: SUBSCRIPTIONS_REQUEST });
 
-  const params = {
-    ...{ organization_id: orgId },
-    ...propsToSnakeCase(extendedParams),
-  };
-
+  const params = createSubscriptionParams(extendedParams);
   return api
     .get('/subscriptions', {}, params)
     .then(({ data }) => {

--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -11,7 +11,8 @@ import ModalProgressBar from '../../move_to_foreman/components/common/ModalProgr
 import ManageManifestModal from './Manifest/';
 import SubscriptionsTable from './SubscriptionsTable';
 import Search from '../../components/Search/index';
-import { orgId } from '../../services/api';
+import api, { orgId } from '../../services/api';
+import { createSubscriptionParams } from './SubscriptionActions.js';
 import {
   BLOCKING_FOREMAN_TASK_TYPES,
   MANIFEST_TASKS_BULK_SEARCH_ID,
@@ -28,6 +29,7 @@ class SubscriptionsPage extends Component {
       disableDeleteButton: true,
       polledTask: null,
       showTaskModal: false,
+      searchQuery: '',
     };
   }
 
@@ -137,6 +139,10 @@ class SubscriptionsPage extends Component {
       },
     });
 
+    const updateSearchQuery = (searchQuery) => {
+      this.setState({ searchQuery });
+    };
+
     const showManageManifestModal = () => {
       this.setState({ manifestModalOpen: true });
     };
@@ -162,6 +168,8 @@ class SubscriptionsPage extends Component {
       this.setState({ disableDeleteButton: !rowsSelected });
     };
 
+    const csvParams = createSubscriptionParams({ search: this.state.searchQuery });
+
     return (
       <Grid bsClass="container-fluid">
         <Row>
@@ -172,7 +180,11 @@ class SubscriptionsPage extends Component {
               <Col sm={12}>
                 <Form className="toolbar-pf-actions">
                   <FormGroup className="toolbar-pf-filter">
-                    <Search onSearch={onSearch} getAutoCompleteParams={getAutoCompleteParams} />
+                    <Search
+                      onSearch={onSearch}
+                      getAutoCompleteParams={getAutoCompleteParams}
+                      updateSearchQuery={updateSearchQuery}
+                    />
                   </FormGroup>
 
                   <div className="toolbar-pf-action-right">
@@ -192,7 +204,9 @@ class SubscriptionsPage extends Component {
                         {__('Manage Manifest')}
                       </Button>
 
-                      <Button>
+                      <Button
+                        onClick={() => { api.open('/subscriptions.csv', csvParams); }}
+                      >
                         {__('Export CSV')}
                       </Button>
 

--- a/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsPage.test.js.snap
+++ b/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsPage.test.js.snap
@@ -42,6 +42,7 @@ exports[`subscriptions page should render 1`] = `
               <Search
                 getAutoCompleteParams={[Function]}
                 onSearch={[Function]}
+                updateSearchQuery={[Function]}
               />
             </FormGroup>
             <div
@@ -81,6 +82,7 @@ exports[`subscriptions page should render 1`] = `
                   bsClass="btn"
                   bsStyle="default"
                   disabled={false}
+                  onClick={[Function]}
                 >
                   Export CSV
                 </Button>

--- a/webpack/services/api/index.js
+++ b/webpack/services/api/index.js
@@ -59,6 +59,24 @@ class Api {
       headers,
     });
   }
+
+  // Use for endpoints that return a file to download
+  open(url, params) {
+    window.location.href = this.getApiUrl(url) + this.createUrlParams(params);
+  }
+
+  /* eslint-disable class-methods-use-this */
+  createUrlParams(params) {
+    let urlParams = '?';
+    Object.keys(params).forEach((key) => {
+      if (urlParams !== '?') {
+        urlParams += '&';
+      }
+      urlParams += `${key}=${encodeURIComponent(params[key])}`;
+    });
+    return urlParams;
+  }
+  /* eslint-enable class-methods-use-this */
 }
 
 export default new Api();

--- a/webpack/services/index.js
+++ b/webpack/services/index.js
@@ -45,8 +45,9 @@ export function getTypeIcon(type) {
   return typeIcon;
 }
 
-export const propsToSnakeCase = ob =>
-  reduce(
+export const propsToSnakeCase = (ob) => {
+  if (typeof (ob) !== 'object') throw Error('propsToSnakeCase only takes objects');
+  return reduce(
     ob,
     (snakeOb, val, key) => {
       // eslint-disable-next-line no-param-reassign
@@ -55,3 +56,4 @@ export const propsToSnakeCase = ob =>
     },
     {},
   );
+};


### PR DESCRIPTION
This adds the export CSV button to both RH repos page
and the Subscription page. It uses the csv functionality
currenlty in foreman with fixed columns for the CSV file.