### PR TITLE
fixes #23899 - pull w/o authentication

### DIFF
--- a/app/controllers/katello/api/v2/environments_controller.rb
+++ b/app/controllers/katello/api/v2/environments_controller.rb
@@ -76,6 +76,7 @@ module Katello
     param :label, String, :desc => N_("label of the environment"), :required => false
     param :description, String, :desc => N_("description of the environment")
     param :registry_name_pattern, String, :desc => N_("pattern for container image names")
+    param :registry_unauthenticated_pull, :bool, :desc => N_("allow unauthenticed pull of container images")
     param :prior_id, Integer, :required => true, :desc => <<-DESC
       ID of an environment that is prior to the new environment in the chain. It has to be
       either the ID of Library or the ID of an environment at the end of a chain.
@@ -95,6 +96,7 @@ module Katello
     param :new_name, String, :desc => N_("new name to be given to the environment")
     param :description, String, :desc => N_("description of the environment")
     param :registry_name_pattern, String, :desc => N_("pattern for container image names")
+    param :registry_unauthenticated_pull, :bool, :desc => N_("allow unauthenticed pull of container images")
     param :async, :bool, desc: N_("Do not wait for the update action to finish. Default: true")
     def update
       async = ::Foreman::Cast.to_bool(params.fetch(:async, true))
@@ -175,9 +177,9 @@ module Katello
 
     def environment_params
       if @environment && @environment.library?
-        attrs = [:registry_name_pattern]
+        attrs = [:registry_name_pattern, :registry_unauthenticated_pull]
       else
-        attrs = [:name, :description, :registry_name_pattern]
+        attrs = [:name, :description, :registry_name_pattern, :registry_unauthenticated_pull]
       end
       attrs << :label if params[:action] == "create"
       parms = params.require(:environment).permit(*attrs)

--- a/app/views/katello/api/v2/environments/show.json.rabl
+++ b/app/views/katello/api/v2/environments/show.json.rabl
@@ -4,7 +4,7 @@ extends 'katello/api/v2/common/identifier'
 extends 'katello/api/v2/common/org_reference'
 
 attributes :library
-attributes :registry_name_pattern
+attributes :registry_name_pattern, :registry_unauthenticated_pull
 
 node :prior do |env|
   if env.prior

--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -6,7 +6,8 @@ extends 'katello/api/v2/common/timestamps'
 attributes :content_type
 attributes :docker_upstream_name
 attributes :mirror_on_sync, :verify_ssl_on_sync
-attributes :unprotected, :full_path, :checksum_type, :container_repository_name
+attributes :unprotected, :full_path, :checksum_type
+attributes :container_repository_name
 attributes :download_policy
 attributes :url,
            :relative_path
@@ -71,5 +72,5 @@ if @object && @object.library_instance_id.nil?
 end
 
 child :environment => :environment do |_repo|
-  attribute :id
+  attribute :id, :registry_unauthenticated_pull
 end

--- a/db/migrate/20180614184822_add_unauthenticated_pull.rb
+++ b/db/migrate/20180614184822_add_unauthenticated_pull.rb
@@ -1,0 +1,9 @@
+class AddUnauthenticatedPull < ActiveRecord::Migration[5.1]
+  def up
+    add_column :katello_environments, :registry_unauthenticated_pull, :boolean, :default => false
+  end
+
+  def down
+    remove_column :katello_environments, :registry_unauthenticated_pull
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-details.html
@@ -13,16 +13,27 @@
     <dt translate>Label</dt>
     <dd>{{ environment.label }}</dd>
 
-    <dt translate>Registry Name Pattern</dt>
-    <dd bst-edit-textarea="environment.registry_name_pattern"
-        on-save="save(environment)"
-        readonly="denied('edit_lifecycle_environments', environment)">
-    </dd>
-
     <dt translate>Description</dt>
     <dd bst-edit-textarea="environment.description"
         on-save="save(environment)"
         readonly="denied('edit_lifecycle_environments', environment) || environment.library">
     </dd>
   </dl>
+
+  <h4 translate>Container Image Registry</h4>
+
+  <dl class="dl-horizontal dl-horizontal-left">
+    <dt translate>Unauthenticated Pull</dt>
+    <dd bst-edit-checkbox="environment.registry_unauthenticated_pull"
+        formatter="booleanToYesNo"
+        on-save="save(environment)"
+        readonly="denied('edit_lifecycle_environments', environment)">
+    </dd>
+    <dt translate>Registry Name Pattern</dt>
+    <dd bst-edit-textarea="environment.registry_name_pattern"
+        on-save="save(environment)"
+        readonly="denied('edit_lifecycle_environments', environment)">
+    </dd>
+  </dl>
+
 </div>

--- a/test/controllers/api/registry/registry_proxies_controller_test.rb
+++ b/test/controllers/api/registry/registry_proxies_controller_test.rb
@@ -1,6 +1,7 @@
 require "katello_test_helper"
 
 module Katello
