### PR TITLE
fixes #24334 - remove sourcerpm as field of srpm

### DIFF
--- a/app/services/katello/pulp/srpm.rb
+++ b/app/services/katello/pulp/srpm.rb
@@ -4,7 +4,7 @@ module Katello
       include LazyAccessor
 
       PULP_SELECT_FIELDS = %w(name epoch version release arch checksumtype checksum).freeze
-      PULP_INDEXED_FIELDS = %w(name version release arch epoch summary sourcerpm checksum filename _id).freeze
+      PULP_INDEXED_FIELDS = %w(name version release arch epoch summary checksum filename _id).freeze
       CONTENT_TYPE = "srpm".freeze
 
       lazy_accessor :pulp_facts, :initializer => :backend_data


### PR DESCRIPTION
There's two options to fix this bug.  Remove sourcerpm as an indexed field, or add a migration to add sourcerpm to the Srpm model. I did option one, but I'm not sure if that's the right solution.

I couldn't actually find an SRPM which had a sourcerpm itself in the wild, but they must exist because there are several Red Hat customer cases showing these tracebacks.  You can mimic the behavior, though.

1. Upload any old SRPM to Katello:

```
# hammer -u admin -p changeme product create --organization-id 1 --name SRPM
# hammer -u admin -p changeme repository create --product SRPM --organization-id 1 --name SRPM --content-type yum
# hammer -u admin -p changeme repository upload-content --product SRPM --name SRPM --path /tmp/pulp-python-2.1.0-0.1.alpha.201807200502gitfabd48c.fc26.src.rpm
```

2. Hack the ~~gibson~~ mongo database so the sourcerpm has a sourcerpm

```
# scl enable rh-mongodb34 /bin/bash
# mongo
> use pulp_database
> db.units_srpm.updateOne({"_id": "7ddfd579-3b37-4f01-8610-40c04c97cb56"}, {$set: {"sourcerpm": "walrus-0.71-1.src.rpm"}}, {})
```
3. Run the reimporter and watch it fail:

```
# rake katello:reimport
NoMethodError: undefined method `sourcerpm' for #<Katello::Srpm:0x0000000b1bad18>
/home/vagrant/.rvm/gems/ruby-2.4.1/gems/activemodel-5.1.6/lib/active_model/attribute_methods.rb:435:in `method_missing'
```

4. Apply this PR.  Run reimporter again. Everything is happy.