### PR TITLE
Fixes #24083 - Set ca-path on sync notifier

### DIFF
--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -32,7 +32,8 @@ module Katello
           :skip_checksum_validation => false,
           :upload_chunk_size => 1_048_575, # upload size in bytes to pulp. see SSLRenegBufferSize in apache
           :sync_threads => 4,
-          :sync_KBlimit => nil
+          :sync_KBlimit => nil,
+          :notifier_ca_path => "/etc/pki/tls/certs/ca-bundle.crt"
         },
         :candlepin => {
           :url => 'https://localhost:8443/candlepin',

--- a/lib/katello/tasks/update_sync_notifications.rake
+++ b/lib/katello/tasks/update_sync_notifications.rake
@@ -1,0 +1,8 @@
+namespace :katello do
+  task :update_sync_notifications => ['environment'] do
+    desc "Task that can be run to update pulp sync notifier"
+    User.current = User.anonymous_api_admin
+    puts ::Katello::Repository.ensure_sync_notification
+    puts "Update completed"
+  end
+end


### PR DESCRIPTION
This commit updates the pulp sync notifier to use a specific ca-bundle
when connecting to katello. This change is to be used in conjunction
with the fix for https://pulp.plan.io/issues/3780