### PR TITLE
Fixes #24222: fix arrow on grouped subscriptions

### DIFF
--- a/webpack/move_to_foreman/components/common/table/components/CollapseSubscriptionGroupButton.js
+++ b/webpack/move_to_foreman/components/common/table/components/CollapseSubscriptionGroupButton.js
@@ -6,7 +6,7 @@ import { Icon } from 'patternfly-react';
 const CollapseSubscriptionGroupButton = ({
   collapsed, onClick, ...props
 }) => {
-  const iconName = collapsed ? 'angle-down' : 'angle-right';
+  const iconName = collapsed ? 'angle-right' : 'angle-down';
 
   return (
     <Icon

--- a/webpack/move_to_foreman/components/common/table/components/__snapshots__/CollapseSubscriptionGroupButton.test.js.snap
+++ b/webpack/move_to_foreman/components/common/table/components/__snapshots__/CollapseSubscriptionGroupButton.test.js.snap
@@ -3,7 +3,7 @@
 exports[`CollapseSubscriptionGroupButton renders CollapseSubscriptionGroupButton collapsed 1`] = `
 <Icon
   className="collapse-subscription-group-button"
-  name="angle-down"
+  name="angle-right"
   onClick={[Function]}
   type="fa"
 />
@@ -12,7 +12,7 @@ exports[`CollapseSubscriptionGroupButton renders CollapseSubscriptionGroupButton
 exports[`CollapseSubscriptionGroupButton renders CollapseSubscriptionGroupButton opened 1`] = `
 <Icon
   className="collapse-subscription-group-button"
-  name="angle-right"
+  name="angle-down"
   onClick={[Function]}
   type="fa"
 />


### PR DESCRIPTION
Fix the direction of the arrow on grouped subscriptions so that it
is toward the right when closed and down when open.

https://projects.theforeman.org/issues/24222