### PR TITLE
Fixes #24143 - Show message when no org is selected on subs...

### DIFF
--- a/webpack/common/helpers.js
+++ b/webpack/common/helpers.js
@@ -1,0 +1,16 @@
+const handleMissingOrg = (orgId, dispatch, type) => {
+  if (!orgId) {
+    const errorMessage = 'No organization specified';
+    dispatch({
+      type,
+      payload: {
+        errors: [errorMessage],
+        displayMessage: errorMessage,
+      },
+    });
+    return true;
+  }
+  return false;
+};
+
+export default handleMissingOrg;

--- a/webpack/components/OrganizationCheck/__tests__/OrganizationCheck.test.js
+++ b/webpack/components/OrganizationCheck/__tests__/OrganizationCheck.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import OrganizationCheck from '../../OrganizationCheck';
+
+describe('Organization check page', () => {
+  /* eslint-disable react/jsx-closing-tag-location */
+  it('should render when passed hide and contain appropiate message', async () => {
+    const wrapper = shallow(<OrganizationCheck
+      hide
+    >
+      <div>hi</div>
+    </OrganizationCheck>);
+    expect(wrapper.find('h2').text()).toEqual('No organization selected');
+  });
+
+  it('should render children when not passed hide prop', async () => {
+    const content = 'some awesome organization-dependent content';
+    const wrapper = shallow(<OrganizationCheck>
+      <h1>{content}</h1>
+    </OrganizationCheck>);
+    expect(wrapper.find('h1').text()).toEqual(content);
+  });
+  /* eslint-enable react/jsx-closing-tag-location */
+});

--- a/webpack/components/OrganizationCheck/index.js
+++ b/webpack/components/OrganizationCheck/index.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Grid, Row, Col } from 'patternfly-react';
+import './index.scss';
+
+const OrganizationCheck = (props) => {
+  const { children, hide } = props;
+  if (hide) {
+    return (
+      <Grid bsClass="container-fluid">
+        <Row>
+          <Col sm={12}>
+            <div className="centered-message">
+              <h2>No organization selected</h2>
+              <h3>
+                The page you are attempting to access requires a selected organization.
+              </h3>
+              <h3>
+                Please select an organization from the dropdown in the top menu bar
+                and you will be redirected.
+              </h3>
+            </div>
+          </Col>
+        </Row>
+      </Grid>
+    );
+  }
+  return (
+    <div>{ children }</div>
+  );
+};
+
+OrganizationCheck.propTypes = {
+  hide: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+};
+
+OrganizationCheck.defaultProps = {
+  hide: false,
+};
+export default OrganizationCheck;

--- a/webpack/components/OrganizationCheck/index.scss
+++ b/webpack/components/OrganizationCheck/index.scss
@@ -1,0 +1,3 @@
+.centered-message {
+  text-align: center;
+}

--- a/webpack/containers/Application/config.js
+++ b/webpack/containers/Application/config.js
@@ -20,6 +20,7 @@ export const links = [
     component: UpstreamSubscriptions,
   },
   {
+    /* eslint-disable-next-line no-useless-escape */
     path: 'subscriptions/:id(\[0-9]*$\)',
     component: SubscriptionDetails,
   },

--- a/webpack/redux/actions/RedHatRepositories/enabled.js
+++ b/webpack/redux/actions/RedHatRepositories/enabled.js
@@ -1,6 +1,9 @@
 import api, { orgId } from '../../../services/api';
