### PR TITLE
Fixes #22914 - Add repo perms to lifecycle environment

### DIFF
--- a/app/models/katello/authorization/repository.rb
+++ b/app/models/katello/authorization/repository.rb
@@ -21,9 +21,10 @@ module Katello
     module ClassMethods
       def readable
         in_products = Repository.where(:product_id => Katello::Product.authorized(:view_products)).select(:id)
+        in_environments = Repository.where(:environment_id => Katello::KTEnvironment.authorized(:view_lifecycle_environments)).select(:id)
         in_content_views = Repository.joins(:content_view_repositories).where("#{ContentViewRepository.table_name}.content_view_id" => Katello::ContentView.readable).select(:id)
         in_versions = Repository.joins(:content_view_version).where("#{Katello::ContentViewVersion.table_name}.content_view_id" => Katello::ContentView.readable).select(:id)
-        where("#{self.table_name}.id in (?) or #{self.table_name}.id in (?) or #{self.table_name}.id in (?)", in_products, in_content_views, in_versions)
+        where("#{self.table_name}.id in (?) or #{self.table_name}.id in (?) or #{self.table_name}.id in (?) or #{self.table_name}.id in (?)", in_products, in_content_views, in_versions, in_environments)
       end
 
       def deletable

--- a/test/models/authorization/repository_authorization_test.rb
+++ b/test/models/authorization/repository_authorization_test.rb
@@ -82,6 +82,14 @@ module Katello
       assert_includes Repository.readable, @fedora_17_x86_64_dev
     end
 
+    def test_readable_with_environment
+      refute_includes Repository.readable, @fedora_17_x86_64
+      setup_current_user_with_permissions(:name => "view_lifecycle_environments", :search => "name = \"#{@fedora_17_x86_64.environment.name}\"")
+      repos = Repository.readable
+      refute_empty repos
+      assert repos.all? { |repo| repo.environment_id == @fedora_17_x86_64.environment_id }
+    end
+
     def test_deletable
       assert_empty Repository.deletable
     end


### PR DESCRIPTION
Adds a lifecycle environment check to readable repositories. Allows custom users to be able to view repositories in a given lifecycle environment even if they don't have access to view the products those repositories are in.

Tests that a user can view repositories in a lifecycle environment and that the same user can't view repositories in a lifecycle environment in which they don't have access.