### PR TITLE
Fixes #23493 - Add description to repos

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -73,6 +73,7 @@ module Katello
     param :library, :bool, :desc => N_("show repositories in Library and the default content view")
     param :content_type, RepositoryTypeManager.repository_types.keys, :desc => N_("limit to only repositories of this type")
     param :name, String, :desc => N_("name of the repository"), :required => false
+    param :description, String, :desc => N_("description of the repository")
     param :available_for, String, :desc => N_("interpret specified object to return only Repositories that can be associated with specified object.  Only 'content_view' is supported."),
           :required => false
     param_group :search, Api::V2::ApiController
@@ -85,11 +86,11 @@ module Katello
           options[:csv] = true
           repos = scoped_search(*base_args, options)
           csv_response(repos,
-                       [:id, :name, :label, :content_type, :arch, :url, :major, :minor,
+                       [:id, :name, :description, :label, :content_type, :arch, :url, :major, :minor,
                         :cp_label, :content_label, :pulp_id, :container_repository_name,
                         :download_policy, 'relative_path', 'product.id', 'product.name',
                         'environment_id'],
-                       ['Id', 'Name', 'label', 'Content Type', 'Arch', 'Url', 'Major', 'Minor',
+                       ['Id', 'Name', 'label', 'Description', 'Content Type', 'Arch', 'Url', 'Major', 'Minor',
                         'Candlepin Label', 'Content Label', 'Pulp Id', 'Container Repository Name',
                         'Download Policy', 'Relative Path', 'Product Id', 'Product Name',
                         'Environment Id'])
@@ -460,7 +461,7 @@ module Katello
     def repository_params
       keys = [:download_policy, :mirror_on_sync, :arch, :verify_ssl_on_sync, :upstream_password, :upstream_username,
               :ostree_upstream_sync_depth, :ostree_upstream_sync_policy, :ignore_global_proxy,
-              :deb_releases, :deb_components, :deb_architectures, {:ignorable_content => []}
+              :deb_releases, :deb_components, :deb_architectures, :description, {:ignorable_content => []}
              ]
 
       keys += [:label, :content_type] if params[:action] == "create"
@@ -481,7 +482,7 @@ module Katello
     end
 
     def construct_repo_from_params(repo_params)
-      repository = @product.add_repo(Hash[repo_params.slice(:label, :name, :url, :content_type, :arch, :unprotected,
+      repository = @product.add_repo(Hash[repo_params.slice(:label, :name, :description, :url, :content_type, :arch, :unprotected,
                                                             :gpg_key, :ssl_ca_cert, :ssl_client_cert, :ssl_client_key,
                                                             :checksum_type, :download_policy).to_h.map { |k, v| [k.to_sym, v] }])
       repository.docker_upstream_name = repo_params[:docker_upstream_name] if repo_params[:docker_upstream_name]

--- a/app/models/katello/glue/pulp/repos.rb
+++ b/app/models/katello/glue/pulp/repos.rb
@@ -211,6 +211,7 @@ module Katello
                        :arch => repo_param[:arch],
                        :name => repo_param[:name],
                        :label => repo_param[:label],
+                       :description => repo_param[:description],
                        :url => repo_param[:url],
                        :gpg_key => repo_param[:gpg_key],
                        :ssl_ca_cert => repo_param[:ssl_ca_cert],

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -176,6 +176,7 @@ module Katello
     scoped_search :on => :ignore_global_proxy, :complete_value => true
     scoped_search :on => :redhat, :complete_value => { :true => true, :false => false }, :ext_method => :search_by_redhat
     scoped_search :on => :container_repository_name, :complete_value => true
+    scoped_search :on => :description, :only_explicit => true
 
     def organization
       if self.environment

--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -25,6 +25,7 @@ attributes :ostree_upstream_sync_policy, :ostree_upstream_sync_depth, :compute_o
 attributes :deb_releases, :deb_components, :deb_architectures
 attributes :ignore_global_proxy
 attributes :ignorable_content
+attributes :description
 
 if @resource.is_a?(Katello::Repository)
   if @resource.distribution_version || @resource.distribution_arch || @resource.distribution_family || @resource.distribution_variant

--- a/db/migrate/20180618195941_add_description_to_repository.rb
+++ b/db/migrate/20180618195941_add_description_to_repository.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToRepository < ActiveRecord::Migration[5.1]
+  def change
+    add_column :katello_repositories, :description, :text, :null => true
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -14,6 +14,12 @@
       <dt translate>Label</dt>
       <dd>{{ repository.label }}</dd>
 
+      <dt translate>Description</dt>
+      <dd bst-edit-text="repository.description"
+	  on-save="save(repository)"
+	  readonly="product.redhat || denied('edit_products', product)">
+      </dd>
+
       <dt translate>Backend Identifier</dt>
       <dd>{{ repository.backend_identifier }}</dd>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -22,6 +22,14 @@
                type="text"
                required/>
       </div>
+
+      <div bst-form-group label="{{ 'Description' | translate }}">
+        <input id="description"
+	       name="description"
+	       ng-model="repository.description"
+	       type="text">
+      </div>
+
       <div bst-form-group label="{{ 'Type' | translate }}">
         <select required
                 id="content_type"

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -228,6 +228,7 @@ module Katello
       product.expects(:add_repo).with(
         :label => 'Fedora_Repository',
         :name => 'Fedora Repository',
+        :description => 'My Description',
         :url => 'http://www.google.com',
         :content_type => 'yum',
         :arch => 'noarch',
@@ -247,7 +248,7 @@ module Katello
       assert_sync_task(::Actions::Katello::Repository::Create, @repository, false, true)
 
       Product.stubs(:find).returns(product)
-      post :create, params: { :name => 'Fedora Repository', :product_id => @product.id, :url => 'http://www.google.com', :content_type => 'yum' }
+      post :create, params: { :name => 'Fedora Repository', :product_id => @product.id, :description => 'My Description', :url => 'http://www.google.com', :content_type => 'yum' }
       assert_response :success
       assert_template 'api/v2/common/create'
     end

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -3,6 +3,7 @@ fedora_17_x86_64:
   pulp_id:              Fedora_17
   content_id:           1
   content_type:         yum
+  description:          'My description'
   label:                fedora_17_x86_64_label
   relative_path:        'ACME_Corporation/library/fedora_17_label'
   environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -8,6 +8,7 @@ module Katello
       @repo = build(:katello_repository, :fedora_17_el6,
                     :environment => @library,
                     :product => katello_products(:fedora),
+                    :description => 'My description',
                     :content_view_version => @library.default_content_view_version
                    )
     end
@@ -879,6 +880,11 @@ module Katello
     def test_search_content_view_id
       repos = Repository.search_for("content_view_id = \"#{@fedora_17_x86_64.content_views.first.id}\"")
       assert_includes repos, @fedora_17_x86_64
+    end
+
+    def test_search_description
+      repos = Repository.search_for("description = \"#{@fedora_17_x86_64.description}\"")
+      assert_equal repos, [@fedora_17_x86_64]
     end
 
     def test_search_distribution_version


### PR DESCRIPTION
Adds description field to product repositories. Can use scoped-search.
Descriptions are not necessary. You can view the description in the repo details page.