### PR TITLE
Fixes #24187 - do not paginate when calling upstream candlepin

### DIFF
--- a/app/controllers/katello/api/v2/upstream_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/upstream_subscriptions_controller.rb
@@ -74,7 +74,7 @@ module Katello
     def upstream_pool_params
       upstream_params = params.permit(:page, :per_page, :order, :sort_by, :quantities_only, :attachable, pool_ids: []).to_h
 
-      if params[:full_result]
+      if params[:full_result] || !upstream_params[:pool_ids].empty?
         upstream_params.delete(:per_page)
         upstream_params.delete(:page)
       elsif !params[:per_page]

--- a/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
@@ -41,6 +41,16 @@ module Katello
       assert_response :success
     end
 
+    def test_index_pool_ids
+      params = {pool_ids: %w(1 2 3), page: '3', per_page: '7', organization_id: @organization.id}
+      # omit page and per_page params for candlepin
+      UpstreamPool.expects(:fetch_pools).with('pool_ids' => %w(1 2 3)).returns({})
+
+      get :index, params: params
+
+      assert_response :success
+    end
+
     def test_index_no_per_page
       params = {page: '3', organization_id: @organization.id }
       UpstreamPool.expects(:fetch_pools).with('page' => '3', 'per_page' => Setting[:entries_per_page]).returns({})


### PR DESCRIPTION
Previously, calls to upstream candlepin could include `per_page`,
which makes tomcat paginate results. However, the pagination will add
an HTTP header with URL links for the next and previous data sets.

If the URL is more than a couple of KB, this header can exceed 8KB
which causes tomcat to refuse to return the result. This is
intentional, since not all services support headers larger than 8KB.

This patch removes the pagination request from the upstream candlepin
call for pools. We do not need to do this since the call is already
limited to just the pools displayed on the page.