### PR TITLE
Fixes #24195 - adapt tests to new audited associations

### DIFF
--- a/test/models/activation_key_test.rb
+++ b/test/models/activation_key_test.rb
@@ -191,7 +191,7 @@ module Katello
 
       test 'should audit when a host_collection is added to a activation_key' do
         recent_audit = @sample_key.audits.last
-        audited_changes = recent_audit.audited_changes[:host_collections]
+        audited_changes = recent_audit.audited_changes[:host_collection_ids]
         assert audited_changes, 'No audits found for activation_keys'
         assert_empty audited_changes.first
         assert_equal @host_collection.name, audited_changes.last


### PR DESCRIPTION
needs to be cherry-picked into 3.7 (compatibility with 1.18), needs to be merged with https://github.com/theforeman/foreman/pull/5753