### PR TITLE
Fixes #24140, #24142 - mount react root component from the layout

### DIFF
--- a/app/views/katello/layouts/react.html.erb
+++ b/app/views/katello/layouts/react.html.erb
@@ -3,13 +3,13 @@
 <% end %>
 
 <% content_for(:javascripts) do %>
-    <%= javascript_include_tag *webpack_asset_paths('katello', :extension => 'js'), "data-turbolinks-track" => true, 'defer' => 'defer' %>
+    <%= javascript_include_tag *webpack_asset_paths('katello', :extension => 'js') %>
 <% end %>
 
 <% content_for(:content) do %>
     <%= notifications %>
-    <div id="reactRoot"></div>
     <div id="organization-id" data-id="<%= Organization.current.id if Organization.current %>" ></div>
+    <div id="reactRoot"></div>
 <% end %>
-
 <%= render file: "layouts/base" %>
+<%= mount_react_component('katello', '#reactRoot') %>

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -4,7 +4,6 @@
 /* eslint-disable import/no-unresolved */
 
 import componentRegistry from 'foremanReact/components/componentRegistry';
-import { mount } from 'foremanReact/common/MountingService';
 import Application from './containers/Application/index';
 import './redux';
 // Not currently mocking anything
@@ -15,4 +14,3 @@ componentRegistry.register({
   type: Application,
 });
 
-mount('katello', '#reactRoot');

--- a/webpack/redux/actions/RedHatRepositories/enabled.js
+++ b/webpack/redux/actions/RedHatRepositories/enabled.js
@@ -23,7 +23,7 @@ export const createEnabledRepoParams = (extendedParams = {}) => {
   ]);
 
   const repoParams = {
-    ...{ organization_id: orgId, enabled: 'true' },
+    ...{ organization_id: orgId(), enabled: 'true' },
     ...propsToSnakeCase(extendedParams),
     search,
   };

--- a/webpack/redux/actions/RedHatRepositories/sets.js
+++ b/webpack/redux/actions/RedHatRepositories/sets.js
@@ -28,7 +28,7 @@ export const loadRepositorySets = (extendedParams = {}) => (dispatch, getState) 
   ]);
 
   const params = {
-    ...{ organization_id: orgId },
+    ...{ organization_id: orgId() },
     ...propsToSnakeCase(extendedParams),
     search,
   };

--- a/webpack/scenes/Organizations/OrganizationActions.js
+++ b/webpack/scenes/Organizations/OrganizationActions.js
@@ -18,7 +18,7 @@ export const loadOrganization = (extendedParams = {}) => (dispatch) => {
   };
 
   return api
