### PR TITLE
Fixes #24436 - use new api for pool consumer ids

### DIFF
--- a/app/lib/katello/resources/candlepin/pool.rb
+++ b/app/lib/katello/resources/candlepin/pool.rb
@@ -28,8 +28,8 @@ module Katello
             self.delete(path(id), self.default_headers).code.to_i
           end
 
-          def entitlements(pool_id, included = [])
-            entitlement_json = self.get("#{path(pool_id)}/entitlements?#{included_list(included)}", self.default_headers).body
+          def consumer_uuids(pool_id)
+            entitlement_json = self.get("#{path(pool_id)}/consumer_uuids", self.default_headers).body
             JSON.parse(entitlement_json)
           end
         end

--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -163,8 +163,7 @@ module Katello
       end
 
       def import_hosts
-        entitlements = Resources::Candlepin::Pool.entitlements(self.cp_id, ["consumer.uuid"])
-        uuids = entitlements.map { |ent| ent["consumer"]["uuid"] }
+        uuids = Resources::Candlepin::Pool.consumer_uuids(self.cp_id)
 
         sub_facet_ids_from_cp = Katello::Host::SubscriptionFacet.where(:uuid => uuids).select(:id).pluck(:id)
         sub_facet_ids_from_pool_table = Katello::SubscriptionFacetPool.where(:pool_id => self.id).select(:subscription_facet_id).pluck(:subscription_facet_id)


### PR DESCRIPTION
When indexing pool to subscription facet association, use
a new api that only returns the consumer uuids