### PR TITLE
Fixes #23672 - publish puppet repos last

### DIFF
--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -31,17 +31,14 @@ module Actions
                 end
               end
 
-              sequence do
-                has_modules = content_view.publish_puppet_environment?
-                plan_action(ContentViewPuppetEnvironment::CreateForVersion, version)
-                plan_action(ContentViewPuppetEnvironment::Clone, version, :environment => library,
-                            :puppet_modules_present => has_modules)
-              end
-
               repos_to_delete(content_view).each do |repo|
                 plan_action(Repository::Destroy, repo, :skip_environment_update => true, :planned_destroy => true)
               end
             end
+            has_modules = content_view.publish_puppet_environment?
+            plan_action(ContentViewPuppetEnvironment::CreateForVersion, version)
+            plan_action(ContentViewPuppetEnvironment::Clone, version, :environment => library,
+                :puppet_modules_present => has_modules)
 
             plan_action(ContentView::UpdateEnvironment, content_view, library)
             plan_action(Katello::Foreman::ContentUpdate, library, content_view)


### PR DESCRIPTION
Previously, CV repos would be sync/published in any order. This could result in
a situation where if your CV had a yum repo and a puppet repo, your puppet repo
could get published first while the yum repo was still being synced. If the
puppet repo had a module that referred to an RPM in the yum repo that was being
published, this could result in puppet errors.

This commit re-orders CV publish so puppet repos are done last. Additionally,
capsule syncs are broken apart so the non-puppet repos are synced in one
concurrent block, and then once that's complete, puppet repos are synced in a
second concurrent block.