### PR TITLE
Fixes #23906 - Fix react re-render after tasks polling

### DIFF
--- a/webpack/scenes/Subscriptions/SubscriptionReducer.js
+++ b/webpack/scenes/Subscriptions/SubscriptionReducer.js
@@ -97,15 +97,14 @@ export default (state = initialState, action) => {
     }
 
     case TASK_BULK_SEARCH_SUCCESS: {
-      let tasks = [];
+      let tasks;
 
       const search = find(action.response, bulkSearch =>
         bulkSearch.search_params.search_id === MANIFEST_TASKS_BULK_SEARCH_ID);
 
-      if (search) {
+      if (search && search.results.length > 0) {
         tasks = search.results;
       }
-
       return state.set('tasks', tasks);
     }
 

--- a/webpack/scenes/Subscriptions/index.js
+++ b/webpack/scenes/Subscriptions/index.js
@@ -10,10 +10,11 @@ import reducer from './SubscriptionReducer';
 import SubscriptionsPage from './SubscriptionsPage';
 import './Subscriptions.scss';
 
+const EMPTY_ARRAY = []
 // map state to props
 const mapStateToProps = state => ({
   subscriptions: state.katello.subscriptions,
-  tasks: state.katello.subscriptions.tasks,
+  tasks: state.katello.subscriptions.tasks || EMPTY_ARRAY,
 });
 
 // map action dispatchers to props


### PR DESCRIPTION
In the new subscriptions page, after tasks polling, react's `render` invoked unnecessary.
this happnens because the reducer returns a blank array with a new ref, which means the prop has been changed with no a real change.

``` javascript
var a = [];
var b = [];
a == b; // returns false
```

we should consider of using `reselect` package which memorizes redux state to props.