### PR TITLE
Fixes #23957 - Use proper Notications API for bulk products

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/products-bulk-advanced-sync-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/bulk/products-bulk-advanced-sync-modal.controller.js
@@ -27,7 +27,7 @@ angular.module('Bastion.products').controller('ProductsBulkAdvancedSyncModalCont
                 message = translate("Product syncs has been initiated in the background. " +
                     "Click %s to monitor the progress.");
 
-                Notification.setRenderedSuccessMessage(message.replace('%s', taskLink));
+                Notification.setSuccessMessage(message.replace('%s', taskLink));
             };
 
             error = function (response) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/products.controller.js
@@ -64,7 +64,7 @@ angular.module('Bastion.products').controller('ProductsController',
             taskUrl = $scope.taskUrl(taskId);
             taskLink = $sce.trustAsHtml("<a href=" + taskUrl + ">here</a>");
             message = translate("Product delete operation has been initiated in the background. Click %s to monitor the progress.");
-            Notification.setRenderedSuccessMessage(message.replace("%", taskLink));
+            Notification.setSuccessMessage(message.replace("%", taskLink));
         });
 
         $scope.unsetProductDeletionTaskId = function () {
@@ -95,7 +95,7 @@ angular.module('Bastion.products').controller('ProductsController',
                 message = translate("Product sync has been initiated in the background. " +
                     "Click %s to monitor the progress.");
 
-                Notification.setRenderedSuccessMessage(message.replace('%s', taskLink));
+                Notification.setSuccessMessage(message.replace('%s', taskLink));
             };
 
             ProductBulkAction.syncProducts(getBulkParams(), success, bulkError);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/tasks.module.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/tasks/tasks.module.js
@@ -27,11 +27,6 @@ angular.module('Bastion.tasks').config(['$stateProvider', function ($stateProvid
         abstract: true,
         templateUrl: 'tasks/views/tasks.html'
     })
-    .state('tasks.index', {
-        url: 'katello_tasks',
-        permission: 'view_tasks',
-        templateUrl: 'tasks/views/tasks-index.html'
-    })
     .state('tasks.details', {
         url: 'katello_tasks/:taskId',
         permission: 'view_tasks',
@@ -40,7 +35,7 @@ angular.module('Bastion.tasks').config(['$stateProvider', function ($stateProvid
         templateUrl: 'tasks/views/task-details-standalone.html'
     })
     .state('task', {
-        url: 'katello_tasks/single/:taskId',
+        url: 'foreman_tasks/tasks/:taskId',
         controller: 'TaskDetailsController',
         permission: 'view_tasks',
         templateUrl: 'tasks/views/task-details-standalone.html'


### PR DESCRIPTION
Three messages to be tested all from the products list with at least one selected product:

- Sync Selected
- Remove
- Advanced Sync -> select one of the options