### PR TITLE
Fixes #24339 - Added Org Label for Subs CSV

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -178,6 +178,15 @@ module Katello
       return Organization.find_by(:id => org_id)
     end
 
+    def csv_response(resources, columns = csv_columns, header = nil, filename = nil)
+      if filename || Organization.current.blank?
+        super
+      else
+        filename = "#{Organization.current.label}-#{controller_name}-#{Date.today}.csv"
+        super(resources, columns, header, filename)
+      end
+    end
+
     def find_default_organization_and_or_environment
       return if (params.keys & %w(organization_id owner environment_id host_collection_id)).any?
 

--- a/test/controllers/api/v2/subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/subscriptions_controller_test.rb
@@ -41,6 +41,16 @@ module Katello
       assert_template 'api/v2/subscriptions/index'
     end
 
+    def test_index_csv
+      Pool.expects(:get_for_organization).returns(Pool.all)
+      get :index, params: {:format => 'csv', :organization_id => @organization.id }
+      assert_response :success
+      assert_equal "text/csv; charset=utf-8", response.headers["Content-Type"]
+      assert_equal "no-cache", response.headers["Cache-Control"]
+      assert_equal "attachment; filename=\"#{@organization.label}-subscriptions-#{Date.today}.csv\"",
+        response.headers["Content-Disposition"]
+    end
+
     def test_index_protected
       allowed_perms = [@read_permission]
       denied_perms = [@attach_permission, @unattach_permission, @import_permission, @delete_permission]

--- a/test/controllers/foreman/hosts_controller_test.rb
+++ b/test/controllers/foreman/hosts_controller_test.rb
@@ -49,7 +49,8 @@ class HostsControllerTest < ActionController::TestCase
       get :content_hosts, params: { :format => 'csv', :organization_id => @host.organization_id }
       assert_equal "text/csv; charset=utf-8", response.headers["Content-Type"]
       assert_equal "no-cache", response.headers["Cache-Control"]
-      assert_equal "attachment; filename=\"hosts-#{Date.today}.csv\"", response.headers["Content-Disposition"]
+      assert_equal "attachment; filename=\"hosts-#{Date.today}.csv\"",
+        response.headers["Content-Disposition"]
       buf = response.stream.instance_variable_get(:@buf)
       assert buf.is_a? Enumerator
       assert_equal "Name,Subscription Status,Installable Updates - Security,Installable Updates - Bug \


### PR DESCRIPTION
As a part of Content-> Subscriptions -> Export CSV
this commit prefixes the Org label to the subscriptions csv file.
