### PR TITLE
refs #23823 - pool hypervisor nullified on host destroy

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -27,6 +27,8 @@ module Katello
         has_many :host_collection_hosts, :class_name => "::Katello::HostCollectionHosts", :foreign_key => :host_id, :dependent => :destroy
         has_many :host_collections, :class_name => "::Katello::HostCollection", :through => :host_collection_hosts
 
+        has_many :hypervisor_pools, :class_name => '::Katello::Pool', :foreign_key => :hypervisor_id, :dependent => :nullify
+
         before_save :correct_puppet_environment
 
         scoped_search :relation => :host_collections, :on => :id, :complete_value => false, :rename => :host_collection_id, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER

--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -199,11 +199,6 @@ module Katello
           Katello::PoolActivationKey.where(:activation_key_id => key.id, :pool_id => self.id).first_or_create
         end
       end
-
-      def hypervisor
-        host = ::Host.unscoped.find_by(id: self.hypervisor_id) if self.hypervisor_id
-        return host if (host && host.authorized?(:view_hosts))
-      end
     end
   end
 end

--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -12,7 +12,8 @@ module Katello
     has_many :subscription_facet_pools, :class_name => "Katello::SubscriptionFacetPool", :dependent => :destroy
     has_many :subscription_facets, :through => :subscription_facet_pools
 
-    belongs_to :organization, :class_name => "Organization", :inverse_of => :pools
+    belongs_to :organization, :class_name => 'Organization', :inverse_of => :pools
+    belongs_to :hypervisor, :class_name => 'Host::Managed', :inverse_of => :hypervisor_pools
 
     scope :in_organization, ->(org_id) { where(:organization_id => org_id) }
     scope :for_activation_key, ->(ak) { joins(:activation_keys).where("#{Katello::ActivationKey.table_name}.id" => ak.id) }

--- a/app/views/katello/api/v2/subscriptions/base.json.rabl
+++ b/app/views/katello/api/v2/subscriptions/base.json.rabl
@@ -18,7 +18,7 @@ attributes :virt_only
 attributes :virt_who
 attributes :upstream? => :upstream
 
-node :hypervisor, :if => lambda { |sub| sub && sub.try(:hypervisor) && sub.hypervisor_id } do |subscription|
+node :hypervisor, :if => lambda { |sub| sub && sub.respond_to?(:hypervisor) && sub.hypervisor } do |subscription|
   {
     id: subscription.hypervisor.id,
     name: subscription.hypervisor.name

--- a/db/migrate/20180612163403_add_foreign_key_to_hypervisor_id.rb
+++ b/db/migrate/20180612163403_add_foreign_key_to_hypervisor_id.rb
@@ -1,0 +1,10 @@
+class AddForeignKeyToHypervisorId < ActiveRecord::Migration[5.1]
+  def up
+    add_foreign_key(:katello_pools, :hosts,
+                    :name => 'katello_pools_hypervisor_fk', :column => 'hypervisor_id')
+  end
+
+  def down
+    remove_foreign_key(:katello_pools, :name => 'katello_pools_hypervisor_fk')
+  end
+end


### PR DESCRIPTION
It could happen that a pool refers to a hypervisor_id for a hypervisor
that does not exist any more, so hypervisor_id is set but calling
\#hypervisor returns nil.  At least one customer hit this, but I can't
figure out how they got in that state to begin with.