### PR TITLE
Fixes #24310 - RH repos disable notify on error

### DIFF
--- a/webpack/scenes/RedHatRepositories/components/EnabledRepositoryContent.js
+++ b/webpack/scenes/RedHatRepositories/components/EnabledRepositoryContent.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import { Spinner, OverlayTrigger, Tooltip } from 'patternfly-react';
+
+const EnabledRepositoryContent = ({ loading, disableTooltipId, disableRepository }) => (
+  <Spinner loading={loading} inline>
+    <OverlayTrigger
+      overlay={<Tooltip id={disableTooltipId}>{__('Disable')}</Tooltip>}
+      placement="bottom"
+      trigger={['hover', 'focus']}
+      rootClose={false}
+    >
+      <button
+        onClick={disableRepository}
+        style={{
+            backgroundColor: 'initial',
+            border: 'none',
+            color: '#0388ce',
+          }}
+      >
+        <i className={cx('fa-2x', 'fa fa-minus-circle')} />
+      </button>
+    </OverlayTrigger>
+  </Spinner>
+);
+
+EnabledRepositoryContent.propTypes = {
+  loading: PropTypes.bool.isRequired,
+  disableTooltipId: PropTypes.string.isRequired,
+  disableRepository: PropTypes.func.isRequired,
+};
+
+export default EnabledRepositoryContent;

--- a/webpack/scenes/RedHatRepositories/components/__tests__/EnabledRepository.test.js
+++ b/webpack/scenes/RedHatRepositories/components/__tests__/EnabledRepository.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import thunk from 'redux-thunk';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import configureMockStore from 'redux-mock-store';
+import EnabledRepository from '../EnabledRepository';
+
+jest.mock('../../../../move_to_foreman/foreman_toast_notifications');
+
+const mockStore = configureMockStore([thunk]);
+const store = mockStore({});
+
+describe('Enabled Repositories Component', () => {
+  let shallowWrapper;
+  beforeEach(() => {
+    shallowWrapper = shallow(<EnabledRepository
+      store={store}
+      id={1}
+      contentId={1}
+      productId={1}
+      name="foo"
+      type="foo"
+      arch="foo"
+      releaseVer="1.1.1"
+      setRepositoryDisabled={() => {}}
+    />);
+  });
+
+  afterEach(() => {
+    store.clearActions();
+  });
+
+  it('should render', async () => {
+    expect(toJson(shallowWrapper)).toMatchSnapshot();
+  });
+});

--- a/webpack/scenes/RedHatRepositories/components/__tests__/EnabledRepositoryContent.test.js
+++ b/webpack/scenes/RedHatRepositories/components/__tests__/EnabledRepositoryContent.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import EnabledRepositoryContent from '../EnabledRepositoryContent';
+
+describe('Enabled Repositories Content Component', () => {
+  const mockCallBack = jest.fn();
+
+  let shallowWrapper;
+  beforeEach(() => {
+    shallowWrapper = shallow(<EnabledRepositoryContent
+      loading
+      disableTooltipId="disable-1"
+      disableRepository={mockCallBack}
+    />);
+  });
+
+  it('should render', async () => {
+    expect(toJson(shallowWrapper)).toMatchSnapshot();
+  });
+
+  it('should run disableRepository on click', async () => {
+    expect(mockCallBack).not.toHaveBeenCalled();
+    shallowWrapper.find('button').at(0).simulate('click');
+    expect(mockCallBack).toHaveBeenCalled();
+  });
+});

--- a/webpack/scenes/RedHatRepositories/components/__tests__/__snapshots__/EnabledRepository.test.js.snap
+++ b/webpack/scenes/RedHatRepositories/components/__tests__/__snapshots__/EnabledRepository.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Enabled Repositories Component should render 1`] = `
+<EnabledRepository
+  arch="foo"
+  contentId={1}
+  id={1}
+  name="foo"
+  productId={1}
+  releaseVer="1.1.1"
+  releasever=""
+  setRepositoryDisabled={[Function]}
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+  type="foo"
+/>
+`;

--- a/webpack/scenes/RedHatRepositories/components/__tests__/__snapshots__/EnabledRepositoryContent.test.js.snap
+++ b/webpack/scenes/RedHatRepositories/components/__tests__/__snapshots__/EnabledRepositoryContent.test.js.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Enabled Repositories Content Component should render 1`] = `
+<Spinner
+  className=""
+  inline={true}
+  inverse={false}
+  loading={true}
+  size="md"
+>
+  <OverlayTrigger
+    defaultOverlayShown={false}
+    overlay={
+      <Tooltip
+        bsClass="tooltip"
+        id="disable-1"
+        placement="right"
+      >
+        Disable
+      </Tooltip>
+    }
+    placement="bottom"
+    rootClose={false}
+    trigger={
+      Array [
+        "hover",
+        "focus",
+      ]
+    }
+  >
+    <button
+      onClick={[MockFunction]}
+      style={
+        Object {
+          "backgroundColor": "initial",
+          "border": "none",
+          "color": "#0388ce",
+        }
+      }
+    >
+      <i
+        className="fa-2x fa fa-minus-circle"
+      />
+    </button>
+  </OverlayTrigger>
+</Spinner>
+`;


### PR DESCRIPTION
This commit adds error handling  to the API call to disable
a repository.

Its also added some linting updates unrelated to this
change as some recent changes broke the linter (due
to our recent addition of the lint step to jenkins,
some PRs didn't have the lint step ran and were merged)

To test, sync a RH repo, add to content view and promote in
content view version. Then, try to disable the repository.