### PR TITLE
fixes #24319 - repo description as text area

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -15,7 +15,7 @@
       <dd>{{ repository.label }}</dd>
 
       <dt translate>Description</dt>
-      <dd bst-edit-text="repository.description"
+      <dd bst-edit-textarea="repository.description"
 	  on-save="save(repository)"
 	  readonly="product.redhat || denied('edit_products', product)">
       </dd>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -24,7 +24,7 @@
       </div>
 
       <div bst-form-group label="{{ 'Description' | translate }}">
-        <input id="description"
+        <textarea id="description"
 	       name="description"
 	       ng-model="repository.description"
 	       type="text"/>


### PR DESCRIPTION
@jturel @johnsonm325 - Give this a look: Changed UI to be a text area instead of a single line UI.