### PR TITLE
Fixes #24131: Use saved LE/CV instead of HG's

### DIFF
--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -76,16 +76,11 @@ module Katello
       end
     end
 
-    def fetch_lifecycle_environment(host, options = {})
-      selected_host_group = options.fetch(:selected_host_group, nil)
-      return lifecycle_environment(selected_host_group) if selected_host_group.present?
-      selected_env = lifecycle_environment(host)
-      return selected_env if selected_env.present?
+    def fetch_lifecycle_environment(host, _options = {})
+      lifecycle_environment(host)
     end
 
-    def fetch_content_view(host, options = {})
-      selected_host_group = options.fetch(:selected_host_group, nil)
-      return content_view(selected_host_group) if selected_host_group.present?
+    def fetch_content_view(host, _options = {})
       content_view(host)
     end
 


### PR DESCRIPTION
We should always show what's in the database, not what's on the hostgroup. Host groups are supposed to populate data on the host during provisioning only. I tested this with foreman-discovery, due to [this issue](https://projects.theforeman.org/issues/15473), and the CV and LE are properly set during provisioning.