### PR TITLE
Fixes #23921 - Change to HTTPS

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/register.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/register.html
@@ -15,7 +15,7 @@
       </li>
       <li>
         <p translate>Install the pre-built bootstrap RPM:</p>
-        <pre><code>rpm -Uvh https://{{ noCapsulesFound ? katelloHostname : hostname(selectedCapsule.url) }}/pub/{{ consumerCertRPM }}</code></pre>
+        <pre><code>curl --insecure --output {{ consumerCertRPM }} https://{{ noCapsulesFound ? katelloHostname : hostname(selectedCapsule.url) }}/pub/{{ consumerCertRPM }}<br>yum localinstall {{ consumerCertRPM }} </code></pre>
       </li>
       <li>
         <p translate>Register using subscription-manager:</p>


### PR DESCRIPTION
Updates to recommend HTTP over HTTPS.

Steps to Reproduce:
1. Using the web ui, navigate to Hosts > Content Hosts
2. Click the Register Content Host
3. Look at the instructions for installing katello-ca-cert