### PR TITLE
Fixes #24423 - fix jest errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "seamless-immutable": "^7.1.2"
   },
   "jest": {
+    "testURL": "http://localhost/",
     "setupFiles": [
       "raf/polyfill",
       "./webpack/test_setup.js"


### PR DESCRIPTION
I'm not sure exactly why our tests started failing this way, but it seems to be due to a node package update. My best understanding of the fix is that local actions (like localStorage) need to have a reference to localhost. Documentation for this attribute is [here](https://jestjs.io/docs/en/configuration.html#testurl-string)