### PR TITLE
Fixes #24229 - Add title to repo type selector

### DIFF
--- a/webpack/move_to_pf/react-bootstrap-select/index.js
+++ b/webpack/move_to_pf/react-bootstrap-select/index.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { FormControl } from 'react-bootstrap';
+import PropTypes from 'prop-types';
 
 require('jquery');
 require('bootstrap-select');
@@ -52,14 +53,24 @@ class BootstrapSelect extends React.Component {
   render() {
     // TODO: these classes are required because foreman assumes that all selects should use select2 and jquery multiselect
     // TODO: see also http://projects.theforeman.org/issues/21952
+    const { noneSelectedText } = this.props;
+
     return <FormControl {...this.props}
-                        data-none-selected-text={__('Nothing selected')}
+                        data-none-selected-text={noneSelectedText}
                         data-selected-text-format="count>3"
                         data-count-selected-text={__('{0} items selected')}
                         componentClass="select"
                         className="without_select2 without_jquery_multiselect"
     />;
   }
+}
+
+BootstrapSelect.propTypes = {
+  noneSelectedText: PropTypes.string,
+}
+
+BootstrapSelect.defaultProps = {
+  noneSelectedText: __('Nothing selected'),
 }
 
 export default BootstrapSelect;

--- a/webpack/scenes/RedHatRepositories/components/SearchBar.js
+++ b/webpack/scenes/RedHatRepositories/components/SearchBar.js
@@ -97,6 +97,7 @@ class SearchBar extends Component {
         <MultiSelect
           value={this.state.filters}
           options={filterOptions}
+          noneSelectedText={__("Filter by type")}
           onChange={(e) => {
             const values = [...e.target.options]
               .filter(({ selected }) => selected)


### PR DESCRIPTION
When there are no repo types selected on the Red Hat repo
page repo type dropdown (on top in the Search Bar), it shows
"Nothing Selected". There is not a great way of knowing
what the dropdown is for. This commit shows the text
"Filter by repo type".

Here is a screenshot of the change:
![here](http://www.clipular.com/c/4958373196595200.png?k=e1Q2tjqWdiizpZtKJiqD-hQUVt4)