### PR TITLE
Fixes #24292 - Fix CDN url input

### DIFF
--- a/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
+++ b/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Col, Tabs, Tab, Form, FormGroup, FormControl, ControlLabel } from 'react-bootstrap';
+import { Col, Tabs, Tab, Form, FormGroup, FormControl, ControlLabel, Row } from 'react-bootstrap';
 import { bindMethods, Button, Icon, Modal, Spinner, OverlayTrigger, Tooltip } from 'patternfly-react';
 import { isEqual } from 'lodash';
 import TooltipButton from 'react-bootstrap-tooltip-button';
@@ -33,6 +33,7 @@ class ManageManifestModal extends Component {
       'refreshManifest',
       'deleteManifest',
       'disabledTooltipText',
+      'updateRepositoryUrl',
     ]);
   }
 
@@ -70,8 +71,12 @@ class ManageManifestModal extends Component {
     this.props.onClose();
   }
 
-  saveOrganization(event) {
-    this.props.saveOrganization({ redhat_repository_url: event.target.value });
+  updateRepositoryUrl(event) {
+    this.setState({ redhat_repository_url: event.target.value });
+  }
+
+  saveOrganization() {
+    this.props.saveOrganization({ redhat_repository_url: this.state.redhat_repository_url });
   }
 
   uploadManifest(fileList) {
@@ -141,7 +146,11 @@ class ManageManifestModal extends Component {
         url: 'http://redhat.com',
       },
     });
-
+    const buttonLoading = (
+      <span>
+        {__('Updating...')}
+        <span className="fa fa-spinner fa-spin" />
+      </span>);
     const getManifestName = () => {
       let name = __('No Manifest Uploaded');
 
@@ -182,16 +191,25 @@ class ManageManifestModal extends Component {
                 <h5>{__('Red Hat Provider Details')}</h5>
                 <hr />
                 <FormGroup>
-                  <ControlLabel className="col-sm-3" htmlFor="cdnUrl">
-                    {__('Red Hat CDN URL')}
-                  </ControlLabel>
+                  <Col sm={3}>
+                    <ControlLabel htmlFor="cdnUrl">
+                      {__('Red Hat CDN URL')}
+                    </ControlLabel>
+                  </Col>
                   <Col sm={9}>
                     <FormControl
                       id="cdnUrl"
                       type="text"
-                      value={organization.redhat_repository_url || ''}
-                      onChange={this.saveOrganization}
+                      value={this.state.redhat_repository_url || organization.redhat_repository_url || ''}
+                      onChange={this.updateRepositoryUrl}
                     />
+                  </Col>
+                </FormGroup>
+                <FormGroup>
+                  <Col smOffset={3} sm={3}>
+                    <Button onClick={this.saveOrganization} disabled={organization.loading}>
+                      {organization.loading ? buttonLoading : __('Update')}
+                    </Button>
                   </Col>
                 </FormGroup>
                 <br />

--- a/webpack/scenes/Subscriptions/Manifest/__tests__/__snapshots__/ManageManifestModal.test.js.snap
+++ b/webpack/scenes/Subscriptions/Manifest/__tests__/__snapshots__/ManageManifestModal.test.js.snap
@@ -73,14 +73,19 @@ exports[`manage manifest modal should render 1`] = `
           <FormGroup
             bsClass="form-group"
           >
-            <ControlLabel
-              bsClass="control-label"
-              className="col-sm-3"
-              htmlFor="cdnUrl"
-              srOnly={false}
+            <Col
+              bsClass="col"
+              componentClass="div"
+              sm={3}
             >
-              Red Hat CDN URL
-            </ControlLabel>
+              <ControlLabel
+                bsClass="control-label"
+                htmlFor="cdnUrl"
+                srOnly={false}
+              >
+                Red Hat CDN URL
+              </ControlLabel>
+            </Col>
             <Col
               bsClass="col"
               componentClass="div"
@@ -94,6 +99,27 @@ exports[`manage manifest modal should render 1`] = `
                 type="text"
                 value="https://redhat.com"
               />
+            </Col>
+          </FormGroup>
+          <FormGroup
+            bsClass="form-group"
+          >
+            <Col
+              bsClass="col"
+              componentClass="div"
+              sm={3}
+              smOffset={3}
+            >
+              <Button
+                active={false}
+                block={false}
+                bsClass="btn"
+                bsStyle="default"
+                disabled={false}
+                onClick={[Function]}
+              >
+                Update
+              </Button>
             </Col>
           </FormGroup>
           <br />


### PR DESCRIPTION
While attempting to edit the cdn url field, on the manage manifest modal, there is no way to determine what is going on. When you try to delete the existing text, the entire field goes blank after a few backspaces. The field is still being edited, you just can't see it.

Additionally, when trying to paste or type text into the box, the same thing happens.

Since there is no 'save' button, a user likely wouldn't know if/when their suspected changes takes place.

![1c808e81-e8fc-4d8a-y8f0-525684852d0a](https://user-images.githubusercontent.com/11807069/43410310-24221ace-942f-11e8-85ff-aa0dcc327d75.gif)
