### PR TITLE
Fixes #23944 - Fix react router SubscriptionDetails path

### DIFF
--- a/webpack/containers/Application/config.js
+++ b/webpack/containers/Application/config.js
@@ -20,7 +20,7 @@ export const links = [
     component: UpstreamSubscriptions,
   },
   {
-    path: 'xui/subscriptions/:id',
+    path: "xui/subscriptions/:id(\[0-9]*$\)",
     component: SubscriptionDetails,
   },
 ];


### PR DESCRIPTION
When `add subscriptions page`  loads, `subscription details page` loads simultaneously:
![192 168 121 17_3000_xui_subscriptions_add](https://user-images.githubusercontent.com/11807069/41443402-4a3725f0-7045-11e8-8efd-4c37e17e8c36.gif)


this happens because Route path on SubscriptionDetailsPage is `xui/subscriptions/:id`
with no any regex filter. therefore the add subscriptions  page with its route `xui/subscriptions/add` triggers both.

`react-router` v4 supports regex filter in path parameter.