### PR TITLE
Fixes #23942 - Reset Pool model after migration

### DIFF
--- a/db/migrate/20180410140909_add_organization_id_to_pool.rb
+++ b/db/migrate/20180410140909_add_organization_id_to_pool.rb
@@ -4,7 +4,8 @@ class AddOrganizationIdToPool < ActiveRecord::Migration[5.1]
     add_foreign_key 'katello_pools', 'taxonomies',
                 :name => 'katello_pools_organization_id', :column => 'organization_id'
 
-    Katello::Pool.find_each do |pool|
+    ::Katello::Pool.reset_column_information
+    ::Katello::Pool.find_each do |pool|
       pool.update_attributes(:organization_id => pool.subscription.organization_id) if pool.subscription
     end
   end


### PR DESCRIPTION
The ::Katello::Pool model changed between 3.6 and 3.7 due to the
Candlepin 2.2 -> 2.3 migration. However the migration script does
not properly reset the column information after associating the
organization to the Pool.
This causes all sorts of foreign key violation errors like
"Error deleting manifest. PG::UniqueViolation:
ERROR: duplicate key value violates unique constraint
"index_katello_pools_on_cp_id""
when re indexing stuff from candlepin