### PR TITLE
Fixes #24398 - add 'danger' class to delete manifest button

### DIFF
--- a/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
+++ b/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
@@ -242,12 +242,20 @@ class ManageManifestModal extends Component {
                     />
 
                     <TooltipButton
-                      onClick={() => this.showDeleteManifestModal(true)}
+                      renderedButton={(
+                        <Button
+                          disabled={!manifestExists(organization) || actionInProgress}
+                          bsStyle="danger"
+                          onClick={() => this.showDeleteManifestModal(true)}
+                        >
+                          {__('Delete')}
+                        </Button>
+                        )}
+
                       tooltipId="delete-manifest-button-tooltip"
                       tooltipText={this.disabledTooltipText()}
                       tooltipPlacement="top"
-                      title={__('Delete')}
-                      disabled={!manifestExists(organization) || actionInProgress}
+
                     />
 
                     <ConfirmDialog

--- a/webpack/scenes/Subscriptions/Manifest/__tests__/__snapshots__/ManageManifestModal.test.js.snap
+++ b/webpack/scenes/Subscriptions/Manifest/__tests__/__snapshots__/ManageManifestModal.test.js.snap
@@ -167,9 +167,18 @@ exports[`manage manifest modal should render 1`] = `
                 tooltipText=""
               />
               <TooltipButton
-                disabled={true}
-                onClick={[Function]}
-                title="Delete"
+                renderedButton={
+                  <Button
+                    active={false}
+                    block={false}
+                    bsClass="btn"
+                    bsStyle="danger"
+                    disabled={true}
+                    onClick={[Function]}
+                  >
+                    Delete
+                  </Button>
+                }
                 tooltipId="delete-manifest-button-tooltip"
                 tooltipPlacement="top"
                 tooltipText="This is disabled because no manifest exists"


### PR DESCRIPTION
![fireshot capture 130 - - http___192 168 121 17_3000_subscriptions](https://user-images.githubusercontent.com/11807069/43272546-e77c74cc-9102-11e8-8de0-56d4d9a00150.png)
