### PR TITLE
fixes #23846 - port robottelo docker repo tests

### DIFF
--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -1,4 +1,5 @@
 require File.expand_path("repository_base", File.dirname(__FILE__))
+require 'katello_test_helper'
 
 module Katello
   class RepositoryCreateTest < RepositoryTestBase
@@ -56,6 +57,19 @@ module Katello
       @repo.url = nil
       @repo.docker_upstream_name = nil
       assert @repo.valid?
+    end
+
+    test_attributes :pid => '7967e6b5-c206-4ad0-bcf5-64a7ce85233b'
+    def test_docker_repository_update_name
+      @repo = build(:katello_repository, :docker,
+                    :environment => @library,
+                    :product => katello_products(:fedora),
+                    :content_view_version => @library.default_content_view_version
+                   )
+      valid_name_list.each do |name|
+        @repo.name = name
+        assert @repo.valid?, "Can't update docker repo with valid name #{name}"
+      end
     end
 
     def test_docker_repository_in_content_view


### PR DESCRIPTION
Port robottelo tier1 api tests for docker repos
part of robottelo minitest port project: https://github.com/SatelliteQE/robottelo/projects/1

Related Robottelo issue: SatelliteQE/robottelo#6003
