### PR TITLE
Fixes #23922: make spinner adhere to pf.

### DIFF
--- a/webpack/containers/Application/config.js
+++ b/webpack/containers/Application/config.js
@@ -20,7 +20,7 @@ export const links = [
     component: UpstreamSubscriptions,
   },
   {
-    path: "xui/subscriptions/:id(\[0-9]*$\)",
+    path: 'xui/subscriptions/:id(\[0-9]*$\)',
     component: SubscriptionDetails,
   },
 ];

--- a/webpack/move_to_pf/LoadingState/LoadingState.js
+++ b/webpack/move_to_pf/LoadingState/LoadingState.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Spinner } from 'patternfly-react';
+import './LoadingState.scss';
+
+const LoadingState = ({
+  loading,
+  loadingText,
+  children,
+}) => {
+  if (loading) {
+    return (
+      <div className="loading-state">
+        <Spinner loading={loading} size="lg" />
+        <p>{loadingText}</p>
+      </div>
+    );
+  }
+
+  return children;
+};
+
+LoadingState.propTypes = {
+  loading: PropTypes.bool,
+  loadingText: PropTypes.string,
+  children: PropTypes.node,
+};
+
+LoadingState.defaultProps = {
+  loading: false,
+  loadingText: __('Loading'),
+  children: null,
+};
+
+export default LoadingState;

--- a/webpack/move_to_pf/LoadingState/LoadingState.scss
+++ b/webpack/move_to_pf/LoadingState/LoadingState.scss
@@ -1,0 +1,12 @@
+.loading-state {
+  margin-top: 5%;
+
+  .spinner {
+    float: none;
+  }
+
+  p {
+    font-size: 15px;
+    text-align: center;
+  }
+}

--- a/webpack/move_to_pf/LoadingState/LoadingState.test.js
+++ b/webpack/move_to_pf/LoadingState/LoadingState.test.js
@@ -1,0 +1,28 @@
+/* eslint-disable */
+// Ignore eslint for this entire file because our rules
+// don't match patternfly-react's rules
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import { LoadingState } from './index';
+
+test('Loading State renders properly while loading', () => {
+  const component = shallow(
+    <LoadingState loading loadingText="Loading">
+      <p>Loading Complete</p>
+    </LoadingState>
+  );
+
+  expect(toJson(component.render())).toMatchSnapshot();
+});
+
+test('Loading State renders properly while not loading', () => {
+  const component = shallow(
+    <LoadingState loading={false} loadingText="Loading">
+      <p>Loading Complete</p>
+    </LoadingState>
+  );
+
+  expect(toJson(component.render())).toMatchSnapshot();
+});

