### PR TITLE
fixes #24376 - ks repo and medium are mutually exlcusive

### DIFF
--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -34,8 +34,6 @@ module Katello
     end
 
     def kickstart_repository_id(host, options = {})
-      return if host.try(:medium_id).present?
-
       host_ks_repo_id = host_hostgroup_kickstart_repository_id(host)
       ks_repo_options = kickstart_repository_options(host, options)
       # if the kickstart repo id is set in the selected_hostgroup use that

--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -17,6 +17,18 @@ module Katello
         scoped_search :relation => :content_source, :on => :name, :complete_value => true, :rename => :content_source, :only_explicit => true
         scoped_search :relation => :content_view, :on => :name, :complete_value => true, :rename => :content_view, :only_explicit => true
         scoped_search :relation => :lifecycle_environment, :on => :name, :complete_value => true, :rename => :lifecycle_environment, :only_explicit => true
+
+        before_validation :correct_kickstart_repository
+      end
+
+      def correct_kickstart_repository
+        # If switched from ks repo to install media:
+        if medium_id_changed? && medium && kickstart_repository_id
+          self.kickstart_repository_id = nil
+        # If switched from install media to ks repo:
+        elsif kickstart_repository && medium
+          self.medium = nil
+        end
       end
 
       def content_view


### PR DESCRIPTION
For provisioning, you can use either synced content or installation
media. The former is provided by Katello, and they should be an
either-or proposition, however, this isn't enforced anywhere. This causes
bugs if you want to switch between them. Another bug that occurs is if
Foreman changes a Host's operating system based on facts, we need
to ensure the kickstart_repo is updated correctly.

For the first issue:

1. Sync a repository with a distribution (e.g. RHEL 7.3 Kickstart)

2. Create an operating system of a different version, say CentOS 7.5 and have it use Foreman's CentOS installation media

3. Create a hostgroup with the synced content selected and save it.  You'll have to select a content view, environment, and content source to see the synced content sources.

4. Try to change the host group to CentOS 7.5 using installation media,
you'll get an error: "The selected kickstart repository is not part of
the assigned content view, lifecycle environment, content source,
operating system, and architecture"

5. Apply this PR, and freely switch back and forth

