### PR TITLE
Fixes #24188 - Filter by OSTree on RH Repos

### DIFF
--- a/webpack/redux/actions/RedHatRepositories/helpers.js
+++ b/webpack/redux/actions/RedHatRepositories/helpers.js
@@ -1,9 +1,9 @@
 const repoTypeSearchQueryMap = {
-  rpm: '(name ~ rpms) and (name !~ source rpm) and (name !~ debug rpm)',
-  sourceRpm: 'name ~ source rpm',
-  debugRpm: 'name ~ debug rpm',
-  kickstart: 'name ~ kickstart',
-  ostree: 'name ~ ostree',
+  rpm: '(name !~ source rpm) and (name !~ debug rpm) and (content_type = yum)',
+  sourceRpm: '(name ~ source rpm) and (content_type = yum)',
+  debugRpm: '(name ~ debug rpm) and (content_type = yum)',
+  kickstart: 'content_type = kickstart',
+  ostree: 'content_type = ostree',
   beta: 'name ~ beta',
 };
 


### PR DESCRIPTION
This commit corrects the 'scope search' parameter
used by the "Filter by" dropdown on the RH Repos page
to search OSTree and other content types.