### PR TITLE
Fixes #24354: update react-bootstrap to 0.32.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "patternfly-react": "^2.5.1",
     "prop-types": "^15.6.0",
     "react": "^16.3.1",
-    "react-bootstrap": "^0.31.5",
+    "react-bootstrap": "^0.32.1",
     "react-bootstrap-tooltip-button": "^1.0.6",
     "react-dom": "^16.3.1",
     "react-ellipsis-with-tooltip": "^1.0.7",


### PR DESCRIPTION
Need to update react-bootstrap to 0.32.1 to fix the black modal
background.

https://projects.theforeman.org/issues/24354