### PR TITLE
Fixes #24134 - Error enabling atomic kickstart repo

### DIFF
--- a/app/lib/katello/util/cdn_var_substitutor.rb
+++ b/app/lib/katello/util/cdn_var_substitutor.rb
@@ -28,9 +28,11 @@ module Katello
         needed_substitutions = PathWithSubstitutions.new(real_path, {}).substitutions_needed
 
         if unused_substitutions.any?
-          fail Errors::CdnSubstitutionError, _("%{unused_substitutes} cannot be specified for %{content_name}"\
-                 " as that information is not substitutable in %{content_url} ") %
-              { unaccepted_substitutions: unused_substitutions, content_name: content.name, content_url: content.content_url }
+          fail Errors::CdnSubstitutionError, _("%{unused_substitutions} cannot be specified for %{content_name}"\
+            " as that information is not substitutable in %{content_url} ") %
+            { unused_substitutions: unused_substitutions.join(','),
+              content_name: content.name,
+              content_url: content.content_url }
         end
 
         if needed_substitutions.any?

--- a/webpack/redux/actions/RedHatRepositories/helpers.js
+++ b/webpack/redux/actions/RedHatRepositories/helpers.js
@@ -2,7 +2,7 @@ const repoTypeSearchQueryMap = {
   rpm: '(name ~ rpms) and (name !~ source rpm) and (name !~ debug rpm)',
   sourceRpm: 'name ~ source rpm',
   debugRpm: 'name ~ debug rpm',
-  kickstarter: 'name ~ kickstart',
+  kickstart: 'name ~ kickstart',
   ostree: 'name ~ ostree',
   beta: 'name ~ beta',
 };

--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepository.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepository.js
@@ -8,6 +8,8 @@ import { setRepositoryEnabled } from '../../../redux/actions/RedHatRepositories/
 import '../index.scss';
 import api from '../../../services/api';
 
+const UNSPECIFIED_ARCH = 'Unspecified';
+
 class RepositorySetRepository extends Component {
   constructor(props) {
     super(props);
@@ -48,7 +50,7 @@ class RepositorySetRepository extends Component {
       const data = {
         id: contentId,
         product_id: productId,
-        basearch: arch,
+        basearch: arch == UNSPECIFIED_ARCH ? undefined : arch,
         releasever: releasever || undefined,
       };
 
@@ -121,7 +123,7 @@ RepositorySetRepository.propTypes = {
 
 RepositorySetRepository.defaultProps = {
   releasever: '',
-  arch: __('Unspecified'),
+  arch: __(UNSPECIFIED_ARCH),
 };
 
 export default connect(null, { setRepositoryEnabled })(RepositorySetRepository);

--- a/webpack/scenes/RedHatRepositories/components/SearchBar.js
+++ b/webpack/scenes/RedHatRepositories/components/SearchBar.js
@@ -17,7 +17,7 @@ const filterOptions = [
   { value: 'rpm', label: __('RPM') },
   { value: 'sourceRpm', label: __('Source RPM') },
   { value: 'debugRpm', label: __('Debug RPM') },
-  { value: 'kickstarter', label: __('Kickstarter') },
+  { value: 'kickstart', label: __('Kickstart') },
   { value: 'ostree', label: __('OSTree') },
   { value: 'beta', label: __('Beta') },
   { value: 'other', label: __('Other') },


### PR DESCRIPTION
This commit addresses a few things:
- "basearch" was being passed when enabling RHEL atomic kickstart repo,
  where there is no $basearch needed for the CDN. This is because we
  are using the value "Unspecified" to fill in the UI when there is
  no arch. This was making its way into the API call, where basearch
  shouldn't be defined.
- The error message being returned wasn't properly templated. This was
  fixed and tests are added.
- "Kickstarter" is an crowdsourcing site and shouldn't be an option
  in the content type drop down :stuck_out_tongue_closed_eyes: