### PR TITLE
Refs #23706 - Show proper content source

### DIFF
--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -41,6 +41,6 @@ end %>
     select_tag cs_select_id, options_from_collection_for_select(proxies, :id, :name, @hostgroup.content_source_id), :data => {"spinner_path" => spinner_path},
                :class => 'form-control',  :name => cs_select_name, include_blank: true
   else
-    select_tag cs_select_id, options_from_collection_for_select(proxies, :id, :name, (@hostgroup || @host).content_source_id), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cs_select_name, include_blank: true
+    select_tag cs_select_id, options_from_collection_for_select(proxies, :id, :name, @host.content_source_id), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cs_select_name, include_blank: true
   end
 end %>


### PR DESCRIPTION
This is basically the same bug we had with CV/LE:

1. Create a host group 'test' with a content source
2. Assign host group 'test' to a host 'A'
3. Clear the content source, or change the content source of 'A'
4. Submit 'A'
5. Edit 'A'

Result: on the UI, 'A' content source will still be the content source
coming from the host group. If you check the API, the host content
source is correct - the one you assigned in step 3.

Expected Result: on the UI, 'A' content source is the one set on step 3

cc @jlsherrill @akofink since this is basically the continuation of https://github.com/Katello/katello/pull/7398