### PR TITLE
Fixes #23935 - Ability to add many RPM filters to CV via API via only one REST call

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filter_bulk_rules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filter_bulk_rules_controller.rb
@@ -1,0 +1,85 @@
+module Katello
+  class Api::V2::ContentViewFilterBulkRulesController < Api::V2::ApiController
+    before_action :find_filter
+    before_action :find_rule, :except => [:create]
+
+    api :POST, "/content_view_filters/:content_view_filter_id/bulk",
+        N_("Create a bunch of filter rules. The parameters included should be based upon the filter type.")
+    param :content_view_filter_id, :number, :desc => N_("filter identifier"), :required => true
+    param :data, Array, :of => [Hash], :desc => N_("hash for RPM bulkloads: \
+                                                    [{'name': 'name', \
+                                                    'version': 'version',\
+                                                    'architecture': 'architecture'}]") do
+      param :name, String, :desc => N_("package name"), :required => true
+      param :version, String, :desc => N_("package version"), :required => false
+      param :architecture, String, :desc => N_("package architecture"), :required => false
+    end
+    def create
+      rule_clazz = ContentViewFilter.rule_class_for(@filter)
+      _data = JSON.parse(params[:data].gsub("'", "\""))
+      if _data.is_a?(Array) and _data.all? { |value| value['name'].length >= 1 and value['version'].length >= 1 }
+        rules = _data.each.map do |bulk_rule|
+          begin
+            rule_clazz.create!([:filter => @filter, name: bulk_rule['name'],
+                                                    version: bulk_rule['version'],
+                                                    architecture: bulk_rule['architecture']])
+          rescue
+            # no need to abort if other rules can be created
+          end
+        end
+      else
+        fail HttpErrors::BadRequest, _("Parameter 'data' must be an array of hash: " \
+                                       + "[{'name': 'name1', 'version': 'ver1', 'architecture': 'arch1'},"\
+                                       + " {'name': 'name2', 'version': 'ver2', 'architecture': 'arch2'},"\
+                                       + " ...]")
+      end
+
+      rules = rules.flatten.select{|v| v != nil}
+
+      if not rules.any?
+        fail HttpErrors::UnprocessableEntity, _("No rules has been created at all. They're supposed to be already created!!!")
+      elsif rules.count != _data.count
+        respond_for_index(:collection => {:results => rules,
+                                          :error => true,
+                                          :total => rules.length},
+                          :template => 'index')
+      else
+        if rules.length == 1
+          respond_for_create resource: rules.first
+        else
+          respond_for_index(:collection => {:results => rules,
+                                            :total => rules.length},
+                            :template => 'index')
+        end
+      end
+
+    end
+
+    api :GET, "/content_view_filters/:content_view_filter_id/rules/:id", N_("Show filter rule info")
+    param :content_view_filter_id, :number, :desc => N_("filter identifier"), :required => true
+    param :id, :number, :desc => N_("rule identifier"), :required => true
+    def show
+      respond :resource => @rule
+    end
+
+    api :DELETE, "/content_view_filters/:content_view_filter_id/bulk/rules/:id", N_("Delete a filter rule")
+    param :content_view_filter_id, :number, :desc => N_("filter identifier"), :required => true
+    param :id, :number, :desc => N_("rule identifier"), :required => true
+    def destroy
+      @rule.destroy
+      respond_for_show :resource => @rule
+    end
+
+    private
+
+    def find_filter
+      @filter = ContentViewFilter.find(params[:content_view_filter_id])
+    end
+
+    def find_rule
+      rule_clazz = ContentViewFilter.rule_class_for(@filter)
+      @rule = rule_clazz.find(params[:id])
+    end
+    
+  end
+end

--- a/app/views/katello/api/v2/content_view_filter_bulk_rules/index.json.rabl
+++ b/app/views/katello/api/v2/content_view_filter_bulk_rules/index.json.rabl
@@ -1,0 +1,3 @@
+object false
+
+extends 'katello/api/v2/common/index'