-import { normalizeRepositorySets, repoTypeFilterToSearchQuery, joinSearchQueries } from './helpers';
-
+import {
+  normalizeRepositorySets,
+  repoTypeFilterToSearchQuery,
+  joinSearchQueries,
+} from './helpers';
 import {
   ENABLED_REPOSITORIES_REQUEST,
   ENABLED_REPOSITORIES_SUCCESS,
@@ -8,6 +11,7 @@ import {
   REPOSITORY_DISABLED,
 } from '../../consts';
 import { propsToSnakeCase } from '../../../services/index';
+import handleMissingOrg from '../../../common/helpers';
 
 export const setRepositoryDisabled = repository => ({
   type: REPOSITORY_DISABLED,
@@ -34,6 +38,8 @@ export const createEnabledRepoParams = (extendedParams = {}) => {
 export const loadEnabledRepos = (extendedParams = {}) => (dispatch) => {
   dispatch({ type: ENABLED_REPOSITORIES_REQUEST, params: extendedParams });
   const { searchParams, repoParams } = createEnabledRepoParams(extendedParams);
+
+  if (handleMissingOrg(repoParams.organization_id, dispatch, ENABLED_REPOSITORIES_FAILURE)) return;
 
   api
     .get('/repositories', {}, repoParams)

--- a/webpack/redux/actions/RedHatRepositories/sets.js
+++ b/webpack/redux/actions/RedHatRepositories/sets.js
@@ -5,7 +5,6 @@ import {
   joinSearchQueries,
   recommendedRepositorySetsQuery,
 } from './helpers';
-
 import {
   REPOSITORY_SETS_REQUEST,
   REPOSITORY_SETS_SUCCESS,
@@ -13,10 +12,13 @@ import {
   REPOSITORY_SETS_UPDATE_RECOMMENDED,
 } from '../../consts';
 import { propsToSnakeCase } from '../../../services/index';
+import handleMissingOrg from '../../../common/helpers';
 
 // eslint-disable-next-line import/prefer-default-export
 export const loadRepositorySets = (extendedParams = {}) => (dispatch, getState) => {
   const { recommended } = getState().katello.redHatRepositories.sets;
+
+  if (handleMissingOrg(orgId, dispatch, REPOSITORY_SETS_FAILURE)) return;
 
   dispatch({ type: REPOSITORY_SETS_REQUEST, params: extendedParams });
 

--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepository.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepository.js
@@ -50,7 +50,7 @@ class RepositorySetRepository extends Component {
       const data = {
         id: contentId,
         product_id: productId,
-        basearch: arch == UNSPECIFIED_ARCH ? undefined : arch,
+        basearch: arch === UNSPECIFIED_ARCH ? undefined : arch,
         releasever: releasever || undefined,
       };
 

--- a/webpack/scenes/RedHatRepositories/helpers.js
+++ b/webpack/scenes/RedHatRepositories/helpers.js
@@ -14,7 +14,7 @@ export const getSetsComponent = (repoSetsState, onPaginationChange) => {
     itemCount,
   } = repoSetsState;
 
-  if (results.length === 0) {
+  if (!results || results.length === 0) {
     if (searchIsActive) {
       return <p>{__('No repository sets match your search criteria.')}</p>;
     }

--- a/webpack/scenes/RedHatRepositories/index.js
+++ b/webpack/scenes/RedHatRepositories/index.js
@@ -13,6 +13,8 @@ import { loadRepositorySets, updateRecommendedRepositorySets } from '../../redux
 import SearchBar from './components/SearchBar';
 import RecommendedRepositorySetsToggler from './components/RecommendedRepositorySetsToggler';
 import { getSetsComponent, getEnabledComponent } from './helpers';
+import OrganizationCheck from '../../components/OrganizationCheck';
+import { orgId } from '../../services/api';
 
 class RedHatRepositoriesPage extends Component {
   componentDidMount() {
@@ -32,50 +34,52 @@ class RedHatRepositoriesPage extends Component {
       <Grid id="redhatRepositoriesPage" bsClass="container-fluid">
         <h1>{__('Red Hat Repositories')}</h1>
 
-        <Row className="toolbar-pf">
-          <Col sm={12}>
-            <SearchBar repoParams={repoParams} />
-          </Col>
-        </Row>
+        <OrganizationCheck hide={!orgId}>
+          <Row className="toolbar-pf">
+            <Col sm={12}>
+              <SearchBar repoParams={repoParams} />
+            </Col>
+          </Row>
 
-        <Row className="row-eq-height">
-          <Col sm={6} className="available-repositories-container">
-            <div className="available-repositories-header">
-              <h2>{__('Available Repositories')}</h2>
-              <RecommendedRepositorySetsToggler
-                enabled={repositorySets.recommended}
-                onChange={value => this.props.updateRecommendedRepositorySets(value)}
-                className="recommended-repositories-toggler"
-              />
-            </div>
-            <LoadingState loading={repositorySets.loading} loadingText={__('Loading')}>
-              {getSetsComponent(
-                repositorySets,
-                (pagination) => {
-                  this.props.loadRepositorySets({
-                    ...pagination,
-                    search: repositorySets.search,
-                  });
-                },
-              )}
-            </LoadingState>
-          </Col>
+          <Row className="row-eq-height">
+            <Col sm={6} className="available-repositories-container">
+              <div className="available-repositories-header">
+                <h2>{__('Available Repositories')}</h2>
+                <RecommendedRepositorySetsToggler
+                  enabled={repositorySets.recommended}
+                  onChange={value => this.props.updateRecommendedRepositorySets(value)}
+                  className="recommended-repositories-toggler"
+                />
+              </div>
+              <LoadingState loading={repositorySets.loading} loadingText={__('Loading')}>
+                {getSetsComponent(
+                  repositorySets,
+                  (pagination) => {
+                    this.props.loadRepositorySets({
+                      ...pagination,
+                      search: repositorySets.search,
+                    });
+                  },
+                )}
+              </LoadingState>
+            </Col>
 
-          <Col sm={6} className="enabled-repositories-container">
-            <h2>{__('Enabled Repositories')}</h2>
-            <LoadingState loading={enabledRepositories.loading} loadingText={__('Loading')}>
-              {getEnabledComponent(
-                enabledRepositories,
-                (pagination) => {
-                  this.props.loadEnabledRepos({
-                    ...pagination,
-                    search: enabledRepositories.search,
-                  });
-                },
-              )}
-            </LoadingState>
-          </Col>
-        </Row>
+            <Col sm={6} className="enabled-repositories-container">
+              <h2>{__('Enabled Repositories')}</h2>
+              <LoadingState loading={enabledRepositories.loading} loadingText={__('Loading')}>
+                {getEnabledComponent(
+                  enabledRepositories,
+                  (pagination) => {
+                    this.props.loadEnabledRepos({
+                      ...pagination,
+                      search: enabledRepositories.search,
+                    });
+                  },
+                )}
+              </LoadingState>
+            </Col>
+          </Row>
+        </OrganizationCheck>
       </Grid>
     );
   }

--- a/webpack/scenes/Subscriptions/SubscriptionActions.js
+++ b/webpack/scenes/Subscriptions/SubscriptionActions.js
@@ -17,6 +17,7 @@ import {
 } from './SubscriptionConstants';
 import { filterRHSubscriptions } from './SubscriptionHelpers.js';
 import { getResponseError } from '../../move_to_foreman/common/helpers.js';
+import handleMissingOrg from '../../common/helpers';
 
 export const createSubscriptionParams = (extendedParams = {}) => ({
   ...{ organization_id: orgId },
@@ -47,6 +48,8 @@ export const loadSubscriptions = (extendedParams = {}) => (dispatch) => {
   dispatch({ type: SUBSCRIPTIONS_REQUEST });
 
   const params = createSubscriptionParams(extendedParams);
+  if (handleMissingOrg(params.organization_id, dispatch, SUBSCRIPTIONS_FAILURE)) return null;
+
   return api
     .get('/subscriptions', {}, params)
     .then(({ data }) => {

--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -13,6 +13,7 @@ import { SubscriptionsTable } from './components/SubscriptionsTable';
 import Search from '../../components/Search/index';
 import api, { orgId } from '../../services/api';
 import { createSubscriptionParams } from './SubscriptionActions.js';
+import OrganizationCheck from '../../components/OrganizationCheck';
 import {
   BLOCKING_FOREMAN_TASK_TYPES,
   MANIFEST_TASKS_BULK_SEARCH_ID,
@@ -192,80 +193,82 @@ class SubscriptionsPage extends Component {
           <Col sm={12}>
             <h1>{__('Red Hat Subscriptions')}</h1>
 
-            <Row className="toolbar-pf table-view-pf-toolbar-external">
-              <Col sm={12}>
-                <Form className="toolbar-pf-actions">
-                  <FormGroup className="toolbar-pf-filter">
-                    <Search
-                      onSearch={onSearch}
-                      getAutoCompleteParams={getAutoCompleteParams}
-                      updateSearchQuery={updateSearchQuery}
-                    />
-                  </FormGroup>
-
-                  <div className="toolbar-pf-action-right">
-                    <FormGroup>
-                      <LinkContainer to="subscriptions/add" disabled={disableManifestActions}>
-                        <TooltipButton
-                          tooltipId="add-subscriptions-button-tooltip"
-                          tooltipText={this.getDisabledReason()}
-                          tooltipPlacement="top"
-                          title={__('Add Subscriptions')}
-                          disabled={disableManifestActions}
-                          bsStyle="primary"
-                        />
-                      </LinkContainer>
-
-                      <Button onClick={showManageManifestModal}>
-                        {__('Manage Manifest')}
-                      </Button>
-
-                      <Button
-                        onClick={() => { api.open('/subscriptions.csv', csvParams); }}
-                      >
-                        {__('Export CSV')}
-                      </Button>
-
-                      <TooltipButton
-                        bsStyle="danger"
-                        onClick={showSubscriptionDeleteModal}
-                        tooltipId="delete-subscriptions-button-tooltip"
-                        tooltipText={this.getDisabledReason(true)}
-                        tooltipPlacement="top"
-                        title={__('Delete')}
-                        disabled={disableManifestActions || this.state.disableDeleteButton}
+            <OrganizationCheck hide={!orgId}>
+              <Row className="toolbar-pf table-view-pf-toolbar-external">
+                <Col sm={12}>
+                  <Form className="toolbar-pf-actions">
+                    <FormGroup className="toolbar-pf-filter">
+                      <Search
+                        onSearch={onSearch}
+                        getAutoCompleteParams={getAutoCompleteParams}
+                        updateSearchQuery={updateSearchQuery}
                       />
-
                     </FormGroup>
-                  </div>
-                </Form>
-              </Col>
-            </Row>
 
-            <ManageManifestModal
-              showModal={this.state.manifestModalOpen}
-              taskInProgress={taskInProgress}
-              disableManifestActions={disableManifestActions}
-              disabledReason={this.getDisabledReason()}
-              onClose={onManageManifestModalClose}
-            />
+                    <div className="toolbar-pf-action-right">
+                      <FormGroup>
+                        <LinkContainer to="subscriptions/add" disabled={disableManifestActions}>
+                          <TooltipButton
+                            tooltipId="add-subscriptions-button-tooltip"
+                            tooltipText={this.getDisabledReason()}
+                            tooltipPlacement="top"
+                            title={__('Add Subscriptions')}
+                            disabled={disableManifestActions}
+                            bsStyle="primary"
+                          />
+                        </LinkContainer>
 
-            <div id="subscriptions-table" className="modal-container">
-              <SubscriptionsTable
-                loadSubscriptions={this.props.loadSubscriptions}
-                updateQuantity={this.props.updateQuantity}
-                subscriptions={this.props.subscriptions}
-                subscriptionDeleteModalOpen={this.state.subscriptionDeleteModalOpen}
-                onSubscriptionDeleteModalClose={onSubscriptionDeleteModalClose}
-                onDeleteSubscriptions={onDeleteSubscriptions}
-                toggleDeleteButton={toggleDeleteButton}
+                        <Button onClick={showManageManifestModal}>
+                          {__('Manage Manifest')}
+                        </Button>
+
+                        <Button
+                          onClick={() => { api.open('/subscriptions.csv', csvParams); }}
+                        >
+                          {__('Export CSV')}
+                        </Button>
+
+                        <TooltipButton
+                          bsStyle="danger"
+                          onClick={showSubscriptionDeleteModal}
+                          tooltipId="delete-subscriptions-button-tooltip"
+                          tooltipText={this.getDisabledReason(true)}
+                          tooltipPlacement="top"
+                          title={__('Delete')}
+                          disabled={disableManifestActions || this.state.disableDeleteButton}
+                        />
+
+                      </FormGroup>
+                    </div>
+                  </Form>
+                </Col>
+              </Row>
+
+              <ManageManifestModal
+                showModal={this.state.manifestModalOpen}
+                taskInProgress={taskInProgress}
+                disableManifestActions={disableManifestActions}
+                disabledReason={this.getDisabledReason()}
+                onClose={onManageManifestModalClose}
               />
-              <ModalProgressBar
-                show={this.state.showTaskModal}
-                container={document.getElementById('subscriptions-table')}
-                task={task}
-              />
-            </div>
+
+              <div id="subscriptions-table" className="modal-container">
+                <SubscriptionsTable
+                  loadSubscriptions={this.props.loadSubscriptions}
+                  updateQuantity={this.props.updateQuantity}
+                  subscriptions={this.props.subscriptions}
+                  subscriptionDeleteModalOpen={this.state.subscriptionDeleteModalOpen}
+                  onSubscriptionDeleteModalClose={onSubscriptionDeleteModalClose}
+                  onDeleteSubscriptions={onDeleteSubscriptions}
+                  toggleDeleteButton={toggleDeleteButton}
+                />
+                <ModalProgressBar
+                  show={this.state.showTaskModal}
+                  container={document.getElementById('subscriptions-table')}
+                  task={task}
+                />
+              </div>
+            </OrganizationCheck>
           </Col>
         </Row>
       </Grid>

--- a/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsPage.test.js.snap
+++ b/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionsPage.test.js.snap
@@ -18,180 +18,184 @@ exports[`subscriptions page should render 1`] = `
       <h1>
         Red Hat Subscriptions
       </h1>
-      <Row
-        bsClass="row"
-        className="toolbar-pf table-view-pf-toolbar-external"
-        componentClass="div"
+      <OrganizationCheck
+        hide={false}
       >
-        <Col
-          bsClass="col"
+        <Row
+          bsClass="row"
+          className="toolbar-pf table-view-pf-toolbar-external"
           componentClass="div"
-          sm={12}
         >
-          <Form
-            bsClass="form"
-            className="toolbar-pf-actions"
-            componentClass="form"
-            horizontal={false}
-            inline={false}
+          <Col
+            bsClass="col"
+            componentClass="div"
+            sm={12}
           >
-            <FormGroup
-              bsClass="form-group"
-              className="toolbar-pf-filter"
-            >
-              <Search
-                getAutoCompleteParams={[Function]}
-                onSearch={[Function]}
-                updateSearchQuery={[Function]}
-              />
-            </FormGroup>
-            <div
-              className="toolbar-pf-action-right"
+            <Form
+              bsClass="form"
+              className="toolbar-pf-actions"
+              componentClass="form"
+              horizontal={false}
+              inline={false}
             >
               <FormGroup
                 bsClass="form-group"
+                className="toolbar-pf-filter"
               >
-                <LinkContainer
-                  activeClassName="active"
-                  exact={false}
-                  replace={false}
-                  strict={false}
-                  to="subscriptions/add"
-                >
-                  <TooltipButton
-                    bsStyle="primary"
-                    title="Add Subscriptions"
-                    tooltipId="add-subscriptions-button-tooltip"
-                    tooltipPlacement="top"
-                    tooltipText={null}
-                  />
-                </LinkContainer>
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
-                  disabled={false}
-                  onClick={[Function]}
-                >
-                  Manage Manifest
-                </Button>
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
-                  disabled={false}
-                  onClick={[Function]}
-                >
-                  Export CSV
-                </Button>
-                <TooltipButton
-                  bsStyle="danger"
-                  disabled={true}
-                  onClick={[Function]}
-                  title="Delete"
-                  tooltipId="delete-subscriptions-button-tooltip"
-                  tooltipPlacement="top"
-                  tooltipText="This is disabled because no subscriptions are selected"
+                <Search
+                  getAutoCompleteParams={[Function]}
+                  onSearch={[Function]}
+                  updateSearchQuery={[Function]}
                 />
               </FormGroup>
-            </div>
-          </Form>
-        </Col>
-      </Row>
-      <Connect(ManageManifestModal)
-        disabledReason={null}
-        onClose={[Function]}
-        showModal={false}
-        taskInProgress={false}
-      />
-      <div
-        className="modal-container"
-        id="subscriptions-table"
-      >
-        <SubscriptionsTable
-          loadSubscriptions={[Function]}
-          onDeleteSubscriptions={[Function]}
-          onSubscriptionDeleteModalClose={[Function]}
-          subscriptionDeleteModalOpen={false}
-          subscriptions={
-            Object {
-              "availableQuantities": Object {},
-              "itemCount": 81,
-              "loading": false,
-              "pagination": Object {
-                "page": 1,
-                "perPage": 2,
-              },
-              "quantitiesLoading": false,
-              "results": Array [
-                Object {
-                  "account_number": null,
-                  "available": -2,
-                  "consumed": 1,
-                  "contract_number": null,
-                  "cores": null,
-                  "cp_id": "ff8080815ea5ea44015ea617b1a5000b",
-                  "end_date": "2047-09-14 15:18:44 -0500",
-                  "id": 3,
-                  "instance_multiplier": 1,
-                  "multi_entitlement": null,
-                  "name": "zoo",
-                  "product_id": "853987721546",
-                  "product_name": "zoo",
-                  "quantity": -1,
-                  "ram": null,
-                  "sockets": null,
-                  "stacking_id": null,
-                  "start_date": "2017-09-21 16:18:44 -0400",
-                  "subscription_id": 2,
-                  "support_level": null,
-                  "type": "NORMAL",
-                  "unmapped_guest": false,
-                  "virt_only": false,
-                  "virt_who": false,
+              <div
+                className="toolbar-pf-action-right"
+              >
+                <FormGroup
+                  bsClass="form-group"
+                >
+                  <LinkContainer
+                    activeClassName="active"
+                    exact={false}
+                    replace={false}
+                    strict={false}
+                    to="subscriptions/add"
+                  >
+                    <TooltipButton
+                      bsStyle="primary"
+                      title="Add Subscriptions"
+                      tooltipId="add-subscriptions-button-tooltip"
+                      tooltipPlacement="top"
+                      tooltipText={null}
+                    />
+                  </LinkContainer>
+                  <Button
+                    active={false}
+                    block={false}
+                    bsClass="btn"
+                    bsStyle="default"
+                    disabled={false}
+                    onClick={[Function]}
+                  >
+                    Manage Manifest
+                  </Button>
+                  <Button
+                    active={false}
+                    block={false}
+                    bsClass="btn"
+                    bsStyle="default"
+                    disabled={false}
+                    onClick={[Function]}
+                  >
+                    Export CSV
+                  </Button>
+                  <TooltipButton
+                    bsStyle="danger"
+                    disabled={true}
+                    onClick={[Function]}
+                    title="Delete"
+                    tooltipId="delete-subscriptions-button-tooltip"
+                    tooltipPlacement="top"
+                    tooltipText="This is disabled because no subscriptions are selected"
+                  />
+                </FormGroup>
+              </div>
+            </Form>
+          </Col>
+        </Row>
+        <Connect(ManageManifestModal)
+          disabledReason={null}
+          onClose={[Function]}
+          showModal={false}
+          taskInProgress={false}
+        />
+        <div
+          className="modal-container"
+          id="subscriptions-table"
+        >
+          <SubscriptionsTable
+            loadSubscriptions={[Function]}
+            onDeleteSubscriptions={[Function]}
+            onSubscriptionDeleteModalClose={[Function]}
+            subscriptionDeleteModalOpen={false}
+            subscriptions={
+              Object {
+                "availableQuantities": Object {},
+                "itemCount": 81,
+                "loading": false,
+                "pagination": Object {
+                  "page": 1,
+                  "perPage": 2,
                 },
-                Object {
-                  "account_number": null,
-                  "available": -1,
-                  "consumed": 0,
-                  "contract_number": null,
-                  "cores": null,
-                  "cp_id": "ff8080815ea5ea44015ebb08e95a0024",
-                  "end_date": "2047-09-18 16:54:36 -0500",
-                  "id": 4,
-                  "instance_multiplier": 1,
-                  "multi_entitlement": null,
-                  "name": "hsdfhsdh",
-                  "product_id": "947637693017",
-                  "product_name": "hsdfhsdh",
-                  "quantity": -1,
-                  "ram": null,
-                  "sockets": null,
-                  "stacking_id": null,
-                  "start_date": "2017-09-25 17:54:36 -0400",
-                  "subscription_id": 3,
-                  "support_level": null,
-                  "type": "NORMAL",
-                  "unmapped_guest": false,
-                  "virt_only": false,
-                  "virt_who": false,
-                },
-              ],
-              "search": undefined,
-              "searchIsActive": false,
+                "quantitiesLoading": false,
+                "results": Array [
+                  Object {
+                    "account_number": null,
+                    "available": -2,
+                    "consumed": 1,
+                    "contract_number": null,
+                    "cores": null,
+                    "cp_id": "ff8080815ea5ea44015ea617b1a5000b",
+                    "end_date": "2047-09-14 15:18:44 -0500",
+                    "id": 3,
+                    "instance_multiplier": 1,
+                    "multi_entitlement": null,
+                    "name": "zoo",
+                    "product_id": "853987721546",
+                    "product_name": "zoo",
+                    "quantity": -1,
+                    "ram": null,
+                    "sockets": null,
+                    "stacking_id": null,
+                    "start_date": "2017-09-21 16:18:44 -0400",
+                    "subscription_id": 2,
+                    "support_level": null,
+                    "type": "NORMAL",
+                    "unmapped_guest": false,
+                    "virt_only": false,
+                    "virt_who": false,
+                  },
+                  Object {
+                    "account_number": null,
+                    "available": -1,
+                    "consumed": 0,
+                    "contract_number": null,
+                    "cores": null,
+                    "cp_id": "ff8080815ea5ea44015ebb08e95a0024",
+                    "end_date": "2047-09-18 16:54:36 -0500",
+                    "id": 4,
+                    "instance_multiplier": 1,
+                    "multi_entitlement": null,
+                    "name": "hsdfhsdh",
+                    "product_id": "947637693017",
+                    "product_name": "hsdfhsdh",
+                    "quantity": -1,
+                    "ram": null,
+                    "sockets": null,
+                    "stacking_id": null,
+                    "start_date": "2017-09-25 17:54:36 -0400",
+                    "subscription_id": 3,
+                    "support_level": null,
+                    "type": "NORMAL",
+                    "unmapped_guest": false,
+                    "virt_only": false,
+                    "virt_who": false,
+                  },
+                ],
+                "search": undefined,
+                "searchIsActive": false,
+              }
             }
-          }
-          toggleDeleteButton={[Function]}
-          updateQuantity={[Function]}
-        />
-        <ModalProgressBar
-          container={null}
-          show={false}
-          task={null}
-        />
-      </div>
+            toggleDeleteButton={[Function]}
+            updateQuantity={[Function]}
+          />
+          <ModalProgressBar
+            container={null}
+            show={false}
+            task={null}
+          />
+        </div>
+      </OrganizationCheck>
     </Col>
   </Row>
 </Grid>

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/SubscriptionsTable.test.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/SubscriptionsTable.test.js
@@ -24,22 +24,22 @@ describe('subscriptions table', () => {
                         </MemoryRouter>);
     expect(toJson(page)).toMatchSnapshot();
   });
-  /* eslint-enable react/jsx-indent */
 
   it('should render an empty state', async () => {
     const page = render(<MemoryRouter>
-      <SubscriptionsTable
-        subscriptions={emptyState}
-        loadSubscriptions={loadSubscriptions}
-        updateQuantity={updateQuantity}
-        subscriptionDeleteModalOpen={false}
-        onSubscriptionDeleteModalClose={() => {}}
-        onDeleteSubscriptions={() => {}}
-        toggleDeleteButton={() => {}}
-      />
+          <SubscriptionsTable
+            subscriptions={emptyState}
+            loadSubscriptions={loadSubscriptions}
+            updateQuantity={updateQuantity}
+            subscriptionDeleteModalOpen={false}
+            onSubscriptionDeleteModalClose={() => {}}
+            onDeleteSubscriptions={() => {}}
+            toggleDeleteButton={() => {}}
+          />
                         </MemoryRouter>);
     expect(toJson(page)).toMatchSnapshot();
   });
+  /* eslint-enable react/jsx-indent */
 
   it('should render a loading state', async () => {
     const page = render(<SubscriptionsTable


### PR DESCRIPTION
page and RH repo page.

When no organization is selected, there is no context for RH repo
page and subs page and that page can't function. This commit
adds a message when you navigate to the page under "Any Organization"
to select an Organization.

We have also been sending requests when navigating to a page
without org context. This commit adds an org id check on applicable
actions. The request isn't sent if no organization ID is present.

This commit also adds a `common` folder in `webpack/` with a
`helpers` file. This is a  place for things that are katello
specific, but need to be shared across components. I'm open to
suggestions on how to structure this better.