### PR TITLE
fixes #24265 - repo discovery w/ gpg_key_id

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery-create.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery-create.html
@@ -44,7 +44,7 @@
 
     <div bst-form-group ng-show="createRepoChoices.newProduct === 'true' && contentCredentials.length !== 0"
          label="{{ 'GPG Key' | translate }}">
-      <select class="form-control" ng-model="createRepoChoices.product.content_credential_id"
+      <select class="form-control" ng-model="createRepoChoices.product.gpg_key_id"
               ng-options="content_credential.id as content_credential.name for content_credential in contentCredentials"/>
     </div>
 


### PR DESCRIPTION
Correctly passes up product create gpg_key_id when repo discovery adding to a new product.