### PR TITLE
fixes #24055 - docker search unauth repos

### DIFF
--- a/app/controllers/katello/api/v2/environments_controller.rb
+++ b/app/controllers/katello/api/v2/environments_controller.rb
@@ -104,6 +104,7 @@ module Katello
       fail HttpErrors::BadRequest, _("Can't update the '%s' environment") % "Library" if @environment.library? && update_params.empty?
       update_params[:name] = params[:environment][:new_name] if params[:environment][:new_name]
       @environment.update_attributes!(update_params)
+      @environment.update_container_repositories(update_params[:registry_unauthenticated_pull]) if update_params.key? :registry_unauthenticated_pull
       if update_params[:registry_name_pattern]
         task = send(async ? :async_task : :sync_task, ::Actions::Katello::Environment::PublishRepositories,
                     @environment, content_type: Katello::Repository::DOCKER_TYPE)

--- a/app/models/katello/kt_environment.rb
+++ b/app/models/katello/kt_environment.rb
@@ -221,6 +221,12 @@ module Katello
       self.repositories.readable.where(:content_type => Katello::Repository::PUPPET_TYPE)
     end
 
+    def update_container_repositories(registry_unauthenticated_pull)
+      self.repositories.readable.where(:content_type => Katello::Repository::DOCKER_TYPE).each do |repository|
+        repository.update_attributes!(registry_unauthenticated_pull: registry_unauthenticated_pull)
+      end
+    end
+
     def as_json(_options = {})
       to_ret = self.attributes
       to_ret['prior'] = self.prior && self.prior.name

--- a/test/actions/katello/capsule_content_test.rb
+++ b/test/actions/katello/capsule_content_test.rb
@@ -67,7 +67,7 @@ module ::Actions::Katello::CapsuleContent
       capsule_content_sync = plan_action(action, capsule_content.capsule, :environment_id => dev_environment.id)
       synced_repos = synced_repos(capsule_content_sync, capsule_content.repos_available_to_capsule)
 
-      assert_equal synced_repos.uniq.count, 7
+      assert_equal synced_repos.uniq.count, 8
     end
 
     it 'fails when trying to sync to the default capsule' do

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -444,9 +444,24 @@ busybox:
   url:                  'http://docker.io'
   docker_upstream_name: 'busybox'
 
+busybox_dev:
+  name:                 busybox
+  pulp_id:              "Default_Organization-Test-busybox-dev"
+  content_id:           1
+  content_type:         docker
+  label:                busybox
+  relative_path:        'ACME_Corporation/dev/busybox'
+  environment_id:       <%= ActiveRecord::FixtureSet.identify(:dev) %>
+  product_id:           <%= ActiveRecord::FixtureSet.identify(:puppet_product) %>
+  gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
+  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_dev_view_version) %>
+  unprotected:           <%= true %>
+  url:                  'http://docker.io'
+  docker_upstream_name: 'busybox'
+
 busybox2:
   name:                 busybox
-  pulp_id:              "Default_Organization-Test-busybox2-library"
+  pulp_id:              "Default_Organization-Test-busybox2-dev"
   content_id:           1
   content_type:         docker
   label:                busybox


### PR DESCRIPTION
To test, similar to https://github.com/Katello/katello/pull/7459 but _docker search_ should find unauth'ed repos when logged in or not logged in.