--- a/app/views/katello/api/v2/content_view_filter_bulk_rules/show.json.rabl
+++ b/app/views/katello/api/v2/content_view_filter_bulk_rules/show.json.rabl
@@ -1,0 +1,18 @@
+object @resource
+
+extends 'katello/api/v2/common/identifier'
+
+attributes :content_view_filter_id
+attributes :uuid, :if => lambda { |rule| rule.respond_to?(:uuid) && !rule.uuid.blank? }
+attributes :version, :if => lambda { |rule| rule.respond_to?(:version) && !rule.version.blank? }
+attributes :min_version, :if => lambda { |rule| rule.respond_to?(:min_version) && !rule.min_version.blank? }
+attributes :max_version, :if => lambda { |rule| rule.respond_to?(:max_version) && !rule.max_version.blank? }
+
+attributes :errata_id, :if => lambda { |rule| rule.respond_to?(:errata_id) && !rule.errata_id.blank? }
+attributes :start_date, :if => lambda { |rule| rule.respond_to?(:start_date) && !rule.start_date.blank? }
+attributes :end_date, :if => lambda { |rule| rule.respond_to?(:end_date) && !rule.end_date.blank? }
+attributes :architecture, :if => lambda { |rule| rule.respond_to?(:architecture) && !rule.architecture.blank? }
+attributes :types, :if => lambda { |rule| rule.respond_to?(:types) && !rule.types.blank? }
+attributes :date_type, :if => lambda { |rule| rule.respond_to?(:date_type) }
+
+extends 'katello/api/v2/common/timestamps'

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -104,6 +104,7 @@ Katello::Engine.routes.draw do
           api_resources :errata, :only => [:index]
           api_resources :package_groups, :only => [:index]
           api_resources :rules, :controller => :content_view_filter_rules
+          api_resources :bulk, :controller => :content_view_filter_bulk_rules
           collection do
             get :auto_complete_search
           end

