### PR TITLE
fixes #24304 - fix remote execution pkg actions

### DIFF
--- a/app/controllers/katello/remote_execution_controller.rb
+++ b/app/controllers/katello/remote_execution_controller.rb
@@ -15,6 +15,12 @@ module Katello
         end
       end
 
+      # to overcome the isolated namespace engine difficulties with paths
+      helper Rails.application.routes.url_helpers
+      def _routes
+        Rails.application.routes
+      end
+
       private
 
       def prepare_composer
@@ -42,12 +48,6 @@ module Katello
       def feature_name
         # getting packageInstall from UI, translating to 'katello_package_install' feature
         "katello_#{params[:remote_action].underscore}"
-      end
-
-      # to overcome the isolated namespace engine difficulties with paths
-      helper Rails.application.routes.url_helpers
-      def _routes
-        Rails.application.routes
       end
     end
   else

--- a/db/seeds.d/75-job_templates.rb
+++ b/db/seeds.d/75-job_templates.rb
@@ -7,10 +7,13 @@ if Katello.with_remote_execution?
         sync = !Rails.env.test? && Setting[:remote_execution_sync_templates]
         # import! was renamed to import_raw! around 1.3.1
         if JobTemplate.respond_to?('import_raw!')
-          JobTemplate.import_raw!(File.read(template), :default => true, :locked => true, :update => sync)
+          template = JobTemplate.import_raw!(File.read(template), :default => true, :locked => true, :update => sync)
         else
-          JobTemplate.import!(File.read(template), :default => true, :locked => true, :update => sync)
+          template = JobTemplate.import!(File.read(template), :default => true, :locked => true, :update => sync)
         end
+
+        template.organizations << Organization.unscoped.all if template && template.organizations.empty?
+        template.locations << Location.unscoped.all if template && template.locations.empty?
       end
     end
   end


### PR DESCRIPTION
Currently, Katello job templates are not in the default taxonomies so
actions do not work out of the box. Additionally, once you place them in
the taxonomies, you get an error that the_routes method is private.