### PR TITLE
Fixes #24336 - upgrade jest and fix errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "format": "prettier --single-quote --trailing-comma es5 --write 'webpack/**/*.js'",
     "build": "npm run format && npm run lint",
     "lint": "eslint webpack/ || exit 0",
-    "lint:fix": "eslint --fix webpack/ || exit 0"
+    "lint:fix": "eslint --fix webpack/ || exit 0",
+    "lint:test": "npm run lint && npm test"
   },
   "repository": {
     "type": "git",
@@ -23,7 +24,7 @@
     "@storybook/react": "^3.2.17",
     "@storybook/storybook-deployer": "^2.0.0",
     "babel-core": "^6.26.3",
-    "babel-jest": "^21.2.0",
+    "babel-jest": "^23.4.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-polyfill": "^6.26.0",
@@ -35,11 +36,11 @@
     "eslint": "^4.8.0",
     "eslint-config-airbnb": "^16.0.0",
     "eslint-plugin-import": "^2.7.0",
-    "eslint-plugin-jest": "^21.2.0",
+    "eslint-plugin-jest": "^21.18.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.4.0",
     "identity-obj-proxy": "^3.0.0",
-    "jest": "^21.2.1",
+    "jest": "^23.4.1",
     "prettier": "^1.7.4",
     "react-test-renderer": "^16.0.0",
     "redux-mock-store": "^1.3.0",
@@ -73,6 +74,7 @@
       "raf/polyfill",
       "./webpack/test_setup.js"
     ],
