### PR TITLE
Fixes #22900 - Add breadcrumbsBar to RH Subscriptions page

### DIFF
--- a/webpack/__mocks__/foremanReact/components/BreadcrumbBar.js
+++ b/webpack/__mocks__/foremanReact/components/BreadcrumbBar.js
@@ -1,0 +1,3 @@
+
+const BreadcrumbsBar = () => jest.fn();
+export default BreadcrumbsBar;

--- a/webpack/scenes/Subscriptions/Details/SubscriptionDetails.js
+++ b/webpack/scenes/Subscriptions/Details/SubscriptionDetails.js
@@ -1,33 +1,70 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Grid, Row, Col } from 'patternfly-react';
+import BreadcrumbsBar from 'foremanReact/components/BreadcrumbBar';
 import SubscriptionDetailInfo from './SubscriptionDetailInfo';
 import SubscriptionDetailAssociations from './SubscriptionDetailAssociations';
 import SubscriptionDetailProducts from './SubscriptionDetailProducts';
 import { LoadingState } from '../../../move_to_pf/LoadingState';
 import { notify } from '../../../move_to_foreman/foreman_toast_notifications';
+import api from '../../../services/api';
 
 class SubscriptionDetails extends Component {
+  constructor() {
+    super();
+    this.handleBreadcrumbSwitcherItem = this.handleBreadcrumbSwitcherItem.bind(this);
+  }
   componentDidMount() {
     // eslint-disable-next-line react/prop-types
     const routerParams = this.props.match.params;
     this.props.loadSubscriptionDetails(parseInt(routerParams.id, 10));
   }
 
+  componentDidUpdate(prevProps) {
+    const routerParams = this.props.match.params;
+    if (routerParams.id !== prevProps.match.params.id) {
+      this.props.loadSubscriptionDetails(parseInt(routerParams.id, 10));
+    }
+  }
+
+  handleBreadcrumbSwitcherItem(e, url) {
+    this.props.history.push(url);
+    e.preventDefault();
+  }
+
   render() {
     const { subscriptionDetails } = this.props;
+    const resource = {
+      nameField: 'name',
+      resourceUrl: api.getApiUrl('/subscriptions'),
+      switcherItemUrl: '/subscriptions/:id',
+    };
 
-    if (subscriptionDetails.error) { notify({ message: subscriptionDetails.error }); }
+    if (subscriptionDetails.error) {
+      notify({ message: subscriptionDetails.error });
+    }
 
     return (
       <Grid bsClass="container-fluid">
+        {!subscriptionDetails.loading && <BreadcrumbsBar
+          onSwitcherItemClick={(e, url) => this.handleBreadcrumbSwitcherItem(e, url)}
+          data={{
+            isSwitchable: true,
+            breadcrumbItems: [
+              {
+                caption: __('Subscriptions'),
+                onClick: () =>
+                  this.props.history.push('/subscriptions'),
+              },
+              {
+                caption: String(subscriptionDetails.name),
+              },
+            ],
+            resource,
+          }}
+        />}
         <div>
           <LoadingState loading={subscriptionDetails.loading} loadingText={__('Loading')}>
-            <Row>
-              <Col sm={12}>
-                <h1>{subscriptionDetails.name}</h1>
-              </Col>
-            </Row>
             <Row>
               <Col sm={6}>
                 <SubscriptionDetailInfo
@@ -53,6 +90,7 @@ class SubscriptionDetails extends Component {
 SubscriptionDetails.propTypes = {
   loadSubscriptionDetails: PropTypes.func.isRequired,
   subscriptionDetails: PropTypes.shape({}).isRequired,
+  history: PropTypes.shape({ push: PropTypes.func.isRequired }).isRequired,
 };
 
 export default SubscriptionDetails;

--- a/webpack/scenes/Subscriptions/Details/__tests__/SubscriptionDetails.test.js
+++ b/webpack/scenes/Subscriptions/Details/__tests__/SubscriptionDetails.test.js
@@ -19,7 +19,6 @@ describe('subscriptions details page', () => {
       subscriptionDetails={successState}
       match={match}
     />);
-    expect(wrapper.find('h1').text()).toEqual(successState.name);
     expect(wrapper.find(SubscriptionDetailAssociations)).toHaveLength(1);
     expect(wrapper.find(SubscriptionDetailInfo)).toHaveLength(1);
     expect(wrapper.find(SubscriptionDetailProducts)).toHaveLength(1);

--- a/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetails.test.js.snap
+++ b/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetails.test.js.snap
@@ -6,25 +6,33 @@ exports[`subscriptions details page should render and contain appropiate compone
   componentClass="div"
   fluid={false}
 >
+  <BreadcrumbsBar
+    data={
+      Object {
+        "breadcrumbItems": Array [
+          Object {
+            "caption": "Subscriptions",
+            "onClick": [Function],
+          },
+          Object {
+            "caption": "OpenShift Employee Subscription",
+          },
+        ],
+        "isSwitchable": true,
+        "resource": Object {
+          "nameField": "name",
+          "resourceUrl": "/katello/api/v2/subscriptions",
+          "switcherItemUrl": "/subscriptions/:id",
+        },
+      }
+    }
+    onSwitcherItemClick={[Function]}
+  />
   <div>
     <LoadingState
       loading={false}
       loadingText="Loading"
     >
-      <Row
-        bsClass="row"
-        componentClass="div"
-      >
-        <Col
-          bsClass="col"
-          componentClass="div"
-          sm={12}
-        >
-          <h1>
-            OpenShift Employee Subscription
-          </h1>
-        </Col>
-      </Row>
       <Row
         bsClass="row"
         componentClass="div"

--- a/webpack/scenes/Subscriptions/Details/index.js
+++ b/webpack/scenes/Subscriptions/Details/index.js
@@ -1,6 +1,6 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-
+import { withRouter } from 'react-router';
 import reducer from './SubscriptionDetailReducer';
 import * as subscriptionDetailActions from './SubscriptionDetailActions';
 import SubscriptionDetails from './SubscriptionDetails';
@@ -16,4 +16,4 @@ const mapDispatchToProps = dispatch => bindActionCreators(subscriptionDetailActi
 export const subscriptionDetails = reducer;
 
 // export connected component
-export default connect(mapStateToProps, mapDispatchToProps)(SubscriptionDetails);
+export default connect(mapStateToProps, mapDispatchToProps)(withRouter(SubscriptionDetails));

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsPage.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Grid, Row, Col } from 'react-bootstrap';
 import { bindMethods, Button } from 'patternfly-react';
+import BreadcrumbsBar from 'foremanReact/components/BreadcrumbBar';
 import { LoadingState } from '../../../move_to_pf/LoadingState';
 import { notify } from '../../../move_to_foreman/foreman_toast_notifications';
 import helpers from '../../../move_to_foreman/common/helpers';
@@ -212,7 +213,19 @@ class UpstreamSubscriptionsPage extends Component {
 
     return (
       <Grid bsClass="container-fluid">
-        <h1>{__('Add Subscriptions')}</h1>
+        <BreadcrumbsBar data={{
+          isSwitchable: false,
+          breadcrumbItems: [
+            {
+              caption: __('Subscriptions'),
+              onClick: () => this.props.history.push('/subscriptions'),
+            },
+            {
+              caption: __('Add Subscriptions'),
+            },
+          ],
+        }}
+        />
 
         <LoadingState loading={upstreamSubscriptions.loading} loadingText={__('Loading')}>
           <Row>
@@ -242,6 +255,7 @@ UpstreamSubscriptionsPage.propTypes = {
     task: PropTypes.shape({}),
     error: PropTypes.shape({}),
   }).isRequired,
+  history: PropTypes.shape({ push: PropTypes.func.isRequired }).isRequired,
 };
 
 export default UpstreamSubscriptionsPage;

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/UpstreamSubscriptionsPage.test.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/UpstreamSubscriptionsPage.test.js
@@ -6,6 +6,7 @@ import { successState } from './upstreamSubscriptions.fixtures';
 import { loadUpstreamSubscriptions, saveUpstreamSubscriptions } from '../UpstreamSubscriptionsActions';
 
 jest.mock('../../../../move_to_foreman/foreman_toast_notifications');
+jest.mock('foremanReact/components/BreadcrumbBar');
 
 describe('upstream subscriptions page', () => {
   const mockHistory = { push: () => {} };

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/__snapshots__/UpstreamSubscriptionsPage.test.js.snap
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/__snapshots__/UpstreamSubscriptionsPage.test.js.snap
@@ -6,9 +6,22 @@ exports[`upstream subscriptions page should render 1`] = `
   componentClass="div"
   fluid={false}
 >
-  <h1>
-    Add Subscriptions
-  </h1>
+  <BreadcrumbsBar
+    data={
+      Object {
+        "breadcrumbItems": Array [
+          Object {
+            "caption": "Subscriptions",
+            "onClick": [Function],
+          },
+          Object {
+            "caption": "Add Subscriptions",
+          },
+        ],
+        "isSwitchable": false,
+      }
+    }
+  />
   <LoadingState
     loading={false}
     loadingText="Loading"


### PR DESCRIPTION
The links don't work because the BreadcrumbsBar component doesn't support in react-router `<Link>`  (anchor tag doesn't work with react-router).
a suggested workaround for that is to use `onClick` instead of `href`, and pass a callback which modify the route path.

![breadcrumbs-subs-2](https://user-images.githubusercontent.com/11807069/41425750-52f29a20-700a-11e8-9fe9-c828bc44f904.png)

![breadcrumbs-subs](https://user-images.githubusercontent.com/11807069/41425755-5729c00a-700a-11e8-9957-c90911e7db78.png)
