### PR TITLE
fixes #24014 - Add line to print missing candlepin/pulp consumers 

### DIFF
--- a/lib/katello/tasks/clean_backend_objects.rake
+++ b/lib/katello/tasks/clean_backend_objects.rake
@@ -59,12 +59,14 @@ namespace :katello do
     def clean_backend_orphans(cleaner)
       cp_uuids = cleaner.cp_orphaned_host_uuids
       print "#{cp_uuids.count} orphaned consumer id(s) found in candlepin.\n"
+      print "Candlepin orphaned consumers: #{cp_uuids}\n"
       cp_uuids.each do |consumer_id|
         execute("exception when destroying candlepin consumer #{consumer_id}") { Katello::Resources::Candlepin::Consumer.destroy(consumer_id) }
       end
 
       pulp_uuids = cleaner.pulp_orphaned_host_uuids
       print "#{pulp_uuids.count} orphaned consumer id(s) found in pulp.\n"
+      print "Pulp orphaned consumers: #{pulp_uuids}\n"
       pulp_uuids.each do |consumer_id|
         execute("exception when destroying pulp consumer #{consumer_id}") { Katello.pulp_server.extensions.consumer.delete(consumer_id) }
       end


### PR DESCRIPTION
Print out the missing consumers for pulp/candlepin otherwise we see the total count of missing consumers but not the list of consumers 