### PR TITLE
Fixes #23908 - add scroll bar in manifest modal

### DIFF
--- a/webpack/scenes/Subscriptions/Manifest/Manifest.scss
+++ b/webpack/scenes/Subscriptions/Manifest/Manifest.scss
@@ -1,3 +1,8 @@
 .manifest-actions > * {
   margin: 10px 5px 0 0 ;
 }
+
+.modal-body {
+  overflow-y: auto;
+  overflow-x: hidden;
+}


### PR DESCRIPTION
before:
![no_scrolling](https://user-images.githubusercontent.com/11807069/41348370-14aa73f0-6f15-11e8-93c4-f7d9ecd1c65d.png)

after:
![manifest-scrolling](https://user-images.githubusercontent.com/11807069/41348372-18c448a8-6f15-11e8-9b08-be501287d240.png)
