### PR TITLE
Fixes #24263 - Added managed content medium provider

### DIFF
--- a/app/models/katello/concerns/redhat_extensions.rb
+++ b/app/models/katello/concerns/redhat_extensions.rb
@@ -3,31 +3,6 @@ module Katello
     module RedhatExtensions
       extend ActiveSupport::Concern
 
-      module Overrides
-        def medium_uri(host, url = nil)
-          kickstart_repo = host.try(:content_facet).try(:kickstart_repository) || host.try(:kickstart_repository)
-
-          if host.try(:content_source) && kickstart_repo.present?
-            return URI.parse(kickstart_repo.full_path(host.content_source))
-          else
-            super(host, url)
-          end
-        end
-
-        # overwrite foreman method in operatingsystem.rb
-        def boot_files_uri(medium, architecture, host = nil)
-          return super(medium, architecture, host) unless host.try(:content_source)
-          family_class = self.family.constantize
-          family_class::PXEFILES.values.collect do |img|
-            "#{medium_uri(host)}/#{pxedir}/#{img}"
-          end
-        end
-      end
-
-      included do
-        prepend Overrides
-      end
-
       module ClassMethods
         def find_or_create_operating_system(repo)
           os_name = construct_name(repo.distribution_family)

--- a/app/services/katello/managed_content_medium_provider.rb
+++ b/app/services/katello/managed_content_medium_provider.rb
@@ -1,0 +1,26 @@
+module Katello
+  class ManagedContentMediumProvider < ::MediumProviders::Provider
+    def validate
+      errors = []
+
+      kickstart_repo = entity.try(:content_facet).try(:kickstart_repository) || entity.try(:kickstart_repository)
+
+      errors << N_("Kickstart repository was not set for host '%{host}'") % { :host => entity } if kickstart_repo.nil?
+      errors << N_("Content source was not set for host '%{host}'") % { :host => entity } if entity.content_source.nil?
+      errors
+    end
+
+    def medium_uri(path = "")
+      kickstart_repo = entity.try(:content_facet).try(:kickstart_repository) || entity.try(:kickstart_repository)
+      url = kickstart_repo.full_path(entity.content_source)
+      url += '/' + path unless path.empty?
+      URI.parse(url)
+    end
+
+    def unique_id
+      @unique_id ||= begin
+        "#{entity.kickstart_repository.name.parameterize}-#{entity.kickstart_repository_id}"
+      end
+    end
+  end
+end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -288,6 +288,8 @@ Foreman::Plugin.register :katello do
 
   register_info_provider Katello::Host::InfoProvider
 
+  medium_providers.register(Katello::ManagedContentMediumProvider)
+
   Katello::PermissionCreator.new(self).define
   add_all_permissions_to_default_roles
 

--- a/test/models/concerns/redhat_extensions_test.rb
+++ b/test/models/concerns/redhat_extensions_test.rb
@@ -63,6 +63,7 @@ module Katello
       @repo_with_distro = katello_repositories(:fedora_17_x86_64)
       version = @repo_with_distro.distribution_version.split('.')
       @os = ::Redhat.create_operating_system("RedHat", version[0], version[1])
+      @os.architectures << architectures(:x86_64)
       @content_source = FactoryBot.create(:smart_proxy, :name => "foobar", :url => "http://capsule.com/")
 
       @host = ::Host.new(:architecture => architectures(:x86_64), :operatingsystem => @os,
@@ -83,11 +84,11 @@ module Katello
       @host.medium = @os.media.first
       @host.content_facet.content_source = nil
       @host.content_facet.kickstart_repository = @repo_with_distro
-      assert_equal @os.media.first.path, @os.medium_uri(@host).to_s
+      assert_equal @os.media.first.path, @host.host_medium_provider.medium_uri.to_s
 
       @host.content_facet.content_source = @content_source
       @host.content_facet.kickstart_repository = nil
-      assert_equal @os.media.first.path, @os.medium_uri(@host).to_s
+      assert_equal @os.media.first.path, @host.host_medium_provider.medium_uri.to_s
     end
 
     def test_medium_uri_for_no_content_source_or_ks_repo_hg
@@ -95,21 +96,21 @@ module Katello
       @hostgroup.medium = @os.media.first
       @hostgroup.content_source = nil
       @hostgroup.kickstart_repository = @repo_with_distro
-      assert_equal @os.media.first.path, @os.medium_uri(@hostgroup).to_s
+      assert_equal @os.media.first.path, @hostgroup.host_medium_provider.medium_uri.to_s
 
       @hostgroup.content_source = @content_source
       @hostgroup.kickstart_repository = nil
-      assert_equal @os.media.first.path, @os.medium_uri(@hostgroup).to_s
+      assert_equal @os.media.first.path, @hostgroup.host_medium_provider.medium_uri.to_s
     end
 
     def test_medium_uri_with_a_kickstart_repo
       @host.content_facet.kickstart_repository = @repo_with_distro
-      assert_equal @repo_with_distro.full_path(@content_source), @os.medium_uri(@host).to_s
+      assert_equal @repo_with_distro.full_path(@content_source), @host.host_medium_provider.medium_uri.to_s
     end
 
     def test_medium_uri_with_a_kickstart_repo_hg
       @hostgroup.kickstart_repository = @repo_with_distro
-      assert_equal @repo_with_distro.full_path(@content_source), @os.medium_uri(@hostgroup).to_s
+      assert_equal @repo_with_distro.full_path(@content_source), @hostgroup.host_medium_provider.medium_uri.to_s
     end
 
     def test_kickstart_repos_with_no_content_source


### PR DESCRIPTION
Instead of monkey patching Redhat class, created a medium provider to be used in foreman.

This PR should be merged after https://github.com/theforeman/foreman/pull/5244 is merged. It changes the way medium_uri is obtained for a host.