### PR TITLE
Fixes #24137 - set default CV filter rule sort_by to ID

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
@@ -7,7 +7,7 @@ module Katello
     param :content_view_filter_id, :number, :desc => N_("filter identifier"), :required => true
     param_group :search, Api::V2::ApiController
     def index
-      respond(collection: scoped_search(index_relation, :name, :asc, resource_class: ContentViewFilter.rule_class_for(@filter)))
+      respond(collection: scoped_search(index_relation, :id, :asc, resource_class: ContentViewFilter.rule_class_for(@filter)))
     end
 
     def index_relation


### PR DESCRIPTION
without this searching CV filter rules results in the following error:
"the field (name) in the order statement is not valid field for search"

Erratum CV Filter rules do not have a name attribute.