### PR TITLE
Fixes #24215 - Add validation for upstream sub quantities

### DIFF
--- a/webpack/move_to_foreman/common/helpers.js
+++ b/webpack/move_to_foreman/common/helpers.js
@@ -6,6 +6,12 @@ const urlBuilder = (controller, action, id = undefined) =>
 const urlWithSearch = (base, searchQuery) =>
   `/${base}?search=${searchQuery}`;
 
+const stringIsInteger = (value) => {
+  // checking for positive integers only
+  const reg = new RegExp('^[0-9]+$');
+  return reg.test(value);
+};
+
 export const getResponseErrorMsgs = ({ data }) => {
   if (data) {
     const messages = (data.errors || data.displayMessage || data.message || data.error);
@@ -44,4 +50,5 @@ export default {
   getResponseErrorMsgs,
   apiError,
   KEY_CODES,
+  stringIsInteger,
 };

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsTableSchema.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsTableSchema.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FormGroup, FormControl, ControlLabel } from 'react-bootstrap';
+import { FormGroup, FormControl, ControlLabel, HelpBlock } from 'react-bootstrap';
 import helpers from '../../../move_to_foreman/common/helpers';
 import {
   headerFormatter,
@@ -71,7 +71,7 @@ export const columns = (controller, selectionController) => [
     },
   },
   {
-    property: 'quantity',
+    property: 'available',
     header: {
       label: __('Available Entitlements'),
       formatters: [headerFormatter],
@@ -96,22 +96,27 @@ export const columns = (controller, selectionController) => [
       formatters: [
         (value, { rowData }) => (
           <td>
-            <FormGroup>
+            <FormGroup
+              validationState={controller.quantityValidationInput(rowData)}
+            >
               <ControlLabel srOnly>{__('Number to Allocate')}</ControlLabel>
               <FormControl
                 type="text"
                 onBlur={e => controller.onChange(e.target.value, rowData)}
                 defaultValue={rowData.updatedQuantity}
+                onChange={(e) => {
+                  controller.onChange(e.target.value, rowData);
+                }}
                 onKeyDown={(e) => {
                   const key = e.charCode ? e.charCode : e.keyCode;
                   if (key === 13) {
-                    controller.onChange(e.target.value, rowData);
                     controller.saveUpstreamSubscriptions();
                     e.preventDefault();
                   }
                 }}
               />
-              <div>{__('Max')} {rowData.quantity}</div>
+              {controller.quantityValidationInput(rowData) === 'error' &&
+                <HelpBlock>{controller.quantityValidation(rowData)[1]}</HelpBlock>}
             </FormGroup>
           </td>
         ),

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/UpstreamSubscriptionsPage.test.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/UpstreamSubscriptionsPage.test.js
@@ -8,15 +8,59 @@ import { loadUpstreamSubscriptions, saveUpstreamSubscriptions } from '../Upstrea
 jest.mock('../../../../move_to_foreman/foreman_toast_notifications');
 
 describe('upstream subscriptions page', () => {
-  const mockHistory = { push: () => {} };
-
-  it('should render', async () => {
-    const page = shallow(<UpstreamSubscriptionsPage
+  let shallowWrapper;
+  beforeEach(() => {
+    shallowWrapper = shallow(<UpstreamSubscriptionsPage
       upstreamSubscriptions={successState}
       loadUpstreamSubscriptions={loadUpstreamSubscriptions}
       saveUpstreamSubscriptions={saveUpstreamSubscriptions}
       history={mockHistory}
     />);
-    expect(toJson(page)).toMatchSnapshot();
+  });
+  const mockHistory = { push: () => {} };
+
+  it('should render', async () => {
+    expect(toJson(shallowWrapper)).toMatchSnapshot();
+  });
+
+  it('should validate correct subscription quantities', async () => {
+    const validPools = [
+      { available: 10, updatedQuantity: 5 },
+      { available: 10, updatedQuantity: '5' },
+      { available: 10, updatedQuantity: '10' },
+      { available: 10, updatedQuantity: '1' },
+      { available: -1, updatedQuantity: '1000' },
+    ];
+    validPools.forEach((pool, i) => {
+      // using object with index attribute to print out index on failure,
+      // jest doesn't support messages on failure :(
+      const result = shallowWrapper.instance().quantityValidation(pool)[0];
+      expect({ index: i, result }).toEqual({ index: i, result: true });
+    });
+  });
+
+  it('should invalidate incorrect subscription quantities', async () => {
+    const invalidPools = [
+      { available: 10, updatedQuantity: 11 },
+      { available: 10, updatedQuantity: 'foo' },
+      { available: 10, updatedQuantity: 0 },
+      { available: 10, updatedQuantity: '0' },
+      { available: 10, updatedQuantity: '11' },
+      { available: 10, updatedQuantity: '2.0' },
+      { available: 10, updatedQuantity: '2/3' },
+      { available: -1, updatedQuantity: '-1' },
+      { available: -1, updatedQuantity: '0' },
+      { available: -1, updatedQuantity: 'foo' },
+      { available: -1, updatedQuantity: '2/3' },
+      { available: -1, updatedQuantity: '2.0' },
+      { available: -1, updatedQuantity: '99999999999' },
+    ];
+
+    invalidPools.forEach((pool, i) => {
+      // using object with index attribute to print out index on failure,
+      // jest doesn't support messages on failure :(
+      const result = shallowWrapper.instance().quantityValidation(pool)[0];
+      expect({ index: i, result }).toEqual({ index: i, result: false });
+    });
   });
 });

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/__snapshots__/UpstreamSubscriptionsPage.test.js.snap
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/__snapshots__/UpstreamSubscriptionsPage.test.js.snap
@@ -107,7 +107,7 @@ exports[`upstream subscriptions page should render 1`] = `
                   ],
                   "label": "Available Entitlements",
                 },
-                "property": "quantity",
+                "property": "available",
               },
               Object {
                 "cell": Object {
@@ -193,7 +193,7 @@ exports[`upstream subscriptions page should render 1`] = `
           block={false}
           bsClass="btn"
           bsStyle="primary"
-          disabled={false}
+          disabled={true}
           onClick={[Function]}
           type="submit"
         >


### PR DESCRIPTION
This commit adds validation for the text fields in the
"Add Subscriptions" page. The validation is handled by:
- The submit button being grey when no subscriptions
  are selected, so the user can't submit a request
  with no subscriptions checked
- The text box turning green or red depending on if the
  quantity is valid
- The quantity values being checked on submission, and
  showing an error notification if its invalid. This
  prevents a bad request from being sent to the API

In addition, the Quantity column on the table has changed
to "Available". This is because the available subscriptions
is the max amount that can be added. Since this quantity is
shown and visual feedback is given to the user if they
exceed this, there is no need for the "MAX" text under the
text box. This closely mirrors the functionality of the Red
Hat Portal.