### PR TITLE
Fixes #24275 - Fixed synced OSTREE version order

### DIFF
--- a/app/controllers/katello/api/v2/ostree_branches_controller.rb
+++ b/app/controllers/katello/api/v2/ostree_branches_controller.rb
@@ -4,7 +4,7 @@ module Katello
     include Katello::Concerns::Api::V2::RepositoryContentController
 
     def default_sort
-      %w(version_date desc)
+      %w(version desc)
     end
 
     private

--- a/test/controllers/api/v2/ostree_branches_controller_test.rb
+++ b/test/controllers/api/v2/ostree_branches_controller_test.rb
@@ -4,7 +4,7 @@ module Katello
   class Api::V2::OstreeBranchesControllerTest < ActionController::TestCase
     def models
       @repo = Repository.find(katello_repositories(:ostree_rhel7).id)
-      @branch = @repo.ostree_branches.create!(:name => "abc123", :uuid => "123xyz")
+      @branch = @repo.ostree_branches.create!(:name => "abc123", :uuid => "123xyz", :version => "1.1")
     end
 
     def setup
@@ -54,6 +54,14 @@ module Katello
       get :compare, params: { :content_view_version_ids => [@lib_repo.content_view_version_id, @view_repo.content_view_version_id], :repository_id => @lib_repo.id }
       assert_response :success
       assert_template "katello/api/v2/ostree_branches/compare"
+    end
+
+    def test_branch_order
+      @repo.ostree_branches.create!(:name => "def456", :uuid => "456uvw", :version => "1.0")
+
+      get :index
+      tree_branch_uuid = JSON.parse(response.body)['results'][0]['uuid']
+      assert_equal "123xyz", tree_branch_uuid
     end
   end
 end


### PR DESCRIPTION
Synced OSTREE versions shows incorrect order when they are listed on hammer server. They were listed in version_date order instead of by order of version.

Steps to reproduce:
 1) Sync all ostree versions.
 2) Check list for all installed OStree versions.

OStree versions are now listed in descending order of version (i.e. 7.4.2 comes before 7.4.1).