### PR TITLE
Fixes #24047 - Get Pulp URL from smart proxy

### DIFF
--- a/app/lib/actions/katello/capsule_content/create_repos.rb
+++ b/app/lib/actions/katello/capsule_content/create_repos.rb
@@ -35,7 +35,7 @@ module Actions
                       content_type: repository.content_type,
                       pulp_id: repository.pulp_id,
                       name: repository.name,
-                      feed: repository.docker? ? repository.docker_feed_url(capsule_content.capsule) : repository.full_path(nil, true),
+                      feed: repository.docker? ? repository.docker_feed_url(capsule_content.capsule) : repository.full_path(capsule_content.capsule, true),
                       ssl_ca_cert: ::Cert::Certs.ca_cert,
                       ssl_client_cert: ueber_cert[:cert],
                       ssl_client_key: ueber_cert[:key],

--- a/app/lib/actions/middleware/backend_services_check.rb
+++ b/app/lib/actions/middleware/backend_services_check.rb
@@ -27,7 +27,7 @@ module Actions
 
       def capsule_id(args)
         capsule_hash = args.select { |x| x[:capsule_id] if x.is_a? Hash }
-        capsule_hash[0] ? capsule_hash[0][:capsule_id] : nil
+        capsule_hash[0] ? capsule_hash[0][:capsule_id] : SmartProxy.default_capsule.id
       end
 
       def source_action

--- a/app/lib/katello/capsule_content.rb
+++ b/app/lib/katello/capsule_content.rb
@@ -132,7 +132,11 @@ module Katello
     end
 
     def pulp_url
-      "https://" + self.capsule.hostname + "/pulp/api/v2/"
+      self.capsule.pulp_url
+    end
+
+    def pulp_uri
+      URI.parse(pulp_url)
     end
 
     def pulp_repo_facts(pulp_id)

--- a/app/models/katello/ping.rb
+++ b/app/models/katello/ping.rb
@@ -97,13 +97,9 @@ module Katello
       end
 
       def pulp_url(capsule_id)
-        if capsule_id
-          capsule_content = ::Katello::CapsuleContent.new(SmartProxy.find(capsule_id))
-          uri = URI.parse(capsule_content.pulp_url)
-          "#{uri.scheme}://#{uri.host.downcase}/pulp/api/v2"
-        else
-          SETTINGS[:katello][:pulp][:url]
-        end
+        capsule_content = ::Katello::CapsuleContent.new(SmartProxy.find(capsule_id))
+        uri = capsule_content.pulp_uri
+        "#{uri.scheme}://#{uri.host.downcase}/pulp/api/v2"
       end
 
       # this checks Pulp is running and responding without need

--- a/config/katello.yaml.example
+++ b/config/katello.yaml.example
@@ -46,10 +46,6 @@
     # :bulk_load_size: 1000
   # Setup your pulp environment here
   :pulp:
-    # refers to the url of the pulp
-    # example https://localhost/pulp/api
-    :url: https://localhost/pulp/api/v2/
-
     :sync_threads: 4
     :bulk_load_size: 100
     # refers to the apache certificate

