### PR TITLE
Fixes #22936 - Enhance repo messaging when all repos enabled

### DIFF
--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepositories.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepositories.js
@@ -25,14 +25,16 @@ class RepositorySetRepositories extends Component {
         </Alert>
       );
     }
-
-    const repos = data.repositories
+    const availableRepos = data.repositories
       .filter(({ enabled }) => !enabled)
       .map(repo => <RepositorySetRepository key={repo.arch + repo.releasever} {...repo} />);
 
+    const repoMessage = (data.repositories.length > 0 && availableRepos.length === 0 ?
+      __('All available architectures for this repo are enabled.') : __('No repositories available.'));
+
     return (
       <Spinner loading={data.loading}>
-        {repos.length ? repos : <div>{__('No repositories available.')}</div>}
+        {availableRepos.length ? availableRepos : <div>{repoMessage}</div>}
       </Spinner>
     );
   }


### PR DESCRIPTION
Screenshot of what the messaging now looks like
<img width="911" alt="redhat_repo_demos" src="https://user-images.githubusercontent.com/230549/41997443-3f3ccfcc-7a15-11e8-919e-6d92a41b890c.png">
