### PR TITLE
fixes #23781 - migrate content_source_id correctly

### DIFF
--- a/db/migrate/20161214151548_move_content_source_id_to_content_facets.rb
+++ b/db/migrate/20161214151548_move_content_source_id_to_content_facets.rb
@@ -6,8 +6,8 @@ class MoveContentSourceIdToContentFacets < ActiveRecord::Migration[4.2]
 
     Host.find_each do |host|
       content_facet = host.content_facet
-      if content_facet && host.content_source_id
-        content_facet.content_source_id = host.content_source_id
+      if content_facet && (content_source_id = host.read_attribute(:content_source_id))
+        content_facet.content_source_id = content_source_id
         content_facet.save!
       end
     end


### PR DESCRIPTION
By the time the migration runs, `host.content_source_id` is delegated to the facet, so the move fails: content_source_id will always be nil. Uses read_attribute instead to read the db column  instead.