### PR TITLE
Fixes #23903 - Hide repo sets without a valid subscription

### DIFF
--- a/app/models/katello/glue/candlepin/owner.rb
+++ b/app/models/katello/glue/candlepin/owner.rb
@@ -39,14 +39,6 @@ module Katello
         self.owner_details['contentAccessMode']
       end
 
-      def pools(consumer_uuid = nil)
-        if consumer_uuid
-          Resources::Candlepin::Owner.pools self.label, :consumer => consumer_uuid
-        else
-          Resources::Candlepin::Owner.pools self.label
-        end
-      end
-
       def generate_debug_cert
         Resources::Candlepin::Owner.generate_ueber_cert(label)
       end

--- a/app/models/katello/product_content.rb
+++ b/app/models/katello/product_content.rb
@@ -12,7 +12,6 @@ module Katello
 
     scope :displayable, -> {
       joins(:content).where.not("#{content_table_name}.content_type IN (?)", Katello::Repository.undisplayable_types)
-      .order("LOWER(#{content_table_name}.name) ASC")
     }
 
     scope :redhat, -> {
@@ -30,6 +29,10 @@ module Katello
 
     def self.enabled(organization)
       joins(:content).where("#{self.content_table_name}.cp_content_id" => Katello::Repository.in_organization(organization).select(:content_id))
+    end
+
+    def self.with_valid_subscription(organization)
+      where(:product_id => Katello::PoolProduct.where(:pool_id => organization.pools).select(:product_id))
     end
 
     # used by Katello::Api::V2::RepositorySetsController#index

--- a/test/controllers/api/v2/repository_sets_controller_test.rb
+++ b/test/controllers/api/v2/repository_sets_controller_test.rb
@@ -65,6 +65,15 @@ module Katello
       assert_response :success
     end
 
+    def test_index_org_with_active_subscription
+      get :index, params: { :organization_id => @organization.id, :with_active_subscription => true }
+
+      body = JSON.parse(response.body)
+
+      assert_empty body['error']
+      assert_response :success
+    end
+
     def test_index_org
       get :index, params: { :organization_id => @organization.id}
 

--- a/webpack/redux/actions/RedHatRepositories/sets.js
+++ b/webpack/redux/actions/RedHatRepositories/sets.js
@@ -28,7 +28,7 @@ export const loadRepositorySets = (extendedParams = {}) => (dispatch, getState) 
   ]);
 
   const params = {
-    ...{ organization_id: orgId() },
+    ...{ organization_id: orgId(), with_active_subscription: true },
     ...propsToSnakeCase(extendedParams),
     search,
   };


### PR DESCRIPTION
This adds a new paramter to the repo sets api, to only return repo sets
that have an active subscription.  This works well with the new UI which seems
to be built around this assumption.  For hammer, we want to still show
either enabled repo sets or repo sets with an active sub, so the new
default behavior is to show these