### PR TITLE
fixes #23841 - remove columns that were moved to facets

### DIFF
--- a/db/migrate/20180612165011_remove_content_fields_from_host.rb
+++ b/db/migrate/20180612165011_remove_content_fields_from_host.rb
@@ -1,0 +1,7 @@
+class RemoveContentFieldsFromHost < ActiveRecord::Migration[5.1]
+  def change
+    # These fields were moved to the content facet
+    remove_column :hosts, :content_view_id
+    remove_column :hosts, :lifecycle_environment_id
+  end
+end


### PR DESCRIPTION
Content view and lifecycle environment columns were moved to the content
facet, and the db columns can be deleted.