### PR TITLE
fixes #23835 - no log for docker blob

### DIFF
--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -419,5 +419,16 @@ module Katello
     def logger
       ::Foreman::Logging.logger('katello/registry_proxy')
     end
+
+    def route_name
+      Engine.routes.router.recognize(request) do |_, params|
+        break params[:action] if params[:action]
+      end
+    end
+
+    def process_action(method_name, *args)
+      ::Api::V2::BaseController.instance_method(:process_action).bind(self).call(method_name, *args)
+      Rails.logger.debug "With body: #{response.body}\n" unless route_name == 'pull_blob'
+    end
   end
 end


### PR DESCRIPTION
To test, simply _sudo docker pull devel.example.com/examplecorp-dockerhub-alpine:latest_ and confirm binary output is not spamming to log/terminal.