+  #rubocop:disable Metrics/BlockLength
   describe Api::Registry::RegistryProxiesController do
     include Support::ForemanTasks::Task
 
@@ -171,6 +172,57 @@ module Katello
         assert_equal "#{expiration}", body['expires_at']
         assert_equal "#{expiration}", body['issued_at']
       end
+
+      it "token - unscoped is unauthorized" do
+        User.current = nil
+        session[:user] = nil
+        reset_api_credentials
+
+        get :token
+        assert_response 401
+      end
+
+      it "token - allow unauthenticated pull" do
+        @docker_repo.set_container_repository_name
+        @docker_repo.save!
+        @docker_repo.environment.registry_unauthenticated_pull = true
+        @docker_repo.environment.save!
+
+        User.current = nil
+        session[:user] = nil
+        reset_api_credentials
+
+        get :token, params: { scope: "repository:#{@docker_repo.container_repository_name}:pull" }
+        assert_response 200
+      end
+
+      it "token - do not allow unauthenticated pull" do
+        @docker_repo.set_container_repository_name
+        @docker_repo.save!
+        @docker_repo.environment.registry_unauthenticated_pull = false
+        @docker_repo.environment.save!
+
+        User.current = nil
+        session[:user] = nil
+        reset_api_credentials
+
+        get :token, params: { scope: "repository:#{@docker_repo.container_repository_name}:pull" }
+        assert_response 401
+      end
+
+      it "token - do not allow unauthenticated push" do
+        @docker_repo.set_container_repository_name
+        @docker_repo.save!
+        @docker_repo.environment.registry_unauthenticated_pull = true
+        @docker_repo.environment.save!
+
+        User.current = nil
+        session[:user] = nil
+        reset_api_credentials
+
+        get :token, params: { scope: "repository:#{@docker_repo.container_repository_name}:push" }
+        assert_response 401
+      end
     end
 
     describe "docker search" do
@@ -201,7 +253,7 @@ module Katello
     describe "docker pull" do
       it "pull manifest - protected" do
         @controller.stubs(:registry_authorize).returns(true)
-        @controller.stubs(:find_repository).returns(@docker_repo)
+        @controller.stubs(:find_readable_repository).returns(@docker_repo)
         Resources::Registry::Proxy.stubs(:get).returns(stubbed: true)
         DockerMetaTag.stubs(:where).with(repository_id: @docker_repo.id, name: @tag.name).returns([@tag])
 
@@ -215,7 +267,21 @@ module Katello
       it "pull manifest - success" do
         manifest = '{"mediaType":"MEDIATYPE"}'
         @controller.stubs(:registry_authorize).returns(true)
-        @controller.stubs(:find_repository).returns(@docker_repo)
+        @controller.stubs(:find_readable_repository).returns(@docker_repo)
+        Resources::Registry::Proxy.stubs(:get).returns(manifest)
+        DockerMetaTag.stubs(:where).with(repository_id: @docker_repo.id, name: @tag.name).returns([@tag])
+
+        get :pull_manifest, params: { repository: @docker_repo.name, tag: @tag.name }
+        assert_response 200
+        assert_equal(manifest, response.body)
+        assert response.header['Content-Type'] =~ /MEDIATYPE/
+        assert_equal response.header['Docker-Content-Digest'], "sha256:#{Digest::SHA256.hexdigest(manifest)}"
+      end
+
+      it "pull manifest no login - success" do
+        manifest = '{"mediaType":"MEDIATYPE"}'
+        @controller.stubs(:registry_authorize).returns(true)
+        @controller.stubs(:find_readable_repository).returns(@docker_repo)
         Resources::Registry::Proxy.stubs(:get).returns(manifest)
         DockerMetaTag.stubs(:where).with(repository_id: @docker_repo.id, name: @tag.name).returns([@tag])
 
@@ -276,8 +342,9 @@ module Katello
         manifest = {
           schemaVersion: 1
         }
-        @controller.stubs(:authorize_repository_write).returns(true)
-        @controller.instance_variable_set('@repository', @repository)
+        @controller.stubs(:authorize).returns(true)
+        @controller.stubs(:find_readable_repository).returns(@repository)
+        @controller.stubs(:find_writable_repository).returns(@repository)
         put :push_manifest, params: { repository: 'repository', tag: 'tag' },
             body: manifest.to_json
         assert_response 200
@@ -292,4 +359,5 @@ module Katello
       @controller.stubs(:pulp_content).returns(content)
     end
   end
+  #rubocop:enable Metrics/BlockLength
 end


### PR DESCRIPTION
Adds an option to lifecycle environments to serve container images without authentication.

To test:
+ add container images via a content view to lifecycle
+ checkbox to allow unauthenticated pull
+ _docker logout_
+ _docker pull devel.example.com/examplecorp-production-dockerhub-dockerhub-busybox:latest_
Should succeed