### PR TITLE
Fixes #24390 - Content Source is inherited when creating host

### DIFF
--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -35,12 +35,11 @@ end %>
 <% cs_select_name =  using_hostgroups_page? ? 'hostgroup[content_source_id]' : 'host[content_facet_attributes][content_source_id]' %>
 <% cs_select_attr = using_hostgroups_page? ? 'content_source' : 'content_facet.content_source' %>
 
-<% proxies = accessible_content_proxies(@host || @hostgroup) %>
 <%= field(f, cs_select_attr, {:label => _("Content Source")}) do
   if using_hostgroups_page?
-    select_tag cs_select_id, options_from_collection_for_select(proxies, :id, :name, @hostgroup.content_source_id), :data => {"spinner_path" => spinner_path},
+    select_tag cs_select_id, content_source_options(@hostgroup, :selected_host_group => @hostgroup.hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)), :data => {"spinner_path" => spinner_path},
                :class => 'form-control',  :name => cs_select_name, include_blank: true
   else
-    select_tag cs_select_id, options_from_collection_for_select(proxies, :id, :name, @host.content_source_id), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cs_select_name, include_blank: true
+    select_tag cs_select_id, content_source_options(@host, :selected_host_group => @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_source)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cs_select_name, include_blank: true
   end
 end %>

--- a/test/helpers/hosts_and_hostgroups_helper_test.rb
+++ b/test/helpers/hosts_and_hostgroups_helper_test.rb
@@ -251,3 +251,44 @@ class HostsAndHostGroupsHelperKickstartRepositoryIDTest < HostsAndHostGroupsHelp
     assert_nil kickstart_repository_id(::Host.new, :selected_host_group => @hostgroup)
   end
 end
+
+class HostAndHostGroupsHelperContentSourceTests < HostsAndHostGroupsHelperTestBase
+  test 'options include inherited content source when provided' do
+    smart_proxy = FactoryBot.build_stubbed(
+      :smart_proxy,
+      :features => [FactoryBot.create(:feature, name: 'Pulp')]
+    )
+    hostgroup = FactoryBot.build_stubbed(
+      :hostgroup,
+      :content_source => smart_proxy
+    )
+    assert_equal(
+      hostgroup.content_source,
+      fetch_content_source(FactoryBot.build_stubbed(:host), :selected_host_group => hostgroup)
+    )
+  end
+
+  test 'if host has a content_source already, do not inherit from hostgroup' do
+    smart_proxy_hostgroup = FactoryBot.build_stubbed(
+      :smart_proxy,
+      :features => [FactoryBot.create(:feature, name: 'Pulp')]
+    )
+    smart_proxy_host = FactoryBot.build_stubbed(
+      :smart_proxy,
+      :features => [FactoryBot.create(:feature, name: 'Pulp')]
+    )
+    hostgroup = FactoryBot.build_stubbed(
+      :hostgroup,
+      :content_source => smart_proxy_hostgroup
+    )
+    host = FactoryBot.build_stubbed(
+      :host,
+      :hostgroup => hostgroup
+    )
+    host.content_source = smart_proxy_host
+    assert_equal(
+      smart_proxy_host,
+      fetch_content_source(host, :selected_host_group => hostgroup)
+    )
+  end
+end


### PR DESCRIPTION
Steps to Reproduce:
1. Create hostgroup with content source
2. Navigate to hosts -> create new host
3. Select hostgroup

Actual results: Content source field is not automatically populated
even though it is provided in hostgroup.

Expected results: Content source field should automatically populate
using value from selected hostgroup.

This is a regression.