### PR TITLE
Fixes #24112 - CV filter rules API should return all attrs

### DIFF
--- a/app/views/katello/api/v2/content_view_filter_rules/show.json.rabl
+++ b/app/views/katello/api/v2/content_view_filter_rules/show.json.rabl
@@ -3,16 +3,16 @@ object @resource
 extends 'katello/api/v2/common/identifier'
 
 attributes :content_view_filter_id
-attributes :uuid, :if => lambda { |rule| rule.respond_to?(:uuid) && !rule.uuid.blank? }
-attributes :version, :if => lambda { |rule| rule.respond_to?(:version) && !rule.version.blank? }
-attributes :min_version, :if => lambda { |rule| rule.respond_to?(:min_version) && !rule.min_version.blank? }
-attributes :max_version, :if => lambda { |rule| rule.respond_to?(:max_version) && !rule.max_version.blank? }
+attributes :uuid
+attributes :version
+attributes :min_version
+attributes :max_version
 
-attributes :errata_id, :if => lambda { |rule| rule.respond_to?(:errata_id) && !rule.errata_id.blank? }
-attributes :start_date, :if => lambda { |rule| rule.respond_to?(:start_date) && !rule.start_date.blank? }
-attributes :end_date, :if => lambda { |rule| rule.respond_to?(:end_date) && !rule.end_date.blank? }
-attributes :architecture, :if => lambda { |rule| rule.respond_to?(:architecture) && !rule.architecture.blank? }
-attributes :types, :if => lambda { |rule| rule.respond_to?(:types) && !rule.types.blank? }
-attributes :date_type, :if => lambda { |rule| rule.respond_to?(:date_type) }
+attributes :errata_id
+attributes :start_date
+attributes :end_date
+attributes :architecture
+attributes :types
+attributes :date_type
 
 extends 'katello/api/v2/common/timestamps'


### PR DESCRIPTION
We don't filter out attributes if they aren't set without Models,
Let not do it for this one.

Currently, the foreman-ansible-modules uses nailgun which requires
all attributes to be returned in order to correctly verify if we
need to update any attributes.