-    .get(`/organizations/${orgId}`, {}, params)
+    .get(`/organizations/${orgId()}`, {}, params)
     .then(({ data }) => {
       dispatch({
         type: GET_ORGANIZATION_SUCCESS,
@@ -37,12 +37,12 @@ export const saveOrganization = (extendedParams = {}) => (dispatch) => {
   dispatch({ type: SAVE_ORGANIZATION_REQUEST });
 
   const params = {
-    ...{ id: orgId },
+    ...{ id: orgId() },
     ...propsToSnakeCase(extendedParams),
   };
 
   return api
-    .put(`/organizations/${orgId}`, params)
+    .put(`/organizations/${orgId()}`, params)
     .then(({ data }) => {
       dispatch({
         type: SAVE_ORGANIZATION_SUCCESS,

--- a/webpack/scenes/RedHatRepositories/components/Search.js
+++ b/webpack/scenes/RedHatRepositories/components/Search.js
@@ -43,7 +43,7 @@ class RepositorySearch extends Component {
 
   getAutoCompleteParams(search) {
     const params = {
-      organization_id: orgId,
+      organization_id: orgId(),
       search,
     };
 

--- a/webpack/scenes/Subscriptions/Details/SubscriptionDetailActions.js
+++ b/webpack/scenes/Subscriptions/Details/SubscriptionDetailActions.js
@@ -10,7 +10,7 @@ export const loadSubscriptionDetails = subscriptionId => (dispatch) => {
   dispatch({ type: SUBSCRIPTION_DETAILS_REQUEST });
 
   return api
-    .get(`/organizations/${orgId}/subscriptions/${subscriptionId}`)
+    .get(`/organizations/${orgId()}/subscriptions/${subscriptionId}`)
     .then(({ data }) => {
       dispatch({
         type: SUBSCRIPTION_DETAILS_SUCCESS,

--- a/webpack/scenes/Subscriptions/Manifest/ManifestActions.js
+++ b/webpack/scenes/Subscriptions/Manifest/ManifestActions.js
@@ -27,7 +27,7 @@ export const uploadManifest = file => (dispatch) => {
   };
 
   return api
-    .post(`/organizations/${orgId}/subscriptions/upload`, formData, config)
+    .post(`/organizations/${orgId()}/subscriptions/upload`, formData, config)
     .then(({ data }) => {
       dispatch({
         type: UPLOAD_MANIFEST_SUCCESS,
@@ -50,7 +50,7 @@ export const refreshManifest = (extendedParams = {}) => (dispatch) => {
   };
 
   return api
-    .put(`/organizations/${orgId}/subscriptions/refresh_manifest`, {}, params)
+    .put(`/organizations/${orgId()}/subscriptions/refresh_manifest`, {}, params)
     .then(({ data }) => {
       dispatch({
         type: REFRESH_MANIFEST_SUCCESS,
@@ -73,7 +73,7 @@ export const deleteManifest = (extendedParams = {}) => (dispatch) => {
   };
 
   return api
-    .post(`/organizations/${orgId}/subscriptions/delete_manifest`, {}, params)
+    .post(`/organizations/${orgId()}/subscriptions/delete_manifest`, {}, params)
     .then(({ data }) => {
       dispatch({
         type: DELETE_MANIFEST_SUCCESS,
@@ -96,7 +96,7 @@ export const loadManifestHistory = (extendedParams = {}) => (dispatch) => {
   };
 
   return api
-    .get(`/organizations/${orgId}/subscriptions/manifest_history`, {}, params)
+    .get(`/organizations/${orgId()}/subscriptions/manifest_history`, {}, params)
     .then(({ data }) => {
       dispatch({
         type: MANIFEST_HISTORY_SUCCESS,

--- a/webpack/scenes/Subscriptions/SubscriptionActions.js
+++ b/webpack/scenes/Subscriptions/SubscriptionActions.js
@@ -19,7 +19,7 @@ import { filterRHSubscriptions } from './SubscriptionHelpers.js';
 import { getResponseError } from '../../move_to_foreman/common/helpers.js';
 
 export const createSubscriptionParams = (extendedParams = {}) => ({
-  ...{ organization_id: orgId },
+  ...{ organization_id: orgId() },
   ...propsToSnakeCase(extendedParams),
 });
 
@@ -28,7 +28,7 @@ export const loadAvailableQuantities = (extendedParams = {}) => (dispatch) => {
 
   const params = createSubscriptionParams(extendedParams);
   return api
-    .get(`/organizations/${orgId}/upstream_subscriptions`, {}, params)
+    .get(`/organizations/${orgId()}/upstream_subscriptions`, {}, params)
     .then(({ data }) => {
       dispatch({
         type: SUBSCRIPTIONS_QUANTITIES_SUCCESS,
@@ -76,7 +76,7 @@ export const updateQuantity = (quantities = {}) => (dispatch) => {
   };
 
   return api
-    .put(`/organizations/${orgId}/upstream_subscriptions`, params)
+    .put(`/organizations/${orgId()}/upstream_subscriptions`, params)
     .then(({ data }) => {
       dispatch({
         type: UPDATE_QUANTITY_SUCCESS,
@@ -99,7 +99,7 @@ export const deleteSubscriptions = poolIds => (dispatch) => {
   };
 
   return api
-    .delete(`/organizations/${orgId}/upstream_subscriptions`, {}, params)
+    .delete(`/organizations/${(orgId())}/upstream_subscriptions`, {}, params)
     .then(({ data }) => {
       dispatch({
         type: DELETE_SUBSCRIPTIONS_SUCCESS,

--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -150,7 +150,7 @@ class SubscriptionsPage extends Component {
     const getAutoCompleteParams = search => ({
       endpoint: '/subscriptions/auto_complete_search',
       params: {
-        organization_id: orgId,
+        organization_id: orgId(),
         search,
       },
     });

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsActions.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsActions.js
@@ -14,12 +14,12 @@ export const loadUpstreamSubscriptions = (extendedParams = {}) => (dispatch) => 
   dispatch({ type: UPSTREAM_SUBSCRIPTIONS_REQUEST });
 
   const params = {
-    ...{ organization_id: orgId, attachable: true },
+    ...{ organization_id: orgId(), attachable: true },
     ...propsToSnakeCase(extendedParams),
   };
 
   return api
-    .get(`/organizations/${orgId}/upstream_subscriptions`, {}, params)
+    .get(`/organizations/${orgId()}/upstream_subscriptions`, {}, params)
     .then(({ data }) => {
       dispatch({
         type: UPSTREAM_SUBSCRIPTIONS_SUCCESS,
@@ -43,7 +43,7 @@ export const saveUpstreamSubscriptions = upstreamSubscriptions => (dispatch) => 
   };
 
   return api
-    .post(`/organizations/${orgId}/upstream_subscriptions`, params)
+    .post(`/organizations/${orgId()}/upstream_subscriptions`, params)
     .then(({ data }) => {
       dispatch({
         type: SAVE_UPSTREAM_SUBSCRIPTIONS_SUCCESS,

--- a/webpack/services/api/index.js
+++ b/webpack/services/api/index.js
@@ -100,6 +100,6 @@ class ForemanTasksApi extends Api {
 export const foremanTasksApi = new ForemanTasksApi();
 
 // eslint-disable-next-line import/prefer-default-export
-const orgNode = document.getElementById('organization-id');
+const orgNode = () => document.getElementById('organization-id');
 // This node does not exist while testing
-export const orgId = orgNode ? orgNode.dataset.id : '1';
+export const orgId = () => (orgNode() ? orgNode().dataset.id : '1');


### PR DESCRIPTION
When hitting back/forward , or `Turbolink.visit` is invoked (i.e switching between organizations via the top bar dropdown) the react root component doesn't remounted, because the `mount` invoked only once when the `webpack/index.js` file is loaded.
