### PR TITLE
Fixes #22768 - Bump runcible to 2.8.1

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "apipie-rails", ">= 0.5.4"
 
   # Pulp
-  gem.add_dependency "runcible", ">= 2.6.0", "< 3.0.0"
+  gem.add_dependency "runcible", ">= 2.8.1", "< 3.0.0"
   gem.add_dependency "anemone"
 
   # UI


### PR DESCRIPTION
This reportedly fixes inability to create file repos