+    "setupTestFrameworkScriptFile": "./webpack/global_test_setup.js",
     "testPathIgnorePatterns": [
       "/node_modules/",
       "<rootDir>/foreman/",

--- a/webpack/components/Search/Search.test.js
+++ b/webpack/components/Search/Search.test.js
@@ -1,17 +1,19 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
+import { mock as mockApi } from '../../mockRequest';
 
 import Search from '../Search';
 
 describe('Search component', () => {
   const getBaseProps = () => ({
     onSearch: () => {},
-    getAutoCompleteParams: () => ({}),
+    getAutoCompleteParams: () => ({ endpoint: '/fake' }),
   });
 
   describe('rendering', () => {
     it('renders correctly', () => {
+      mockApi.onGet('/katello/api/v2/fake').reply(200, []);
       const component = shallow(<Search {...getBaseProps()} />);
 
       expect(toJson(component)).toMatchSnapshot();

--- a/webpack/global_test_setup.js
+++ b/webpack/global_test_setup.js
@@ -1,0 +1,6 @@
+// runs before each test to make sure console.error output will
+// fail a test (i.e. default PropType missing). Check the error
+// output and traceback for actual error.
+global.console.error = (error) => {
+  throw new Error(error);
+};

--- a/webpack/move_to_foreman/components/common/table/components/__snapshots__/CollapseSubscriptionGroupButton.test.js.snap
+++ b/webpack/move_to_foreman/components/common/table/components/__snapshots__/CollapseSubscriptionGroupButton.test.js.snap
@@ -4,7 +4,7 @@ exports[`CollapseSubscriptionGroupButton renders CollapseSubscriptionGroupButton
 <Icon
   className="collapse-subscription-group-button"
   name="angle-right"
-  onClick={[Function]}
+  onClick={[MockFunction]}
   type="fa"
 />
 `;
@@ -13,7 +13,7 @@ exports[`CollapseSubscriptionGroupButton renders CollapseSubscriptionGroupButton
 <Icon
   className="collapse-subscription-group-button"
   name="angle-down"
-  onClick={[Function]}
+  onClick={[MockFunction]}
   type="fa"
 />
 `;

--- a/webpack/move_to_foreman/components/common/table/components/__snapshots__/TableSelectionCell.test.js.snap
+++ b/webpack/move_to_foreman/components/common/table/components/__snapshots__/TableSelectionCell.test.js.snap
@@ -9,7 +9,7 @@ exports[`TableSelectionCell renders TableSelectionCell 1`] = `
     checked={true}
     id="some id"
     label="some label"
-    onChange={[Function]}
+    onChange={[MockFunction]}
   />
   some after
 </TableSelectionCell>

--- a/webpack/move_to_foreman/components/common/table/components/__snapshots__/TableSelectionHeaderCell.test.js.snap
+++ b/webpack/move_to_foreman/components/common/table/components/__snapshots__/TableSelectionHeaderCell.test.js.snap
@@ -9,7 +9,7 @@ exports[`TableSelectionHeaderCell renders TableSelectionHeaderCell 1`] = `
     checked={true}
     id="some id"
     label="some label"
-    onChange={[Function]}
+    onChange={[MockFunction]}
   />
 </TableSelectionHeading>
 `;

--- a/webpack/scenes/Subscriptions/Details/__tests__/SubscriptionDetails.test.js
+++ b/webpack/scenes/Subscriptions/Details/__tests__/SubscriptionDetails.test.js
@@ -13,10 +13,12 @@ jest.mock('../../../../move_to_foreman/foreman_toast_notifications');
 describe('subscriptions details page', () => {
   it('should render and contain appropiate components', async () => {
     const match = { params: { id: 1 } };
+    const noop = () => {};
 
     const wrapper = shallow(<SubscriptionDetails
       loadSubscriptionDetails={loadSubscriptionDetails}
       subscriptionDetails={successState}
+      history={{ push: noop }}
       match={match}
     />);
     expect(wrapper.find(SubscriptionDetailAssociations)).toHaveLength(1);

--- a/webpack/scenes/Subscriptions/Manifest/__tests__/ManageManifestModal.test.js
+++ b/webpack/scenes/Subscriptions/Manifest/__tests__/ManageManifestModal.test.js
@@ -17,6 +17,7 @@ describe('manage manifest modal', () => {
       organization={organization}
       loadOrganization={noop}
       saveOrganization={noop}
+      bulkSearch={noop}
       manifestHistory={manifestHistorySuccessState}
       taskInProgress={false}
       showModal

--- a/webpack/scenes/Subscriptions/SubscriptionReducer.js
+++ b/webpack/scenes/Subscriptions/SubscriptionReducer.js
@@ -87,7 +87,7 @@ export default (state = initialState, action) => {
     case SUBSCRIPTIONS_QUANTITIES_REQUEST:
       return state.merge({
         quantitiesLoading: true,
-        availableQuantities: null
+        availableQuantities: null,
       });
 
     case SUBSCRIPTIONS_QUANTITIES_SUCCESS: {
@@ -100,7 +100,7 @@ export default (state = initialState, action) => {
     case SUBSCRIPTIONS_QUANTITIES_FAILURE: {
       return state.merge({
         quantitiesLoading: false,
-        availableQuantities: {}
+        availableQuantities: {},
       });
     }
 

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsPage.js
@@ -266,7 +266,6 @@ class UpstreamSubscriptionsPage extends Component {
 }
 
 UpstreamSubscriptionsPage.propTypes = {
-  history: PropTypes.shape({ push: PropTypes.func }).isRequired,
   loadUpstreamSubscriptions: PropTypes.func.isRequired,
   saveUpstreamSubscriptions: PropTypes.func.isRequired,
   upstreamSubscriptions: PropTypes.shape({

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/SubscriptionsTable.test.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/SubscriptionsTable.test.js
@@ -21,6 +21,7 @@ describe('subscriptions table', () => {
             onSubscriptionDeleteModalClose={() => { }}
             onDeleteSubscriptions={() => {}}
             toggleDeleteButton={() => {}}
+            emptyState={{}}
           />
                         </MemoryRouter>);
     expect(toJson(page)).toMatchSnapshot();
@@ -58,6 +59,7 @@ describe('subscriptions table', () => {
       onSubscriptionDeleteModalClose={() => { }}
       onDeleteSubscriptions={() => {}}
       toggleDeleteButton={() => {}}
+      emptyState={{}}
     />);
     jest.runAllTimers();
     page.update();

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`subscriptions table should render a loading state 1`] = `
 <SubscriptionsTable
+  emptyState={Object {}}
   loadSubscriptions={[Function]}
   onDeleteSubscriptions={[Function]}
   onSubscriptionDeleteModalClose={[Function]}


### PR DESCRIPTION
This does a few things:
- upgrades jest to 23.4.1 and adds new snapshots
  to be compatible  with the new version.
- adds a script to run before every test that makes
  the test fail when there are console errors. This
  is helpful in catching missing propTypes from the
  tests, since those will print console errors, but
  not actually fail the test itself.
- Fixes PropType errors.
- Fixes unhandled promise warning.