### PR TITLE
fixes #23943 - use order instead of sort

### DIFF
--- a/lib/katello/tasks/repository.rake
+++ b/lib/katello/tasks/repository.rake
@@ -29,7 +29,7 @@ namespace :katello do
     repos = lookup_repositories
 
     if repos.any?
-      task = ForemanTasks.async_task(Actions::Katello::Repository::BulkMetadataGenerate, repos.all.sort)
+      task = ForemanTasks.async_task(Actions::Katello::Repository::BulkMetadataGenerate, repos.all.order(:name))
       puts "Regenerating #{repos.count} repositories.  You can monitor these on task id #{task.id}\n"
     else
       puts "No repositories found for regeneration."
@@ -42,7 +42,7 @@ namespace :katello do
     repos = lookup_repositories
 
     if repos.any?
-      task = ForemanTasks.async_task(::Actions::BulkAction, Actions::Katello::Repository::RefreshRepository, repos.all.sort)
+      task = ForemanTasks.async_task(::Actions::BulkAction, Actions::Katello::Repository::RefreshRepository, repos.all.order(:name))
       puts "Refreshing #{repos.count} repositories.  You can monitor these on task id #{task.id}\n"
     else
       puts "No repositories found for regeneration."

--- a/test/lib/tasks/repository_test.rb
+++ b/test/lib/tasks/repository_test.rb
@@ -32,7 +32,7 @@ module Katello
 
     def test_regenerate_repo_metadata
       ForemanTasks.expects(:async_task).with(::Actions::Katello::Repository::BulkMetadataGenerate,
-                                             Katello::Repository.all.sort).returns(ForemanTasks::Task.new)
+                                             Katello::Repository.all.order(:name)).returns(ForemanTasks::Task.new)
 
       Rake.application.invoke_task('katello:regenerate_repo_metadata')
     end
@@ -40,9 +40,10 @@ module Katello
     def test_regenerate_repo_metadata_env
       ENV['LIFECYCLE_ENVIRONMENT'] = @library_repo.environment.name
 
-      expected_repos = Katello::Repository.joins(:environment).where('katello_environments.name' => @library_repo.environment.name)
+      expected_repos = Katello::Repository.in_environment(@library_repo.environment).order(:name)
+      Katello::Repository.stubs(:in_environment).returns(expected_repos)
       ForemanTasks.expects(:async_task).with(::Actions::Katello::Repository::BulkMetadataGenerate,
-                                             expected_repos.sort).returns(ForemanTasks::Task.new)
+                                             expected_repos).returns(ForemanTasks::Task.new)
 
       Rake.application.invoke_task('katello:regenerate_repo_metadata')
     end
@@ -57,7 +58,7 @@ module Katello
 
     def test_refresh_pulp_repo_details
       ForemanTasks.expects(:async_task).with(::Actions::BulkAction, Actions::Katello::Repository::RefreshRepository,
-                                             Katello::Repository.all.sort).returns(ForemanTasks::Task.new)
+                                             Katello::Repository.all.order(:name)).returns(ForemanTasks::Task.new)
 
       Rake.application.invoke_task('katello:refresh_pulp_repo_details')
     end


### PR DESCRIPTION
`#sort` in Rails 5 returns an array, but scopes like in_default_view is later called on the sorted array.  This changes the rake task to use SQL sorting with `#order` instead.