### PR TITLE
Fixes #23761 - Subscription quantity shows as automatic

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-add-subscriptions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-add-subscriptions.controller.js
@@ -36,7 +36,7 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyAddSubscripti
         $scope.isAdding = false;
         $scope.contentNutupane.setSearchKey('subscriptionSearch');
         $scope.contentNutupane.masterOnly = true;
-
+        $scope.contextAdd = true;
         $scope.groupedSubscriptions = {};
         $scope.$watch('table.rows', function (rows) {
             $scope.groupedSubscriptions = SubscriptionsHelper.groupByProductName(rows);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-subscriptions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-subscriptions.controller.js
@@ -31,6 +31,7 @@ angular.module('Bastion.activation-keys').controller('ActivationKeySubscriptions
         $scope.contentNutupane.masterOnly = true;
         $scope.contentNutupane.setSearchKey('subscriptionSearch');
         $scope.isRemoving = false;
+        $scope.contextAdd = false;
 
         $scope.groupedSubscriptions = {};
         $scope.$watch('table.rows', function (rows) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/common/views/subscription-add-or-remove.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/common/views/subscription-add-or-remove.html
@@ -21,7 +21,7 @@
        </td>
      </tr>
      <tr class="grey-table-row" bst-table-row ng-repeat-end ng-repeat="subscription in subscriptions" row-select="subscription">
-       <td bst-table-cell>
+       <td bst-table-cell ng-show="contextAdd">
          <span ng-hide="subscription.multi_entitlement">
            1
          </span>
@@ -32,7 +32,7 @@
            <option value="">{{ "Automatic" | translate }}</option>
          </select>
        </td>
-
+       <td bst-table-cell ng-hide="contextAdd">{{ subscription.quantity_consumed }}</td>
        <td bst-table-cell>
          <a ui-sref="subscription.info({subscriptionId: subscription.id})">
            {{ subscription | subscriptionConsumedFilter }}

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-add-subscriptions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-add-subscriptions.controller.js
@@ -31,7 +31,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostAddSubscriptionsC
         $scope.nutupane.setSearchKey('subscriptionSearch');
         $scope.nutupane.masterOnly = true;
         $scope.table = $scope.nutupane.table;
-
+        $scope.contextAdd = true;
         $scope.isAdding = false;
         $scope.groupedSubscriptions = {};
 
@@ -40,7 +40,6 @@ angular.module('Bastion.content-hosts').controller('ContentHostAddSubscriptionsC
         });
 
         $scope.getAmountSelectorValues = SubscriptionsHelper.getAmountSelectorValues;
-
         $scope.showMatchHost = false;
         $scope.showMatchInstalled = false;
         $scope.showNoOverlap = false;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-subscriptions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-subscriptions.controller.js
@@ -29,7 +29,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostSubscriptionsCont
         $scope.table = $scope.nutupane.table;
         $scope.nutupane.masterOnly = true;
         $scope.isRemoving = false;
-
+        $scope.contextAdd = false;
         $scope.groupedSubscriptions = {};
         $scope.$watch('table.rows', function (rows) {
             $scope.groupedSubscriptions = SubscriptionsHelper.groupByProductName(rows);


### PR DESCRIPTION
Steps to Reproduce:

1. On satellite 6.3, Install virt-who and do required configuration.
2. Once the hypervisors are listed under satellite WebUI, Attach a VDC subscription to it and check the "Quantity" field in List/Remove tab of subscriptions.

Actual result:
It is showing a word "Automatic" instead of the quantity number.

Expected result:
It should the actual number of subscription quantity attached in Quantity field.