### PR TITLE
Fixes #23887 - Unclear error on manage repo set bulk action

### DIFF
--- a/app/lib/actions/katello/host/update_content_overrides.rb
+++ b/app/lib/actions/katello/host/update_content_overrides.rb
@@ -6,6 +6,7 @@ module Actions
 
         def plan(host, content_override_params, prune_invalid_content_overrides = true)
           action_subject(host)
+          fail _("This Host is not currently registered with subscription-manager.") unless host.subscription_facet
           plan_self(:host_id => host.id, :host_name => host.name, :content_overrides => content_override_params,
                     :prune_invalid_content_overrides => prune_invalid_content_overrides)
         end


### PR DESCRIPTION
### Description
When trying to perform bulk action "Manage Repository Sets" on Content Hosts, if a Content Host has never registered, it will fail and return an undefined method error:

_NoMethodError: undefined method `uuid' for nil:NilClass_
****
### Steps to reproduce
1. Create a Host: WebUI-> Hosts -> All Hosts -> Create Host - But do not actually build one yet or register that host.

2. Go to WebUI -> Content Hosts and select a number of hosts, including the one just created (which should show as "Never registered" and "Never checked in"

3. Select "Select Action" -> "Manage Repository Sets" and choose a Repository set and either "Override to Enabled" or "Override to disabled"