### PR TITLE
Fixes #24093 - Notification is sent only when disk > 90%

### DIFF
--- a/app/services/katello/ui_notifications/pulp/proxy_disk_space.rb
+++ b/app/services/katello/ui_notifications/pulp/proxy_disk_space.rb
@@ -8,27 +8,24 @@ module Katello
               percentage = proxy.statuses[:pulp].storage['pulp_dir']['percent']
               if percentage[0..2].to_i < 90 && notification_already_exists?(proxy)
                 blueprint.notifications.where(subject: proxy).destroy_all
-                next
-              end
-              next unless update_notifications(proxy).empty?
-              ::Notification.create!(
-                :subject => proxy,
-                :initiator => User.anonymous_admin,
-                :audience => Notification::AUDIENCE_ADMIN,
-                :message => ::UINotifications::StringParser.new(
-                  blueprint.message,
+              elsif update_notifications(proxy).empty? && percentage[0..2].to_i > 90
+                ::Notification.create!(
                   :subject => proxy,
-                  :percentage => percentage
-                ),
-                :notification_blueprint => blueprint
-              )
+                  :initiator => User.anonymous_admin,
+                  :audience => Notification::AUDIENCE_ADMIN,
+                  :message => ::UINotifications::StringParser.new(
+                    blueprint.message,
+                    :subject => proxy,
+                    :percentage => percentage
+                  ),
+                  :notification_blueprint => blueprint
+                )
+              end
             end
           end
 
           def notification_already_exists?(subject)
-            low_disk_notification = Notification.unscoped.find_by(:subject => subject)
-            return false if low_disk_notification.blank?
-            low_disk_notification.notification_blueprint == blueprint
+            blueprint.notifications.where(:subject => subject).any?
           end
 
           def update_notifications(subject)


### PR DESCRIPTION
Here’s what happens for a proxy where the disk 12% full:

When the code runs, percentage 12% is < 90%.
The notification does not exist, therefore:

```ruby
percentage[0..2].to_i < 90 && notification_already_exists?(proxy)
true && false
false # so it does not skip the loop
```

The next line tries to update old notifications. Since
there are no notifications at this point,
update_notifications(proxy).empty? is true.

Finally it creates the notification (at this point we
have a notification for proxy ‘foreman.example.com’ full at 12%).

After that, the job is scheduled, and when it runs (12h later):

The percentage is less than 90, 12%, and the notification
already exists. At this point Foreman is happy and proceeds
to remove the notification.

```ruby
 percentage[0..2].to_i < 90 && notification_already_exists?(proxy)
 # evaluates to
 true && true
```

For the next 12h, we don’t have the notification.
Now, 12h later… GOTO beginning of the post :wink:
Basically right before creating the notification I added a check
for > 90% full. The rest of the logic should be fine.