### PR TITLE
Fixes #24337 - Add robottelo to ActiveSupport tests

### DIFF
--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -147,6 +147,7 @@ class ActionController::TestCase
 end
 
 class ActiveSupport::TestCase
+  extend Robottelo::Reporter::TestAttributes
   include FactoryBot::Syntax::Methods
   include FixtureTestCase
   include ForemanTasks::TestHelpers::WithInThreadExecutor


### PR DESCRIPTION
@ldjebran I was seeing a test failure on the organization model. This should fix it.