### PR TITLE
fixes #24149 - use new template renderer

### DIFF
--- a/app/lib/katello/concerns/input_template_scope_extensions.rb
+++ b/app/lib/katello/concerns/input_template_scope_extensions.rb
@@ -1,0 +1,21 @@
+module Katello
+  module Concerns
+    module InputTemplateScopeExtensions
+      extend ActiveSupport::Concern
+
+      module Overrides
+        def allowed_helpers
+          super + [:errata]
+        end
+      end
+
+      included do
+        prepend Overrides
+      end
+
+      def errata(id)
+        Katello::Erratum.with_identifiers(id).map(&:attributes).first.slice!('created_at', 'updated_at')
+      end
+    end
+  end
+end

--- a/app/lib/katello/concerns/renderer_extensions.rb
+++ b/app/lib/katello/concerns/renderer_extensions.rb
@@ -7,10 +7,10 @@ module Katello
         def kickstart_attributes
           super
 
-          content_view = @host.try(:content_facet).try(:content_view) || @host.try(:content_view)
-          if content_view && @host.operatingsystem.is_a?(Redhat) &&
-                  @host.operatingsystem.kickstart_repos(@host).first.present?
-            @mediapath ||= @host.operatingsystem.mediumpath(@host)
+          content_view = host.try(:content_facet).try(:content_view) || host.try(:content_view)
+          if content_view && host.operatingsystem.is_a?(Redhat) &&
+                  host.operatingsystem.kickstart_repos(host).first.present?
+            @mediapath ||= host.operatingsystem.mediumpath(host)
           end
         end
       end

--- a/app/models/katello/input_template_renderer.rb
+++ b/app/models/katello/input_template_renderer.rb
@@ -1,7 +1,0 @@
-class InputTemplateRenderer
-  include UnattendedHelper
-
-  def errata(id)
-    Katello::Erratum.with_identifiers(id).map(&:attributes).first.slice!('created_at', 'updated_at')
-  end
-end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -132,13 +132,11 @@ module Katello
         fail Foreman::Exception, N_("Organizations disabled, try allowing them in foreman/config/settings.yaml")
       end
 
-      # Rendering concerns needs to be injected to controllers, Foreman::Renderer was already included
-      # otherwise subscription_manager_configuration_url is not available in template preview
-      (TemplatesController.descendants + [TemplatesController]).each do |klass|
-        klass.send(:include, Katello::KatelloUrlsHelper)
-      end
       # Lib Extensions
-      ::Foreman::Renderer.send :include, Katello::Concerns::RendererExtensions
+      ::Foreman::Renderer::Scope::Variables::Base.send :include, Katello::Concerns::RendererExtensions
+      if Katello.with_remote_execution?
+        ::ForemanRemoteExecution::Renderer::Scope::Input.send :include, Katello::Concerns::InputTemplateScopeExtensions
+      end
 
       # Model extensions
       ::Environment.send :include, Katello::Concerns::EnvironmentExtensions

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -192,6 +192,8 @@ Foreman::Plugin.register :katello do
        :turbolinks => false
 
   allowed_template_helpers :subscription_manager_configuration_url, :repository_url
+  extend_template_helpers Katello::KatelloUrlsHelper
+
   search_path_override("Katello") do |resource|
     "/#{Katello::Util::Model.model_to_controller_path(resource)}/auto_complete_search"
   end


### PR DESCRIPTION
This needs theforeman/foreman#5683 and https://github.com/theforeman/foreman_remote_execution/pull/363.

I don't have a katello development environment at hand and don't know the codebase well enough. This is a shot in the dark. Please help me with testing this.