--- a/webpack/move_to_pf/LoadingState/__snapshots__/LoadingState.test.js.snap
+++ b/webpack/move_to_pf/LoadingState/__snapshots__/LoadingState.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Loading State renders properly while loading 1`] = `
+<div
+  class="loading-state"
+>
+  <div
+    class="spinner spinner-lg"
+  />
+  <p>
+    Loading
+  </p>
+</div>
+`;
+
+exports[`Loading State renders properly while not loading 1`] = `
+<p>
+  Loading Complete
+</p>
+`;

--- a/webpack/move_to_pf/LoadingState/index.js
+++ b/webpack/move_to_pf/LoadingState/index.js
@@ -1,0 +1,3 @@
+// patternfly-react doesn't use this rule and this is how their components are structured
+// eslint-disable-next-line import/prefer-default-export
+export { default as LoadingState } from './LoadingState';

--- a/webpack/scenes/RedHatRepositories/index.js
+++ b/webpack/scenes/RedHatRepositories/index.js
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Grid, Row, Col } from 'react-bootstrap';
-import { Spinner } from 'patternfly-react';
+import { LoadingState } from '../../move_to_pf/LoadingState';
 
 import { createEnabledRepoParams, loadEnabledRepos } from '../../redux/actions/RedHatRepositories/enabled';
 import { loadRepositorySets, updateRecommendedRepositorySets } from '../../redux/actions/RedHatRepositories/sets';
@@ -48,7 +48,7 @@ class RedHatRepositoriesPage extends Component {
                 className="recommended-repositories-toggler"
               />
             </div>
-            <Spinner loading={repositorySets.loading}>
+            <LoadingState loading={repositorySets.loading} loadingText={__('Loading')}>
               {getSetsComponent(
                 repositorySets,
                 (pagination) => {
@@ -58,12 +58,12 @@ class RedHatRepositoriesPage extends Component {
                   });
                 },
               )}
-            </Spinner>
+            </LoadingState>
           </Col>
 
           <Col sm={6} className="enabled-repositories-container">
             <h2>{__('Enabled Repositories')}</h2>
-            <Spinner loading={enabledRepositories.loading} className="small-spacer">
+            <LoadingState loading={enabledRepositories.loading} loadingText={__('Loading')}>
               {getEnabledComponent(
                 enabledRepositories,
                 (pagination) => {
@@ -73,7 +73,7 @@ class RedHatRepositoriesPage extends Component {
                   });
                 },
               )}
-            </Spinner>
+            </LoadingState>
           </Col>
         </Row>
       </Grid>

--- a/webpack/scenes/RedHatRepositories/index.scss
+++ b/webpack/scenes/RedHatRepositories/index.scss
@@ -15,10 +15,6 @@
   color: $color-pf-red-200;
 }
 
-.small-spacer {
-  margin: 10px 0;
-}
-
 #redhatRepositoriesPage {
   .list-group-item-header .list-view-pf-description,
   .enabled-repositories-container .list-view-pf-description {

--- a/webpack/scenes/Subscriptions/Details/SubscriptionDetails.js
+++ b/webpack/scenes/Subscriptions/Details/SubscriptionDetails.js
@@ -1,9 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Spinner, Grid, Row, Col } from 'patternfly-react';
+import { Grid, Row, Col } from 'patternfly-react';
 import SubscriptionDetailInfo from './SubscriptionDetailInfo';
 import SubscriptionDetailAssociations from './SubscriptionDetailAssociations';
 import SubscriptionDetailProducts from './SubscriptionDetailProducts';
+import { LoadingState } from '../../../move_to_pf/LoadingState';
 import { notify } from '../../../move_to_foreman/foreman_toast_notifications';
 
 class SubscriptionDetails extends Component {
@@ -21,7 +22,7 @@ class SubscriptionDetails extends Component {
     return (
       <Grid bsClass="container-fluid">
         <div>
-          <Spinner loading={subscriptionDetails.loading}>
+          <LoadingState loading={subscriptionDetails.loading} loadingText={__('Loading')}>
             <Row>
               <Col sm={12}>
                 <h1>{subscriptionDetails.name}</h1>
@@ -42,7 +43,7 @@ class SubscriptionDetails extends Component {
                 />
               </Col>
             </Row>
-          </Spinner>
+          </LoadingState>
         </div>
       </Grid>
     );

--- a/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetails.test.js.snap
+++ b/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetails.test.js.snap
@@ -7,12 +7,9 @@ exports[`subscriptions details page should render and contain appropiate compone
   fluid={false}
 >
   <div>
-    <Spinner
-      className=""
-      inline={false}
-      inverse={false}
+    <LoadingState
       loading={false}
-      size="md"
+      loadingText="Loading"
     >
       <Row
         bsClass="row"
@@ -429,7 +426,7 @@ exports[`subscriptions details page should render and contain appropiate compone
           />
         </Col>
       </Row>
-    </Spinner>
+    </LoadingState>
   </div>
 </Grid>
 `;

--- a/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
+++ b/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
@@ -4,6 +4,7 @@ import { Col, Tabs, Tab, Form, FormGroup, FormControl, ControlLabel } from 'reac
 import { bindMethods, Button, Icon, Modal, Spinner, OverlayTrigger, Tooltip } from 'patternfly-react';
 import { isEqual } from 'lodash';
 import TooltipButton from 'react-bootstrap-tooltip-button';
+import { LoadingState } from '../../../move_to_pf/LoadingState';
 import { Table } from '../../../move_to_foreman/components/common/table';
 import { columns } from './ManifestHistoryTableSchema';
 import ConfirmDialog from '../../../move_to_foreman/components/common/ConfirmDialog';
@@ -242,13 +243,13 @@ class ManageManifestModal extends Component {
             </Tab>
 
             <Tab eventKey={2} title={__('Manifest History')}>
-              <Spinner loading={manifestHistory.loading} className="small-spacer">
+              <LoadingState loading={manifestHistory.loading} loadingText={__('Loading')}>
                 <Table
                   rows={manifestHistory.results}
                   columns={columns}
                   emptyState={emptyStateData()}
                 />
-              </Spinner>
+              </LoadingState>
             </Tab>
           </Tabs>
         </Modal.Body>

--- a/webpack/scenes/Subscriptions/Manifest/__tests__/__snapshots__/ManageManifestModal.test.js.snap
+++ b/webpack/scenes/Subscriptions/Manifest/__tests__/__snapshots__/ManageManifestModal.test.js.snap
@@ -212,12 +212,9 @@ exports[`manage manifest modal should render 1`] = `
         eventKey={2}
         title="Manifest History"
       >
-        <Spinner
-          className="small-spacer"
-          inline={false}
-          inverse={false}
+        <LoadingState
           loading={false}
-          size="md"
+          loadingText="Loading"
         >
           <Table
             columns={
@@ -340,7 +337,7 @@ exports[`manage manifest modal should render 1`] = `
               ]
             }
           />
