### PR TITLE
fixes #24068 - correctly remove schedules for repos

### DIFF
--- a/app/lib/actions/katello/product/update.rb
+++ b/app/lib/actions/katello/product/update.rb
@@ -9,6 +9,7 @@ module Actions
             plan_action(::Actions::Katello::Product::RepositoriesGpgReset, product)
           end
 
+          product.reload
           plan_action(::Actions::Pulp::Repos::Update, product) if ::SETTINGS[:katello][:use_pulp]
         end
       end

--- a/lib/katello/tasks/repository.rake
+++ b/lib/katello/tasks/repository.rake
@@ -102,6 +102,15 @@ namespace :katello do
     end
   end
 
+  desc "Refresh pulp sync schedules"
+  task :refresh_sync_schedule => ["environment", "check_ping"] do
+    User.current = User.anonymous_api_admin
+    Katello::Product.all.each do |product|
+      puts "Updating #{product}"
+      ForemanTasks.sync_task(::Actions::Pulp::Repos::Update, product)
+    end
+  end
+
   def lookup_repositories
     lifecycle_envs = Katello::KTEnvironment.where(:name => ENV['LIFECYCLE_ENVIRONMENT']) if ENV['LIFECYCLE_ENVIRONMENT']
     content_views = Katello::ContentView.where(:name => ENV['CONTENT_VIEW']) if ENV['CONTENT_VIEW']

--- a/test/actions/katello/product_test.rb
+++ b/test/actions/katello/product_test.rb
@@ -111,6 +111,7 @@ module ::Actions::Katello::Product
 
     it 'plans' do
       action.expects(:action_subject).with(product)
+      product.expects(:reload)
       plan_action action, product, :gpg_key_id => key.id
       assert_action_planed_with(action,
                                 ::Actions::Katello::Product::RepositoriesGpgReset,


### PR DESCRIPTION
Schedules are not currently correctly removed from pulp when a sync plan is deleted.  We update the
product to disassociate the sync plan, but the object needs to be reloaded otherwise sync_plan_id is still set when it gets sent to the Pulp::Repos::Update action.

How to reproduce:

1. Create a sync plan, add a product to it
2. Notice repos have a schedule in pulp:

```
[root@centos7-devel ~]# pulp-admin -u admin -p admin rpm repo sync schedules list --repo-id 8d3787f5-f86a-4951-bb2a-d89797a894c5
+----------------------------------------------------------------------+
                               Schedules
+----------------------------------------------------------------------+

Schedule: 2018-06-25T14:59:00-04:00/PT1H
Id:       5b3106e8070491666a98dfcb
Enabled:  True
Next Run: 2018-06-25T18:59:00Z
```
3. Delete sync plan, schedule is still there in pulp

4. Apply this patch, run this rake task:

```
rake katello:refresh_sync_schedule
```

5. Notice schedule is fixed.

```
[root@centos7-devel ~]# pulp-admin -u admin -p admin rpm repo sync schedules list  --repo-id 8d3787f5-f86a-4951-bb2a-d89797a894c5
+----------------------------------------------------------------------+
                               Schedules
+----------------------------------------------------------------------+

There are no schedules defined for this operation.
```

6. With the patch applied, do steps 1-2 again, and notice in step 3 schedule was correctly removed