--- a/test/controllers/api/v2/content_view_filter_bulk_rules_controller_test.rb
+++ b/test/controllers/api/v2/content_view_filter_bulk_rules_controller_test.rb
@@ -1,0 +1,156 @@
+# encoding: utf-8
+
+require "katello_test_helper"
+
+module Katello
+  class Api::V2::ContentViewFilterBulkRulesControllerTest < ActionController::TestCase
+    def models
+      @filter = katello_content_view_filters(:simple_filter)
+      @rule = katello_content_view_package_filter_rules(:test_package)
+      @rule_for_different_filter = katello_content_view_package_filter_rules(:package_rule)
+    end
+
+    def permissions
+      @view_permission = :view_content_views
+      @create_permission = :create_content_views
+      @update_permission = :edit_content_views
+      @destroy_permission = :destroy_content_views
+    end
+
+    def setup
+      setup_controller_defaults_api
+      models
+      permissions
+    end
+
+    def test_index
+      get :index, params: { :content_view_filter_id => @filter.id }
+
+      assert_response :success
+      assert_template 'api/v2/content_view_filter_bulk_rules/index'
+    end
+
+    def test_index_protected
+      allowed_perms = [@view_permission]
+      denied_perms = [@create_permission, @update_permission, @destroy_permission]
+
+      assert_protected_action(:index, allowed_perms, denied_perms) do
+        get :index, params: { :content_view_filter_id => @filter.id }
+      end
+    end
+
+    def test_create
+      post :create, params: { :content_view_filter_id => @filter.id, :data => [
+                                                                               {'name': 'name1',
+                                                                                'version': 'ver1',
+                                                                                'architecture': 'arch1'
+                                                                               }
+                                                                              ]
+                            }
+
+      assert_response :success
+
+      assert_template :layout => 'katello/api/v2/layouts/resource'
+      assert_template 'katello/api/v2/common/create'
+      assert_equal @filter.reload.package_rules.second.name, "name1"
+      assert_equal @filter.package_rules.second.version, "ver1"
+    end
+
+    def test_create_with_name_array
+      post :create, params: { :content_view_filter_id => @filter.id, :data => [
+                                                                               {'name': 'name1',
+                                                                                'version': 'ver1',
+                                                                                'architecture': 'arch1'
+                                                                               },
+                                                                               {'name': 'name2',
+                                                                                'version': 'ver2',
+                                                                                'architecture': 'arch2'
+                                                                               }
+                                                                              ]
+                            }
+
+      assert_response :success
+
+      assert_template layout: 'katello/api/v2/layouts/collection'
+      assert_template 'katello/api/v2/content_view_filter_bulk_rules/index'
+      assert_equal @filter.reload.package_rules.sort.map(&:name), %w(package\ def name1 name2)
+      assert_equal @filter.package_rules.map(&:version), %w(ver1 ver2)
+    end
+
+      assert_response :success
+
+      assert_template layout: 'katello/api/v2/layouts/collection'
+      assert_template 'katello/api/v2/content_view_filter_bulk_rules/index'
+      assert_equal @filter.reload.package_rules.sort.map(&:name), %w(name1 name2)
+      assert_equal @filter.package_rules.map(&:version), %w(ver1 ver2)
+      assert_equal @filter.package_rules.map(&:architecture), %w(arch1 arch2)
+    end
+
+      assert_response :success
+
+      assert_template layout: 'katello/api/v2/layouts/collection'
+      assert_template 'katello/api/v2/content_view_filter_bulk_rules/index'
+      assert_equal @filter.reload.package_rules.sort.map(&:name), %w(name1 name2)
+      assert_equal @filter.package_rules.map(&:version), %w(ver1 ver2)
+      assert_equal @filter.package_rules.map(&:architecture), %w(arch1 arch2)
+    end
+
+    def test_create_protected
+      allowed_perms = [@update_permission]
+      denied_perms = [@view_permission, @create_permission, @destroy_permission]
+
+      assert_protected_action(:create, allowed_perms, denied_perms) do
+        post :create, params: { :content_view_filter_id => @filter.id, :data => [
+                                                                                 {'name': 'name1',
+                                                                                  'version': 'ver1',
+                                                                                  'architecture': 'arch1'
+                                                                                 }
+                                                                                ]
+                              }
+      end
+    end
+
+    def test_show
+      get :show, params: { :content_view_filter_id => @filter.id, :id => @rule.id }
+
+      assert_response :success
+      assert_template 'api/v2/content_view_filter_bulk_rules/show'
+    end
+
+    def test_mismatched_filter_and_rule
+      get :show, params: { :content_view_filter_id => @filter.id, :id => @rule_for_different_filter.id }
+
+      assert_response 404
+    end
+
+    def test_show_protected
+      allowed_perms = [@view_permission]
+      denied_perms = [@create_permission, @update_permission, @destroy_permission]
+
+      assert_protected_action(:show, allowed_perms, denied_perms) do
+        get :show, params: { :content_view_filter_id => @filter.id, :id => @rule.id }
+      end
+    end
+
+
+    def test_destroy
+      delete :destroy, params: { :content_view_filter_id => @filter.id, :id => @rule.id }
+
+      results = JSON.parse(response.body)
+      refute results.blank?
+      assert_equal results['id'], @rule.id
+
+      assert_response :success
+      assert_nil ContentViewPackageFilterRule.find_by_id(@rule.id)
+    end
+
+    def test_destroy_protected
+      allowed_perms = [@update_permission]
+      denied_perms = [@view_permission, @create_permission, @destroy_permission]
+
+      assert_protected_action(:destroy, allowed_perms, denied_perms) do
+        delete :destroy, params: { :content_view_filter_id => @filter.id, :id => @rule.id }
+      end
+    end
+  end
+end


### PR DESCRIPTION
We are creating RPM filters in ContentViews with more than 800 filter rules. Is too overhead to create all of them one by one, so would be nice to can create all of them at once.