### PR TITLE
fixes #23822 - allow slashes in registry repo routes

### DIFF
--- a/config/routes/api/registry.rb
+++ b/config/routes/api/registry.rb
@@ -9,18 +9,18 @@ Katello::Engine.routes.draw do
     scope :module => :registry, :constraints => { :tag => /[0-9a-zA-Z\-_.:]*/, :digest => /[0-9a-zA-Z:]*/ } do
       match '/v2/token' => 'registry_proxies#token', :via => :get
       match '/v2/token' => 'registry_proxies#token', :via => :post
-      match '/v2/:repository/manifests/:tag' => 'registry_proxies#pull_manifest', :via => :get
-      match '/v2/:repository/manifests/:tag' => 'registry_proxies#push_manifest', :via => :put
-      match '/v2/:repository/blobs/:digest' => 'registry_proxies#pull_blob', :via => :get
-      match '/v2/:repository/blobs/:digest' => 'registry_proxies#check_blob', :via => :head
-      match '/v2/:repository/blobs/uploads' => 'registry_proxies#start_upload_blob', :via => :post
-      match '/v2/:repository/blobs/uploads/:uuid' => 'registry_proxies#chunk_upload_blob', :via => :post
-      match '/v2/:repository/blobs/uploads/:uuid' => 'registry_proxies#finish_upload_blob', :via => :put
-      match '/v2/:repository/blobs/uploads/:uuid' => 'registry_proxies#upload_blob', :via => :patch
-      match '/v2/:repository/blobs/uploads/:uuid' => 'registry_proxies#status_upload_blob', :via => :get
-      match '/v2/:repository/blobs/uploads/:uuid' => 'registry_proxies#cancel_upload_blob', :via => :delete
+      match '/v2/*repository/manifests/:tag' => 'registry_proxies#pull_manifest', :via => :get
+      match '/v2/*repository/manifests/:tag' => 'registry_proxies#push_manifest', :via => :put
+      match '/v2/*repository/blobs/:digest' => 'registry_proxies#pull_blob', :via => :get
+      match '/v2/*repository/blobs/:digest' => 'registry_proxies#check_blob', :via => :head
+      match '/v2/*repository/blobs/uploads' => 'registry_proxies#start_upload_blob', :via => :post
+      match '/v2/*repository/blobs/uploads/:uuid' => 'registry_proxies#chunk_upload_blob', :via => :post
+      match '/v2/*repository/blobs/uploads/:uuid' => 'registry_proxies#finish_upload_blob', :via => :put
+      match '/v2/*repository/blobs/uploads/:uuid' => 'registry_proxies#upload_blob', :via => :patch
+      match '/v2/*repository/blobs/uploads/:uuid' => 'registry_proxies#status_upload_blob', :via => :get
+      match '/v2/*repository/blobs/uploads/:uuid' => 'registry_proxies#cancel_upload_blob', :via => :delete
       match '/v2/_catalog' => 'registry_proxies#catalog', :via => :get
-      match '/v2/:repository/tags/list' => 'registry_proxies#tags_list', :via => :get
+      match '/v2/*repository/tags/list' => 'registry_proxies#tags_list', :via => :get
       match '/v2' => 'registry_proxies#ping', :via => :get
       match '/v1/_ping' => 'registry_proxies#v1_ping', :via => :get
       match '/v1/search' => 'registry_proxies#v1_search', :via => :get


### PR DESCRIPTION
To test, try _docker pull_ an image that has slashes in it:
+ Set registry name pattern on a lifecycle env to be _<%= repository.docker_upstream_name%>_ 
+ Make sure a repo in that env came from an upstream with slashes (eg. openshift3/origin)
+ Try _docker pull devel.example.com/openshift3/origin_