--- a/db/migrate/20180622183321_add_pulp_url_to_smart_proxy.rb
+++ b/db/migrate/20180622183321_add_pulp_url_to_smart_proxy.rb
@@ -1,0 +1,5 @@
+class AddPulpUrlToSmartProxy < ActiveRecord::Migration[5.1]
+  def change
+    add_column :smart_proxies, :pulp_url, :text
+  end
+end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -27,7 +27,6 @@ module Katello
         :consumer_cert_sh => 'katello-rhsm-consumer',
         :pulp => {
           :default_login => 'admin',
-          :url => 'https://localhost/pulp/api/v2/',
           :bulk_load_size => 100,
           :skip_checksum_validation => false,
           :upload_chunk_size => 1_048_575, # upload size in bytes to pulp. see SSLRenegBufferSize in apache

--- a/lib/proxy_api/pulp.rb
+++ b/lib/proxy_api/pulp.rb
@@ -18,5 +18,12 @@ module ProxyAPI
     rescue => e
       raise ::ProxyAPI::ProxyException.new(url, e, N_("Unable to detect puppet path"))
     end
+
+    def pulp_settings
+      @url += "/settings"
+      @settings ||= parse(get)
+    rescue => e
+      raise ::ProxyAPI::ProxyException.new(url, e, N_("Unable to detect pulp settings"))
+    end
   end
 end

--- a/lib/proxy_api/pulp_node.rb
+++ b/lib/proxy_api/pulp_node.rb
@@ -18,5 +18,12 @@ module ProxyAPI
     rescue => e
       raise ::ProxyAPI::ProxyException.new(url, e, N_("Unable to detect puppet path"))
     end
+
+    def pulp_settings
+      @url += "/settings"
+      @settings ||= parse(get)
+    rescue => e
+      raise ::ProxyAPI::ProxyException.new(url, e, N_("Unable to detect pulp settings"))
+    end
   end
 end

--- a/test/glue/pulp/repository_test.rb
+++ b/test/glue/pulp/repository_test.rb
@@ -12,7 +12,8 @@ module Katello
       set_user
       backend_stubs
 
-      FactoryBot.create(:smart_proxy, :default_smart_proxy)
+      @default_smart_proxy = FactoryBot.create(:smart_proxy, :default_smart_proxy)
+      @default_smart_proxy.stub(:pulp_url).returns("https://localhost/pulp")
       @fedora_17_x86_64_dev = katello_repositories(:fedora_17_x86_64_dev)
       @fedora_17_x86_64 = katello_repositories(:fedora_17_x86_64)
       @fedora_17_library_library_view = katello_repositories(:fedora_17_library_library_view)
@@ -117,7 +118,7 @@ module Katello
   class GluePulpNonVcrTests < GluePulpRepoTestBase
     def test_importer_feed_url
       proxy = SmartProxy.new(:url => 'http://foo.com/foo')
-      pulp_host = URI.parse(SETTINGS[:katello][:pulp][:url]).host
+      pulp_host = Katello::CapsuleContent.new(@default_smart_proxy).pulp_uri.host
       repo = ::Katello::Repository.new(:url => 'http://zodiak.com/ted', :unprotected => false, :relative_path => '/elbow')
 
       assert_equal repo.importer_feed_url, 'http://zodiak.com/ted'

--- a/test/support/vcr.rb
+++ b/test/support/vcr.rb
@@ -60,7 +60,7 @@ def configure_vcr
     c.hook_into :webmock
 
     if ENV['record'] == "false" && mode != :none
-      uri = URI.parse(SETTINGS[:katello][:pulp][:url])
+      uri = URI.parse("http://localhost/pulp/api/v2/")
       c.ignore_hosts uri.host
     end
 


### PR DESCRIPTION
There are two primary reasons for this change:

 1) We inconsistently reference Pulp's url via the Smart Proxy or in SETTINGS
 2) In a scenario where Pulp and Smart Proxy do not live at the same hostname (e.g. containers), we need a single source of truth for where Pulp is at

This change moves to always relying on the smart proxy to tell us where Pulp is located. This follows a previous pattern of caching the value between refreshes to prevent round trips to the smart proxy for every Pulp call. This requires an adjustment to the smart proxy plugin to provide an API that returns the Pulp URL from the smart proxies settings (https://github.com/theforeman/smart_proxy_pulp/pull/11). This further solidifies an assumption in the code that to run a Pulp installation a corresponding Smart Proxy must exist somewhere that knows about Pulp. This will be the case for the Pulp master and Pulp children.

This needs careful testing.

Note the value being retrieved is already configured by the installer -- https://github.com/theforeman/puppet-foreman_proxy/blob/master/templates/plugin/pulp.yml.erb#L4