### PR TITLE
Fixes #24324 - Update eslint commands and fix issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test:current": "jest webpack --watch",
     "format": "prettier --single-quote --trailing-comma es5 --write 'webpack/**/*.js'",
     "build": "npm run format && npm run lint",
-    "lint": "eslint --fix webpack/ || exit 0"
+    "lint": "eslint webpack/ || exit 0",
+    "lint:fix": "eslint --fix webpack/ || exit 0"
   },
   "repository": {
     "type": "git",

--- a/webpack/scenes/RedHatRepositories/components/SearchBar.js
+++ b/webpack/scenes/RedHatRepositories/components/SearchBar.js
@@ -97,7 +97,7 @@ class SearchBar extends Component {
         <MultiSelect
           value={this.state.filters}
           options={filterOptions}
-          noneSelectedText={__("Filter by type")}
+          noneSelectedText={__('Filter by type')}
           onChange={(e) => {
             const values = [...e.target.options]
               .filter(({ selected }) => selected)

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/UpstreamSubscriptionsPage.test.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/UpstreamSubscriptionsPage.test.js
@@ -9,6 +9,7 @@ jest.mock('../../../../move_to_foreman/foreman_toast_notifications');
 
 describe('upstream subscriptions page', () => {
   let shallowWrapper;
+  const mockHistory = { push: () => {} };
   beforeEach(() => {
     shallowWrapper = shallow(<UpstreamSubscriptionsPage
       upstreamSubscriptions={successState}
@@ -17,7 +18,6 @@ describe('upstream subscriptions page', () => {
       history={mockHistory}
     />);
   });
-  const mockHistory = { push: () => {} };
 
   it('should render', async () => {
     expect(toJson(shallowWrapper)).toMatchSnapshot();


### PR DESCRIPTION
This is to prepare our codebase for eslint being added
to jenkins. Currently we do not run linting tasks for
code in webpack/ on PRs using jenkins. I've changed
the tasks to `npm run lint`, which runs eslint normally
and `npm run lint:fix`, which runs `eslint` with `--fix`.
I also corrected any eslint issues.

There will be an accompanying PR to foreman-infra to add
`npm run lint` to the jenkins job, so it runs on PRs.

To test, run `npm run lint` and make sure there are no errors.