### PR TITLE
Fixes #23968 - fix adding/removing multiple subs

### DIFF
--- a/app/lib/actions/katello/host/remove_subscriptions.rb
+++ b/app/lib/actions/katello/host/remove_subscriptions.rb
@@ -13,7 +13,7 @@ module Actions
             end
             cp_consumer = host.subscription_facet.candlepin_consumer
             entitlements = pools_with_quantities.map do |pool_with_quantities|
-              cp_consumer.filter_entitlements(pool_with_quantities.pool.cp_id, pool_with_quantities.quantities)
+              cp_consumer.filter_entitlements(pool_with_quantities.pool.cp_id)
             end
 
             entitlements.flatten.each do |entitlement|

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-subscriptions-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-subscriptions-modal.html
@@ -65,7 +65,7 @@
                class="table table-striped table-bordered">
           <thead>
           <tr bst-table-head row-select>
-            <th bst-table-column="quantity" sortable class="align-center"><span translate>Quantity</span></th>
+            <th bst-table-column="quantity" sortable class="align-center"><span translate>Quantity (To Add)</span></th>
             <th bst-table-column="attached" sortable><span translate>Attached</span></th>
             <th bst-table-column="type"><span translate>Type</span></th>
             <th bst-table-column="startDate" sortable><span translate>Starts</span></th>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-add-subscriptions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-add-subscriptions.controller.js
@@ -39,7 +39,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostAddSubscriptionsC
             $scope.groupedSubscriptions = SubscriptionsHelper.groupByProductName(rows);
         });
 
-        $scope.getAmountSelectorValues = SubscriptionsHelper.getAmountSelectorValues;
+        $scope.amountSelectorValues = SubscriptionsHelper.getAmountSelectorValues;
         $scope.showMatchHost = false;
         $scope.showMatchInstalled = false;
         $scope.showNoOverlap = false;

--- a/engines/bastion_katello/test/content-hosts/details/content-host-add-subscriptions.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-add-subscriptions.controller.test.js
@@ -164,6 +164,6 @@ describe('Controller: ContentHostAddSubscriptionsController', function() {
     });
 
     it("sets a local scope function for getting the selector amount values from the subscription helper", function () {
-        expect($scope.getAmountSelectorValues).toBe(SubscriptionsHelper.getAmountSelectorValues);
+        expect($scope.amountSelectorValues).toBe(SubscriptionsHelper.getAmountSelectorValues);
     });
 });

--- a/test/services/katello/candlepin/consumer_test.rb
+++ b/test/services/katello/candlepin/consumer_test.rb
@@ -36,6 +36,7 @@ module Katello
         assert_equal [ENTITLEMENT_A, ENTITLEMENT_B, ENTITLEMENT_C], @consumer.filter_entitlements(1, nil)
         assert_equal [ENTITLEMENT_A, ENTITLEMENT_B], @consumer.filter_entitlements(1, [1, 1])
         assert_equal [ENTITLEMENT_A, ENTITLEMENT_C], @consumer.filter_entitlements(1, [1, 3])
+        assert_equal [ENTITLEMENT_A, ENTITLEMENT_B, ENTITLEMENT_C], @consumer.filter_entitlements(1)
       end
 
       def test_compliance_reasons


### PR DESCRIPTION
### Issue 1: 
We have subscriptions which are "multi-entitlement". Today you can add just one quantity of such subscription (Automatic) from individual content host page. However, bulk pages (Host Collections etc) allow you to add multiple quantities of such subs to a host.
#### Steps to reproduce:
1. Go to Content host > content host record > Subscription tab > Add
2. If you have any multi-entitlement subs, you should see a drop-down with only one option "Automatic" to choose from.
![automatic](https://user-images.githubusercontent.com/21146741/41677070-4b59529c-7495-11e8-8e3c-a9ac0ff54a87.png)
However, if you go to bulk actions (eg: Host collections> Actions> Subscription Management), you will see options to choose from when adding quantity.
![automatic2](https://user-images.githubusercontent.com/21146741/41677222-b0d73ddc-7495-11e8-9645-b681e7e4b78a.png)
***** 
### Issue 2:
When deleting subs from bulk actions (eg: Host collections> Actions> Subscription Management), choosing automatic option as quantity to delete results in a successful job but no subs are actually removed.
#### Steps to reproduce:
1. Go to Host Collections > host collection record > Actions pane> Subscription Management
2. After adding some quantity of multi-entitlement subs, try to delete subs using automatic as option
3. The task runs successfully but subs are not actually removed.


