### PR TITLE
fixes #23954 - test stubs should return dynflow task

### DIFF
--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -694,7 +694,7 @@ module Katello
     def test_remove_content
       @repository.rpms << @rpm
       @controller.expects(:sync_task).with(::Actions::Katello::Repository::RemoveContent,
-                                           @repository, [@rpm], sync_capsule: true).once.returns(::ForemanTasks::Task.new)
+                                           @repository, [@rpm], sync_capsule: true).once.returns(::ForemanTasks::Task::DynflowTask.new)
 
       put :remove_content, params: { :id => @repository.id, :ids => [@rpm.uuid] }
 

--- a/test/lib/tasks/clean_published_repo_directories_test.rb
+++ b/test/lib/tasks/clean_published_repo_directories_test.rb
@@ -19,7 +19,7 @@ module Katello
       Dir.stubs(:glob).with('/var/lib/pulp/published/yum/master/yum_distributor/*').returns(['Default_Organization-Test-busybox', 'Default_Organization-Test-ostree', 'fedora_17_dev_library_view'])
       ENV['COMMIT'] = 'true'
       ForemanTasks.expects(:sync_task).with(Actions::Katello::Repository::MetadataGenerate,
-                                            Katello::Repository.where(pulp_id: 'Fedora_17').first).returns(ForemanTasks::Task.new)
+                                            Katello::Repository.where(pulp_id: 'Fedora_17').first).returns(ForemanTasks::Task::DynflowTask.new)
 
       Rake.application.invoke_task('katello:clean_published_repo_directories')
     end

--- a/test/lib/tasks/repository_test.rb
+++ b/test/lib/tasks/repository_test.rb
@@ -32,7 +32,7 @@ module Katello
 
     def test_regenerate_repo_metadata
       ForemanTasks.expects(:async_task).with(::Actions::Katello::Repository::BulkMetadataGenerate,
-                                             Katello::Repository.all.order(:name)).returns(ForemanTasks::Task.new)
+                                             Katello::Repository.all.order(:name)).returns(ForemanTasks::Task::DynflowTask::DynflowTask.new)
 
       Rake.application.invoke_task('katello:regenerate_repo_metadata')
     end
@@ -43,7 +43,7 @@ module Katello
       expected_repos = Katello::Repository.in_environment(@library_repo.environment).order(:name)
       Katello::Repository.stubs(:in_environment).returns(expected_repos)
       ForemanTasks.expects(:async_task).with(::Actions::Katello::Repository::BulkMetadataGenerate,
-                                             expected_repos).returns(ForemanTasks::Task.new)
+                                             expected_repos).returns(ForemanTasks::Task::DynflowTask.new)
 
       Rake.application.invoke_task('katello:regenerate_repo_metadata')
     end
@@ -51,14 +51,14 @@ module Katello
     def test_regenerate_repo_metadata_cv
       ENV['CONTENT_VIEW'] = @cv_repo.content_view.name
       ForemanTasks.expects(:async_task).with(::Actions::Katello::Repository::BulkMetadataGenerate,
-                                             [@cv_repo]).returns(ForemanTasks::Task.new)
+                                             [@cv_repo]).returns(ForemanTasks::Task::DynflowTask.new)
 
       Rake.application.invoke_task('katello:regenerate_repo_metadata')
     end
 
     def test_refresh_pulp_repo_details
       ForemanTasks.expects(:async_task).with(::Actions::BulkAction, Actions::Katello::Repository::RefreshRepository,
-                                             Katello::Repository.all.order(:name)).returns(ForemanTasks::Task.new)
+                                             Katello::Repository.all.order(:name)).returns(ForemanTasks::Task::DynflowTask.new)
 
       Rake.application.invoke_task('katello:refresh_pulp_repo_details')
     end


### PR DESCRIPTION
ForemanTask.async_task returns a dynflow task, and tests that stub this should also return the same class of object.  ForemanTask::Task doesn't have all the same methods as Task::DynflowTask, e.g. `#get_humanized`.

With latest foreman tasks release, a test is failing:

```
Failure:
Katello::Api::V2::RepositoriesControllerTest#test_remove_content [/var/lib/workspace/workspace/katello-pr-test/test/controllers/api/v2/repositories_controller_test.rb:701]:
Expected response to be a <2XX: success>, but was a <500: Internal Server Error>
Response body: {"displayMessage":"undefined method `get_humanized' for #\u003cForemanTasks::Task:0x0000000077384470\u003e\nDid you mean?  humanized","errors":["undefined method `get_humanized' for #\u003cForemanTasks::Task:0x0000000077384470\u003e\nDid you mean?  humanized"]}

bin/rails test /var/lib/workspace/workspace/katello-pr-test/test/controllers/api/v2/repositories_controller_test.rb:694
```