-        </Spinner>
+        </LoadingState>
       </Tab>
     </Uncontrolled(Tabs)>
   </ModalBody>

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsPage.js
@@ -4,7 +4,8 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Grid, Row, Col } from 'react-bootstrap';
-import { bindMethods, Button, Spinner } from 'patternfly-react';
+import { bindMethods, Button } from 'patternfly-react';
+import { LoadingState } from '../../../move_to_pf/LoadingState';
 import { notify } from '../../../move_to_foreman/foreman_toast_notifications';
 import helpers from '../../../move_to_foreman/common/helpers';
 import { Table } from '../../../move_to_foreman/components/common/table';
@@ -213,7 +214,7 @@ class UpstreamSubscriptionsPage extends Component {
       <Grid bsClass="container-fluid">
         <h1>{__('Add Subscriptions')}</h1>
 
-        <Spinner loading={upstreamSubscriptions.loading} className="small-spacer">
+        <LoadingState loading={upstreamSubscriptions.loading} loadingText={__('Loading')}>
           <Row>
             <Col sm={12}>
               <Table
@@ -227,7 +228,7 @@ class UpstreamSubscriptionsPage extends Component {
             </Col>
           </Row>
           {getSubscriptionActions()}
-        </Spinner>
+        </LoadingState>
       </Grid>
     );
   }

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/__snapshots__/UpstreamSubscriptionsPage.test.js.snap
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/__snapshots__/UpstreamSubscriptionsPage.test.js.snap
@@ -9,12 +9,9 @@ exports[`upstream subscriptions page should render 1`] = `
   <h1>
     Add Subscriptions
   </h1>
-  <Spinner
-    className="small-spacer"
-    inline={false}
-    inverse={false}
+  <LoadingState
     loading={false}
-    size="md"
+    loadingText="Loading"
   >
     <Row
       bsClass="row"
@@ -221,6 +218,6 @@ exports[`upstream subscriptions page should render 1`] = `
         </LinkContainer>
       </Col>
     </Row>
-  </Spinner>
+  </LoadingState>
 </Grid>
 `;

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTable.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTable.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { sprintf } from 'jed';
 import { cloneDeep, findIndex, isEqual } from 'lodash';
-import { Spinner, Table, Alert } from 'patternfly-react';
+import { Table, Alert } from 'patternfly-react';
+import { LoadingState } from '../../../../move_to_pf/LoadingState';
 import { Table as ForemanTable, TableBody as ForemanTableBody } from '../../../../move_to_foreman/components/common/table';
 import ConfirmDialog from '../../../../move_to_foreman/components/common/ConfirmDialog';
 import Dialog from '../../../../move_to_foreman/components/common/Dialog';
@@ -256,7 +257,7 @@ class SubscriptionsTable extends Component {
     );
 
     return (
-      <Spinner loading={subscriptions.loading} className="small-spacer">
+      <LoadingState loading={subscriptions.loading} loadingText={__('Loading')}>
         <ErrorAlerts
           errors={[
             subscriptions.error,
@@ -343,7 +344,7 @@ class SubscriptionsTable extends Component {
           onConfirm={() => this.props.onDeleteSubscriptions(this.state.selectedRows)}
           onCancel={this.props.onSubscriptionDeleteModalClose}
         />
-      </Spinner>
+      </LoadingState>
     );
   }
 }

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
@@ -2,8 +2,15 @@
 
 exports[`subscriptions table should render a loading state 1`] = `
 <div
-  class="small-spacer spinner spinner-md"
-/>
+  class="loading-state"
+>
+  <div
+    class="spinner spinner-lg"
+  />
+  <p>
+    Loading
+  </p>
+</div>
 `;
 
 exports[`subscriptions table should render a table 1`] = `


### PR DESCRIPTION
Make the spinner adhere to patternfly best practices by centering
it and by including the word "Loading". This commit introduces a
LoadingState component that should be moved to patternfly-react
in the future.

http://projects.theforeman.org/issues/23922

Before:
![screenshot from 2018-06-14 11-16-10](https://user-images.githubusercontent.com/4116405/41421251-5ead42ca-6fc4-11e8-904e-4c38dc0a4d06.png)

After:
![screenshot from 2018-06-14 11-20-34](https://user-images.githubusercontent.com/4116405/41421525-01779438-6fc5-11e8-8526-158b8cb81239.png)

