### PR TITLE
Fixes #24311 - add default value to pagination row

### DIFF
--- a/webpack/components/PaginationRow/index.js
+++ b/webpack/components/PaginationRow/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Paginator } from 'patternfly-react';
 import { isEqual } from 'lodash';
 
-const defaultPerPageOptions = [5, 10, 15, 25, 50];
+const defaultPerPageOptions = [5, 10, 15, 20, 25, 50];
 
 const initPagination = (props) => {
   const pagination = props.pagination || {};

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
@@ -311,6 +311,18 @@ exports[`subscriptions table should render a table 1`] = `
               role="menuitem"
               tabindex="-1"
             >
+              20
+            </a>
+          </li>
+          <li
+            class=""
+            role="presentation"
+          >
+            <a
+              href="#"
+              role="menuitem"
+              tabindex="-1"
+            >
               25
             </a>
           </li>


### PR DESCRIPTION
On the Subscriptions page, the default pagination is 20. However, if user changes it he cannot reselect it.