### PR TITLE
Fixes #24436 - use new api for pool consumer ids

### DIFF
--- a/app/lib/katello/resources/candlepin/pool.rb
+++ b/app/lib/katello/resources/candlepin/pool.rb
@@ -28,8 +28,8 @@ module Katello
             self.delete(path(id), self.default_headers).code.to_i
           end
 
-          def entitlements(pool_id, included = [])
-            entitlement_json = self.get("#{path(pool_id)}/entitlements?#{included_list(included)}", self.default_headers).body
+          def consumer_uuids(pool_id)
+            entitlement_json = self.get("#{path(pool_id)}/entitlements/consumer_uuids", self.default_headers).body
             JSON.parse(entitlement_json)
           end
         end

--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -163,8 +163,7 @@ module Katello
       end
 
       def import_hosts
-        entitlements = Resources::Candlepin::Pool.entitlements(self.cp_id, ["consumer.uuid"])
-        uuids = entitlements.map { |ent| ent["consumer"]["uuid"] }
+        uuids = Resources::Candlepin::Pool.consumer_uuids(self.cp_id)
 
         sub_facet_ids_from_cp = Katello::Host::SubscriptionFacet.where(:uuid => uuids).select(:id).pluck(:id)
         sub_facet_ids_from_pool_table = Katello::SubscriptionFacetPool.where(:pool_id => self.id).select(:subscription_facet_id).pluck(:subscription_facet_id)

--- a/test/fixtures/vcr_cassettes/scenarios/org_create.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/org_create.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://dev.example.com:8443/candlepin/owners/
+    uri: https://alpha.partello.example.com:8443/candlepin/owners/
     body:
       encoding: UTF-8
       base64_string: |
@@ -17,9 +17,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp",
-        oauth_nonce="OQE1VI9YCvf1cATKqWjMrkDGF6L1dalIkH09bZOltI", oauth_signature="8UcsP27sRl3NQFxPtGIrzr%2BMCmQ%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1528379902", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="f3SrjSXwpnyQJkiNLCAuePYsZU5UbVUw",
+        oauth_nonce="8ASzLbwwqkJk4dTIAsEBFd3nv2lFzALqkQbbDBGV05E", oauth_signature="zP3vdWQFmdryw3SJ3YeWmlyTZUo%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1532984101", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -36,21 +36,21 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 8ccf1313-7a57-4955-8ea2-571d73e818e5
+      - a0020342-7d26-4f52-8b86-7df75ce781da
       X-Version:
-      - 2.3.8-1
+      - 2.4.5-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 07 Jun 2018 13:58:21 GMT
+      - Mon, 30 Jul 2018 20:55:00 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOC0wNi0wN1QxMzo1ODoyMiswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTgtMDYtMDdUMTM6NTg6MjIrMDAwMCIsImlkIjoiNDAyOGY5NTE2
-        M2RhNWIxYjAxNjNkYThhODllNDAwMDAiLCJrZXkiOiJzY2VuYXJpb190ZXN0
+        eyJjcmVhdGVkIjoiMjAxOC0wNy0zMFQyMDo1NTowMSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMDctMzBUMjA6NTU6MDErMDAwMCIsImlkIjoiNDAyOGU5NDQ2
+        NGVjYzg0MzAxNjRlY2Y5MDljZDAwMDYiLCJrZXkiOiJzY2VuYXJpb190ZXN0
         IiwiZGlzcGxheU5hbWUiOiJzY2VuYXJpb190ZXN0IiwicGFyZW50T3duZXIi
         Om51bGwsImNvbnRlbnRQcmVmaXgiOiIvc2NlbmFyaW9fdGVzdC8kZW52Iiwi
         ZGVmYXVsdFNlcnZpY2VMZXZlbCI6bnVsbCwidXBzdHJlYW1Db25zdW1lciI6
@@ -59,10 +59,10 @@ http_interactions:
         Y2Vzc01vZGVMaXN0IjoiZW50aXRsZW1lbnQiLCJsYXN0UmVmcmVzaGVkIjpu
         dWxsLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0=
     http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:22 GMT
+  recorded_at: Mon, 30 Jul 2018 20:55:01 GMT
 - request:
     method: post
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/environments
+    uri: https://alpha.partello.example.com:8443/candlepin/owners/scenario_test/environments
     body:
       encoding: UTF-8
       base64_string: |
@@ -76,9 +76,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp",
-        oauth_nonce="EES9D8yA8Rt5yMUN7ksC95gVmbtyZtBbEwk5Gak4U0", oauth_signature="N83OjnRkxzpEKw1Xp6CvKCd6E%2Fg%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1528379902", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="f3SrjSXwpnyQJkiNLCAuePYsZU5UbVUw",
+        oauth_nonce="YUMMFSvb0atcvsCws1aEjQrs2GMzo655FWploaV3KNQ", oauth_signature="lhebjua%2FSaHuLaWGdwGczNfLeD0%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1532984101", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -95,30 +95,30 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 64f9102a-4e78-4a10-9640-1211b1019ffd
+      - 34f16d2c-ab15-42c3-a7a6-a228633efe38
       X-Version:
-      - 2.3.8-1
+      - 2.4.5-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 07 Jun 2018 13:58:21 GMT
+      - Mon, 30 Jul 2018 20:55:00 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOC0wNi0wN1QxMzo1ODoyMiswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTgtMDYtMDdUMTM6NTg6MjIrMDAwMCIsImlkIjoiMTE5YzQ3NTNm
+        eyJjcmVhdGVkIjoiMjAxOC0wNy0zMFQyMDo1NTowMSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMDctMzBUMjA6NTU6MDErMDAwMCIsImlkIjoiMTE5YzQ3NTNm
         ZjZkM2I3YmQwYjc2ZGU2ZDVhNWY5NGEiLCJuYW1lIjoiTGlicmFyeSIsImRl
-        c2NyaXB0aW9uIjpudWxsLCJvd25lciI6eyJpZCI6IjQwMjhmOTUxNjNkYTVi
-        MWIwMTYzZGE4YTg5ZTQwMDAwIiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRp
+        c2NyaXB0aW9uIjpudWxsLCJvd25lciI6eyJpZCI6IjQwMjhlOTQ0NjRlY2M4
+        NDMwMTY0ZWNmOTA5Y2QwMDA2Iiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRp
         c3BsYXlOYW1lIjoic2NlbmFyaW9fdGVzdCIsImhyZWYiOiIvb3duZXJzL3Nj
         ZW5hcmlvX3Rlc3QifSwiZW52aXJvbm1lbnRDb250ZW50IjpbXX0=
     http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:22 GMT
+  recorded_at: Mon, 30 Jul 2018 20:55:01 GMT
 - request:
     method: get
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/uebercert
+    uri: https://alpha.partello.example.com:8443/candlepin/owners/scenario_test/uebercert
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,9 +130,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="F7nMn0NR9B9BezZfE3ra9aXP5d6UFFaIQloZcTIx0II",
-        oauth_signature="%2B8L6P2bATpyabKFTXKj8r9Nwx1w%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1528379902", oauth_version="1.0"
+      - OAuth oauth_consumer_key="f3SrjSXwpnyQJkiNLCAuePYsZU5UbVUw", oauth_nonce="cdTiZ21Z9lRHp0TwROHWSma7Bmokq3W3xMP8KRoPkU",
+        oauth_signature="yDyH04yD4mSse5qgXvoJkbDuXHE%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1532984101", oauth_version="1.0"
       Cp-User:
       - foreman_admin
   response:
@@ -143,28 +143,28 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - f4869456-60c9-4b55-895e-da6bb8d81ee6
+      - 65127e2c-6d4c-40ec-b071-62f1d64c4189
       X-Version:
-      - 2.3.8-1
-      - 2.3.8-1
+      - 2.4.5-1
+      - 2.4.5-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 07 Jun 2018 13:58:21 GMT
+      - Mon, 30 Jul 2018 20:55:00 GMT
     body:
       encoding: UTF-8
       base64_string: |
         eyJkaXNwbGF5TWVzc2FnZSI6InViZXIgY2VydGlmaWNhdGUgZm9yIG93bmVy
         IHNjZW5hcmlvX3Rlc3Qgd2FzIG5vdCBmb3VuZC4gUGxlYXNlIGdlbmVyYXRl
-        IG9uZS4iLCJyZXF1ZXN0VXVpZCI6ImY0ODY5NDU2LTYwYzktNGI1NS04OTVl
-        LWRhNmJiOGQ4MWVlNiJ9
+        IG9uZS4iLCJyZXF1ZXN0VXVpZCI6IjY1MTI3ZTJjLTZkNGMtNDBlYy1iMDcx
+        LTYyZjFkNjRjNDE4OSJ9
     http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:22 GMT
+  recorded_at: Mon, 30 Jul 2018 20:55:01 GMT
 - request:
     method: post
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/uebercert
+    uri: https://alpha.partello.example.com:8443/candlepin/owners/scenario_test/uebercert
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -178,9 +178,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp",
-        oauth_nonce="k2201bJDKWRPhOgfwoqrY4gd1HEoGPcV8YeIWmYwtsY", oauth_signature="%2BHQxHSM5gZSBidJmk5VNoVwQm90%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1528379902", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="f3SrjSXwpnyQJkiNLCAuePYsZU5UbVUw",
+        oauth_nonce="PqqKSJPdihBNd80zm69hzBESqkgHJNrGkt5O1Ow4I", oauth_signature="IE%2F%2F19xsL0JvOl8kvSsFkZ765R8%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1532984101", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -197,122 +197,123 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - f0e74f88-1eef-4095-bdfb-650fe8893e56
+      - 9dc43199-b6dd-4755-9ed8-889b36c3cad1
       X-Version:
-      - 2.3.8-1
+      - 2.4.5-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 07 Jun 2018 13:58:23 GMT
+      - Mon, 30 Jul 2018 20:55:00 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOC0wNi0wN1QxMzo1ODoyMiswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTgtMDYtMDdUMTM6NTg6MjMrMDAwMCIsImtleSI6Ii0tLS0tQkVH
-        SU4gUlNBIFBSSVZBVEUgS0VZLS0tLS1cbk1JSUVwUUlCQUFLQ0FRRUFrNGE2
-        RjEvSk5xcjlJdU8zczAwN0ZtQVE1aFlPTVNLQnVseDV5cTJzUStsUE5ZSGdc
-        bkh3RkhIcHExQ04xZHF4eVRZOU8vbEc4blp3MkIrNEQ5VlF6MmNETEZYeitB
-        NEpJeTBzT3p1dFh3eGdGSTB1QStcbjdtLzZXV1VnQ3NZbytSOGcwdk1nWi9S
-        Vy96VDFrOWxYNTRuY21oMy9rcEt6b0RlczlQKzY5TTNDcy9pdW93OHJcbm5X
-        c1laZmxpQ2prbHlnRUxQRXc3KytET0sxaXpTRWNxNDcvQ3BTSzhvVlJHNHdr
-        ZjRpNWNYRDloRGJBQk1JUWVcbmtFTXFXT3VRdXpYdkZobC9LWnB3d1RmUm8v
-        V2xxdk4wVHFDbjlhWkxBRGRVVGtGTEczTTY4Q3IzaXVvTmJRMitcbndScEhR
-        aDh1eWhvclNqYlB2bTIySWVQRytaYnMvQjN2QmhJRUx3SURBUUFCQW9JQkFR
-        Q0lBN1E0N3JndUxmSGJcbkpBWnZTcXBLaytHZ3NQNytzQ2paTUgrZHJRZmhT
-        UThkYnhPNm9rdjIzSDVDb1EzR1FEOW56NGVYaSsvUkpIUU5cbjlMd2NtU254
-        QWU1VlJkQkZ2S1VkQ3cvL0YxYTR4K0JqaEJxaGJSNXRJejRxa002ZitPSWpl
-        OE1KOVEzc2wrQS9cbkl5alhzWlJ4aDJ6bHIxbnJRc20wekw2TEM5WVNaTE9S
-        UU9YQkw0cVJGWjNsb0U1dzNYai9iMXVBekgzSkVpdTJcbkNObC9CN05HRGRM
-        L1NxT0VxUlo5eUoybC9GR1grbEhSVnF2bXNnUWMrZTRVeXIxWHhrSWNNRkUx
-        Wi8yVUNGSzVcbk03dUtoNzJBSmFKMmU4ZHpjSU5mRjlOcmhRNmRTMndrd0hL
-        ZlJ5S2lDTUV3cytONGI0SExGWWt6Ulp1a0JiWFdcbm9Qbm1zc2RwQW9HQkFN
-        eXcyV1RPYmZXMkJJQnRoNnFIdCtMVS9ZVnVkY2EzYUI2Q2NnQWRoNUpBaGNL
-        clNOOVZcblJZa3c0alJlaEkrVnpMaytXWVFaU0pDamJ6SGVJRkJzTi9KTTE4
-        emtjdDhzV3hNQXRvZjJsU0ZCS1Znd3RVSVBcbkxsQ0xUWUxJbWw1bHhuaHFE
-        SkNLdGxSRGhPRmQxemt4TmhsL2NKK0Z4VFpoZnVhZDRyKzRYUmc3QW9HQkFM
-        aUJcbmx2eFN2Q2s0Mk1Ic2psbUVMMjY5TDVPL0dEU3FaVUF4VnNzOEtyYjR3
-        SnlsS1ZFdGo0d2pwZSswKysxSUdOeEdcbkFJa0RCK1JlcTErVG1pbkZ2Vndw
-        cHZKYXZiMkxsdFUxeTlDRkQwODh3NXR4YmRIVlc1Tzd3cFdvTnBIb09mVi9c
-        bjlDZXZTZGkvTW9yVlZYQkd6cEJ2TXArUGxuZHdCVTZxNThGNWMvaWRBb0dB
-        SGsxWUFZcGwwT2cvUmx2d3A1Z3JcbjZ0S3BMV1dxM2Q0czljZE41U0o1L1hh
-        NzFwUFExKzhodWl1WWNUUkUzNVRIbCt6WkI2dE9pTXNKSFJMTEtkeTdcbmM0
-        MVlyU1pzc3drMytsb3lxM0lmcGFxbDJqNXJ0dm5VVzJ3ajcyYVBJOFpoV1ZZ
-        cHdnUW05ZGFCQjNRQzlwNklcbmFjSHFCRk9qWEdlV2g4RjczZklISmgwQ2dZ
-        RUFneVVoby9KTzZtSU11REtqci84a0UrdUhRTlpvcHk2aXozRUNcbmgyMFow
-        M3FXdGdFemtBNzVaSndHRzQ4aUxyTzdiLzZWN00xcHM2cVMxMW04RDRzTklO
-        QSthUytVaElFTzBqZnRcbnlpWjZEbEZibkVhUXo4QisybEJ3YkIzbncrZzBJ
-        a3N6eVcxdjZROW1Kb2FpdHk2dExyN0xWZDBqRDN4aFdWeGpcblpRTW1Lb1VD
-        Z1lFQWxoUE9xUndyNVJSc0JVdHBRc3RnM3lvbUd4YmxvWkYzQjJoNmhVL3pC
-        d1lLN3JSWkp2WXpcbjdyMjhiWlV0QzNiYS81YTFUNmQrcWRZL0hXS28xNE1o
-        Z1NyTEJLV0paZTZtMnRyWkptZTZWREZCa3AzdjRFRDhcbmhlb2k3MGZFMHg5
-        UmZFZzBFd0ZqOWtiVjZXVDVTSE1VTFN2MWtzQ3JnSThJTGJZUnM4WmpGSUk9
+        eyJjcmVhdGVkIjoiMjAxOC0wNy0zMFQyMDo1NTowMSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMDctMzBUMjA6NTU6MDErMDAwMCIsImtleSI6Ii0tLS0tQkVH
+        SU4gUlNBIFBSSVZBVEUgS0VZLS0tLS1cbk1JSUVwZ0lCQUFLQ0FRRUFzMkZy
+        SG5oNE1KVTFJYnd1bkJQRzAyTkdyYW9YUWlTVGRGM3JFUWFUdit2SisxUjhc
+        bmJlZTdJajJ2ajVxMks1MnUvSmpYTEZ4NUVBM2tOcldUU210bUU0c2swaDBZ
+        NEp1T0g2eFNYOU94YVd0aGxuQXJcblN4VWhjSzdxVTR4TXhkbzNIVWxWOFBK
+        VUZtUWxlc3RmM01zUEZ5R25GdE5YK01qVCtQSXNnc0dvVW5IUSs5ck1cbmFX
+        eDgzSU9XMW9meHpza0hLalVFT1F1WjgrbzNUZ0xCMmVjOUZSYmw4a2t5TmlL
+        cStiVlFrdzRiQjBwanhYQitcbkh3WmMrMnFQb2w3TzFJRS9NbTU3clRvaHlz
+        dFJnQ3JiYzI4N0ErOWZsTVkwQ1NuZXRLTHFzVFpwdzlOR1VkRXJcbjBJcjJ1
+        M0laTjB4R3BmdjJWVVM2c1BNNllVZzExTWkydHBiWVZRSURBUUFCQW9JQkFR
+        Q2ZUUitOSXQxUi85LzhcbmdwczkvbzR2QWxZdE9nV0h0dVhBalB1SjFqWjJW
+        VmE5dll6M0tibFZza1JzR3JBM1VjU3FESzNpZG9rSXlkMW1cbi9KKytrbHhI
+        ZE9XUk4wZjFpQStTYnoyRVhvS0twVk0zLzR0akZYUHFGMXlBTC9PcUxaMk9n
+        NmN2NEhUdW9hZHJcblFwdHlnRjU1WTJoNDY5MlBVZ0oxYmRRN2x2SDlyQnBY
+        M1hmWnRZUVZJTWN6Q3NHbHZKb21kZDl0ZlJ2MWRlRlZcbnNhd2h0dnFHMTNL
+        L1RaUE9PWkQwS1ExRGR6QWd6d0ZwaXV1RFhCdzFzbE9uK3ZvZ3h1Y0IvMVNJ
+        T1U3Tnc4RmZcbmZ3d0lRUVpiNnJkc2tDRHg4OStTTElFWVA4WU9ZcmhMaWF1
+        UHA1Wit6WkN2dXVHT3krMVpjNVpLejFVRXhXY2NcblBJb0RPVllOQW9HQkFP
+        aFp4U1JUK2lMNzR4dDhWYzZ0MnExWElpWCs1YjI5SmJhS1g3L0xEbmgxa2c2
+        aG5vUGNcbjBqOWxXNm9OYWRJNDgwNlJVclBkMnVtV2NqSDl5aGhVSHMzK05M
+        dUFHckZscll0MmRnM0dxR2FXODZhcGtlY2pcbkoyNmcyQzhRM0IyeGlKdS85
+        dUtpR0RYQnVWTU9qeUQrZ1JlMmNBSk85T01GeHFGU2F0eFArOC9iQW9HQkFN
+        V2pcbmI0OU9VNzRUOW9VN2RYOTdtZ2JhdVFHVjR0Wm81T2h5M2J2ZFBtcmdP
+        d0VpR2l6TnZOdGRqWlB3dHJHeG9EZHZcbllZY0k0aFc0SnplMFBLbUpJUFFC
+        RGtjSnFyT1BmbTVkYXVqc0w1aWRUMUMySkdTYk5vWHJtUDlSRmtmeDViZHhc
+        bmN0OENBQkM3ajZyZWhpYVhyK0ZheTJEOGV5VjltaFNmZkk3dFdFZVBBb0dC
+        QUkzRWNELzVLUzc5UjVXMnFGaGhcbnhZSnNIcjdXSnZFOUhteWhRMGl2cVpX
+        Z0RzejBtZFpVL3NlRm5ZZEZoZUtwc3ZLbVFyTFNVOGFnYis3R3JlOW9cbkxC
+        OTkwa2p4SWRoSmRMa2FQMitxWFlleTVOazByM3c2KzgxSlFINS9KLzdLR3RN
+        Rkxxc2JRZkJTMGpPMk4yaG5cblFQYnA3cS9KNHlzOWsvTk1hVDBoWkVCdkFv
+        R0JBTUJ3ZkI3NHNKZkREbVg2V0ZWU1A4N3V4L2VnUDJod2FIdGhcbjVUK1ls
+        TDh5S0tIWTE4M0tZbHJpeEFsSitFb2JYNXE2ckNiMDRsY3RvWm9ldUhhSG5I
+        dWFUNUdoK3dHdDlmaDJcbm83TzZ6amwyNnhUMjFZYlVqd2xsTnV0YnhDczNn
+        V3JXWDNoL2xScTExcFVVNldESWtDd0k0VUZGZG84eHRvYmdcbktFTnZIV2RI
+        QW9HQkFKZnlHdy92TzAyZVRvSEk3ZEVUVGdDMG5LeVduL1VaaEFRVTlWTFhn
+        cVNiMEh4ZzlONzFcbnc3WTFJaXQ0UWlsbEJ4aXErTlVkZHIyOW1saXZxcnp0
+        S1VVbWU5WWdGZU4zallPVENWUXBUODRKeVdwaDZjVm5cblcyOERoWVlrWS9L
+        UjU0WFVFV0NMTDZ1N0hDV1NEbXBBbUp6cisxVGcxcmhiOXVQdjJwUnFQOGhr
         XG4tLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLVxuIiwiY2VydCI6Ii0t
-        LS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLVxuTUlJRzFqQ0NCYjZnQXdJQkFn
-        SUlGZHFxQm9QL0IxTXdEUVlKS29aSWh2Y05BUUVMQlFBd2VqRUxNQWtHQTFV
-        RVxuQmhNQ1ZWTXhGekFWQmdOVkJBZ1REazV2Y25Sb0lFTmhjbTlzYVc1aE1S
-        QXdEZ1lEVlFRSEV3ZFNZV3hsYVdkb1xuTVJBd0RnWURWUVFLRXdkTFlYUmxi
-        R3h2TVJRd0VnWURWUVFMRXd0VGIyMWxUM0puVlc1cGRERVlNQllHQTFVRVxu
-        QXhNUFpHVjJMbVY0WVcxd2JHVXVZMjl0TUI0WERURTRNRFl3TnpFek5UZ3lN
-        bG9YRFRRNU1USXdNVEV6TURBd1xuTUZvd0dERVdNQlFHQTFVRUNnd05jMk5s
-        Ym1GeWFXOWZkR1Z6ZERDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRFxuZ2dF
-        UEFEQ0NBUW9DZ2dFQkFKT0d1aGRmeVRhcS9TTGp0N05OT3haZ0VPWVdEakVp
-        Z2JwY2VjcXRyRVBwVHpXQlxuNEI4QlJ4NmF0UWpkWGFzY2syUFR2NVJ2SjJj
-        TmdmdUEvVlVNOW5BeXhWOC9nT0NTTXRMRHM3clY4TVlCU05MZ1xuUHU1dits
-        bGxJQXJHS1BrZklOTHpJR2YwVnY4MDlaUFpWK2VKM0pvZC81S1NzNkEzclBU
-        L3V2VE53clA0cnFNUFxuSzUxckdHWDVZZ281SmNvQkN6eE1PL3Zneml0WXMw
-        aEhLdU8vd3FVaXZLRlVSdU1KSCtJdVhGdy9ZUTJ3QVRDRVxuSHBCREtsanJr
-        THMxN3hZWmZ5bWFjTUUzMGFQMXBhcnpkRTZncC9XbVN3QTNWRTVCU3h0ek92
-        QXE5NHJxRFcwTlxudnNFYVIwSWZMc29hSzBvMno3NXR0aUhqeHZtVzdQd2Q3
-        d1lTQkM4Q0F3RUFBYU9DQThBd2dnTzhNQkVHQ1dDR1xuU0FHRytFSUJBUVFF
-        QXdJRm9EQUxCZ05WSFE4RUJBTUNCTEF3Z2F3R0ExVWRJd1NCcERDQm9ZQVV2
-        V3UwYU9qU1xudUxRT2ZQSk9XRnNyV1ZtanFnYWhmcVI4TUhveEN6QUpCZ05W
-        QkFZVEFsVlRNUmN3RlFZRFZRUUlFdzVPYjNKMFxuYUNCRFlYSnZiR2x1WVRF
-        UU1BNEdBMVVFQnhNSFVtRnNaV2xuYURFUU1BNEdBMVVFQ2hNSFMyRjBaV3hz
-        YnpFVVxuTUJJR0ExVUVDeE1MVTI5dFpVOXlaMVZ1YVhReEdEQVdCZ05WQkFN
-        VEQyUmxkaTVsZUdGdGNHeGxMbU52YllJSlxuQU5ENWREd2xkdFNNTUIwR0Ex
-        VWREZ1FXQkJSdHQ1elp0SDdRYzZ3SktyemRMa0RnUTBsMlJ6QVRCZ05WSFNV
-        RVxuRERBS0JnZ3JCZ0VGQlFjREFqQXhCaEFyQmdFRUFaSUlDUUdzdmRTcWxr
-        Y0JCQjBNRzNOalpXNWhjbWx2WDNSbFxuYzNSZmRXVmlaWEpmY0hKdlpIVmpk
-        REFXQmhBckJnRUVBWklJQ1FHc3ZkU3Fsa2NEQkFJTUFEQVdCaEFyQmdFRVxu
-        QVpJSUNRR3N2ZFNxbGtjQ0JBSU1BREFXQmhBckJnRUVBWklJQ1FHc3ZkU3Fs
-        a2NGQkFJTUFEQVpCaEFyQmdFRVxuQVpJSUNRS3N2ZFNxbGtnQkJBVU1BM2wx
-        YlRBa0JoRXJCZ0VFQVpJSUNRS3N2ZFNxbGtnQkFRUVBEQTExWldKbFxuY2w5
-        amIyNTBaVzUwTURJR0VTc0dBUVFCa2dnSkFxeTkxS3FXU0FFQ0JCME1HekUx
-        TWpnek56azVNREkzT1RGZlxuZFdWaVpYSmZZMjl1ZEdWdWREQWRCaEVyQmdF
-        RUFaSUlDUUtzdmRTcWxrZ0JCUVFJREFaRGRYTjBiMjB3SlFZUlxuS3dZQkJB
-        R1NDQWtDckwzVXFwWklBUVlFRUF3T0wzTmpaVzVoY21sdlgzUmxjM1F3RndZ
-        Ukt3WUJCQUdTQ0FrQ1xuckwzVXFwWklBUWNFQWd3QU1CZ0dFU3NHQVFRQmtn
-        Z0pBcXk5MUtxV1NBRUlCQU1NQVRFd0t3WUtLd1lCQkFHU1xuQ0FrRUFRUWRE
-        QnR6WTJWdVlYSnBiMTkwWlhOMFgzVmxZbVZ5WDNCeWIyUjFZM1F3RUFZS0t3
-        WUJCQUdTQ0FrRVxuQWdRQ0RBQXdIUVlLS3dZQkJBR1NDQWtFQXdRUERBMHhO
-        VEk0TXpjNU9UQXlOemt4TUJFR0Npc0dBUVFCa2dnSlxuQkFVRUF3d0JNVEFr
-        QmdvckJnRUVBWklJQ1FRR0JCWU1GREl3TVRndE1EWXRNRGRVTVRNNk5UZzZN
-        akphTUNRR1xuQ2lzR0FRUUJrZ2dKQkFjRUZnd1VNakEwT1MweE1pMHdNVlF4
-        TXpvd01Eb3dNRm93RVFZS0t3WUJCQUdTQ0FrRVxuREFRRERBRXdNQkFHQ2lz
-        R0FRUUJrZ2dKQkFvRUFnd0FNQkFHQ2lzR0FRUUJrZ2dKQkEwRUFnd0FNQkVH
-        Q2lzR1xuQVFRQmtnZ0pCQTRFQXd3Qk1EQVJCZ29yQmdFRUFaSUlDUVFMQkFN
-        TUFURXdOQVlLS3dZQkJBR1NDQWtGQVFRbVxuRENSaVl6bG1NakE1TVMweU1E
-        TXhMVFEzT1RZdE9ESTFPUzA1TW1OaFpqRXlZMkV5TkRVd0RRWUpLb1pJaHZj
-        TlxuQVFFTEJRQURnZ0VCQUg3MXUwNE5McHVadjlwOUFjNFhiZENYUk1oUmRn
-        VHY5WjJuRWNVbHV4ai9NRXk0RWRVSFxuRDZiTkNrZU1wekdBRitUZWtNb0x1
-        ZW5vbWZIVG16TWhhZW80UW0ySXRJVEYxT1VJRnZEdHBPanQxb1B5bHN0blxu
-        UklsR3orejZpRFdTTGdZeU9BM0dtRzU0Tjk5YzcrckNxS3JpZUg5QXl6eWZn
-        WDRkbW5GcnE2ZTVIQzFIdjY3NFxuejRScm50QW1TeUJ3S2kvMGd4ak5ZQ2lq
-        N0ZOVUdwKzMxazFxdXdrMkgzWHdNU3Zkc0RiTUw2T0F6WVlHdVdOVlxuT1Ns
-        NmY2bm5MdStXSnUwS2ZCMFczbnlvUlZ5QlFmYmwwN3dORmNPYVZQanBqWUR4
-        UzBYNGVyY3BGQ29PQ0tJYVxuQW9zL0Z5WGttQ1dTMEN1SnQzZGNSS2NObWpp
-        RXg3U0srTDQ9XG4tLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tXG4iLCJzZXJp
-        YWwiOnsiY3JlYXRlZCI6IjIwMTgtMDYtMDdUMTM6NTg6MjIrMDAwMCIsInVw
-        ZGF0ZWQiOiIyMDE4LTA2LTA3VDEzOjU4OjIyKzAwMDAiLCJpZCI6MTU3NDc1
-        Nzk2NDY4MDQ2NDIxMSwicmV2b2tlZCI6ZmFsc2UsImNvbGxlY3RlZCI6ZmFs
-        c2UsImV4cGlyYXRpb24iOiIyMDQ5LTEyLTAxVDEzOjAwOjAwKzAwMDAiLCJz
-        ZXJpYWwiOjE1NzQ3NTc5NjQ2ODA0NjQyMTF9LCJpZCI6IjQwMjhmOTUxNjNk
-        YTViMWIwMTYzZGE4YThjNTYwMDAzIiwib3duZXIiOnsiaWQiOiI0MDI4Zjk1
-        MTYzZGE1YjFiMDE2M2RhOGE4OWU0MDAwMCIsImtleSI6InNjZW5hcmlvX3Rl
-        c3QiLCJkaXNwbGF5TmFtZSI6InNjZW5hcmlvX3Rlc3QiLCJocmVmIjoiL293
-        bmVycy9zY2VuYXJpb190ZXN0In19
+        LS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLVxuTUlJRzhEQ0NCZGlnQXdJQkFn
+        SUlFcEh0SkI0QnRXY3dEUVlKS29aSWh2Y05BUUVMQlFBd2dZVXhDekFKQmdO
+        VlxuQkFZVEFsVlRNUmN3RlFZRFZRUUlFdzVPYjNKMGFDQkRZWEp2YkdsdVlU
+        RVFNQTRHQTFVRUJ4TUhVbUZzWldsblxuYURFUU1BNEdBMVVFQ2hNSFMyRjBa
+        V3hzYnpFVU1CSUdBMVVFQ3hNTFUyOXRaVTl5WjFWdWFYUXhJekFoQmdOVlxu
+        QkFNVEdtRnNjR2hoTG5CaGNuUmxiR3h2TG1WNFlXMXdiR1V1WTI5dE1CNFhE
+        VEU0TURjek1ESXdOVFV3TVZvWFxuRFRRNU1USXdNVEV6TURBd01Gb3dHREVX
+        TUJRR0ExVUVDZ3dOYzJObGJtRnlhVzlmZEdWemREQ0NBU0l3RFFZSlxuS29a
+        SWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTE5oYXg1NGVEQ1ZOU0c4
+        THB3VHh0TmpScTJxRjBJa1xuazNSZDZ4RUdrNy9yeWZ0VWZHM251eUk5cjQr
+        YXRpdWRydnlZMXl4Y2VSQU41RGExazBwclpoT0xKTklkR09DYlxuamgrc1Vs
+        L1RzV2xyWVpad0swc1ZJWEN1NmxPTVRNWGFOeDFKVmZEeVZCWmtKWHJMWDl6
+        TER4Y2hweGJUVi9qSVxuMC9qeUxJTEJxRkp4MFB2YXpHbHNmTnlEbHRhSDhj
+        N0pCeW8xQkRrTG1mUHFOMDRDd2RublBSVVc1ZkpKTWpZaVxucXZtMVVKTU9H
+        d2RLWThWd2ZoOEdYUHRxajZKZXp0U0JQekp1ZTYwNkljckxVWUFxMjNOdk93
+        UHZYNVRHTkFrcFxuM3JTaTZyRTJhY1BUUmxIUks5Q0s5cnR5R1RkTVJxWDc5
+        bFZFdXJEek9tRklOZFRJdHJhVzJGVUNBd0VBQWFPQ1xuQTg0d2dnUEtNQkVH
+        Q1dDR1NBR0crRUlCQVFRRUF3SUZvREFMQmdOVkhROEVCQU1DQkxBd2dib0dB
+        MVVkSXdTQlxuc2pDQnI0QVV1aEI4c2J1VjdPUThXRlJXaGVqRnRkWFhhVXlo
+        Z1l1a2dZZ3dnWVV4Q3pBSkJnTlZCQVlUQWxWVFxuTVJjd0ZRWURWUVFJRXc1
+        T2IzSjBhQ0JEWVhKdmJHbHVZVEVRTUE0R0ExVUVCeE1IVW1Gc1pXbG5hREVR
+        TUE0R1xuQTFVRUNoTUhTMkYwWld4c2J6RVVNQklHQTFVRUN4TUxVMjl0WlU5
+        eVoxVnVhWFF4SXpBaEJnTlZCQU1UR21Gc1xuY0doaExuQmhjblJsYkd4dkxt
+        VjRZVzF3YkdVdVkyOXRnZ2tBMTVpb3BSK0ZybXd3SFFZRFZSME9CQllFRk9U
+        VFxuYnpsd2dLTGRUdVkyc0xsU05STTM5eTFxTUJNR0ExVWRKUVFNTUFvR0ND
+        c0dBUVVGQndNQ01ERUdFQ3NHQVFRQlxua2dnSkFhek81K1NVWmdFRUhRd2Jj
+        Mk5sYm1GeWFXOWZkR1Z6ZEY5MVpXSmxjbDl3Y205a2RXTjBNQllHRUNzR1xu
+        QVFRQmtnZ0pBYXpPNStTVVpnTUVBZ3dBTUJZR0VDc0dBUVFCa2dnSkFhek81
+        K1NVWmdJRUFnd0FNQllHRUNzR1xuQVFRQmtnZ0pBYXpPNStTVVpnVUVBZ3dB
+        TUJrR0VDc0dBUVFCa2dnSkFxek81K1NVWndFRUJRd0RlWFZ0TUNRR1xuRVNz
+        R0FRUUJrZ2dKQXF6TzUrU1Vad0VCQkE4TURYVmxZbVZ5WDJOdmJuUmxiblF3
+        TWdZUkt3WUJCQUdTQ0FrQ1xuck03bjVKUm5BUUlFSFF3Yk1UVXpNams0TkRF
+        d01UUTNPRjkxWldKbGNsOWpiMjUwWlc1ME1CMEdFU3NHQVFRQlxua2dnSkFx
+        ek81K1NVWndFRkJBZ01Ca04xYzNSdmJUQWxCaEVyQmdFRUFaSUlDUUtzenVm
+        a2xHY0JCZ1FRREE0dlxuYzJObGJtRnlhVzlmZEdWemREQVhCaEVyQmdFRUFa
+        SUlDUUtzenVma2xHY0JCd1FDREFBd0dBWVJLd1lCQkFHU1xuQ0FrQ3JNN241
+        SlJuQVFnRUF3d0JNVEFyQmdvckJnRUVBWklJQ1FRQkJCME1HM05qWlc1aGNt
+        bHZYM1JsYzNSZlxuZFdWaVpYSmZjSEp2WkhWamREQVFCZ29yQmdFRUFaSUlD
+        UVFDQkFJTUFEQWRCZ29yQmdFRUFaSUlDUVFEQkE4TVxuRFRFMU16STVPRFF4
+        TURFME56Z3dFUVlLS3dZQkJBR1NDQWtFQlFRRERBRXhNQ1FHQ2lzR0FRUUJr
+        Z2dKQkFZRVxuRmd3VU1qQXhPQzB3Tnkwek1GUXlNRG8xTlRvd01Wb3dKQVlL
+        S3dZQkJBR1NDQWtFQndRV0RCUXlNRFE1TFRFeVxuTFRBeFZERXpPakF3T2pB
+        d1dqQVJCZ29yQmdFRUFaSUlDUVFNQkFNTUFUQXdFQVlLS3dZQkJBR1NDQWtF
+        Q2dRQ1xuREFBd0VBWUtLd1lCQkFHU0NBa0VEUVFDREFBd0VRWUtLd1lCQkFH
+        U0NBa0VEZ1FEREFFd01CRUdDaXNHQVFRQlxua2dnSkJBc0VBd3dCTVRBMEJn
+        b3JCZ0VFQVpJSUNRVUJCQ1lNSkdVM056azNPRGcxTFRJMllqTXRORGM1Tmkx
+        aFxuT0dSbExUTTRZbUUxT1RjM09UazVZakFOQmdrcWhraUc5dzBCQVFzRkFB
+        T0NBUUVBSmF2RFVZcjkwNFZNTzhlMFxudWZPVFdmaXNsRW85SmdNMktBZ0Rr
+        bXlRQkpuVmdNSXZsU1RZZEVYV2UzYTA5YUlXSWxLYWJKQnRzcjFwaWlLL1xu
+        Umhnc0UrWGUyWDdCV05reS9vRDFNNEJKZEx2alo3TFBkb2luM3QyYWd6a0Rz
+        SVMxTW5nNE4vUFFRdUgzRHBuSlxud0d0WDFBbmJKVEN6VXIzNTBqeG5BN3VG
+        UDFaMlgzZFZVbGIxWjVMM3lSN095WHJCbzZ1QlRTd1ZiNEJteWlVWVxubXh4
+        SVRubDY5VVh3dVN1VmUyMWIvbnpNZ3hsbjFWYll4WnpncU15d1pvTHFoOVVs
+        ZWhWd3pDSTk3UkQxcVg4R1xuZXlQaTFYNG1NamFRdERCVk1hZndwN0J0c2p4
+        VVJsMGdyWjhDOWVsNzB0YTkrZzlqNlZYRjU5Mjk5ME5MYkxGNVxuejVPRld3
+        PT1cbi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS1cbiIsInNlcmlhbCI6eyJj
+        cmVhdGVkIjoiMjAxOC0wNy0zMFQyMDo1NTowMSswMDAwIiwidXBkYXRlZCI6
+        IjIwMTgtMDctMzBUMjA6NTU6MDErMDAwMCIsImlkIjoxMzM4MTExMzAzNjgz
+        NzgxOTkxLCJyZXZva2VkIjpmYWxzZSwiY29sbGVjdGVkIjpmYWxzZSwiZXhw
+        aXJhdGlvbiI6IjIwNDktMTItMDFUMTM6MDA6MDArMDAwMCIsInNlcmlhbCI6
+        MTMzODExMTMwMzY4Mzc4MTk5MX0sImlkIjoiNDAyOGU5NDQ2NGVjYzg0MzAx
+        NjRlY2Y5MGFhZTAwMDkiLCJvd25lciI6eyJpZCI6IjQwMjhlOTQ0NjRlY2M4
+        NDMwMTY0ZWNmOTA5Y2QwMDA2Iiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRp
+        c3BsYXlOYW1lIjoic2NlbmFyaW9fdGVzdCIsImhyZWYiOiIvb3duZXJzL3Nj
+        ZW5hcmlvX3Rlc3QifX0=
     http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:23 GMT
+  recorded_at: Mon, 30 Jul 2018 20:55:01 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/organization_destroy.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/organization_destroy.yml
@@ -1,45 +1,6 @@
 ---
 http_interactions:
 - request:
-    method: delete
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 07 Jun 2018 13:58:47 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2ExOGY5N2MxLWZlNmUtNDJkNi04NzA3LTZiYzlhZTg0ZDA1MS8iLCAi
-        dGFza19pZCI6ICJhMThmOTdjMS1mZTZlLTQyZDYtODcwNy02YmM5YWU4NGQw
-        NTEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:47 GMT
-- request:
     method: get
     uri: https://dev.example.com/pulp/api/v2/tasks/a18f97c1-fe6e-42d6-8707-6bc9ae84d051/
     body:
@@ -149,44 +110,193 @@ http_interactions:
   recorded_at: Thu, 07 Jun 2018 13:58:47 GMT
 - request:
     method: delete
-    uri: https://dev.example.com:8443/candlepin/environments/119c4753ff6d3b7bd0b76de6d5a5f94a
+    uri: https://alpha.partello.example.com/pulp/api/v2/repositories/scenario_test/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
-      - "*/*"
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="dvcuibjaAdy2H7Gk5Y601XPWas8yhrj14eSQmjC7Q4",
-        oauth_signature="QADJiBV41665MaZFZjtepOOyF%2Bo%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1528379927", oauth_version="1.0"
-      Cp-User:
-      - foreman_admin
+      Content-Type:
+      - application/json
   response:
     status:
-      code: 204
-      message: No Content
+      code: 202
+      message: ACCEPTED
     headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - a02032de-dd7f-442d-9c58-feaa8479e2e1
-      X-Version:
-      - 2.3.8-1
       Date:
-      - Thu, 07 Jun 2018 13:58:47 GMT
+      - Mon, 30 Jul 2018 20:55:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
     body:
       encoding: UTF-8
-      base64_string: ''
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzBhNzRkNGIxLWQyMTEtNGZhMC04ZTY5LTFjNWY0NTg3NDhkYi8iLCAi
+        dGFza19pZCI6ICIwYTc0ZDRiMS1kMjExLTRmYTAtOGU2OS0xYzVmNDU4NzQ4
+        ZGIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:47 GMT
+  recorded_at: Mon, 30 Jul 2018 20:55:26 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/0a74d4b1-d211-4fa0-8e69-1c5f458748db/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '553'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wYTc0ZDRiMS1kMjExLTRmYTAtOGU2OS0xYzVmNDU4NzQ4
+        ZGIvIiwgInRhc2tfaWQiOiAiMGE3NGQ0YjEtZDIxMS00ZmEwLThlNjktMWM1
+        ZjQ1ODc0OGRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUi
+        OiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBu
+        dWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwg
+        InByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiTm9uZS5kcSIsICJz
+        dGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWI1
+        ZjdiM2UyZjVlYTIyODhmNmY0ODVlIn0sICJpZCI6ICI1YjVmN2IzZTJmNWVh
+        MjI4OGY2ZjQ4NWUifQ==
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:26 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/0a74d4b1-d211-4fa0-8e69-1c5f458748db/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '671'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wYTc0ZDRiMS1kMjExLTRmYTAtOGU2OS0xYzVmNDU4NzQ4
+        ZGIvIiwgInRhc2tfaWQiOiAiMGE3NGQ0YjEtZDIxMS00ZmEwLThlNjktMWM1
+        ZjQ1ODc0OGRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUi
+        OiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAi
+        MjAxOC0wNy0zMFQyMDo1NToyNloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
+        YXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVl
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWxwaGEucGFydGVs
+        bG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBhbHBoYS5w
+        YXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3Ii
+        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjViNWY3YjNlMmY1ZWEyMjg4ZjZm
+        NDg1ZSJ9LCAiaWQiOiAiNWI1ZjdiM2UyZjVlYTIyODhmNmY0ODVlIn0=
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:26 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/0a74d4b1-d211-4fa0-8e69-1c5f458748db/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '690'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wYTc0ZDRiMS1kMjExLTRmYTAtOGU2OS0xYzVmNDU4NzQ4
+        ZGIvIiwgInRhc2tfaWQiOiAiMGE3NGQ0YjEtZDIxMS00ZmEwLThlNjktMWM1
+        ZjQ1ODc0OGRiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUi
+        OiAiMjAxOC0wNy0zMFQyMDo1NToyNloiLCAiX25zIjogInRhc2tfc3RhdHVz
+        IiwgInN0YXJ0X3RpbWUiOiAiMjAxOC0wNy0zMFQyMDo1NToyNloiLCAidHJh
+        Y2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNz
+        X3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTBAYWxwaGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUi
+        OiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTBAYWxwaGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        YjVmN2IzZTJmNWVhMjI4OGY2ZjQ4NWUifSwgImlkIjogIjViNWY3YjNlMmY1
+        ZWEyMjg4ZjZmNDg1ZSJ9
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:26 GMT
 - request:
     method: delete
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test
+    uri: https://alpha.partello.example.com:8443/candlepin/environments/119c4753ff6d3b7bd0b76de6d5a5f94a
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -198,9 +308,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="pd8jj0iAIRGmQdoKbOunOzklhyuP00tXOzDNNCwBcc",
-        oauth_signature="4mdfKXSRxeQVpOISIk%2FWJBRGqFM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1528379927", oauth_version="1.0"
+      - OAuth oauth_consumer_key="f3SrjSXwpnyQJkiNLCAuePYsZU5UbVUw", oauth_nonce="a7Vjq5gatlEjTcxdvLlSl5Ue1pA20nujqpOTNE7iRM",
+        oauth_signature="ertL9Ichw140BIF46kwm7Q5AmFc%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1532984126", oauth_version="1.0"
       Cp-User:
       - foreman_admin
   response:
@@ -211,14 +321,51 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 7b843607-1391-42e7-8697-13e2dc7a2322
+      - 1a456756-6fca-4595-8f27-dddfaab3fb73
       X-Version:
-      - 2.3.8-1
+      - 2.4.5-1
       Date:
-      - Thu, 07 Jun 2018 13:58:47 GMT
+      - Mon, 30 Jul 2018 20:55:26 GMT
     body:
       encoding: UTF-8
       base64_string: ''
     http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:48 GMT
+  recorded_at: Mon, 30 Jul 2018 20:55:26 GMT
+- request:
+    method: delete
+    uri: https://alpha.partello.example.com:8443/candlepin/owners/scenario_test
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Authorization:
+      - OAuth oauth_consumer_key="f3SrjSXwpnyQJkiNLCAuePYsZU5UbVUw", oauth_nonce="drtnDkH2brGb9ngNdgIbSjqE4Xmn4TwI9ElYVwI",
+        oauth_signature="6lzjM4kXi3FDdLciyBnJkmRV1DA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1532984126", oauth_version="1.0"
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 56423575-1c5f-4292-ad52-2a2bc1f21acb
+      X-Version:
+      - 2.4.5-1
+      Date:
+      - Mon, 30 Jul 2018 20:55:26 GMT
+    body:
+      encoding: UTF-8
+      base64_string: ''
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:26 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/product_create.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/product_create.yml
@@ -1,267 +1,6 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/products/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJuYW1lIjoiU2NlbmFyaW8gUHJvZHVjdCIsImlkIjoiN2M4MjUwMTNjYWIw
-        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJtdWx0aXBsaWVyIjoxLCJhdHRyaWJ1
-        dGVzIjpbeyJuYW1lIjoiYXJjaCIsInZhbHVlIjoiQUxMIn1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp",
-        oauth_nonce="p2gwFj9JeGhWxI9F6UTyOuHPgNz0NS9br4EGNTZqmU", oauth_signature="EvSKbNpjSlA5aYcmCHx4iCBw%2BGk%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1528379903", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-      Content-Length:
-      - '127'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 759c8316-2fae-498d-a67c-17bd817d1bc1
-      X-Version:
-      - 2.3.8-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Thu, 07 Jun 2018 13:58:23 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOC0wNi0wN1QxMzo1ODoyMyswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTgtMDYtMDdUMTM6NTg6MjMrMDAwMCIsInV1aWQiOiI0MDI4Zjk1
-        MTYzZGE1YjFiMDE2M2RhOGE4ZGIzMDAwNCIsImlkIjoiN2M4MjUwMTNjYWIw
-        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
-        dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
-        IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
-        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOTUxNjNkYTViMWIwMTYzZGE4YThkYjMw
-        MDA0IiwicHJvZHVjdENvbnRlbnQiOltdfQ==
-    http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:23 GMT
-- request:
-    method: post
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/pools
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzdGFydERhdGUiOiIyMDE3LTAxLTAxVDIwOjE1OjAxLjAwMFoiLCJlbmRE
-        YXRlIjoiMjA0Ni0xMi0yNVQyMDoxNTowMS4wMDBaIiwicXVhbnRpdHkiOi0x
-        LCJhY2NvdW50TnVtYmVyIjoiIiwicHJvZHVjdElkIjoiN2M4MjUwMTNjYWIw
-        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJwcm92aWRlZFByb2R1Y3RzIjpbXSwi
-        Y29udHJhY3ROdW1iZXIiOiIifQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp",
-        oauth_nonce="vhI9HLjd1lj5lDtpZrIWW76uwsRxcpN841sAxrCPHaE", oauth_signature="hDkI3pVDWsN76IeNyQ9tcTS5P6I%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1528379903", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-      Content-Length:
-      - '199'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 88a2f272-98fb-4ad3-a48c-08c6d0655822
-      X-Version:
-      - 2.3.8-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Thu, 07 Jun 2018 13:58:23 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOC0wNi0wN1QxMzo1ODoyMyswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTgtMDYtMDdUMTM6NTg6MjMrMDAwMCIsImlkIjoiNDAyOGY5NTE2
-        M2RhNWIxYjAxNjNkYThhOGUxZTAwMDUiLCJ0eXBlIjoiTk9STUFMIiwib3du
-        ZXIiOnsiaWQiOiI0MDI4Zjk1MTYzZGE1YjFiMDE2M2RhOGE4OWU0MDAwMCIs
-        ImtleSI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5TmFtZSI6InNjZW5hcmlv
-        X3Rlc3QiLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0sImFjdGl2
-        ZVN1YnNjcmlwdGlvbiI6dHJ1ZSwiY3JlYXRlZEJ5U2hhcmUiOmZhbHNlLCJo
-        YXNTaGFyZWRBbmNlc3RvciI6ZmFsc2UsInNvdXJjZUVudGl0bGVtZW50Ijpu
-        dWxsLCJxdWFudGl0eSI6LTEsInN0YXJ0RGF0ZSI6IjIwMTctMDEtMDFUMjA6
-        MTU6MDErMDAwMCIsImVuZERhdGUiOiIyMDQ2LTEyLTI1VDIwOjE1OjAxKzAw
-        MDAiLCJhdHRyaWJ1dGVzIjpbXSwicmVzdHJpY3RlZFRvVXNlcm5hbWUiOm51
-        bGwsImNvbnRyYWN0TnVtYmVyIjpudWxsLCJhY2NvdW50TnVtYmVyIjpudWxs
-        LCJvcmRlck51bWJlciI6bnVsbCwiY29uc3VtZWQiOjAsImV4cG9ydGVkIjow
-        LCJzaGFyZWQiOjAsImJyYW5kaW5nIjpbXSwiY2FsY3VsYXRlZEF0dHJpYnV0
-        ZXMiOm51bGwsInVwc3RyZWFtUG9vbElkIjpudWxsLCJ1cHN0cmVhbUVudGl0
-        bGVtZW50SWQiOm51bGwsInVwc3RyZWFtQ29uc3VtZXJJZCI6bnVsbCwicHJv
-        ZHVjdE5hbWUiOiJTY2VuYXJpbyBQcm9kdWN0IiwicHJvZHVjdElkIjoiN2M4
-        MjUwMTNjYWIwMTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJwcm9kdWN0QXR0cmli
-        dXRlcyI6W3sibmFtZSI6ImFyY2giLCJ2YWx1ZSI6IkFMTCJ9XSwic3RhY2tJ
-        ZCI6bnVsbCwic3RhY2tlZCI6ZmFsc2UsInNvdXJjZVN0YWNrSWQiOm51bGws
-        ImRldmVsb3BtZW50UG9vbCI6ZmFsc2UsImRlcml2ZWRQcm9kdWN0QXR0cmli
-        dXRlcyI6W10sImRlcml2ZWRQcm9kdWN0SWQiOm51bGwsImRlcml2ZWRQcm9k
-        dWN0TmFtZSI6bnVsbCwicHJvdmlkZWRQcm9kdWN0cyI6W10sImRlcml2ZWRQ
-        cm92aWRlZFByb2R1Y3RzIjpbXSwic3Vic2NyaXB0aW9uU3ViS2V5IjpudWxs
-        LCJzdWJzY3JpcHRpb25JZCI6bnVsbCwiaHJlZiI6Ii9wb29scy80MDI4Zjk1
-        MTYzZGE1YjFiMDE2M2RhOGE4ZTFlMDAwNSJ9
-    http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:23 GMT
-- request:
-    method: get
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="kThwHpA47lsfZ0XmN5pbWHoODsYJcG28YhoPUBGsuA",
-        oauth_signature="uNX8UgCAkACDg%2BMTv7k%2FIRMIod4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1528379903", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 1dc003dd-12fa-484d-96f8-35e2b61a7192
-      X-Version:
-      - 2.3.8-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Thu, 07 Jun 2018 13:58:23 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOC0wNi0wN1QxMzo1ODoyMyswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTgtMDYtMDdUMTM6NTg6MjMrMDAwMCIsInV1aWQiOiI0MDI4Zjk1
-        MTYzZGE1YjFiMDE2M2RhOGE4ZGIzMDAwNCIsImlkIjoiN2M4MjUwMTNjYWIw
-        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
-        dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
-        IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
-        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOTUxNjNkYTViMWIwMTYzZGE4YThkYjMw
-        MDA0IiwicHJvZHVjdENvbnRlbnQiOltdfQ==
-    http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:23 GMT
-- request:
-    method: get
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/pools?add_future=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="lPFCIYVZAWPY6RQqCgpzrmWcaqmEdQr2Zeyv0T8j5Q",
-        oauth_signature="NX1ls%2F%2Bnxw4Yzoo7pJnhT76jW0Y%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1528379903", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 99bb3165-4eb3-4315-9a23-32d40813c2bc
-      X-Version:
-      - 2.3.8-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Thu, 07 Jun 2018 13:58:23 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3siY3JlYXRlZCI6IjIwMTgtMDYtMDdUMTM6NTg6MjMrMDAwMCIsInVwZGF0
-        ZWQiOiIyMDE4LTA2LTA3VDEzOjU4OjIzKzAwMDAiLCJpZCI6IjQwMjhmOTUx
-        NjNkYTViMWIwMTYzZGE4YThlMWUwMDA1IiwidHlwZSI6Ik5PUk1BTCIsIm93
-        bmVyIjp7ImlkIjoiNDAyOGY5NTE2M2RhNWIxYjAxNjNkYThhODllNDAwMDAi
-        LCJrZXkiOiJzY2VuYXJpb190ZXN0IiwiZGlzcGxheU5hbWUiOiJzY2VuYXJp
-        b190ZXN0IiwiaHJlZiI6Ii9vd25lcnMvc2NlbmFyaW9fdGVzdCJ9LCJhY3Rp
-        dmVTdWJzY3JpcHRpb24iOnRydWUsImNyZWF0ZWRCeVNoYXJlIjpmYWxzZSwi
-        aGFzU2hhcmVkQW5jZXN0b3IiOmZhbHNlLCJzb3VyY2VFbnRpdGxlbWVudCI6
-        bnVsbCwicXVhbnRpdHkiOi0xLCJzdGFydERhdGUiOiIyMDE3LTAxLTAxVDIw
-        OjE1OjAxKzAwMDAiLCJlbmREYXRlIjoiMjA0Ni0xMi0yNVQyMDoxNTowMSsw
-        MDAwIiwiYXR0cmlidXRlcyI6W10sInJlc3RyaWN0ZWRUb1VzZXJuYW1lIjpu
-        dWxsLCJjb250cmFjdE51bWJlciI6bnVsbCwiYWNjb3VudE51bWJlciI6bnVs
-        bCwib3JkZXJOdW1iZXIiOm51bGwsImNvbnN1bWVkIjowLCJleHBvcnRlZCI6
-        MCwic2hhcmVkIjowLCJicmFuZGluZyI6W10sImNhbGN1bGF0ZWRBdHRyaWJ1
-        dGVzIjp7ImNvbXBsaWFuY2VfdHlwZSI6IlN0YW5kYXJkIn0sInVwc3RyZWFt
-        UG9vbElkIjpudWxsLCJ1cHN0cmVhbUVudGl0bGVtZW50SWQiOm51bGwsInVw
-        c3RyZWFtQ29uc3VtZXJJZCI6bnVsbCwicHJvZHVjdE5hbWUiOiJTY2VuYXJp
-        byBQcm9kdWN0IiwicHJvZHVjdElkIjoiN2M4MjUwMTNjYWIwMTM0OWFlOGNi
-        OGRiMTg3ZGUzOTEiLCJwcm9kdWN0QXR0cmlidXRlcyI6W3sibmFtZSI6ImFy
-        Y2giLCJ2YWx1ZSI6IkFMTCJ9XSwic3RhY2tJZCI6bnVsbCwic3RhY2tlZCI6
-        ZmFsc2UsInNvdXJjZVN0YWNrSWQiOm51bGwsImRldmVsb3BtZW50UG9vbCI6
-        ZmFsc2UsImRlcml2ZWRQcm9kdWN0QXR0cmlidXRlcyI6W10sImRlcml2ZWRQ
-        cm9kdWN0SWQiOm51bGwsImRlcml2ZWRQcm9kdWN0TmFtZSI6bnVsbCwicHJv
-        dmlkZWRQcm9kdWN0cyI6W10sImRlcml2ZWRQcm92aWRlZFByb2R1Y3RzIjpb
-        XSwic3Vic2NyaXB0aW9uU3ViS2V5IjpudWxsLCJzdWJzY3JpcHRpb25JZCI6
-        bnVsbCwiaHJlZiI6Ii9wb29scy80MDI4Zjk1MTYzZGE1YjFiMDE2M2RhOGE4
-        ZTFlMDAwNSJ9XQ==
-    http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:23 GMT
-- request:
     method: get
     uri: https://dev.example.com:8443/candlepin/pools/4028f95163da5b1b0163da8a8e1e0005
     body:
@@ -335,53 +74,6 @@ http_interactions:
   recorded_at: Thu, 07 Jun 2018 13:58:23 GMT
 - request:
     method: get
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/activation_keys/?include=pools.pool.id
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="HhcKJ0bCW5rSoZ7cPYjwpkvangCF6l5FcjaaSgQOg4",
-        oauth_signature="5VX8LPCjLjJ8U9d62xUq9kJ84o8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1528379903", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - ca1e5a9a-7ed9-4a1b-b6c4-82761d2b00fb
-      X-Version:
-      - 2.3.8-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Thu, 07 Jun 2018 13:58:23 GMT
-    body:
-      encoding: UTF-8
-      base64_string: 'W10=
-
-'
-    http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:23 GMT
-- request:
-    method: get
     uri: https://dev.example.com:8443/candlepin/pools/4028f95163da5b1b0163da8a8e1e0005/entitlements?include=consumer.uuid
     body:
       encoding: US-ASCII
@@ -427,4 +119,431 @@ http_interactions:
 '
     http_version: 
   recorded_at: Thu, 07 Jun 2018 13:58:23 GMT
+- request:
+    method: post
+    uri: https://alpha.partello.example.com:8443/candlepin/owners/scenario_test/products/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiU2NlbmFyaW8gUHJvZHVjdCIsImlkIjoiN2M4MjUwMTNjYWIw
+        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJtdWx0aXBsaWVyIjoxLCJhdHRyaWJ1
+        dGVzIjpbeyJuYW1lIjoiYXJjaCIsInZhbHVlIjoiQUxMIn1dfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="f3SrjSXwpnyQJkiNLCAuePYsZU5UbVUw",
+        oauth_nonce="zooyoTOXT4u9oOs47MerA05E5Znb5JPYiq1bLRloc", oauth_signature="utFHr3%2FWnZP5%2BjsJCySfknniMGo%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1532984101", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '127'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - b960ec41-6623-4a13-bbb2-b12c1743a31f
+      X-Version:
+      - 2.4.5-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 30 Jul 2018 20:55:01 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0wNy0zMFQyMDo1NTowMSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMDctMzBUMjA6NTU6MDErMDAwMCIsInV1aWQiOiI0MDI4ZTk0
+        NDY0ZWNjODQzMDE2NGVjZjkwYmQ4MDAwYSIsImlkIjoiN2M4MjUwMTNjYWIw
+        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
+        dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
+        IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
+        cmVmIjoiL3Byb2R1Y3RzLzQwMjhlOTQ0NjRlY2M4NDMwMTY0ZWNmOTBiZDgw
+        MDBhIiwicHJvZHVjdENvbnRlbnQiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:01 GMT
+- request:
+    method: post
+    uri: https://alpha.partello.example.com:8443/candlepin/owners/scenario_test/pools
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzdGFydERhdGUiOiIyMDE3LTAxLTAxVDIwOjE1OjAxLjAwMFoiLCJlbmRE
+        YXRlIjoiMjA0Ni0xMi0yNVQyMDoxNTowMS4wMDBaIiwicXVhbnRpdHkiOi0x
+        LCJhY2NvdW50TnVtYmVyIjoiIiwicHJvZHVjdElkIjoiN2M4MjUwMTNjYWIw
+        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJwcm92aWRlZFByb2R1Y3RzIjpbXSwi
+        Y29udHJhY3ROdW1iZXIiOiIifQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="f3SrjSXwpnyQJkiNLCAuePYsZU5UbVUw",
+        oauth_nonce="LjTdrNntPHbj8GSAuXuOjFCC5ylFXeWkUtOXy3pnk", oauth_signature="D1eJS%2Bxozt4QDgKPbH3S5pr61ZI%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1532984101", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '199'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 7b8df9ae-dda1-4129-8917-e82d442089cd
+      X-Version:
+      - 2.4.5-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 30 Jul 2018 20:55:01 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0wNy0zMFQyMDo1NTowMSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMDctMzBUMjA6NTU6MDErMDAwMCIsImlkIjoiNDAyOGU5NDQ2
+        NGVjYzg0MzAxNjRlY2Y5MGMzNjAwMGIiLCJ0eXBlIjoiTk9STUFMIiwib3du
+        ZXIiOnsiaWQiOiI0MDI4ZTk0NDY0ZWNjODQzMDE2NGVjZjkwOWNkMDAwNiIs
+        ImtleSI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5TmFtZSI6InNjZW5hcmlv
+        X3Rlc3QiLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0sImFjdGl2
+        ZVN1YnNjcmlwdGlvbiI6dHJ1ZSwiY3JlYXRlZEJ5U2hhcmUiOmZhbHNlLCJo
+        YXNTaGFyZWRBbmNlc3RvciI6ZmFsc2UsInNvdXJjZUVudGl0bGVtZW50Ijpu
+        dWxsLCJxdWFudGl0eSI6LTEsInN0YXJ0RGF0ZSI6IjIwMTctMDEtMDFUMjA6
+        MTU6MDErMDAwMCIsImVuZERhdGUiOiIyMDQ2LTEyLTI1VDIwOjE1OjAxKzAw
+        MDAiLCJhdHRyaWJ1dGVzIjpbXSwicmVzdHJpY3RlZFRvVXNlcm5hbWUiOm51
+        bGwsImNvbnRyYWN0TnVtYmVyIjpudWxsLCJhY2NvdW50TnVtYmVyIjpudWxs
+        LCJvcmRlck51bWJlciI6bnVsbCwiY29uc3VtZWQiOjAsImV4cG9ydGVkIjow
+        LCJzaGFyZWQiOjAsImJyYW5kaW5nIjpbXSwiY2FsY3VsYXRlZEF0dHJpYnV0
+        ZXMiOm51bGwsInVwc3RyZWFtUG9vbElkIjpudWxsLCJ1cHN0cmVhbUVudGl0
+        bGVtZW50SWQiOm51bGwsInVwc3RyZWFtQ29uc3VtZXJJZCI6bnVsbCwicHJv
+        ZHVjdE5hbWUiOiJTY2VuYXJpbyBQcm9kdWN0IiwicHJvZHVjdElkIjoiN2M4
+        MjUwMTNjYWIwMTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJwcm9kdWN0QXR0cmli
+        dXRlcyI6W3sibmFtZSI6ImFyY2giLCJ2YWx1ZSI6IkFMTCJ9XSwic3RhY2tJ
+        ZCI6bnVsbCwic3RhY2tlZCI6ZmFsc2UsInNvdXJjZVN0YWNrSWQiOm51bGws
+        ImRldmVsb3BtZW50UG9vbCI6ZmFsc2UsImRlcml2ZWRQcm9kdWN0QXR0cmli
+        dXRlcyI6W10sImRlcml2ZWRQcm9kdWN0SWQiOm51bGwsImRlcml2ZWRQcm9k
+        dWN0TmFtZSI6bnVsbCwicHJvdmlkZWRQcm9kdWN0cyI6W10sImRlcml2ZWRQ
+        cm92aWRlZFByb2R1Y3RzIjpbXSwic3Vic2NyaXB0aW9uU3ViS2V5IjpudWxs
+        LCJzdWJzY3JpcHRpb25JZCI6bnVsbCwiaHJlZiI6Ii9wb29scy80MDI4ZTk0
+        NDY0ZWNjODQzMDE2NGVjZjkwYzM2MDAwYiJ9
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:01 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Authorization:
+      - OAuth oauth_consumer_key="f3SrjSXwpnyQJkiNLCAuePYsZU5UbVUw", oauth_nonce="hghyz5EU12vySbBGgrYXYm5WnfPgVYldpGSULuDtk",
+        oauth_signature="Fa6WzTQkQt1OH%2FZ8w2FjypzJJ2M%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1532984102", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - a487c558-d173-42a5-8360-4a3ae6d65558
+      X-Version:
+      - 2.4.5-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 30 Jul 2018 20:55:01 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0wNy0zMFQyMDo1NTowMSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMDctMzBUMjA6NTU6MDErMDAwMCIsInV1aWQiOiI0MDI4ZTk0
+        NDY0ZWNjODQzMDE2NGVjZjkwYmQ4MDAwYSIsImlkIjoiN2M4MjUwMTNjYWIw
+        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
+        dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
+        IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
+        cmVmIjoiL3Byb2R1Y3RzLzQwMjhlOTQ0NjRlY2M4NDMwMTY0ZWNmOTBiZDgw
+        MDBhIiwicHJvZHVjdENvbnRlbnQiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:02 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com:8443/candlepin/owners/scenario_test/pools?add_future=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Authorization:
+      - OAuth oauth_consumer_key="f3SrjSXwpnyQJkiNLCAuePYsZU5UbVUw", oauth_nonce="HNyDUVwfTBaGhZO4nPvCcHnHL9QRetQUkuqoMkukCOQ",
+        oauth_signature="OOQ5QjvGN7QkzVsk7f1utIOMmqQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1532984102", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 568ec477-5b46-49d1-b2f6-b4ca0fe04e8c
+      X-Version:
+      - 2.4.5-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 30 Jul 2018 20:55:01 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        W3siY3JlYXRlZCI6IjIwMTgtMDctMzBUMjA6NTU6MDErMDAwMCIsInVwZGF0
+        ZWQiOiIyMDE4LTA3LTMwVDIwOjU1OjAxKzAwMDAiLCJpZCI6IjQwMjhlOTQ0
+        NjRlY2M4NDMwMTY0ZWNmOTBjMzYwMDBiIiwidHlwZSI6Ik5PUk1BTCIsIm93
+        bmVyIjp7ImlkIjoiNDAyOGU5NDQ2NGVjYzg0MzAxNjRlY2Y5MDljZDAwMDYi
+        LCJrZXkiOiJzY2VuYXJpb190ZXN0IiwiZGlzcGxheU5hbWUiOiJzY2VuYXJp
+        b190ZXN0IiwiaHJlZiI6Ii9vd25lcnMvc2NlbmFyaW9fdGVzdCJ9LCJhY3Rp
+        dmVTdWJzY3JpcHRpb24iOnRydWUsImNyZWF0ZWRCeVNoYXJlIjpmYWxzZSwi
+        aGFzU2hhcmVkQW5jZXN0b3IiOmZhbHNlLCJzb3VyY2VFbnRpdGxlbWVudCI6
+        bnVsbCwicXVhbnRpdHkiOi0xLCJzdGFydERhdGUiOiIyMDE3LTAxLTAxVDIw
+        OjE1OjAxKzAwMDAiLCJlbmREYXRlIjoiMjA0Ni0xMi0yNVQyMDoxNTowMSsw
+        MDAwIiwiYXR0cmlidXRlcyI6W10sInJlc3RyaWN0ZWRUb1VzZXJuYW1lIjpu
+        dWxsLCJjb250cmFjdE51bWJlciI6bnVsbCwiYWNjb3VudE51bWJlciI6bnVs
+        bCwib3JkZXJOdW1iZXIiOm51bGwsImNvbnN1bWVkIjowLCJleHBvcnRlZCI6
+        MCwic2hhcmVkIjowLCJicmFuZGluZyI6W10sImNhbGN1bGF0ZWRBdHRyaWJ1
+        dGVzIjp7ImNvbXBsaWFuY2VfdHlwZSI6IlN0YW5kYXJkIn0sInVwc3RyZWFt
+        UG9vbElkIjpudWxsLCJ1cHN0cmVhbUVudGl0bGVtZW50SWQiOm51bGwsInVw
+        c3RyZWFtQ29uc3VtZXJJZCI6bnVsbCwicHJvZHVjdE5hbWUiOiJTY2VuYXJp
+        byBQcm9kdWN0IiwicHJvZHVjdElkIjoiN2M4MjUwMTNjYWIwMTM0OWFlOGNi
+        OGRiMTg3ZGUzOTEiLCJwcm9kdWN0QXR0cmlidXRlcyI6W3sibmFtZSI6ImFy
+        Y2giLCJ2YWx1ZSI6IkFMTCJ9XSwic3RhY2tJZCI6bnVsbCwic3RhY2tlZCI6
+        ZmFsc2UsInNvdXJjZVN0YWNrSWQiOm51bGwsImRldmVsb3BtZW50UG9vbCI6
+        ZmFsc2UsImRlcml2ZWRQcm9kdWN0QXR0cmlidXRlcyI6W10sImRlcml2ZWRQ
+        cm9kdWN0SWQiOm51bGwsImRlcml2ZWRQcm9kdWN0TmFtZSI6bnVsbCwicHJv
+        dmlkZWRQcm9kdWN0cyI6W10sImRlcml2ZWRQcm92aWRlZFByb2R1Y3RzIjpb
+        XSwic3Vic2NyaXB0aW9uU3ViS2V5IjpudWxsLCJzdWJzY3JpcHRpb25JZCI6
+        bnVsbCwiaHJlZiI6Ii9wb29scy80MDI4ZTk0NDY0ZWNjODQzMDE2NGVjZjkw
+        YzM2MDAwYiJ9XQ==
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:02 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com:8443/candlepin/pools/4028e94464ecc8430164ecf90c36000b
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Authorization:
+      - OAuth oauth_consumer_key="f3SrjSXwpnyQJkiNLCAuePYsZU5UbVUw", oauth_nonce="qmgvkWHY6prgvI7B2wGbioo9kLbNf8uGmCwtMqks",
+        oauth_signature="A4CP8uoo3PbVaOuLqtYM901tHP8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1532984102", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - e60dde7c-d716-4627-9ea3-6bf0e9fdab97
+      X-Version:
+      - 2.4.5-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 30 Jul 2018 20:55:01 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0wNy0zMFQyMDo1NTowMSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMDctMzBUMjA6NTU6MDErMDAwMCIsImlkIjoiNDAyOGU5NDQ2
+        NGVjYzg0MzAxNjRlY2Y5MGMzNjAwMGIiLCJ0eXBlIjoiTk9STUFMIiwib3du
+        ZXIiOnsiaWQiOiI0MDI4ZTk0NDY0ZWNjODQzMDE2NGVjZjkwOWNkMDAwNiIs
+        ImtleSI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5TmFtZSI6InNjZW5hcmlv
+        X3Rlc3QiLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0sImFjdGl2
+        ZVN1YnNjcmlwdGlvbiI6dHJ1ZSwiY3JlYXRlZEJ5U2hhcmUiOmZhbHNlLCJo
+        YXNTaGFyZWRBbmNlc3RvciI6ZmFsc2UsInNvdXJjZUVudGl0bGVtZW50Ijpu
+        dWxsLCJxdWFudGl0eSI6LTEsInN0YXJ0RGF0ZSI6IjIwMTctMDEtMDFUMjA6
+        MTU6MDErMDAwMCIsImVuZERhdGUiOiIyMDQ2LTEyLTI1VDIwOjE1OjAxKzAw
+        MDAiLCJhdHRyaWJ1dGVzIjpbXSwicmVzdHJpY3RlZFRvVXNlcm5hbWUiOm51
+        bGwsImNvbnRyYWN0TnVtYmVyIjpudWxsLCJhY2NvdW50TnVtYmVyIjpudWxs
+        LCJvcmRlck51bWJlciI6bnVsbCwiY29uc3VtZWQiOjAsImV4cG9ydGVkIjow
+        LCJzaGFyZWQiOjAsImJyYW5kaW5nIjpbXSwiY2FsY3VsYXRlZEF0dHJpYnV0
+        ZXMiOnsiY29tcGxpYW5jZV90eXBlIjoiU3RhbmRhcmQifSwidXBzdHJlYW1Q
+        b29sSWQiOm51bGwsInVwc3RyZWFtRW50aXRsZW1lbnRJZCI6bnVsbCwidXBz
+        dHJlYW1Db25zdW1lcklkIjpudWxsLCJwcm9kdWN0TmFtZSI6IlNjZW5hcmlv
+        IFByb2R1Y3QiLCJwcm9kdWN0SWQiOiI3YzgyNTAxM2NhYjAxMzQ5YWU4Y2I4
+        ZGIxODdkZTM5MSIsInByb2R1Y3RBdHRyaWJ1dGVzIjpbeyJuYW1lIjoiYXJj
+        aCIsInZhbHVlIjoiQUxMIn1dLCJzdGFja0lkIjpudWxsLCJzdGFja2VkIjpm
+        YWxzZSwic291cmNlU3RhY2tJZCI6bnVsbCwiZGV2ZWxvcG1lbnRQb29sIjpm
+        YWxzZSwiZGVyaXZlZFByb2R1Y3RBdHRyaWJ1dGVzIjpbXSwiZGVyaXZlZFBy
+        b2R1Y3RJZCI6bnVsbCwiZGVyaXZlZFByb2R1Y3ROYW1lIjpudWxsLCJwcm92
+        aWRlZFByb2R1Y3RzIjpbXSwiZGVyaXZlZFByb3ZpZGVkUHJvZHVjdHMiOltd
+        LCJzdWJzY3JpcHRpb25TdWJLZXkiOm51bGwsInN1YnNjcmlwdGlvbklkIjpu
+        dWxsLCJocmVmIjoiL3Bvb2xzLzQwMjhlOTQ0NjRlY2M4NDMwMTY0ZWNmOTBj
+        MzYwMDBiIn0=
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:02 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com:8443/candlepin/owners/scenario_test/activation_keys/?include=pools.pool.id
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Authorization:
+      - OAuth oauth_consumer_key="f3SrjSXwpnyQJkiNLCAuePYsZU5UbVUw", oauth_nonce="Qk5c08ZQYw4deteJkCpWU86FnpkvGRSpTPvGX9ZWxQ",
+        oauth_signature="0jrxGiRSyr1tFY8zBIErXs4LvKE%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1532984102", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - dc32a2f6-832a-450e-9170-9d56dd335589
+      X-Version:
+      - 2.4.5-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 30 Jul 2018 20:55:01 GMT
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:02 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com:8443/candlepin/pools/4028e94464ecc8430164ecf90c36000b/entitlements/consumer_uuids
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Authorization:
+      - OAuth oauth_consumer_key="f3SrjSXwpnyQJkiNLCAuePYsZU5UbVUw", oauth_nonce="V8pcsbPqH3W7XS3xp4FUMQ43Ms4Uw4K6lottAX4AiE",
+        oauth_signature="G%2BNEEF0hdmsBYcQWrhfNdA7Y82Y%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1532984102", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 5ffbc380-96d7-444a-bf81-e459f71eda73
+      X-Version:
+      - 2.4.5-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 30 Jul 2018 20:55:01 GMT
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:02 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/repo_create.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/repo_create.yml
@@ -2,136 +2,6 @@
 http_interactions:
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5X25hbWUiOiJTY2VuYXJp
-        byB5dW0gcHJvZHVjdCIsImltcG9ydGVyX3R5cGVfaWQiOiJ5dW1faW1wb3J0
-        ZXIiLCJpbXBvcnRlcl9jb25maWciOnsiZmVlZCI6ImZpbGU6Ly8vdmFyL3d3
-        dy90ZXN0X3JlcG9zL3pvbyIsInByb3h5X2hvc3QiOm51bGwsInNzbF9jYV9j
-        ZXJ0IjpudWxsLCJzc2xfY2xpZW50X2NlcnQiOm51bGwsInNzbF9jbGllbnRf
-        a2V5IjpudWxsLCJzc2xfdmFsaWRhdGlvbiI6dHJ1ZSwiZG93bmxvYWRfcG9s
-        aWN5IjoiaW1tZWRpYXRlIiwicmVtb3ZlX21pc3NpbmciOnRydWV9LCJub3Rl
-        cyI6eyJfcmVwby10eXBlIjoicnBtLXJlcG8ifSwiZGlzdHJpYnV0b3JzIjpb
-        eyJkaXN0cmlidXRvcl90eXBlX2lkIjoieXVtX2Rpc3RyaWJ1dG9yIiwiZGlz
-        dHJpYnV0b3JfY29uZmlnIjp7InJlbGF0aXZlX3VybCI6InNjZW5hcmlvX3Rl
-        c3QiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3RlY3RlZCI6dHJ1
-        ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3JfaWQiOiJzY2Vu
-        YXJpb190ZXN0In0seyJkaXN0cmlidXRvcl90eXBlX2lkIjoiZXhwb3J0X2Rp
-        c3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7Imh0dHAiOmZhbHNl
-        LCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6InNjZW5hcmlvX3Rlc3Qi
-        fSwiYXV0b19wdWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJleHBv
-        cnRfZGlzdHJpYnV0b3IifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
-        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
-        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJzY2VuYXJpb190ZXN0In0sImF1
-        dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoic2NlbmFyaW9f
-        dGVzdF9jbG9uZSJ9XX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '914'
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Thu, 07 Jun 2018 13:58:24 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '332'
-      Location:
-      - "/pulp/api/v2/repositories/scenario_test/"
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiU2NlbmFyaW8g
-        eXVtIHByb2R1Y3QiLCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0
-        X2FkZGVkIjogbnVsbCwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
-        ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
-        aXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lkIjogeyIkb2lk
-        IjogIjViMTkzYTAwNDE4YThhMDRjOTExMjFiOSJ9LCAiaWQiOiAic2NlbmFy
-        aW9fdGVzdCIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVz
-        L3NjZW5hcmlvX3Rlc3QvIn0=
-    http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:24 GMT
-- request:
-    method: post
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/content/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJuYW1lIjoiU2NlbmFyaW8geXVtIHByb2R1Y3QiLCJjb250ZW50VXJsIjoi
-        L2N1c3RvbS9TY2VuYXJpb19Qcm9kdWN0L1NjZW5hcmlvX3l1bV9wcm9kdWN0
-        IiwidHlwZSI6Inl1bSIsImFyY2hlcyI6bnVsbCwibGFiZWwiOiJzY2VuYXJp
-        b190ZXN0X1NjZW5hcmlvX1Byb2R1Y3RfU2NlbmFyaW9feXVtX3Byb2R1Y3Qi
-        LCJtZXRhZGF0YUV4cGlyZSI6MSwidmVuZG9yIjoiQ3VzdG9tIn0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp",
-        oauth_nonce="SDkuyCBByJLCQmRkN6IMWYnqpiMhsFAlyZLjOav4zA", oauth_signature="kR%2FmpACaIONhIhbjQra53pJnoSo%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1528379904", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-      Content-Length:
-      - '218'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 91bb1993-e905-4731-ab2f-450e9a9d775f
-      X-Version:
-      - 2.3.8-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Thu, 07 Jun 2018 13:58:24 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOC0wNi0wN1QxMzo1ODoyNCswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTgtMDYtMDdUMTM6NTg6MjQrMDAwMCIsInV1aWQiOiI0MDI4Zjk1
-        MTYzZGE1YjFiMDE2M2RhOGE5MTNkMDAwNyIsImlkIjoiMTUyODM3OTkwNDMx
-        MCIsInR5cGUiOiJ5dW0iLCJsYWJlbCI6InNjZW5hcmlvX3Rlc3RfU2NlbmFy
-        aW9fUHJvZHVjdF9TY2VuYXJpb195dW1fcHJvZHVjdCIsIm5hbWUiOiJTY2Vu
-        YXJpbyB5dW0gcHJvZHVjdCIsInZlbmRvciI6IkN1c3RvbSIsImNvbnRlbnRV
-        cmwiOiIvY3VzdG9tL1NjZW5hcmlvX1Byb2R1Y3QvU2NlbmFyaW9feXVtX3By
-        b2R1Y3QiLCJyZXF1aXJlZFRhZ3MiOm51bGwsImdwZ1VybCI6bnVsbCwibW9k
-        aWZpZWRQcm9kdWN0SWRzIjpbXSwiYXJjaGVzIjpudWxsLCJtZXRhZGF0YUV4
-        cGlyZSI6MSwicmVsZWFzZVZlciI6bnVsbH0=
-    http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:24 GMT
-- request:
-    method: post
     uri: https://dev.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/content/1528379904310?enabled=true
     body:
       encoding: UTF-8
@@ -194,58 +64,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 07 Jun 2018 13:58:24 GMT
 - request:
-    method: get
-    uri: https://dev.example.com:8443/candlepin/environments/119c4753ff6d3b7bd0b76de6d5a5f94a
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="Ct1QC2STFmLMtUrNyqnvvzMAbjDp3zECFN9ota4",
-        oauth_signature="T%2BpEFWtp6sD8ICtlAGJkSmj9XRw%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1528379904", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 1ffb5562-2598-4d60-a2a5-a3b1df32de47
-      X-Version:
-      - 2.3.8-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Thu, 07 Jun 2018 13:58:24 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOC0wNi0wN1QxMzo1ODoyMiswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTgtMDYtMDdUMTM6NTg6MjIrMDAwMCIsImlkIjoiMTE5YzQ3NTNm
-        ZjZkM2I3YmQwYjc2ZGU2ZDVhNWY5NGEiLCJuYW1lIjoiTGlicmFyeSIsImRl
-        c2NyaXB0aW9uIjpudWxsLCJvd25lciI6eyJpZCI6IjQwMjhmOTUxNjNkYTVi
-        MWIwMTYzZGE4YTg5ZTQwMDAwIiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRp
-        c3BsYXlOYW1lIjoic2NlbmFyaW9fdGVzdCIsImhyZWYiOiIvb3duZXJzL3Nj
-        ZW5hcmlvX3Rlc3QifSwiZW52aXJvbm1lbnRDb250ZW50IjpbXX0=
-    http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:24 GMT
-- request:
     method: post
     uri: https://dev.example.com:8443/candlepin/environments/119c4753ff6d3b7bd0b76de6d5a5f94a/content
     body:
@@ -303,139 +121,6 @@ http_interactions:
         OiIvam9icy9yZWdlbl9lbnRpdGxlbWVudF9jZXJ0X29mX2VudjdiNTQxMjg4
         LTYyZDMtNDNiNS04NGI5LWY2Mzk5YjQ0YTFiZSIsImdyb3VwIjoiYXN5bmMg
         Z3JvdXAifQ==
-    http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:24 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 07 Jun 2018 13:58:24 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"9a5f367436b1ec8bc75c758fdd613626-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2292'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiU2NlbmFyaW8g
-        eXVtIHByb2R1Y3QiLCAiZGVzY3JpcHRpb24iOiBudWxsLCAiZGlzdHJpYnV0
-        b3JzIjogW3sicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgImxhc3RfdXBk
-        YXRlZCI6ICIyMDE4LTA2LTA3VDEzOjU4OjI0WiIsICJfaHJlZiI6ICIvcHVs
-        cC9hcGkvdjIvcmVwb3NpdG9yaWVzL3NjZW5hcmlvX3Rlc3QvZGlzdHJpYnV0
-        b3JzL3NjZW5hcmlvX3Rlc3RfY2xvbmUvIiwgImxhc3Rfb3ZlcnJpZGVfY29u
-        ZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3Jf
-        dHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJs
-        aXNoIjogZmFsc2UsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19k
-        aXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjViMTkzYTAwNDE4YThh
-        MDRjOTExMjFiZCJ9LCAiY29uZmlnIjogeyJkZXN0aW5hdGlvbl9kaXN0cmli
-        dXRvcl9pZCI6ICJzY2VuYXJpb190ZXN0In0sICJpZCI6ICJzY2VuYXJpb190
-        ZXN0X2Nsb25lIn0sIHsicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgImxh
-        c3RfdXBkYXRlZCI6ICIyMDE4LTA2LTA3VDEzOjU4OjI0WiIsICJfaHJlZiI6
-        ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL3NjZW5hcmlvX3Rlc3QvZGlz
-        dHJpYnV0b3JzL3NjZW5hcmlvX3Rlc3QvIiwgImxhc3Rfb3ZlcnJpZGVfY29u
-        ZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3Jf
-        dHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjog
-        dHJ1ZSwgInNjcmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1
-        dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAiNWIxOTNhMDA0MThhOGEwNGM5MTEy
-        MWJiIn0sICJjb25maWciOiB7InByb3RlY3RlZCI6IHRydWUsICJodHRwIjog
-        ZmFsc2UsICJodHRwcyI6IHRydWUsICJyZWxhdGl2ZV91cmwiOiAic2NlbmFy
-        aW9fdGVzdCJ9LCAiaWQiOiAic2NlbmFyaW9fdGVzdCJ9LCB7InJlcG9faWQi
-        OiAic2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOC0wNi0w
-        N1QxMzo1ODoyNFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRv
-        cmllcy9zY2VuYXJpb190ZXN0L2Rpc3RyaWJ1dG9ycy9leHBvcnRfZGlzdHJp
-        YnV0b3IvIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1
-        Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJleHBvcnRf
-        ZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNo
-        cGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjog
-        eyIkb2lkIjogIjViMTkzYTAwNDE4YThhMDRjOTExMjFiYyJ9LCAiY29uZmln
-        IjogeyJodHRwIjogZmFsc2UsICJyZWxhdGl2ZV91cmwiOiAic2NlbmFyaW9f
-        dGVzdCIsICJodHRwcyI6IGZhbHNlfSwgImlkIjogImV4cG9ydF9kaXN0cmli
-        dXRvciJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3RlcyI6IHsi
-        X3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3JlbW92ZWQi
-        OiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25zIjogInJl
-        cG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAic2NlbmFyaW9fdGVz
-        dCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOC0wNi0wN1QxMzo1ODoyNFoiLCAi
-        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJpb190
-        ZXN0L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2lt
-        cG9ydGVycyIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjogbnVs
-        bCwgInNjcmF0Y2hwYWQiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjViMTkz
-        YTAwNDE4YThhMDRjOTExMjFiYSJ9LCAiY29uZmlnIjogeyJmZWVkIjogImZp
-        bGU6Ly8vdmFyL3d3dy90ZXN0X3JlcG9zL3pvbyIsICJzc2xfdmFsaWRhdGlv
-        biI6IHRydWUsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9w
-        b2xpY3kiOiAiaW1tZWRpYXRlIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0s
-        ICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQiOiAi
-        NWIxOTNhMDA0MThhOGEwNGM5MTEyMWI5In0sICJ0b3RhbF9yZXBvc2l0b3J5
-        X3VuaXRzIjogMCwgImlkIjogInNjZW5hcmlvX3Rlc3QiLCAiX2hyZWYiOiAi
-        L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJpb190ZXN0LyJ9
-    http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:24 GMT
-- request:
-    method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/actions/publish/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6InNjZW5hcmlvX3Rlc3QiLCJvdmVycmlkZV9jb25maWciOnsiZm9y
-        Y2VfZnVsbCI6ZmFsc2V9fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '61'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 07 Jun 2018 13:58:24 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2RiYWYyZDMwLTQ1ZjAtNDAxMi1hMWQ1LTBhMDRhZGYxODdkOS8iLCAi
-        dGFza19pZCI6ICJkYmFmMmQzMC00NWYwLTQwMTItYTFkNS0wYTA0YWRmMTg3
-        ZDkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
   recorded_at: Thu, 07 Jun 2018 13:58:24 GMT
 - request:
@@ -1069,4 +754,1122 @@ http_interactions:
         LCAiaWQiOiAiNWIxOTNhMDA0ODNlZmQwYTQ3YzNhY2M0In0=
     http_version: 
   recorded_at: Thu, 07 Jun 2018 13:58:25 GMT
+- request:
+    method: post
+    uri: https://alpha.partello.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5X25hbWUiOiJTY2VuYXJp
+        byB5dW0gcHJvZHVjdCIsImltcG9ydGVyX3R5cGVfaWQiOiJ5dW1faW1wb3J0
+        ZXIiLCJpbXBvcnRlcl9jb25maWciOnsiZmVlZCI6ImZpbGU6Ly8vdmFyL3d3
+        dy90ZXN0X3JlcG9zL3pvbyIsInByb3h5X2hvc3QiOm51bGwsInNzbF9jYV9j
+        ZXJ0IjpudWxsLCJzc2xfY2xpZW50X2NlcnQiOm51bGwsInNzbF9jbGllbnRf
+        a2V5IjpudWxsLCJzc2xfdmFsaWRhdGlvbiI6dHJ1ZSwiZG93bmxvYWRfcG9s
+        aWN5IjoiaW1tZWRpYXRlIiwicmVtb3ZlX21pc3NpbmciOnRydWV9LCJub3Rl
+        cyI6eyJfcmVwby10eXBlIjoicnBtLXJlcG8ifSwiZGlzdHJpYnV0b3JzIjpb
+        eyJkaXN0cmlidXRvcl90eXBlX2lkIjoieXVtX2Rpc3RyaWJ1dG9yIiwiZGlz
+        dHJpYnV0b3JfY29uZmlnIjp7InJlbGF0aXZlX3VybCI6InNjZW5hcmlvX3Rl
+        c3QiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRydWUsInByb3RlY3RlZCI6dHJ1
+        ZX0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3JfaWQiOiJzY2Vu
+        YXJpb190ZXN0In0seyJkaXN0cmlidXRvcl90eXBlX2lkIjoiZXhwb3J0X2Rp
+        c3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7Imh0dHAiOmZhbHNl
+        LCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6InNjZW5hcmlvX3Rlc3Qi
+        fSwiYXV0b19wdWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJleHBv
+        cnRfZGlzdHJpYnV0b3IifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1f
+        Y2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVz
+        dGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJzY2VuYXJpb190ZXN0In0sImF1
+        dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoic2NlbmFyaW9f
+        dGVzdF9jbG9uZSJ9XX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '914'
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:02 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '332'
+      Location:
+      - https://alpha.partello.example.com/pulp/api/v2/repositories/scenario_test/
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiU2NlbmFyaW8g
+        eXVtIHByb2R1Y3QiLCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0
+        X2FkZGVkIjogbnVsbCwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
+        ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
+        aXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lkIjogeyIkb2lk
+        IjogIjViNWY3YjI2ZDZjYzA2NDcyNTA4YTk1ZCJ9LCAiaWQiOiAic2NlbmFy
+        aW9fdGVzdCIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVz
+        L3NjZW5hcmlvX3Rlc3QvIn0=
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:02 GMT
+- request:
+    method: post
+    uri: https://alpha.partello.example.com:8443/candlepin/owners/scenario_test/content/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiU2NlbmFyaW8geXVtIHByb2R1Y3QiLCJjb250ZW50VXJsIjoi
+        L2N1c3RvbS9TY2VuYXJpb19Qcm9kdWN0L1NjZW5hcmlvX3l1bV9wcm9kdWN0
+        IiwidHlwZSI6Inl1bSIsImFyY2hlcyI6bnVsbCwibGFiZWwiOiJzY2VuYXJp
+        b190ZXN0X1NjZW5hcmlvX1Byb2R1Y3RfU2NlbmFyaW9feXVtX3Byb2R1Y3Qi
+        LCJtZXRhZGF0YUV4cGlyZSI6MSwidmVuZG9yIjoiQ3VzdG9tIn0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="f3SrjSXwpnyQJkiNLCAuePYsZU5UbVUw",
+        oauth_nonce="CPLIvY2aIAYLSgIAZFr1we4o10940Ymp7bn2wCL0iNM", oauth_signature="TKHedLDIXQPdG5b7RNpArdlSvMk%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1532984102", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '218'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 528e738c-3803-45fd-994f-342a9bc54e6c
+      X-Version:
+      - 2.4.5-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 30 Jul 2018 20:55:01 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0wNy0zMFQyMDo1NTowMiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMDctMzBUMjA6NTU6MDIrMDAwMCIsInV1aWQiOiI0MDI4ZTk0
+        NDY0ZWNjODQzMDE2NGVjZjkwZjdkMDAwZCIsImlkIjoiMTUzMjk4NDEwMjc4
+        MCIsInR5cGUiOiJ5dW0iLCJsYWJlbCI6InNjZW5hcmlvX3Rlc3RfU2NlbmFy
+        aW9fUHJvZHVjdF9TY2VuYXJpb195dW1fcHJvZHVjdCIsIm5hbWUiOiJTY2Vu
+        YXJpbyB5dW0gcHJvZHVjdCIsInZlbmRvciI6IkN1c3RvbSIsImNvbnRlbnRV
+        cmwiOiIvY3VzdG9tL1NjZW5hcmlvX1Byb2R1Y3QvU2NlbmFyaW9feXVtX3By
+        b2R1Y3QiLCJyZXF1aXJlZFRhZ3MiOm51bGwsImdwZ1VybCI6bnVsbCwibW9k
+        aWZpZWRQcm9kdWN0SWRzIjpbXSwiYXJjaGVzIjpudWxsLCJtZXRhZGF0YUV4
+        cGlyZSI6MSwicmVsZWFzZVZlciI6bnVsbH0=
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:02 GMT
+- request:
+    method: post
+    uri: https://alpha.partello.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/content/1532984102780?enabled=true
+    body:
+      encoding: UTF-8
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="f3SrjSXwpnyQJkiNLCAuePYsZU5UbVUw",
+        oauth_nonce="NZfoPyuL2quk0cDhd9TntgJesMEyDoYE0wJdwstuOo", oauth_signature="GcnMoH9YGT47Tni6kUfidZe3ESk%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1532984102", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - c8f130c2-aee5-4e4b-8d0c-11fa3909e804
+      X-Version:
+      - 2.4.5-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 30 Jul 2018 20:55:02 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0wNy0zMFQyMDo1NTowMSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMDctMzBUMjA6NTU6MDIrMDAwMCIsInV1aWQiOiI0MDI4ZTk0
+        NDY0ZWNjODQzMDE2NGVjZjkwZmQ1MDAwZSIsImlkIjoiN2M4MjUwMTNjYWIw
+        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
+        dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
+        IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
+        cmVmIjoiL3Byb2R1Y3RzLzQwMjhlOTQ0NjRlY2M4NDMwMTY0ZWNmOTBmZDUw
+        MDBlIiwicHJvZHVjdENvbnRlbnQiOlt7ImNvbnRlbnQiOnsiY3JlYXRlZCI6
+        IjIwMTgtMDctMzBUMjA6NTU6MDIrMDAwMCIsInVwZGF0ZWQiOiIyMDE4LTA3
+        LTMwVDIwOjU1OjAyKzAwMDAiLCJ1dWlkIjoiNDAyOGU5NDQ2NGVjYzg0MzAx
+        NjRlY2Y5MGY3ZDAwMGQiLCJpZCI6IjE1MzI5ODQxMDI3ODAiLCJ0eXBlIjoi
+        eXVtIiwibGFiZWwiOiJzY2VuYXJpb190ZXN0X1NjZW5hcmlvX1Byb2R1Y3Rf
+        U2NlbmFyaW9feXVtX3Byb2R1Y3QiLCJuYW1lIjoiU2NlbmFyaW8geXVtIHBy
+        b2R1Y3QiLCJ2ZW5kb3IiOiJDdXN0b20iLCJjb250ZW50VXJsIjoiL2N1c3Rv
+        bS9TY2VuYXJpb19Qcm9kdWN0L1NjZW5hcmlvX3l1bV9wcm9kdWN0IiwicmVx
+        dWlyZWRUYWdzIjpudWxsLCJncGdVcmwiOm51bGwsIm1vZGlmaWVkUHJvZHVj
+        dElkcyI6W10sImFyY2hlcyI6bnVsbCwibWV0YWRhdGFFeHBpcmUiOjEsInJl
+        bGVhc2VWZXIiOm51bGx9LCJlbmFibGVkIjp0cnVlfV19
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:02 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com:8443/candlepin/environments/119c4753ff6d3b7bd0b76de6d5a5f94a
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Authorization:
+      - OAuth oauth_consumer_key="f3SrjSXwpnyQJkiNLCAuePYsZU5UbVUw", oauth_nonce="1pbaYbZ3xnKMY1zBVbh2JTTmkX4zJyldZKXAlFREtI",
+        oauth_signature="nP%2BnCu%2FoV4lpKnE0gofvmhHVJpg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1532984102", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - ce25a0bb-b8d8-4d02-a292-8c70da25857b
+      X-Version:
+      - 2.4.5-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 30 Jul 2018 20:55:02 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0wNy0zMFQyMDo1NTowMSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMDctMzBUMjA6NTU6MDErMDAwMCIsImlkIjoiMTE5YzQ3NTNm
+        ZjZkM2I3YmQwYjc2ZGU2ZDVhNWY5NGEiLCJuYW1lIjoiTGlicmFyeSIsImRl
+        c2NyaXB0aW9uIjpudWxsLCJvd25lciI6eyJpZCI6IjQwMjhlOTQ0NjRlY2M4
+        NDMwMTY0ZWNmOTA5Y2QwMDA2Iiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRp
+        c3BsYXlOYW1lIjoic2NlbmFyaW9fdGVzdCIsImhyZWYiOiIvb3duZXJzL3Nj
+        ZW5hcmlvX3Rlc3QifSwiZW52aXJvbm1lbnRDb250ZW50IjpbXX0=
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:02 GMT
+- request:
+    method: post
+    uri: https://alpha.partello.example.com:8443/candlepin/environments/119c4753ff6d3b7bd0b76de6d5a5f94a/content
+    body:
+      encoding: UTF-8
+      base64_string: 'W3siY29udGVudElkIjoiMTUzMjk4NDEwMjc4MCJ9XQ==
+
+'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="f3SrjSXwpnyQJkiNLCAuePYsZU5UbVUw",
+        oauth_nonce="uCcfrJ79MJ9GBWxDvEuR2NupZYt3BGFy0i9INDKGY", oauth_signature="jCcwcd2IZ3yB%2BE3Db8HXVf28lm4%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1532984102", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '31'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 583cba0c-7947-4e81-939d-c989ce8311f6
+      X-Version:
+      - 2.4.5-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 30 Jul 2018 20:55:02 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0wNy0zMFQyMDo1NTowMyswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMDctMzBUMjA6NTU6MDMrMDAwMCIsImlkIjoicmVnZW5fZW50
+        aXRsZW1lbnRfY2VydF9vZl9lbnZkYjMxNGFhMy0yYWE3LTQyOTktODhiZS02
+        YmM4MGU2NzE5ZTIiLCJzdGF0ZSI6IkNSRUFURUQiLCJzdGFydFRpbWUiOm51
+        bGwsImZpbmlzaFRpbWUiOm51bGwsInJlc3VsdCI6bnVsbCwicHJpbmNpcGFs
+        TmFtZSI6ImZvcmVtYW5fYWRtaW4iLCJ0YXJnZXRUeXBlIjpudWxsLCJ0YXJn
+        ZXRJZCI6bnVsbCwib3duZXJJZCI6bnVsbCwiY29ycmVsYXRpb25JZCI6bnVs
+        bCwicmVzdWx0RGF0YSI6bnVsbCwiZG9uZSI6ZmFsc2UsInN0YXR1c1BhdGgi
+        OiIvam9icy9yZWdlbl9lbnRpdGxlbWVudF9jZXJ0X29mX2VudmRiMzE0YWEz
+        LTJhYTctNDI5OS04OGJlLTZiYzgwZTY3MTllMiIsImdyb3VwIjoiYXN5bmMg
+        Z3JvdXAifQ==
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:03 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/repositories/scenario_test/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:03 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2292'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiU2NlbmFyaW8g
+        eXVtIHByb2R1Y3QiLCAiZGVzY3JpcHRpb24iOiBudWxsLCAiZGlzdHJpYnV0
+        b3JzIjogW3sicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgImxhc3RfdXBk
+        YXRlZCI6ICIyMDE4LTA3LTMwVDIwOjU1OjAyWiIsICJfaHJlZiI6ICIvcHVs
+        cC9hcGkvdjIvcmVwb3NpdG9yaWVzL3NjZW5hcmlvX3Rlc3QvZGlzdHJpYnV0
+        b3JzL3NjZW5hcmlvX3Rlc3RfY2xvbmUvIiwgImxhc3Rfb3ZlcnJpZGVfY29u
+        ZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3Jf
+        dHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJs
+        aXNoIjogZmFsc2UsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19k
+        aXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjViNWY3YjI2ZDZjYzA2
+        NDcyNTA4YTk2MSJ9LCAiY29uZmlnIjogeyJkZXN0aW5hdGlvbl9kaXN0cmli
+        dXRvcl9pZCI6ICJzY2VuYXJpb190ZXN0In0sICJpZCI6ICJzY2VuYXJpb190
+        ZXN0X2Nsb25lIn0sIHsicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgImxh
+        c3RfdXBkYXRlZCI6ICIyMDE4LTA3LTMwVDIwOjU1OjAyWiIsICJfaHJlZiI6
+        ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL3NjZW5hcmlvX3Rlc3QvZGlz
+        dHJpYnV0b3JzL3NjZW5hcmlvX3Rlc3QvIiwgImxhc3Rfb3ZlcnJpZGVfY29u
+        ZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3Jf
+        dHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjog
+        dHJ1ZSwgInNjcmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1
+        dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAiNWI1ZjdiMjZkNmNjMDY0NzI1MDhh
+        OTVmIn0sICJjb25maWciOiB7InByb3RlY3RlZCI6IHRydWUsICJodHRwIjog
+        ZmFsc2UsICJodHRwcyI6IHRydWUsICJyZWxhdGl2ZV91cmwiOiAic2NlbmFy
+        aW9fdGVzdCJ9LCAiaWQiOiAic2NlbmFyaW9fdGVzdCJ9LCB7InJlcG9faWQi
+        OiAic2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOC0wNy0z
+        MFQyMDo1NTowMloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRv
+        cmllcy9zY2VuYXJpb190ZXN0L2Rpc3RyaWJ1dG9ycy9leHBvcnRfZGlzdHJp
+        YnV0b3IvIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1
+        Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJleHBvcnRf
+        ZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNo
+        cGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjog
+        eyIkb2lkIjogIjViNWY3YjI2ZDZjYzA2NDcyNTA4YTk2MCJ9LCAiY29uZmln
+        IjogeyJodHRwIjogZmFsc2UsICJyZWxhdGl2ZV91cmwiOiAic2NlbmFyaW9f
+        dGVzdCIsICJodHRwcyI6IGZhbHNlfSwgImlkIjogImV4cG9ydF9kaXN0cmli
+        dXRvciJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3RlcyI6IHsi
+        X3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3JlbW92ZWQi
+        OiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25zIjogInJl
+        cG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAic2NlbmFyaW9fdGVz
+        dCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOC0wNy0zMFQyMDo1NTowMloiLCAi
+        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJpb190
+        ZXN0L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2lt
+        cG9ydGVycyIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjogbnVs
+        bCwgInNjcmF0Y2hwYWQiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjViNWY3
+        YjI2ZDZjYzA2NDcyNTA4YTk1ZSJ9LCAiY29uZmlnIjogeyJmZWVkIjogImZp
+        bGU6Ly8vdmFyL3d3dy90ZXN0X3JlcG9zL3pvbyIsICJzc2xfdmFsaWRhdGlv
+        biI6IHRydWUsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9w
+        b2xpY3kiOiAiaW1tZWRpYXRlIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0s
+        ICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQiOiAi
+        NWI1ZjdiMjZkNmNjMDY0NzI1MDhhOTVkIn0sICJ0b3RhbF9yZXBvc2l0b3J5
+        X3VuaXRzIjogMCwgImlkIjogInNjZW5hcmlvX3Rlc3QiLCAiX2hyZWYiOiAi
+        L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJpb190ZXN0LyJ9
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:03 GMT
+- request:
+    method: post
+    uri: https://alpha.partello.example.com/pulp/api/v2/repositories/scenario_test/actions/publish/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6InNjZW5hcmlvX3Rlc3QiLCJvdmVycmlkZV9jb25maWciOnsiZm9y
+        Y2VfZnVsbCI6ZmFsc2V9fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '61'
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:03 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2FmOGUxMWVhLWZmN2EtNGZiNC1hZTBkLTM5OTI2NWI2OGFhNC8iLCAi
+        dGFza19pZCI6ICJhZjhlMTFlYS1mZjdhLTRmYjQtYWUwZC0zOTkyNjViNjhh
+        YTQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:03 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/af8e11ea-ff7a-4fb4-ae0d-399265b68aa4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:03 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '560'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9hZjhlMTFlYS1mZjdhLTRmYjQtYWUwZC0zOTky
+        NjViNjhhYTQvIiwgInRhc2tfaWQiOiAiYWY4ZTExZWEtZmY3YS00ZmI0LWFl
+        MGQtMzk5MjY1YjY4YWE0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIk5vbmUu
+        ZHEiLCAic3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6IG51bGws
+        ICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
+        IjogIjViNWY3YjI3MmY1ZWEyMjg4ZjZmNDg0YyJ9LCAiaWQiOiAiNWI1Zjdi
+        MjcyZjVlYTIyODhmNmY0ODRjIn0=
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:03 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/af8e11ea-ff7a-4fb4-ae0d-399265b68aa4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:03 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '678'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9hZjhlMTFlYS1mZjdhLTRmYjQtYWUwZC0zOTky
+        NjViNjhhYTQvIiwgInRhc2tfaWQiOiAiYWY4ZTExZWEtZmY3YS00ZmI0LWFl
+        MGQtMzk5MjY1YjY4YWE0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMDctMzBUMjA6NTU6MDNaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFscGhh
+        LnBhcnRlbGxvLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmci
+        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
+        YWxwaGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwg
+        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YjVmN2IyNzJmNWVh
+        MjI4OGY2ZjQ4NGMifSwgImlkIjogIjViNWY3YjI3MmY1ZWEyMjg4ZjZmNDg0
+        YyJ9
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:03 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/af8e11ea-ff7a-4fb4-ae0d-399265b68aa4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:03 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4039'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9hZjhlMTFlYS1mZjdhLTRmYjQtYWUwZC0zOTky
+        NjViNjhhYTQvIiwgInRhc2tfaWQiOiAiYWY4ZTExZWEtZmY3YS00ZmI0LWFl
+        MGQtMzk5MjY1YjY4YWE0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMDctMzBUMjA6NTU6MDNaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjgyYjZkMjBjLTMyMjktNDM2Mi1hMTc0LWEyMjNjYjAyMDQ0NyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmODY4
+        NjE5OS1iMTY0LTRmY2EtYmE4Yy1iYzMyYTExNGI2MTAiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI5ZGQzYjMyOC0xYmE1LTQ1ZGEtODhlMS04YjExNjAxY2Y3
+        MmYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNTVmYzgxYi0xYTgy
+        LTQ3MTgtOTM1Zi0yMDk0MzZkMzhiNGMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiNGZjZTEyOTEtMDBhOS00OGE5LTk1Y2MtMmUxNmUyZDM2M2I4
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90
+        eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
+        VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUyMzg2ZDYzLTQ3
+        MTktNGNiZC04NDUyLWNmMDY5ZmUzOGFhZCIsICJudW1fcHJvY2Vzc2VkIjog
+        MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImEyODE2NDExLTdmNzYtNGVkZi1hYzczLTRkZGQ3
+        YTA3YmM2MSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwg
+        InN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3Rv
+        dGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImY5MTI5Zjk1LTNjNWYtNGMzOS1hMTE5LTg0NGU2NWY3MDE2
+        NiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
+        ZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJhZmU1NWQxNC1hZGFmLTQ0MjctOWYzYS01NjE4NTc5NzJlMjgiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAi
+        cmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2MTM4
+        OTAxMi1jMzE2LTRlZDgtOGJmOS0zOGE3ZjZiMjk2ZDciLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3Zp
+        ZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzkzYjQxZDQtZWUyMC00ZDE1LWE1
+        ZmMtYzc4ZWU3ZTVkODQ0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVz
+        IHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAi
+        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiZmFhZTliODAtYzBiZi00ZDM2LTlmNjEtMzNl
+        MzBkY2QwZDQxIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZpbGUi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJlY2VlZDU5NS03ZDc1LTQwMTYtOTUxMS05Mjk3
+        OWMzMDIzNzEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBhbHBoYS5wYXJ0ZWxsby5leGFt
+        cGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFscGhhLnBhcnRlbGxv
+        LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNWI1ZjdiMjcyZjVlYTIyODhmNmY0ODRjIn0s
+        ICJpZCI6ICI1YjVmN2IyNzJmNWVhMjI4OGY2ZjQ4NGMifQ==
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:03 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/af8e11ea-ff7a-4fb4-ae0d-399265b68aa4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:03 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4016'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9hZjhlMTFlYS1mZjdhLTRmYjQtYWUwZC0zOTky
+        NjViNjhhYTQvIiwgInRhc2tfaWQiOiAiYWY4ZTExZWEtZmY3YS00ZmI0LWFl
+        MGQtMzk5MjY1YjY4YWE0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMDctMzBUMjA6NTU6MDNaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjgyYjZkMjBjLTMyMjktNDM2Mi1hMTc0LWEyMjNjYjAyMDQ0NyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmODY4
+        NjE5OS1iMTY0LTRmY2EtYmE4Yy1iYzMyYTExNGI2MTAiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI5ZGQzYjMyOC0xYmE1LTQ1ZGEtODhlMS04YjExNjAxY2Y3
+        MmYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNTVmYzgxYi0xYTgy
+        LTQ3MTgtOTM1Zi0yMDk0MzZkMzhiNGMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiNGZjZTEyOTEtMDBhOS00OGE5LTk1Y2MtMmUxNmUyZDM2M2I4Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
+        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUyMzg2ZDYzLTQ3MTktNGNi
+        ZC04NDUyLWNmMDY5ZmUzOGFhZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
+        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogImEyODE2NDExLTdmNzYtNGVkZi1hYzczLTRkZGQ3YTA3YmM2MSIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY5
+        MTI5Zjk1LTNjNWYtNGMzOS1hMTE5LTg0NGU2NWY3MDE2NiIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
+        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
+        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFmZTU1ZDE0LWFkYWYt
+        NDQyNy05ZjNhLTU2MTg1Nzk3MmUyOCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcg
+        b2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9k
+        YXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjYxMzg5MDEyLWMzMTYtNGVkOC04YmY5
+        LTM4YTdmNmIyOTZkNyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        Ijc5M2I0MWQ0LWVlMjAtNGQxNS1hNWZjLWM3OGVlN2U1ZDg0NCIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjog
+        InB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZhYWU5
+        YjgwLWMwYmYtNGQzNi05ZjYxLTMzZTMwZGNkMGQ0MSIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
+        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWNlZWQ1
+        OTUtN2Q3NS00MDE2LTk1MTEtOTI5NzljMzAyMzcxIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTBAYWxwaGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        cnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMEBhbHBoYS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQi
+        OiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjViNWY3
+        YjI3MmY1ZWEyMjg4ZjZmNDg0YyJ9LCAiaWQiOiAiNWI1ZjdiMjcyZjVlYTIy
+        ODhmNmY0ODRjIn0=
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:03 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/af8e11ea-ff7a-4fb4-ae0d-399265b68aa4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:03 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4010'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9hZjhlMTFlYS1mZjdhLTRmYjQtYWUwZC0zOTky
+        NjViNjhhYTQvIiwgInRhc2tfaWQiOiAiYWY4ZTExZWEtZmY3YS00ZmI0LWFl
+        MGQtMzk5MjY1YjY4YWE0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMDctMzBUMjA6NTU6MDNaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjgyYjZkMjBjLTMyMjktNDM2Mi1hMTc0LWEyMjNjYjAyMDQ0NyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmODY4
+        NjE5OS1iMTY0LTRmY2EtYmE4Yy1iYzMyYTExNGI2MTAiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI5ZGQzYjMyOC0xYmE1LTQ1ZGEtODhlMS04YjExNjAxY2Y3
+        MmYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNTVmYzgxYi0xYTgy
+        LTQ3MTgtOTM1Zi0yMDk0MzZkMzhiNGMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiNGZjZTEyOTEtMDBhOS00OGE5LTk1Y2MtMmUxNmUyZDM2M2I4Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBl
+        IjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUyMzg2ZDYzLTQ3MTktNGNi
+        ZC04NDUyLWNmMDY5ZmUzOGFhZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBN
+        ZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogImEyODE2NDExLTdmNzYtNGVkZi1hYzczLTRkZGQ3YTA3YmM2MSIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY5
+        MTI5Zjk1LTNjNWYtNGMzOS1hMTE5LTg0NGU2NWY3MDE2NiIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdl
+        bmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
+        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFmZTU1ZDE0LWFkYWYt
+        NDQyNy05ZjNhLTU2MTg1Nzk3MmUyOCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcg
+        b2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9k
+        YXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjYxMzg5MDEyLWMzMTYtNGVkOC04YmY5
+        LTM4YTdmNmIyOTZkNyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        Ijc5M2I0MWQ0LWVlMjAtNGQxNS1hNWZjLWM3OGVlN2U1ZDg0NCIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjog
+        InB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZhYWU5Yjgw
+        LWMwYmYtNGQzNi05ZjYxLTMzZTMwZGNkMGQ0MSIsICJudW1fcHJvY2Vzc2Vk
+        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3Jp
+        dGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXpl
+        X3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWNlZWQ1OTUtN2Q3
+        NS00MDE2LTk1MTEtOTI5NzljMzAyMzcxIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWxw
+        aGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEBhbHBoYS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjViNWY3YjI3MmY1
+        ZWEyMjg4ZjZmNDg0YyJ9LCAiaWQiOiAiNWI1ZjdiMjcyZjVlYTIyODhmNmY0
+        ODRjIn0=
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:03 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/af8e11ea-ff7a-4fb4-ae0d-399265b68aa4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:03 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '8021'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9hZjhlMTFlYS1mZjdhLTRmYjQtYWUwZC0zOTky
+        NjViNjhhYTQvIiwgInRhc2tfaWQiOiAiYWY4ZTExZWEtZmY3YS00ZmI0LWFl
+        MGQtMzk5MjY1YjY4YWE0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTgtMDctMzBUMjA6NTU6MDNaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTgtMDctMzBUMjA6NTU6MDNa
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
+        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
+        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjgyYjZkMjBjLTMyMjktNDM2Mi1hMTc0
+        LWEyMjNjYjAyMDQ0NyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
+        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJmODY4NjE5OS1iMTY0LTRmY2EtYmE4Yy1iYzMyYTEx
+        NGI2MTAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
+        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5ZGQzYjMyOC0xYmE1LTQ1
+        ZGEtODhlMS04YjExNjAxY2Y3MmYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
+        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICIxNTVmYzgxYi0xYTgyLTQ3MTgtOTM1Zi0yMDk0MzZkMzhiNGMiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
+        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGZjZTEyOTEtMDBhOS00OGE5LTk1
+        Y2MtMmUxNmUyZDM2M2I4IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBz
+        IGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        ImUyMzg2ZDYzLTQ3MTktNGNiZC04NDUyLWNmMDY5ZmUzOGFhZCIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
+        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImEyODE2NDExLTdmNzYtNGVkZi1h
+        YzczLTRkZGQ3YTA3YmM2MSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImY5MTI5Zjk1LTNjNWYtNGMzOS1hMTE5LTg0NGU2
+        NWY3MDE2NiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
+        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImFmZTU1ZDE0LWFkYWYtNDQyNy05ZjNhLTU2MTg1Nzk3MmUyOCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6
+        ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjYxMzg5
+        MDEyLWMzMTYtNGVkOC04YmY5LTM4YTdmNmIyOTZkNyIsICJudW1fcHJvY2Vz
+        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        R2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmll
+        dyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjc5M2I0MWQ0LWVlMjAtNGQxNS1hNWZjLWM3
+        OGVlN2U1ZDg0NCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3
+        ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImZhYWU5YjgwLWMwYmYtNGQzNi05ZjYxLTMzZTMwZGNkMGQ0
+        MSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBf
+        dHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiZWNlZWQ1OTUtN2Q3NS00MDE2LTk1MTEtOTI5NzljMzAyMzcxIiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTBAYWxwaGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWxwaGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRp
+        b24iOiBudWxsLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgInN0YXJ0
+        ZWQiOiAiMjAxOC0wNy0zMFQyMDo1NTowM1oiLCAiX25zIjogInJlcG9fcHVi
+        bGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE4LTA3LTMwVDIwOjU1
+        OjAzWiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9p
+        ZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6IHsiZ2VuZXJhdGUg
+        c3FsaXRlIjogIlNLSVBQRUQiLCAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
+        IjogIkZJTklTSEVEIiwgInJlbW92ZV9vbGRfcmVwb2RhdGEiOiAiRklOSVNI
+        RUQiLCAiY2xvc2VfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJkcnBt
+        cyI6ICJTS0lQUEVEIiwgImNvbXBzIjogIkZJTklTSEVEIiwgImVycmF0YSI6
+        ICJGSU5JU0hFRCIsICJkaXN0cmlidXRpb24iOiAiRklOSVNIRUQiLCAicmVw
+        b3ZpZXciOiAiU0tJUFBFRCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJGSU5J
+        U0hFRCIsICJycG1zIjogIkZJTklTSEVEIiwgIm1ldGFkYXRhIjogIkZJTklT
+        SEVEIn0sICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lk
+        IjogInNjZW5hcmlvX3Rlc3QiLCAiaWQiOiAiNWI1ZjdiMjdkNmNjMDY0ODY2
+        Yjc1ZjYyIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNj
+        cmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVw
+        X3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3Rv
+        dGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjgyYjZkMjBjLTMyMjktNDM2Mi1hMTc0LWEyMjNjYjAyMDQ0NyIs
+        ICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
+        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAi
+        c3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJm
+        ODY4NjE5OS1iMTY0LTRmY2EtYmE4Yy1iYzMyYTExNGI2MTAiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICI5ZGQzYjMyOC0xYmE1LTQ1ZGEtODhlMS04YjExNjAx
+        Y2Y3MmYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJz
+        dGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNTVmYzgxYi0x
+        YTgyLTQ3MTgtOTM1Zi0yMDk0MzZkMzhiNGMiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
+        c2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNf
+        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiNGZjZTEyOTEtMDBhOS00OGE5LTk1Y2MtMmUxNmUyZDM2M2I4
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90
+        eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUyMzg2ZDYzLTQ3MTkt
+        NGNiZC04NDUyLWNmMDY5ZmUzOGFhZCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImEyODE2NDExLTdmNzYtNGVkZi1hYzczLTRkZGQ3YTA3YmM2
+        MSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBf
+        dHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjog
+        MSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        ImY5MTI5Zjk1LTNjNWYtNGMzOS1hMTE5LTg0NGU2NWY3MDE2NiIsICJudW1f
+        cHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjog
+        ImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFmZTU1ZDE0LWFk
+        YWYtNDQyNy05ZjNhLTU2MTg1Nzk3MmUyOCIsICJudW1fcHJvY2Vzc2VkIjog
+        MH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zp
+        bmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3Jl
+        cG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjYxMzg5MDEyLWMzMTYtNGVkOC04
+        YmY5LTM4YTdmNmIyOTZkNyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1M
+        IGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjc5M2I0MWQ0LWVlMjAtNGQxNS1hNWZjLWM3OGVlN2U1ZDg0NCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
+        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZhYWU5
+        YjgwLWMwYmYtNGQzNi05ZjYxLTMzZTMwZGNkMGQ0MSIsICJudW1fcHJvY2Vz
+        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
+        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWNlZWQ1OTUt
+        N2Q3NS00MDE2LTk1MTEtOTI5NzljMzAyMzcxIiwgIm51bV9wcm9jZXNzZWQi
+        OiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjViNWY3
+        YjI3MmY1ZWEyMjg4ZjZmNDg0YyJ9LCAiaWQiOiAiNWI1ZjdiMjcyZjVlYTIy
+        ODhmNmY0ODRjIn0=
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:03 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/repo_sync.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/repo_sync.yml
@@ -1,49 +1,6 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/actions/sync/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
-        Ijp0cnVlfX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '53'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 07 Jun 2018 13:58:45 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzNlODE2ZGI0LTZjYmUtNDYzOC1iZTlmLTI1YjU5OTA3M2ViMS8iLCAi
-        dGFza19pZCI6ICIzZTgxNmRiNC02Y2JlLTQ2MzgtYmU5Zi0yNWI1OTkwNzNl
-        YjEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:45 GMT
-- request:
     method: get
     uri: https://dev.example.com/pulp/api/v2/tasks/3e816db4-6cbe-4638-be9f-25b599073eb1/
     body:
@@ -2080,85 +2037,6 @@ http_interactions:
   recorded_at: Thu, 07 Jun 2018 13:58:46 GMT
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwiZmllbGRzIjp7InVu
-        aXQiOltdLCJhc3NvY2lhdGlvbiI6WyJ1bml0X2lkIl19fX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '80'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 07 Jun 2018 13:58:46 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1672'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIyNTRkNTUxNy05ZWY5LTRiYmUtYWJi
-        Ny05NTExMmI4YjBiMjQiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
-        Il9pZCI6IHsiJG9pZCI6ICI1YjE5M2ExNTQ4M2VmZDBhNDdjM2FjY2IifSwg
-        InVuaXRfaWQiOiAiMjU0ZDU1MTctOWVmOS00YmJlLWFiYjctOTUxMTJiOGIw
-        YjI0IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogIjViYmQ5NjA5LTEwNWItNGIwNy1iMjI5LTllN2U0ZmEyYjNhOCIs
-        ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
-        IjViMTkzYTE1NDgzZWZkMGE0N2MzYWNjOSJ9LCAidW5pdF9pZCI6ICI1YmJk
-        OTYwOS0xMDViLTRiMDctYjIyOS05ZTdlNGZhMmIzYTgiLCAidW5pdF90eXBl
-        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNmIwZGIxMGQt
-        NmFmMS00YTQ4LWI0OTYtMGNlYTIxZGM1MGZjIiwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNWIxOTNhMTU0ODNlZmQw
-        YTQ3YzNhY2M4In0sICJ1bml0X2lkIjogIjZiMGRiMTBkLTZhZjEtNGE0OC1i
-        NDk2LTBjZWEyMWRjNTBmYyIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
-        bWV0YWRhdGEiOiB7Il9pZCI6ICI5ZTIxZTBmMS03ZjE2LTRmMTMtOTBkZS1m
-        MmEwMjAyMGI4MDgiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1YjE5M2ExNTQ4M2VmZDBhNDdjM2FjYzcifSwgInVu
-        aXRfaWQiOiAiOWUyMWUwZjEtN2YxNi00ZjEzLTkwZGUtZjJhMDIwMjBiODA4
-        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
-        IjogImMyN2E0MDU1LTE1ZDMtNDE4Yy1iYzk3LWMzNWEzMWZiMGMyMCIsICJf
-        Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjVi
-        MTkzYTE1NDgzZWZkMGE0N2MzYWNjZCJ9LCAidW5pdF9pZCI6ICJjMjdhNDA1
-        NS0xNWQzLTQxOGMtYmM5Ny1jMzVhMzFmYjBjMjAiLCAidW5pdF90eXBlX2lk
-        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiZDQ2Yjg0Y2QtZWVm
-        NC00ZjU2LTk0NDUtN2MzYWE0NzA0NjEzIiwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNWIxOTNhMTU0ODNlZmQwYTQ3
-        YzNhY2M2In0sICJ1bml0X2lkIjogImQ0NmI4NGNkLWVlZjQtNGY1Ni05NDQ1
-        LTdjM2FhNDcwNDYxMyIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
-        YWRhdGEiOiB7Il9pZCI6ICJkOTU3ZGVmOC1hZmNhLTQxOTQtOGE4ZC04Y2Fl
-        MzI3OTRiNTQiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1YjE5M2ExNTQ4M2VmZDBhNDdjM2FjY2EifSwgInVuaXRf
-        aWQiOiAiZDk1N2RlZjgtYWZjYS00MTk0LThhOGQtOGNhZTMyNzk0YjU0Iiwg
-        InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
-        ImU0NzIyMjUzLTk1ZTgtNDJlMi05MTE0LTFhOTY0ZGU3YThkYiIsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjViMTkz
-        YTE1NDgzZWZkMGE0N2MzYWNjYyJ9LCAidW5pdF9pZCI6ICJlNDcyMjI1My05
-        NWU4LTQyZTItOTExNC0xYTk2NGRlN2E4ZGIiLCAidW5pdF90eXBlX2lkIjog
-        InJwbSJ9XQ==
-    http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:46 GMT
-- request:
-    method: post
     uri: https://dev.example.com/pulp/api/v2/content/units/rpm/search/
     body:
       encoding: UTF-8
@@ -2292,104 +2170,6 @@ http_interactions:
         aCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2Nv
         bnRlbnQvdW5pdHMvcnBtL2U0NzIyMjUzLTk1ZTgtNDJlMi05MTE0LTFhOTY0
         ZGU3YThkYi8ifV0=
-    http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:46 GMT
-- request:
-    method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJzcnBtIl0sImZpZWxkcyI6eyJ1
-        bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '81'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 07 Jun 2018 13:58:46 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '2'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: 'W10=
-
-'
-    http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:46 GMT
-- request:
-    method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImZpZWxkcyI6
-        eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '84'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 07 Jun 2018 13:58:46 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '696'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIwMDQ3ZDg1NC0yYjE0LTQ5NGMtODhh
-        Yi01MDQ0MzIxNGY5NTkiLCAicGtnbGlzdCI6IFtdLCAiX2NvbnRlbnRfdHlw
-        ZV9pZCI6ICJlcnJhdHVtIn0sICJfaWQiOiB7IiRvaWQiOiAiNWIxOTNhMTY0
-        ODNlZmQwYTQ3YzNhY2NmIn0sICJ1bml0X2lkIjogIjAwNDdkODU0LTJiMTQt
-        NDk0Yy04OGFiLTUwNDQzMjE0Zjk1OSIsICJ1bml0X3R5cGVfaWQiOiAiZXJy
-        YXR1bSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYjQwODlmNjEtMjZjZC00
-        ZTE0LTkxNWUtYWY3ZjdlMGEyOTEzIiwgInBrZ2xpc3QiOiBbXSwgIl9jb250
-        ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lkIjogeyIkb2lkIjogIjVi
-        MTkzYTE2NDgzZWZkMGE0N2MzYWNkMCJ9LCAidW5pdF9pZCI6ICJiNDA4OWY2
-        MS0yNmNkLTRlMTQtOTE1ZS1hZjdmN2UwYTI5MTMiLCAidW5pdF90eXBlX2lk
-        IjogImVycmF0dW0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjogImVhYTg3NGE2
-        LWFiNmMtNGRkNi1iMmUyLTBiNzY5ZWFiNDU0OSIsICJwa2dsaXN0IjogW10s
-        ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0ifSwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1YjE5M2ExNjQ4M2VmZDBhNDdjM2FjZDEifSwgInVuaXRfaWQiOiAi
-        ZWFhODc0YTYtYWI2Yy00ZGQ2LWIyZTItMGI3NjllYWI0NTQ5IiwgInVuaXRf
-        dHlwZV9pZCI6ICJlcnJhdHVtIn1d
     http_version: 
   recorded_at: Thu, 07 Jun 2018 13:58:46 GMT
 - request:
@@ -2549,58 +2329,6 @@ http_interactions:
   recorded_at: Thu, 07 Jun 2018 13:58:46 GMT
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwYWNrYWdlX2dyb3VwIl0sImZp
-        ZWxkcyI6eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '90'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 07 Jun 2018 13:58:46 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '458'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI3NmJiZGMwMy0zODFjLTRkMTktYmUz
-        Ny04MTI0OWZmMGFmZWYiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNrYWdl
-        X2dyb3VwIn0sICJfaWQiOiB7IiRvaWQiOiAiNWIxOTNhMTY0ODNlZmQwYTQ3
-        YzNhY2QyIn0sICJ1bml0X2lkIjogIjc2YmJkYzAzLTM4MWMtNGQxOS1iZTM3
-        LTgxMjQ5ZmYwYWZlZiIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91
-        cCJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNzhiNmUwYmUtOGM5NS00MjU0
-        LTk4Y2UtNzEwNzY2ZDEwZGE4IiwgIl9jb250ZW50X3R5cGVfaWQiOiAicGFj
-        a2FnZV9ncm91cCJ9LCAiX2lkIjogeyIkb2lkIjogIjViMTkzYTE2NDgzZWZk
-        MGE0N2MzYWNkMyJ9LCAidW5pdF9pZCI6ICI3OGI2ZTBiZS04Yzk1LTQyNTQt
-        OThjZS03MTA3NjZkMTBkYTgiLCAidW5pdF90eXBlX2lkIjogInBhY2thZ2Vf
-        Z3JvdXAifV0=
-    http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:46 GMT
-- request:
-    method: post
     uri: https://dev.example.com/pulp/api/v2/content/units/package_group/search/
     body:
       encoding: UTF-8
@@ -2672,116 +2400,6 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 07 Jun 2018 13:58:46 GMT
 - request:
-    method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkaXN0cmlidXRpb24iXX19
-
-'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '42'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 07 Jun 2018 13:58:46 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1201'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7ImZpbGVzIjogW3sicmVsYXRpdmVwYXRoIjogImlt
-        YWdlcy90ZXN0Mi5pbWciLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiIsICJj
-        aGVja3N1bSI6ICJlM2IwYzQ0Mjk4ZmMxYzE0OWFmYmY0Yzg5OTZmYjkyNDI3
-        YWU0MWU0NjQ5YjkzNGNhNDk1OTkxYjc4NTJiODU1In0sIHsicmVsYXRpdmVw
-        YXRoIjogImVtcHR5LmlzbyIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2Iiwg
-        ImNoZWNrc3VtIjogImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0
-        MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifSwgeyJyZWxhdGl2
-        ZXBhdGgiOiAiaW1hZ2VzL3Rlc3QxLmltZyIsICJjaGVja3N1bXR5cGUiOiAi
-        c2hhMjU2IiwgImNoZWNrc3VtIjogImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRj
-        ODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifV0s
-        ICJfc3RvcmFnZV9wYXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0
-        cy9kaXN0cmlidXRpb24vOWIvODMxMjU2YTEyNDcxOGJmMzkxNjZiNTY0ZDhl
-        Njg5OTU0ZmYwYThmMGY0NzliYTI0Y2ZhMjYzNTAxMDliYzUiLCAiZmFtaWx5
-        IjogIlRlc3QgRmFtaWx5IiwgImRvd25sb2FkZWQiOiB0cnVlLCAidGltZXN0
-        YW1wIjogMTMyMzExMjE1My4wOSwgIl9sYXN0X3VwZGF0ZWQiOiAxNTI4Mzc5
-        OTI2LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJkaXN0cmlidXRpb24iLCAidmFy
-        aWFudCI6ICJUZXN0VmFyaWFudCIsICJpZCI6ICJrcy1UZXN0IEZhbWlseS1U
-        ZXN0VmFyaWFudC0xNi14ODZfNjQiLCAidmVyc2lvbiI6ICIxNiIsICJ2ZXJz
-        aW9uX3NvcnRfaW5kZXgiOiAiMDItMTYiLCAicHVscF91c2VyX21ldGFkYXRh
-        Ijoge30sICJwYWNrYWdlZGlyIjogIiIsICJfaWQiOiAiNzIxNTNhZTAtZWRl
-        ZS00MDM3LWEzNWEtOWVkODM4YjlmZjYzIiwgImFyY2giOiAieDg2XzY0Iiwg
-        Il9ucyI6ICJ1bml0c19kaXN0cmlidXRpb24ifSwgInVwZGF0ZWQiOiAiMjAx
-        OC0wNi0wN1QxMzo1ODo0NloiLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0
-        IiwgImNyZWF0ZWQiOiAiMjAxOC0wNi0wN1QxMzo1ODo0NloiLCAidW5pdF90
-        eXBlX2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogIjcyMTUzYWUw
-        LWVkZWUtNDAzNy1hMzVhLTllZDgzOGI5ZmY2MyIsICJfaWQiOiB7IiRvaWQi
-        OiAiNWIxOTNhMTY0ODNlZmQwYTQ3YzNhY2NlIn19XQ==
-    http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:46 GMT
-- request:
-    method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/actions/content/regenerate_applicability//
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwYXJhbGxlbCI6dHJ1ZSwicmVwb19jcml0ZXJpYSI6eyJmaWx0ZXJzIjp7
-        ImlkIjp7IiRpbiI6WyJzY2VuYXJpb190ZXN0Il19fX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '78'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Thu, 07 Jun 2018 13:58:46 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '127'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJncm91cF9pZCI6ICIzNWE2ZWU3YS00NDU2LTRkM2UtYTA5Ni1iMWMyYmI4
-        Mjk0YTIiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tfZ3JvdXBzLzM1
-        YTZlZTdhLTQ0NTYtNGQzZS1hMDk2LWIxYzJiYjgyOTRhMi8ifQ==
-    http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:46 GMT
-- request:
     method: get
     uri: https://dev.example.com/pulp/api/v2/task_groups/35a6ee7a-4456-4d3e-a096-b1c2bb8294a2/state_summary/
     body:
@@ -2824,8 +2442,49 @@ http_interactions:
     http_version: 
   recorded_at: Thu, 07 Jun 2018 13:58:46 GMT
 - request:
+    method: post
+    uri: https://alpha.partello.example.com/pulp/api/v2/repositories/scenario_test/actions/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
+        Ijp0cnVlfX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '53'
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:23 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzU2N2RkOWFmLWRmNWEtNDNkYi05YmU3LWRlOGQxZDJiOGRjNy8iLCAi
+        dGFza19pZCI6ICI1NjdkZDlhZi1kZjVhLTQzZGItOWJlNy1kZThkMWQyYjhk
+        YzcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:23 GMT
+- request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/?details=true
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/567dd9af-df5a-43db-9be7-de8d1d2b8dc7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2844,17 +2503,2868 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 07 Jun 2018 13:58:47 GMT
+      - Mon, 30 Jul 2018 20:55:23 GMT
       Server:
       - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"79fac29fc96ea41aca3c439f54f4a0df-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '669'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NjdkZDlhZi1kZjVhLTQzZGItOWJlNy1kZThkMWQyYjhk
+        YzcvIiwgInRhc2tfaWQiOiAiNTY3ZGQ5YWYtZGY1YS00M2RiLTliZTctZGU4
+        ZDFkMmI4ZGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMDctMzBUMjA6NTU6MjNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVl
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFscGhhLnBhcnRlbGxv
+        LmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2Vy
+        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWxwaGEucGFy
+        dGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YjVmN2IzYjJmNWVhMjI4OGY2ZjQ4
+        NGQifSwgImlkIjogIjViNWY3YjNiMmY1ZWEyMjg4ZjZmNDg0ZCJ9
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/567dd9af-df5a-43db-9be7-de8d1d2b8dc7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1138'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NjdkZDlhZi1kZjVhLTQzZGItOWJlNy1kZThkMWQyYjhk
+        YzcvIiwgInRhc2tfaWQiOiAiNTY3ZGQ5YWYtZGY1YS00M2RiLTliZTctZGU4
+        ZDFkMmI4ZGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMDctMzBUMjA6NTU6MjNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMEBhbHBoYS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6
+        ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0wQGFscGhhLnBhcnRlbGxvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWI1
+        ZjdiM2IyZjVlYTIyODhmNmY0ODRkIn0sICJpZCI6ICI1YjVmN2IzYjJmNWVh
+        MjI4OGY2ZjQ4NGQifQ==
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/567dd9af-df5a-43db-9be7-de8d1d2b8dc7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1146'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NjdkZDlhZi1kZjVhLTQzZGItOWJlNy1kZThkMWQyYjhk
+        YzcvIiwgInRhc2tfaWQiOiAiNTY3ZGQ5YWYtZGY1YS00M2RiLTliZTctZGU4
+        ZDFkMmI4ZGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMDctMzBUMjA6NTU6MjNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUi
+        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIs
+        ICJzaXplX2xlZnQiOiAxNzg3MiwgIml0ZW1zX2xlZnQiOiA4fSwgImNvbXBz
+        IjogeyJzdGF0ZSI6ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRl
+        cyI6IHsic3RhdGUiOiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291
+        cmNlX3dvcmtlci0wQGFscGhhLnBhcnRlbGxvLmV4YW1wbGUuY29tLmRxIiwg
+        InN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTBAYWxwaGEucGFydGVsbG8uZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1YjVmN2IzYjJmNWVhMjI4OGY2ZjQ4NGQifSwgImlkIjogIjViNWY3
+        YjNiMmY1ZWEyMjg4ZjZmNDg0ZCJ9
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/567dd9af-df5a-43db-9be7-de8d1d2b8dc7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1146'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NjdkZDlhZi1kZjVhLTQzZGItOWJlNy1kZThkMWQyYjhk
+        YzcvIiwgInRhc2tfaWQiOiAiNTY3ZGQ5YWYtZGY1YS00M2RiLTliZTctZGU4
+        ZDFkMmI4ZGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMDctMzBUMjA6NTU6MjNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUi
+        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogMiwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIs
+        ICJzaXplX2xlZnQiOiAxMzQwNCwgIml0ZW1zX2xlZnQiOiA2fSwgImNvbXBz
+        IjogeyJzdGF0ZSI6ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRl
+        cyI6IHsic3RhdGUiOiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJOT1RfU1RBUlRFRCJ9LCAibWV0YWRhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn19fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291
+        cmNlX3dvcmtlci0wQGFscGhhLnBhcnRlbGxvLmV4YW1wbGUuY29tLmRxIiwg
+        InN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTBAYWxwaGEucGFydGVsbG8uZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1YjVmN2IzYjJmNWVhMjI4OGY2ZjQ4NGQifSwgImlkIjogIjViNWY3
+        YjNiMmY1ZWEyMjg4ZjZmNDg0ZCJ9
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/567dd9af-df5a-43db-9be7-de8d1d2b8dc7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1145'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NjdkZDlhZi1kZjVhLTQzZGItOWJlNy1kZThkMWQyYjhk
+        YzcvIiwgInRhc2tfaWQiOiAiNTY3ZGQ5YWYtZGY1YS00M2RiLTliZTctZGU4
+        ZDFkMmI4ZGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMDctMzBUMjA6NTU6MjNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUi
+        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogNSwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIs
+        ICJzaXplX2xlZnQiOiA2NjkyLCAiaXRlbXNfbGVmdCI6IDN9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIk5PVF9TVEFSVEVEIn0sICJwdXJnZV9kdXBsaWNhdGVz
+        IjogeyJzdGF0ZSI6ICJOT1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjog
+        eyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
+        OiB7InN0YXRlIjogIk5PVF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTBAYWxwaGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEiLCAi
+        c3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMEBhbHBoYS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIs
+        ICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
+        IjogIjViNWY3YjNiMmY1ZWEyMjg4ZjZmNDg0ZCJ9LCAiaWQiOiAiNWI1Zjdi
+        M2IyZjVlYTIyODhmNmY0ODRkIn0=
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/567dd9af-df5a-43db-9be7-de8d1d2b8dc7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1142'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NjdkZDlhZi1kZjVhLTQzZGItOWJlNy1kZThkMWQyYjhk
+        YzcvIiwgInRhc2tfaWQiOiAiNTY3ZGQ5YWYtZGY1YS00M2RiLTliZTctZGU4
+        ZDFkMmI4ZGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMDctMzBUMjA6NTU6MjNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUi
+        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIs
+        ICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJOT1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAYWxwaGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEiLCAic3Rh
+        dGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEBhbHBoYS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJy
+        ZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjog
+        IjViNWY3YjNiMmY1ZWEyMjg4ZjZmNDg0ZCJ9LCAiaWQiOiAiNWI1ZjdiM2Iy
+        ZjVlYTIyODhmNmY0ODRkIn0=
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/567dd9af-df5a-43db-9be7-de8d1d2b8dc7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1139'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NjdkZDlhZi1kZjVhLTQzZGItOWJlNy1kZThkMWQyYjhk
+        YzcvIiwgInRhc2tfaWQiOiAiNTY3ZGQ5YWYtZGY1YS00M2RiLTliZTctZGU4
+        ZDFkMmI4ZGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMDctMzBUMjA6NTU6MjNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIsICJz
+        aXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJOT1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
+        c190b3RhbCI6IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMX0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTBAYWxwaGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUi
+        OiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMEBhbHBoYS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1
+        bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVi
+        NWY3YjNiMmY1ZWEyMjg4ZjZmNDg0ZCJ9LCAiaWQiOiAiNWI1ZjdiM2IyZjVl
+        YTIyODhmNmY0ODRkIn0=
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/567dd9af-df5a-43db-9be7-de8d1d2b8dc7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1136'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NjdkZDlhZi1kZjVhLTQzZGItOWJlNy1kZThkMWQyYjhk
+        YzcvIiwgInRhc2tfaWQiOiAiNTY3ZGQ5YWYtZGY1YS00M2RiLTliZTctZGU4
+        ZDFkMmI4ZGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMDctMzBUMjA6NTU6MjNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIsICJz
+        aXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJOT1RfU1RBUlRFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVt
+        c190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRl
+        IjogIklOX1BST0dSRVNTIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTBAYWxwaGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAi
+        cnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMEBhbHBoYS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQi
+        OiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjViNWY3
+        YjNiMmY1ZWEyMjg4ZjZmNDg0ZCJ9LCAiaWQiOiAiNWI1ZjdiM2IyZjVlYTIy
+        ODhmNmY0ODRkIn0=
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/567dd9af-df5a-43db-9be7-de8d1d2b8dc7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1127'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NjdkZDlhZi1kZjVhLTQzZGItOWJlNy1kZThkMWQyYjhk
+        YzcvIiwgInRhc2tfaWQiOiAiNTY3ZGQ5YWYtZGY1YS00M2RiLTliZTctZGU4
+        ZDFkMmI4ZGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMDctMzBUMjA6NTU6MjNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIsICJz
+        aXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
+        bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
+        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWxwaGEu
+        cGFydGVsbG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBh
+        bHBoYS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjViNWY3YjNiMmY1ZWEy
+        Mjg4ZjZmNDg0ZCJ9LCAiaWQiOiAiNWI1ZjdiM2IyZjVlYTIyODhmNmY0ODRk
+        In0=
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/567dd9af-df5a-43db-9be7-de8d1d2b8dc7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1127'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NjdkZDlhZi1kZjVhLTQzZGItOWJlNy1kZThkMWQyYjhk
+        YzcvIiwgInRhc2tfaWQiOiAiNTY3ZGQ5YWYtZGY1YS00M2RiLTliZTctZGU4
+        ZDFkMmI4ZGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMDctMzBUMjA6NTU6MjNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIsICJz
+        aXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
+        bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
+        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWxwaGEu
+        cGFydGVsbG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBh
+        bHBoYS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjViNWY3YjNiMmY1ZWEy
+        Mjg4ZjZmNDg0ZCJ9LCAiaWQiOiAiNWI1ZjdiM2IyZjVlYTIyODhmNmY0ODRk
+        In0=
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/567dd9af-df5a-43db-9be7-de8d1d2b8dc7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2316'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NjdkZDlhZi1kZjVhLTQzZGItOWJlNy1kZThkMWQyYjhk
+        YzcvIiwgInRhc2tfaWQiOiAiNTY3ZGQ5YWYtZGY1YS00M2RiLTliZTctZGU4
+        ZDFkMmI4ZGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMDctMzBUMjA6NTU6MjNaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2UwMDJjNGYyLTExMTAtNDlkNi1hNzZlLTIzNzI5
+        MDM0MTVlMi8iLCAidGFza19pZCI6ICJlMDAyYzRmMi0xMTEwLTQ5ZDYtYTc2
+        ZS0yMzcyOTAzNDE1ZTIifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIs
+        ICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
+        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWxw
+        aGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNo
+        ZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTBAYWxwaGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJy
+        ZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAic2NlbmFyaW9f
+        dGVzdCIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE4LTA3
+        LTMwVDIwOjU1OjI0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAi
+        Y29tcGxldGVkIjogIjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgImltcG9ydGVy
+        X3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBu
+        dWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50Ijog
+        MCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWI1ZjdiM2NkNmNjMDY0
+        ODY2Yjc1ZjZmIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90
+        YWwiOiAxNzg3MiwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiA4
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
+        bHMiOiB7InJwbV90b3RhbCI6IDgsICJycG1fZG9uZSI6IDgsICJkcnBtX3Rv
+        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
+        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1YjVmN2IzYjJmNWVhMjI4OGY2ZjQ4NGQifSwgImlkIjogIjViNWY3
+        YjNiMmY1ZWEyMjg4ZjZmNDg0ZCJ9
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/e002c4f2-1110-49d6-a76e-2372903415e2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '660'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9lMDAyYzRmMi0xMTEwLTQ5ZDYtYTc2ZS0yMzcy
+        OTAzNDE1ZTIvIiwgInRhc2tfaWQiOiAiZTAwMmM0ZjItMTExMC00OWQ2LWE3
+        NmUtMjM3MjkwMzQxNWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2Vy
+        dmVkX3Jlc291cmNlX3dvcmtlci0wQGFscGhhLnBhcnRlbGxvLmV4YW1wbGUu
+        Y29tLmRxIiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWxwaGEucGFydGVsbG8uZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1YjVmN2IzYzJmNWVhMjI4OGY2ZjQ4NWQifSwgImlk
+        IjogIjViNWY3YjNjMmY1ZWEyMjg4ZjZmNDg1ZCJ9
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/567dd9af-df5a-43db-9be7-de8d1d2b8dc7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2316'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NjdkZDlhZi1kZjVhLTQzZGItOWJlNy1kZThkMWQyYjhk
+        YzcvIiwgInRhc2tfaWQiOiAiNTY3ZGQ5YWYtZGY1YS00M2RiLTliZTctZGU4
+        ZDFkMmI4ZGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMDctMzBUMjA6NTU6MjNaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2UwMDJjNGYyLTExMTAtNDlkNi1hNzZlLTIzNzI5
+        MDM0MTVlMi8iLCAidGFza19pZCI6ICJlMDAyYzRmMi0xMTEwLTQ5ZDYtYTc2
+        ZS0yMzcyOTAzNDE1ZTIifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIs
+        ICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
+        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWxw
+        aGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNo
+        ZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTBAYWxwaGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJy
+        ZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAic2NlbmFyaW9f
+        dGVzdCIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE4LTA3
+        LTMwVDIwOjU1OjI0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAi
+        Y29tcGxldGVkIjogIjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgImltcG9ydGVy
+        X3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBu
+        dWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50Ijog
+        MCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWI1ZjdiM2NkNmNjMDY0
+        ODY2Yjc1ZjZmIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90
+        YWwiOiAxNzg3MiwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiA4
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
+        bHMiOiB7InJwbV90b3RhbCI6IDgsICJycG1fZG9uZSI6IDgsICJkcnBtX3Rv
+        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
+        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1YjVmN2IzYjJmNWVhMjI4OGY2ZjQ4NGQifSwgImlkIjogIjViNWY3
+        YjNiMmY1ZWEyMjg4ZjZmNDg0ZCJ9
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/e002c4f2-1110-49d6-a76e-2372903415e2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4294'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9lMDAyYzRmMi0xMTEwLTQ5ZDYtYTc2ZS0yMzcy
+        OTAzNDE1ZTIvIiwgInRhc2tfaWQiOiAiZTAwMmM0ZjItMTExMC00OWQ2LWE3
+        NmUtMjM3MjkwMzQxNWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIzYzZmZDU5Yy0zYzE1LTRmZTUtYjg0NS05
+        YjdkZTVkY2RmZDMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiSU5fUFJPR1JFU1Mi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNWZiYzc3ZWEtZjZiMi00MmI4LWE5
+        MmMtNTVkYmZiMDAyYTUzIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3Ry
+        aWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjFhZDgwOWQzLTdhYzgtNDEzMy1iYzY5LTdl
+        NzA5N2VjNzQzYSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0
+        ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE1NjQ1MWI4
+        LWIxNTQtNGE1Zi1iZDQwLTc3MGIyMTQ5ZTc4OSIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJlNjYyNWRkYy02ZDZlLTQ5YzUtODY4OS03NGFl
+        YjZjZjE1OGMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzUwZDQ1
+        ODgtMjY5ZS00YTU3LWIwYzItZmI5ZjM1OTA4NjNhIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjEwMjBiNjM0LWZmNTMtNDhjNy04NDcyLTE4
+        ZGQ3NTI2NDViOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4i
+        LCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        ImJjY2MwOTBhLTEwM2ItNGQ1Yi1iNWJhLWNlNTQ2NTA3OWRlOSIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJj
+        bG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjk0Y2Q5
+        YzIzLTg0YWUtNDgwNi04MWIxLTkxYjc0OGVjZDI0YiIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        R2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVy
+        YXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
+        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNjNjYmM0Zi03ODZl
+        LTQzYjItOTczYi0yOTVhZjgwMDIyMTIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5n
+        IG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBv
+        ZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZDMyZGMzZi03OWYyLTQzMjEt
+        YTc3NC05ZjUwNDZiZWZmNzYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRN
+        TCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiZDllM2M2NTAtYmUwZS00NzNlLWEyZWYtZThlOGE3ZTE4ODg4
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVw
+        X3R5cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAx
+        LCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiMGE4YmRjZWMtMWE1My00ZGEzLWIxNmQtNGJjODdiOGJiNTRiIiwgIm51
+        bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjog
+        ImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICI0ODEzZTFiNS03ZjgwLTQ2NWItODIwZS1hNGQwZmRjZWY1MGYiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMEBhbHBoYS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcSIsICJz
+        dGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0wQGFscGhhLnBhcnRlbGxvLmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNWI1ZjdiM2MyZjVlYTIyODhmNmY0ODVkIn0sICJpZCI6ICI1YjVmN2Iz
+        YzJmNWVhMjI4OGY2ZjQ4NWQifQ==
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/567dd9af-df5a-43db-9be7-de8d1d2b8dc7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2316'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NjdkZDlhZi1kZjVhLTQzZGItOWJlNy1kZThkMWQyYjhk
+        YzcvIiwgInRhc2tfaWQiOiAiNTY3ZGQ5YWYtZGY1YS00M2RiLTliZTctZGU4
+        ZDFkMmI4ZGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMDctMzBUMjA6NTU6MjNaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2UwMDJjNGYyLTExMTAtNDlkNi1hNzZlLTIzNzI5
+        MDM0MTVlMi8iLCAidGFza19pZCI6ICJlMDAyYzRmMi0xMTEwLTQ5ZDYtYTc2
+        ZS0yMzcyOTAzNDE1ZTIifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIs
+        ICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
+        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWxw
+        aGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNo
+        ZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTBAYWxwaGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJy
+        ZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAic2NlbmFyaW9f
+        dGVzdCIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE4LTA3
+        LTMwVDIwOjU1OjI0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAi
+        Y29tcGxldGVkIjogIjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgImltcG9ydGVy
+        X3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBu
+        dWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50Ijog
+        MCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWI1ZjdiM2NkNmNjMDY0
+        ODY2Yjc1ZjZmIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90
+        YWwiOiAxNzg3MiwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiA4
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
+        bHMiOiB7InJwbV90b3RhbCI6IDgsICJycG1fZG9uZSI6IDgsICJkcnBtX3Rv
+        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
+        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1YjVmN2IzYjJmNWVhMjI4OGY2ZjQ4NGQifSwgImlkIjogIjViNWY3
+        YjNiMmY1ZWEyMjg4ZjZmNDg0ZCJ9
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/e002c4f2-1110-49d6-a76e-2372903415e2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4288'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9lMDAyYzRmMi0xMTEwLTQ5ZDYtYTc2ZS0yMzcy
+        OTAzNDE1ZTIvIiwgInRhc2tfaWQiOiAiZTAwMmM0ZjItMTExMC00OWQ2LWE3
+        NmUtMjM3MjkwMzQxNWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIzYzZmZDU5Yy0zYzE1LTRmZTUtYjg0NS05
+        YjdkZTVkY2RmZDMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNWZiYzc3ZWEtZjZiMi00MmI4LWE5MmMt
+        NTVkYmZiMDAyYTUzIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjFhZDgwOWQzLTdhYzgtNDEzMy1iYzY5LTdlNzA5N2Vj
+        NzQzYSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIklOX1BS
+        T0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE1NjQ1MWI4LWIxNTQt
+        NGE1Zi1iZDQwLTc3MGIyMTQ5ZTc4OSIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJlNjYyNWRkYy02ZDZlLTQ5YzUtODY4OS03NGFlYjZjZjE1
+        OGMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzUwZDQ1ODgtMjY5
+        ZS00YTU3LWIwYzItZmI5ZjM1OTA4NjNhIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjEwMjBiNjM0LWZmNTMtNDhjNy04NDcyLTE4ZGQ3NTI2
+        NDViOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3Rl
+        cF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJjY2Mw
+        OTBhLTEwM2ItNGQ1Yi1iNWJhLWNlNTQ2NTA3OWRlOSIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        Q2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9y
+        ZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
+        VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjk0Y2Q5YzIzLTg0
+        YWUtNDgwNi04MWIxLTkxYjc0OGVjZDI0YiIsICJudW1fcHJvY2Vzc2VkIjog
+        MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
+        dGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNx
+        bGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNjNjYmM0Zi03ODZlLTQzYjIt
+        OTczYi0yOTVhZjgwMDIyMTIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCBy
+        ZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJhZDMyZGMzZi03OWYyLTQzMjEtYTc3NC05
+        ZjUwNDZiZWZmNzYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxl
+        cyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAx
+        LCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiZDllM2M2NTAtYmUwZS00NzNlLWEyZWYtZThlOGE3ZTE4ODg4IiwgIm51
+        bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUi
+        OiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGE4
+        YmRjZWMtMWE1My00ZGEzLWIxNmQtNGJjODdiOGJiNTRiIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRp
+        YWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0ODEz
+        ZTFiNS03ZjgwLTQ2NWItODIwZS1hNGQwZmRjZWY1MGYiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMEBhbHBoYS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6
+        ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0wQGFscGhhLnBhcnRlbGxvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWI1
+        ZjdiM2MyZjVlYTIyODhmNmY0ODVkIn0sICJpZCI6ICI1YjVmN2IzYzJmNWVh
+        MjI4OGY2ZjQ4NWQifQ==
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/567dd9af-df5a-43db-9be7-de8d1d2b8dc7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2316'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NjdkZDlhZi1kZjVhLTQzZGItOWJlNy1kZThkMWQyYjhk
+        YzcvIiwgInRhc2tfaWQiOiAiNTY3ZGQ5YWYtZGY1YS00M2RiLTliZTctZGU4
+        ZDFkMmI4ZGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMDctMzBUMjA6NTU6MjNaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2UwMDJjNGYyLTExMTAtNDlkNi1hNzZlLTIzNzI5
+        MDM0MTVlMi8iLCAidGFza19pZCI6ICJlMDAyYzRmMi0xMTEwLTQ5ZDYtYTc2
+        ZS0yMzcyOTAzNDE1ZTIifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIs
+        ICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
+        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWxw
+        aGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNo
+        ZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTBAYWxwaGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJy
+        ZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAic2NlbmFyaW9f
+        dGVzdCIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE4LTA3
+        LTMwVDIwOjU1OjI0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAi
+        Y29tcGxldGVkIjogIjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgImltcG9ydGVy
+        X3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBu
+        dWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50Ijog
+        MCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWI1ZjdiM2NkNmNjMDY0
+        ODY2Yjc1ZjZmIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90
+        YWwiOiAxNzg3MiwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiA4
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
+        bHMiOiB7InJwbV90b3RhbCI6IDgsICJycG1fZG9uZSI6IDgsICJkcnBtX3Rv
+        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
+        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1YjVmN2IzYjJmNWVhMjI4OGY2ZjQ4NGQifSwgImlkIjogIjViNWY3
+        YjNiMmY1ZWEyMjg4ZjZmNDg0ZCJ9
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/e002c4f2-1110-49d6-a76e-2372903415e2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4288'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9lMDAyYzRmMi0xMTEwLTQ5ZDYtYTc2ZS0yMzcy
+        OTAzNDE1ZTIvIiwgInRhc2tfaWQiOiAiZTAwMmM0ZjItMTExMC00OWQ2LWE3
+        NmUtMjM3MjkwMzQxNWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIzYzZmZDU5Yy0zYzE1LTRmZTUtYjg0NS05
+        YjdkZTVkY2RmZDMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNWZiYzc3ZWEtZjZiMi00MmI4LWE5MmMt
+        NTVkYmZiMDAyYTUzIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjFhZDgwOWQzLTdhYzgtNDEzMy1iYzY5LTdlNzA5N2Vj
+        NzQzYSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIklOX1BS
+        T0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE1NjQ1MWI4LWIxNTQt
+        NGE1Zi1iZDQwLTc3MGIyMTQ5ZTc4OSIsICJudW1fcHJvY2Vzc2VkIjogOH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJlNjYyNWRkYy02ZDZlLTQ5YzUtODY4OS03NGFlYjZjZjE1
+        OGMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzUwZDQ1ODgtMjY5
+        ZS00YTU3LWIwYzItZmI5ZjM1OTA4NjNhIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjEwMjBiNjM0LWZmNTMtNDhjNy04NDcyLTE4ZGQ3NTI2
+        NDViOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3Rl
+        cF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJjY2Mw
+        OTBhLTEwM2ItNGQ1Yi1iNWJhLWNlNTQ2NTA3OWRlOSIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        Q2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9y
+        ZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
+        VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjk0Y2Q5YzIzLTg0
+        YWUtNDgwNi04MWIxLTkxYjc0OGVjZDI0YiIsICJudW1fcHJvY2Vzc2VkIjog
+        MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
+        dGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNx
+        bGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNjNjYmM0Zi03ODZlLTQzYjIt
+        OTczYi0yOTVhZjgwMDIyMTIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCBy
+        ZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJhZDMyZGMzZi03OWYyLTQzMjEtYTc3NC05
+        ZjUwNDZiZWZmNzYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxl
+        cyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAx
+        LCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiZDllM2M2NTAtYmUwZS00NzNlLWEyZWYtZThlOGE3ZTE4ODg4IiwgIm51
+        bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUi
+        OiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGE4
+        YmRjZWMtMWE1My00ZGEzLWIxNmQtNGJjODdiOGJiNTRiIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRp
+        YWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0ODEz
+        ZTFiNS03ZjgwLTQ2NWItODIwZS1hNGQwZmRjZWY1MGYiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMEBhbHBoYS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6
+        ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0wQGFscGhhLnBhcnRlbGxvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWI1
+        ZjdiM2MyZjVlYTIyODhmNmY0ODVkIn0sICJpZCI6ICI1YjVmN2IzYzJmNWVh
+        MjI4OGY2ZjQ4NWQifQ==
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/567dd9af-df5a-43db-9be7-de8d1d2b8dc7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2316'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NjdkZDlhZi1kZjVhLTQzZGItOWJlNy1kZThkMWQyYjhk
+        YzcvIiwgInRhc2tfaWQiOiAiNTY3ZGQ5YWYtZGY1YS00M2RiLTliZTctZGU4
+        ZDFkMmI4ZGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMDctMzBUMjA6NTU6MjNaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2UwMDJjNGYyLTExMTAtNDlkNi1hNzZlLTIzNzI5
+        MDM0MTVlMi8iLCAidGFza19pZCI6ICJlMDAyYzRmMi0xMTEwLTQ5ZDYtYTc2
+        ZS0yMzcyOTAzNDE1ZTIifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIs
+        ICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
+        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWxw
+        aGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNo
+        ZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTBAYWxwaGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJy
+        ZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAic2NlbmFyaW9f
+        dGVzdCIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE4LTA3
+        LTMwVDIwOjU1OjI0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAi
+        Y29tcGxldGVkIjogIjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgImltcG9ydGVy
+        X3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBu
+        dWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50Ijog
+        MCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWI1ZjdiM2NkNmNjMDY0
+        ODY2Yjc1ZjZmIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90
+        YWwiOiAxNzg3MiwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiA4
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
+        bHMiOiB7InJwbV90b3RhbCI6IDgsICJycG1fZG9uZSI6IDgsICJkcnBtX3Rv
+        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
+        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1YjVmN2IzYjJmNWVhMjI4OGY2ZjQ4NGQifSwgImlkIjogIjViNWY3
+        YjNiMmY1ZWEyMjg4ZjZmNDg0ZCJ9
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/e002c4f2-1110-49d6-a76e-2372903415e2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4275'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9lMDAyYzRmMi0xMTEwLTQ5ZDYtYTc2ZS0yMzcy
+        OTAzNDE1ZTIvIiwgInRhc2tfaWQiOiAiZTAwMmM0ZjItMTExMC00OWQ2LWE3
+        NmUtMjM3MjkwMzQxNWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIzYzZmZDU5Yy0zYzE1LTRmZTUtYjg0NS05
+        YjdkZTVkY2RmZDMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNWZiYzc3ZWEtZjZiMi00MmI4LWE5MmMt
+        NTVkYmZiMDAyYTUzIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjFhZDgwOWQzLTdhYzgtNDEzMy1iYzY5LTdlNzA5N2Vj
+        NzQzYSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE1NjQ1MWI4LWIxNTQtNGE1
+        Zi1iZDQwLTc3MGIyMTQ5ZTc4OSIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImU2NjI1ZGRjLTZkNmUtNDljNS04Njg5LTc0YWViNmNmMTU4YyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
+        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzNTBkNDU4OC0yNjllLTRhNTctYjBj
+        Mi1mYjlmMzU5MDg2M2EiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        dWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMg
+        ZmlsZSIsICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        MTAyMGI2MzQtZmY1My00OGM3LTg0NzItMThkZDc1MjY0NWI5IiwgIm51bV9w
+        cm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiSU5fUFJPR1JF
+        U1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYmNjYzA5MGEtMTAzYi00ZDVi
+        LWI1YmEtY2U1NDY1MDc5ZGU5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8g
+        bWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiOTRjZDljMjMtODRhZS00ODA2LTgxYjEt
+        OTFiNzQ4ZWNkMjRiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBm
+        aWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImE2M2NiYzRmLTc4NmUtNDNiMi05NzNiLTI5NWFmODAw
+        MjIxMiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogImFkMzJkYzNmLTc5ZjItNDMyMS1hNzc0LTlmNTA0NmJlZmY3NiIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
+        Y3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlw
+        ZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkOWUzYzY1MC1i
+        ZTBlLTQ3M2UtYTJlZi1lOGU4YTdlMTg4ODgiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
+        c2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2Rp
+        cmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RB
+        UlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYThiZGNlYy0xYTUzLTRk
+        YTMtYjE2ZC00YmM4N2I4YmI1NGIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlz
+        dGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21l
+        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFS
+        VEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ4MTNlMWI1LTdmODAtNDY1
+        Yi04MjBlLWE0ZDBmZGNlZjUwZiIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwg
+        InF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGFscGhhLnBh
+        cnRlbGxvLmV4YW1wbGUuY29tLmRxIiwgInN0YXRlIjogInJ1bm5pbmciLCAi
+        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWxw
+        aGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YjVmN2IzYzJmNWVhMjI4
+        OGY2ZjQ4NWQifSwgImlkIjogIjViNWY3YjNjMmY1ZWEyMjg4ZjZmNDg1ZCJ9
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/567dd9af-df5a-43db-9be7-de8d1d2b8dc7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2316'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NjdkZDlhZi1kZjVhLTQzZGItOWJlNy1kZThkMWQyYjhk
+        YzcvIiwgInRhc2tfaWQiOiAiNTY3ZGQ5YWYtZGY1YS00M2RiLTliZTctZGU4
+        ZDFkMmI4ZGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMDctMzBUMjA6NTU6MjNaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2UwMDJjNGYyLTExMTAtNDlkNi1hNzZlLTIzNzI5
+        MDM0MTVlMi8iLCAidGFza19pZCI6ICJlMDAyYzRmMi0xMTEwLTQ5ZDYtYTc2
+        ZS0yMzcyOTAzNDE1ZTIifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIs
+        ICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
+        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWxw
+        aGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNo
+        ZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTBAYWxwaGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJy
+        ZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAic2NlbmFyaW9f
+        dGVzdCIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE4LTA3
+        LTMwVDIwOjU1OjI0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAi
+        Y29tcGxldGVkIjogIjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgImltcG9ydGVy
+        X3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBu
+        dWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50Ijog
+        MCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWI1ZjdiM2NkNmNjMDY0
+        ODY2Yjc1ZjZmIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90
+        YWwiOiAxNzg3MiwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiA4
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
+        bHMiOiB7InJwbV90b3RhbCI6IDgsICJycG1fZG9uZSI6IDgsICJkcnBtX3Rv
+        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
+        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1YjVmN2IzYjJmNWVhMjI4OGY2ZjQ4NGQifSwgImlkIjogIjViNWY3
+        YjNiMmY1ZWEyMjg4ZjZmNDg0ZCJ9
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/e002c4f2-1110-49d6-a76e-2372903415e2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4252'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9lMDAyYzRmMi0xMTEwLTQ5ZDYtYTc2ZS0yMzcy
+        OTAzNDE1ZTIvIiwgInRhc2tfaWQiOiAiZTAwMmM0ZjItMTExMC00OWQ2LWE3
+        NmUtMjM3MjkwMzQxNWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIzYzZmZDU5Yy0zYzE1LTRmZTUtYjg0NS05
+        YjdkZTVkY2RmZDMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNWZiYzc3ZWEtZjZiMi00MmI4LWE5MmMt
+        NTVkYmZiMDAyYTUzIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjFhZDgwOWQzLTdhYzgtNDEzMy1iYzY5LTdlNzA5N2Vj
+        NzQzYSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE1NjQ1MWI4LWIxNTQtNGE1
+        Zi1iZDQwLTc3MGIyMTQ5ZTc4OSIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImU2NjI1ZGRjLTZkNmUtNDljNS04Njg5LTc0YWViNmNmMTU4YyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
+        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzNTBkNDU4OC0yNjllLTRhNTctYjBj
+        Mi1mYjlmMzU5MDg2M2EiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        dWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMg
+        ZmlsZSIsICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAz
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        MTAyMGI2MzQtZmY1My00OGM3LTg0NzItMThkZDc1MjY0NWI5IiwgIm51bV9w
+        cm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYmNjYzA5MGEtMTAzYi00ZDViLWI1
+        YmEtY2U1NDY1MDc5ZGU5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0
+        YWRhdGEiLCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAi
+        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiOTRjZDljMjMtODRhZS00ODA2LTgxYjEtOTFiNzQ4
+        ZWNkMjRiIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIs
+        ICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiYTYzY2JjNGYtNzg2ZS00M2IyLTk3M2ItMjk1YWY4MDAyMjEyIiwgIm51
+        bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJSZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjog
+        InJlbW92ZV9vbGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWQzMmRj
+        M2YtNzlmMi00MzIxLWE3NzQtOWY1MDQ2YmVmZjc2IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJH
+        ZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiZDllM2M2NTAtYmUwZS00NzNlLWEyZWYtZThl
+        OGE3ZTE4ODg4IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdl
+        YiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiMGE4YmRjZWMtMWE1My00ZGEzLWIxNmQtNGJjODdiOGJiNTRi
+        IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJk
+        ZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90
+        eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICI0ODEzZTFiNS03ZjgwLTQ2NWItODIwZS1hNGQwZmRjZWY1MGYiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDF9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEBhbHBoYS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcSIs
+        ICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVk
+        X3Jlc291cmNlX3dvcmtlci0wQGFscGhhLnBhcnRlbGxvLmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRv
+        aWQiOiAiNWI1ZjdiM2MyZjVlYTIyODhmNmY0ODVkIn0sICJpZCI6ICI1YjVm
+        N2IzYzJmNWVhMjI4OGY2ZjQ4NWQifQ==
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/567dd9af-df5a-43db-9be7-de8d1d2b8dc7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2316'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81NjdkZDlhZi1kZjVhLTQzZGItOWJlNy1kZThkMWQyYjhk
+        YzcvIiwgInRhc2tfaWQiOiAiNTY3ZGQ5YWYtZGY1YS00M2RiLTliZTctZGU4
+        ZDFkMmI4ZGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMDctMzBUMjA6NTU6MjNaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2UwMDJjNGYyLTExMTAtNDlkNi1hNzZlLTIzNzI5
+        MDM0MTVlMi8iLCAidGFza19pZCI6ICJlMDAyYzRmMi0xMTEwLTQ5ZDYtYTc2
+        ZS0yMzcyOTAzNDE1ZTIifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiA4LCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogOCwgInJwbV9kb25lIjogOCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMTc4NzIs
+        ICJzaXplX2xlZnQiOiAwLCAiaXRlbXNfbGVmdCI6IDB9LCAiY29tcHMiOiB7
+        InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190
+        b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAYWxw
+        aGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEiLCAic3RhdGUiOiAiZmluaXNo
+        ZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTBAYWxwaGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJy
+        ZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAic2NlbmFyaW9f
+        dGVzdCIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE4LTA3
+        LTMwVDIwOjU1OjI0WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAi
+        Y29tcGxldGVkIjogIjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgImltcG9ydGVy
+        X3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBu
+        dWxsLCAic3VtbWFyeSI6IHsiY29udGVudCI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVycmF0YSI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5J
+        U0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1vdmVkX2NvdW50Ijog
+        MCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWI1ZjdiM2NkNmNjMDY0
+        ODY2Yjc1ZjZmIiwgImRldGFpbHMiOiB7ImNvbnRlbnQiOiB7InNpemVfdG90
+        YWwiOiAxNzg3MiwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiA4
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFp
+        bHMiOiB7InJwbV90b3RhbCI6IDgsICJycG1fZG9uZSI6IDgsICJkcnBtX3Rv
+        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
+        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1YjVmN2IzYjJmNWVhMjI4OGY2ZjQ4NGQifSwgImlkIjogIjViNWY3
+        YjNiMmY1ZWEyMjg4ZjZmNDg0ZCJ9
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/tasks/e002c4f2-1110-49d6-a76e-2372903415e2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '8529'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9lMDAyYzRmMi0xMTEwLTQ5ZDYtYTc2ZS0yMzcy
+        OTAzNDE1ZTIvIiwgInRhc2tfaWQiOiAiZTAwMmM0ZjItMTExMC00OWQ2LWE3
+        NmUtMjM3MjkwMzQxNWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTgtMDctMzBUMjA6NTU6MjRa
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0
+        ZXBfdHlwZSI6ICJzYXZlX3RhciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzYzZmZDU5
+        Yy0zYzE1LTRmZTUtYjg0NS05YjdkZTVkY2RmZDMiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIklu
+        aXRpYWxpemluZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNWZiYzc3
+        ZWEtZjZiMi00MmI4LWE5MmMtNTVkYmZiMDAyYTUzIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIERpc3RyaWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
+        ZGlzdHJpYnV0aW9uIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjFhZDgwOWQzLTdhYzgt
+        NDEzMy1iYzY5LTdlNzA5N2VjNzQzYSIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        IHsibnVtX3N1Y2Nlc3MiOiA4LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjog
+        OCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjE1NjQ1MWI4LWIxNTQtNGE1Zi1iZDQwLTc3MGIyMTQ5ZTc4OSIsICJudW1f
+        cHJvY2Vzc2VkIjogOH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJk
+        cnBtcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImU2NjI1ZGRjLTZkNmUtNDljNS04Njg5
+        LTc0YWViNmNmMTU4YyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEi
+        LCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzNTBk
+        NDU4OC0yNjllLTRhNTctYjBjMi1mYjlmMzU5MDg2M2EiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29tcHMi
+        LCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiMTAyMGI2MzQtZmY1My00OGM3LTg0NzItMThk
+        ZDc1MjY0NWI5IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2Vz
+        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIs
+        ICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYmNj
+        YzA5MGEtMTAzYi00ZDViLWI1YmEtY2U1NDY1MDc5ZGU5IiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
+        ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNsb3Nl
+        X3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTRjZDljMjMtODRh
+        ZS00ODA2LTgxYjEtOTFiNzQ4ZWNkMjRiIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
+        aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3Fs
+        aXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiYTYzY2JjNGYtNzg2ZS00M2IyLTk3M2It
+        Mjk1YWY4MDAyMjEyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVwb2Rh
+        dGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiYWQzMmRjM2YtNzlmMi00MzIxLWE3NzQtOWY1MDQ2YmVm
+        Zjc2IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAic3Rl
+        cF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDllM2M2NTAt
+        YmUwZS00NzNlLWEyZWYtZThlOGE3ZTE4ODg4IiwgIm51bV9wcm9jZXNzZWQi
+        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJs
+        aXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9k
+        aXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGE4YmRjZWMtMWE1My00ZGEz
+        LWIxNmQtNGJjODdiOGJiNTRiIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJu
+        dW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3Rp
+        bmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRh
+        ZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0ODEzZTFiNS03ZjgwLTQ2NWItODIw
+        ZS1hNGQwZmRjZWY1MGYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9XX0sICJxdWV1
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBhbHBoYS5wYXJ0ZWxs
+        by5leGFtcGxlLmNvbS5kcSIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBhbHBoYS5w
+        YXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJz
+        dWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5h
+        cmlvX3Rlc3QiLCAic3RhcnRlZCI6ICIyMDE4LTA3LTMwVDIwOjU1OjI0WiIs
+        ICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjog
+        IjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgInRyYWNlYmFjayI6IG51bGwsICJk
+        aXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1t
+        YXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJycG1zIjog
+        IkZJTklTSEVEIiwgImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSI6ICJGSU5J
+        U0hFRCIsICJyZW1vdmVfb2xkX3JlcG9kYXRhIjogIkZJTklTSEVEIiwgInJl
+        cG92aWV3IjogIlNLSVBQRUQiLCAiY2xvc2VfcmVwb19tZXRhZGF0YSI6ICJG
+        SU5JU0hFRCIsICJkcnBtcyI6ICJTS0lQUEVEIiwgImNvbXBzIjogIkZJTklT
+        SEVEIiwgImRpc3RyaWJ1dGlvbiI6ICJGSU5JU0hFRCIsICJzYXZlX3RhciI6
+        ICJGSU5JU0hFRCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJGSU5JU0hFRCIs
+        ICJlcnJhdGEiOiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAiRklOSVNIRUQi
+        fSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAi
+        c2NlbmFyaW9fdGVzdCIsICJpZCI6ICI1YjVmN2IzY2Q2Y2MwNjQ4NjZiNzVm
+        NzAiLCAiZGV0YWlscyI6IFt7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0
+        aW9uIjogIkNvcHlpbmcgZmlsZXMiLCAic3RlcF90eXBlIjogInNhdmVfdGFy
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjNjNmZkNTljLTNjMTUtNGZlNS1iODQ1LTli
+        N2RlNWRjZGZkMyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0
+        YWRhdGEiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0
+        YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI1ZmJjNzdlYS1mNmIyLTQyYjgtYTkyYy01
+        NWRiZmIwMDJhNTMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0
+        aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiMWFkODA5ZDMtN2FjOC00MTMzLWJjNjktN2U3MDk3ZWM3
+        NDNhIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBl
+        IjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTU2NDUxYjgtYjE1NC00YTVm
+        LWJkNDAtNzcwYjIxNDllNzg5IiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERl
+        bHRhIFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiZTY2MjVkZGMtNmQ2ZS00OWM1LTg2ODktNzRhZWI2Y2YxNThjIiwgIm51
+        bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlw
+        dGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJy
+        YXRhIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjM1MGQ0NTg4LTI2OWUtNGE1Ny1iMGMy
+        LWZiOWYzNTkwODYzYSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1
+        Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBm
+        aWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIx
+        MDIwYjYzNC1mZjUzLTQ4YzctODQ3Mi0xOGRkNzUyNjQ1YjkiLCAibnVtX3By
+        b2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRh
+        ZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiY2NjMDkwYS0xMDNiLTRkNWItYjVi
+        YS1jZTU0NjUwNzlkZTkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
+        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRh
+        ZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICI5NGNkOWMyMy04NGFlLTQ4MDYtODFiMS05MWI3NDhl
+        Y2QyNGIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwg
+        InN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJhNjNjYmM0Zi03ODZlLTQzYjItOTczYi0yOTVhZjgwMDIyMTIiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0
+        aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAi
+        cmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZDMyZGMz
+        Zi03OWYyLTQzMjEtYTc3NC05ZjUwNDZiZWZmNzYiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdl
+        bmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXci
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJkOWUzYzY1MC1iZTBlLTQ3M2UtYTJlZi1lOGU4
+        YTdlMTg4ODgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2Vi
+        IiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICIwYThiZGNlYy0xYTUzLTRkYTMtYjE2ZC00YmM4N2I4YmI1NGIi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjQ4MTNlMWI1LTdmODAtNDY1Yi04MjBlLWE0ZDBmZGNlZjUwZiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1YjVmN2IzYzJmNWVhMjI4OGY2ZjQ4NWQifSwgImlkIjogIjVi
+        NWY3YjNjMmY1ZWEyMjg4ZjZmNDg1ZCJ9
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: post
+    uri: https://alpha.partello.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwiZmllbGRzIjp7InVu
+        aXQiOltdLCJhc3NvY2lhdGlvbiI6WyJ1bml0X2lkIl19fX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '80'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1672'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIwNDhlNWVlNS00MjEzLTQ2ZmMtYTk2
+        My04ZGJkYzFhYmY4YTciLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1YjVmN2IzYzJmNWVhMjI4OGY2ZjQ4NTQifSwg
+        InVuaXRfaWQiOiAiMDQ4ZTVlZTUtNDIxMy00NmZjLWE5NjMtOGRiZGMxYWJm
+        OGE3IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
+        X2lkIjogIjFmMzcxYTdlLThjMzItNGY2Ny04MDdmLWY5NGQ0NTJhNDRjMiIs
+        ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
+        IjViNWY3YjNjMmY1ZWEyMjg4ZjZmNDg0ZSJ9LCAidW5pdF9pZCI6ICIxZjM3
+        MWE3ZS04YzMyLTRmNjctODA3Zi1mOTRkNDUyYTQ0YzIiLCAidW5pdF90eXBl
+        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiMmFkYmQ0ZWUt
+        Y2Q1YS00MDFkLWE3ZTQtZGJjNWMwMDBmODE1IiwgIl9jb250ZW50X3R5cGVf
+        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNWI1ZjdiM2MyZjVlYTIy
+        ODhmNmY0ODRmIn0sICJ1bml0X2lkIjogIjJhZGJkNGVlLWNkNWEtNDAxZC1h
+        N2U0LWRiYzVjMDAwZjgxNSIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
+        bWV0YWRhdGEiOiB7Il9pZCI6ICIzNzAwZmQyNS1hMDQwLTQyYjItYjUyZC0w
+        ZTJkZGY0ZjhhZWIiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1YjVmN2IzYzJmNWVhMjI4OGY2ZjQ4NTAifSwgInVu
+        aXRfaWQiOiAiMzcwMGZkMjUtYTA0MC00MmIyLWI1MmQtMGUyZGRmNGY4YWVi
+        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
+        IjogIjc0MTUwMTM5LTBjMTQtNDM4Ny1hOWQ3LWE4OTZlOWJmODk2OSIsICJf
+        Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjVi
+        NWY3YjNjMmY1ZWEyMjg4ZjZmNDg1MiJ9LCAidW5pdF9pZCI6ICI3NDE1MDEz
+        OS0wYzE0LTQzODctYTlkNy1hODk2ZTliZjg5NjkiLCAidW5pdF90eXBlX2lk
+        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiODY1YmM1OTMtMDE1
+        NS00MGY4LWJkNDMtOGFiNTE1OGE4YTU5IiwgIl9jb250ZW50X3R5cGVfaWQi
+        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNWI1ZjdiM2MyZjVlYTIyODhm
+        NmY0ODUzIn0sICJ1bml0X2lkIjogIjg2NWJjNTkzLTAxNTUtNDBmOC1iZDQz
+        LThhYjUxNThhOGE1OSIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
+        YWRhdGEiOiB7Il9pZCI6ICJkYTdhNGZiNC00NGUzLTQ2ZjgtOGQxMy02NjJl
+        ZTBlNGFjNWEiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
+        IHsiJG9pZCI6ICI1YjVmN2IzYzJmNWVhMjI4OGY2ZjQ4NTUifSwgInVuaXRf
+        aWQiOiAiZGE3YTRmYjQtNDRlMy00NmY4LThkMTMtNjYyZWUwZTRhYzVhIiwg
+        InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
+        ImVjNmZjYTFkLTMzMDctNDQzZS1hYTUxLTQ4MWJlN2UzYjZmYiIsICJfY29u
+        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjViNWY3
+        YjNjMmY1ZWEyMjg4ZjZmNDg1MSJ9LCAidW5pdF9pZCI6ICJlYzZmY2ExZC0z
+        MzA3LTQ0M2UtYWE1MS00ODFiZTdlM2I2ZmIiLCAidW5pdF90eXBlX2lkIjog
+        InJwbSJ9XQ==
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: post
+    uri: https://alpha.partello.example.com/pulp/api/v2/content/units/rpm/search/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJsaW1pdCI6OCwic2tpcCI6MCwiZmllbGRzIjpbIm5h
+        bWUiLCJ2ZXJzaW9uIiwicmVsZWFzZSIsImFyY2giLCJlcG9jaCIsInN1bW1h
+        cnkiLCJzb3VyY2VycG0iLCJjaGVja3N1bSIsImZpbGVuYW1lIiwiX2lkIl0s
+        ImZpbHRlcnMiOnsiX2lkIjp7IiRpbiI6WyIwNDhlNWVlNS00MjEzLTQ2ZmMt
+        YTk2My04ZGJkYzFhYmY4YTciLCIxZjM3MWE3ZS04YzMyLTRmNjctODA3Zi1m
+        OTRkNDUyYTQ0YzIiLCIyYWRiZDRlZS1jZDVhLTQwMWQtYTdlNC1kYmM1YzAw
+        MGY4MTUiLCIzNzAwZmQyNS1hMDQwLTQyYjItYjUyZC0wZTJkZGY0ZjhhZWIi
+        LCI3NDE1MDEzOS0wYzE0LTQzODctYTlkNy1hODk2ZTliZjg5NjkiLCI4NjVi
+        YzU5My0wMTU1LTQwZjgtYmQ0My04YWI1MTU4YThhNTkiLCJkYTdhNGZiNC00
+        NGUzLTQ2ZjgtOGQxMy02NjJlZTBlNGFjNWEiLCJlYzZmY2ExZC0zMzA3LTQ0
+        M2UtYWE1MS00ODFiZTdlM2I2ZmIiXX19fSwiaW5jbHVkZV9yZXBvcyI6dHJ1
+        ZX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '497'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '3836'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVzdCJd
+        LCAic291cmNlcnBtIjogImxpb24tMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUi
+        OiAibGlvbiIsICJjaGVja3N1bSI6ICIxMjQwMGRjOTVjMjNhNGMxNjA3MjVh
+        OTA4NzE2Y2QzZmNkZDdhODk4MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0Iiwg
+        InN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGxpb24iLCAiZmlsZW5h
+        bWUiOiAibGlvbi0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAi
+        MDQ4ZTVlZTUtNDIxMy00NmZjLWE5NjMtOGRiZGMxYWJmOGE3IiwgImFyY2gi
+        OiAibm9hcmNoIiwgImNoaWxkcmVuIjoge30sICJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvY29udGVudC91bml0cy9ycG0vMDQ4ZTVlZTUtNDIxMy00NmZjLWE5
+        NjMtOGRiZGMxYWJmOGE3LyJ9LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMi
+        OiBbInNjZW5hcmlvX3Rlc3QiXSwgInNvdXJjZXJwbSI6ICJtb25rZXktMC4z
+        LTAuOC5zcmMucnBtIiwgIm5hbWUiOiAibW9ua2V5IiwgImNoZWNrc3VtIjog
+        IjBlOGZhNTBkMDEyOGZiYWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2
+        MTY2Y2I4ZTJjODRkZTg1MDFkYjEiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBh
+        Y2thZ2Ugb2YgbW9ua2V5IiwgImZpbGVuYW1lIjogIm1vbmtleS0wLjMtMC44
+        Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIs
+        ICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiMWYzNzFhN2UtOGMzMi00ZjY3
+        LTgwN2YtZjk0ZDQ1MmE0NGMyIiwgImFyY2giOiAibm9hcmNoIiwgImNoaWxk
+        cmVuIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0
+        cy9ycG0vMWYzNzFhN2UtOGMzMi00ZjY3LTgwN2YtZjk0ZDQ1MmE0NGMyLyJ9
+        LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbInNjZW5hcmlvX3Rlc3Qi
+        XSwgInNvdXJjZXJwbSI6ICJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwgIm5h
+        bWUiOiAid2FscnVzIiwgImNoZWNrc3VtIjogIjZlOGQ2ZGMwNTdlM2UyYzk4
+        MTlmMGRjN2U2YzdiN2Y4NmJmMmU4NTcxYmJhNDE0YWRlYzdmYjYyMWE0NjFk
+        ZmQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwg
+        ImZpbGVuYW1lIjogIndhbHJ1cy0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBv
+        Y2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIs
+        ICJfaWQiOiAiMmFkYmQ0ZWUtY2Q1YS00MDFkLWE3ZTQtZGJjNWMwMDBmODE1
+        IiwgImFyY2giOiAibm9hcmNoIiwgImNoaWxkcmVuIjoge30sICJfaHJlZiI6
+        ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vMmFkYmQ0ZWUtY2Q1
+        YS00MDFkLWE3ZTQtZGJjNWMwMDBmODE1LyJ9LCB7InJlcG9zaXRvcnlfbWVt
+        YmVyc2hpcHMiOiBbInNjZW5hcmlvX3Rlc3QiXSwgInNvdXJjZXJwbSI6ICJw
+        ZW5ndWluLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogInBlbmd1aW4iLCAi
+        Y2hlY2tzdW0iOiAiM2ZjYjJjOTI3ZGU5ZTEzYmY2ODQ2OTAzMmEyOGIxMzlk
+        M2U1YWQyZTU4NTY0ZmMyMTBmZDZlNDg2MzViZTY5NCIsICJzdW1tYXJ5Ijog
+        IkEgZHVtbXkgcGFja2FnZSBvZiBwZW5ndWluIiwgImZpbGVuYW1lIjogInBl
+        bmd1aW4tMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVy
+        c2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjM3MDBm
+        ZDI1LWEwNDAtNDJiMi1iNTJkLTBlMmRkZjRmOGFlYiIsICJhcmNoIjogIm5v
+        YXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L2NvbnRlbnQvdW5pdHMvcnBtLzM3MDBmZDI1LWEwNDAtNDJiMi1iNTJkLTBl
+        MmRkZjRmOGFlYi8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJz
+        Y2VuYXJpb190ZXN0Il0sICJzb3VyY2VycG0iOiAiY2hlZXRhaC0wLjMtMC44
+        LnNyYy5ycG0iLCAibmFtZSI6ICJjaGVldGFoIiwgImNoZWNrc3VtIjogIjQy
+        MmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIzZTE3ZjU3OGY5MjRmNzQ4ODBk
+        ZWJkYmI3ZDY1ZmIzNjhkYWUiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2th
+        Z2Ugb2YgY2hlZXRhaCIsICJmaWxlbmFtZSI6ICJjaGVldGFoLTAuMy0wLjgu
+        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
+        InJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICI3NDE1MDEzOS0wYzE0LTQzODct
+        YTlkNy1hODk2ZTliZjg5NjkiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRy
+        ZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRz
+        L3JwbS83NDE1MDEzOS0wYzE0LTQzODctYTlkNy1hODk2ZTliZjg5NjkvIn0s
+        IHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVzdCJd
+        LCAic291cmNlcnBtIjogImVsZXBoYW50LTAuMy0wLjguc3JjLnJwbSIsICJu
+        YW1lIjogImVsZXBoYW50IiwgImNoZWNrc3VtIjogIjNlMWM3MGNkMWI0MjEz
+        MjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBh
+        NzAxZjMiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgZWxlcGhh
+        bnQiLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBt
+        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6
+        ICIwLjgiLCAiX2lkIjogIjg2NWJjNTkzLTAxNTUtNDBmOC1iZDQzLThhYjUx
+        NThhOGE1OSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAi
+        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtLzg2NWJj
+        NTkzLTAxNTUtNDBmOC1iZDQzLThhYjUxNThhOGE1OS8ifSwgeyJyZXBvc2l0
+        b3J5X21lbWJlcnNoaXBzIjogWyJzY2VuYXJpb190ZXN0Il0sICJzb3VyY2Vy
+        cG0iOiAiZ2lyYWZmZS0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJnaXJh
+        ZmZlIiwgImNoZWNrc3VtIjogImYyNWQ2N2QxZDlkYTA0ZjEyZTU3Y2EzMjMy
+        NDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQiLCAic3Vt
+        bWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgZ2lyYWZmZSIsICJmaWxlbmFt
+        ZSI6ICJnaXJhZmZlLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIw
+        IiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6
+        ICJkYTdhNGZiNC00NGUzLTQ2ZjgtOGQxMy02NjJlZTBlNGFjNWEiLCAiYXJj
+        aCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxw
+        L2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9kYTdhNGZiNC00NGUzLTQ2Zjgt
+        OGQxMy02NjJlZTBlNGFjNWEvIn0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlw
+        cyI6IFsic2NlbmFyaW9fdGVzdCJdLCAic291cmNlcnBtIjogInNxdWlycmVs
+        LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogInNxdWlycmVsIiwgImNoZWNr
+        c3VtIjogIjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUx
+        ZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCAic3VtbWFyeSI6ICJBIGR1
+        bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCAiZmlsZW5hbWUiOiAic3F1aXJy
+        ZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lv
+        biI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogImVjNmZjYTFk
+        LTMzMDctNDQzZS1hYTUxLTQ4MWJlN2UzYjZmYiIsICJhcmNoIjogIm5vYXJj
+        aCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2Nv
+        bnRlbnQvdW5pdHMvcnBtL2VjNmZjYTFkLTMzMDctNDQzZS1hYTUxLTQ4MWJl
+        N2UzYjZmYi8ifV0=
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: post
+    uri: https://alpha.partello.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJzcnBtIl0sImZpZWxkcyI6eyJ1
+        bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '81'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: post
+    uri: https://alpha.partello.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImZpZWxkcyI6
+        eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '84'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '696'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIxYmQwZTY5YS1mZGQyLTQ5ODItOWU3
+        OC05ODNiNDEyMmQ1NjMiLCAicGtnbGlzdCI6IFtdLCAiX2NvbnRlbnRfdHlw
+        ZV9pZCI6ICJlcnJhdHVtIn0sICJfaWQiOiB7IiRvaWQiOiAiNWI1ZjdiM2My
+        ZjVlYTIyODhmNmY0ODU4In0sICJ1bml0X2lkIjogIjFiZDBlNjlhLWZkZDIt
+        NDk4Mi05ZTc4LTk4M2I0MTIyZDU2MyIsICJ1bml0X3R5cGVfaWQiOiAiZXJy
+        YXR1bSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNmVjMjc4M2MtNTlmYi00
+        MGM0LThkMzItYWI5MWI0ZjdmNmMyIiwgInBrZ2xpc3QiOiBbXSwgIl9jb250
+        ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lkIjogeyIkb2lkIjogIjVi
+        NWY3YjNjMmY1ZWEyMjg4ZjZmNDg1OSJ9LCAidW5pdF9pZCI6ICI2ZWMyNzgz
+        Yy01OWZiLTQwYzQtOGQzMi1hYjkxYjRmN2Y2YzIiLCAidW5pdF90eXBlX2lk
+        IjogImVycmF0dW0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjogImI3MzI1MjQ5
+        LTQ1YTQtNDY5Zi1hNDRlLTc5M2Y1NjBhYzVmMyIsICJwa2dsaXN0IjogW10s
+        ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0ifSwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1YjVmN2IzYzJmNWVhMjI4OGY2ZjQ4NTcifSwgInVuaXRfaWQiOiAi
+        YjczMjUyNDktNDVhNC00NjlmLWE0NGUtNzkzZjU2MGFjNWYzIiwgInVuaXRf
+        dHlwZV9pZCI6ICJlcnJhdHVtIn1d
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: post
+    uri: https://alpha.partello.example.com/pulp/api/v2/content/units/erratum/search/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJsaW1pdCI6Mywic2tpcCI6MCwiZmlsdGVycyI6eyJf
+        aWQiOnsiJGluIjpbIjFiZDBlNjlhLWZkZDItNDk4Mi05ZTc4LTk4M2I0MTIy
+        ZDU2MyIsIjZlYzI3ODNjLTU5ZmItNDBjNC04ZDMyLWFiOTFiNGY3ZjZjMiIs
+        ImI3MzI1MjQ5LTQ1YTQtNDY5Zi1hNDRlLTc5M2Y1NjBhYzVmMyJdfX19LCJp
+        bmNsdWRlX3JlcG9zIjp0cnVlfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '199'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4793'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVzdCJd
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvZXJyYXR1
+        bS8xYmQwZTY5YS1mZGQyLTQ5ODItOWU3OC05ODNiNDEyMmQ1NjMvIiwgImlz
+        c3VlZCI6ICIyMDEwLTExLTEwIDAwOjAwOjAwIiwgInJlZmVyZW5jZXMiOiBb
+        eyJocmVmIjogImh0dHBzOi8vcmhuLnJlZGhhdC5jb20vZXJyYXRhL1JIU0Et
+        MjAxMC0wODU4Lmh0bWwiLCAidHlwZSI6ICJzZWxmIiwgImlkIjogbnVsbCwg
+        InRpdGxlIjogIlJIU0EtMjAxMDowODU4In0sIHsiaHJlZiI6ICJodHRwczov
+        L2J1Z3ppbGxhLnJlZGhhdC5jb20vYnVnemlsbGEvc2hvd19idWcuY2dpP2lk
+        PTYyNzg4MiIsICJ0eXBlIjogImJ1Z3ppbGxhIiwgImlkIjogIjYyNzg4MiIs
+        ICJ0aXRsZSI6ICJDVkUtMjAxMC0wNDA1IGJ6aXAyOiBpbnRlZ2VyIG92ZXJm
+        bG93IGZsYXcgaW4gQloyX2RlY29tcHJlc3MifSwgeyJocmVmIjogImh0dHBz
+        Oi8vd3d3LnJlZGhhdC5jb20vc2VjdXJpdHkvZGF0YS9jdmUvQ1ZFLTIwMTAt
+        MDQwNS5odG1sIiwgInR5cGUiOiAiY3ZlIiwgImlkIjogIkNWRS0yMDEwLTA0
+        MDUiLCAidGl0bGUiOiAiQ1ZFLTIwMTAtMDQwNSJ9LCB7ImhyZWYiOiAiaHR0
+        cDovL3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5L3VwZGF0ZXMvY2xhc3NpZmlj
+        YXRpb24vI2ltcG9ydGFudCIsICJ0eXBlIjogIm90aGVyIiwgImlkIjogbnVs
+        bCwgInRpdGxlIjogbnVsbH1dLCAicHVscF91c2VyX21ldGFkYXRhIjoge30s
+        ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiUkhTQS0y
+        MDEwOjA4NTgiLCAiZnJvbSI6ICJzZWN1cml0eUByZWRoYXQuY29tIiwgInNl
+        dmVyaXR5IjogIkltcG9ydGFudCIsICJ0aXRsZSI6ICJJbXBvcnRhbnQ6IGJ6
+        aXAyIHNlY3VyaXR5IHVwZGF0ZSIsICJjaGlsZHJlbiI6IHt9LCAidmVyc2lv
+        biI6ICIzIiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAi
+        c2VjdXJpdHkiLCAicGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjog
+        ImJ6aXAyLTEuMC41LTcuZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6aXAy
+        LWRldmVsIiwgInN1bSI6IFsic2hhMjU2IiwgImVhNjdjNjY0ZGExZmY5NmE2
+        ZGM5NGQzMzAwOWI3M2Q4ZmFiMzFiNTk4MjQxODNmYjQ1ZTliYTJlYmY4MmQ1
+        ODMiXSwgImZpbGVuYW1lIjogImJ6aXAyLWRldmVsLTEuMC41LTcuZWw2XzAu
+        aTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41Iiwg
+        InJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogImk2ODYifSwgeyJzcmMi
+        OiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnpp
+        cDItbGlicyIsICJzdW0iOiBbInNoYTI1NiIsICJjOWYwNjRhNjg2MjU3M2Zi
+        OWYyYTZhZmY3YzM2MjFmMTk0MGI0OTJkZjJlZGZjMmViYmRjMGI4MzA1ZjUx
+        MTQ3Il0sICJmaWxlbmFtZSI6ICJiemlwMi1saWJzLTEuMC41LTcuZWw2XzAu
+        aTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41Iiwg
+        InJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogImk2ODYifSwgeyJzcmMi
+        OiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnpp
+        cDIiLCAic3VtIjogWyJzaGEyNTYiLCAiYjhhM2Y3MmJjMmIwZDg5YmE3Mzcw
+        OTlhYzk4YmY4ZDJhZjRiZWEwMmQzMTg4NGMwMmRiOTdmN2Y2NmMzZDVjMiJd
+        LCAiZmlsZW5hbWUiOiAiYnppcDItMS4wLjUtNy5lbDZfMC54ODZfNjQucnBt
+        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNl
+        IjogIjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJzcmMiOiAiYnpp
+        cDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2
+        ZWwiLCAic3VtIjogWyJzaGEyNTYiLCAiN2Y2MzEyNGU0NjU1YjdjOTJkMjNl
+        YzRjMzgyMjZmNWQzNzQ2NTY4ODUzZGZmNzUwZmM4NWUwNThlNzRiNWNmNiJd
+        LCAiZmlsZW5hbWUiOiAiYnppcDItZGV2ZWwtMS4wLjUtNy5lbDZfMC54ODZf
+        NjQucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJy
+        ZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJzcmMi
+        OiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnpp
+        cDItbGlicyIsICJzdW0iOiBbInNoYTI1NiIsICI4MDJmNDM5OWRiZGQwMTQ3
+        NmUyNTRjM2IzMmM0MGFmZjU5Y2Y1ZDIzYTQ1ZmE0ODhjNjkxN2NlODkwNGQ2
+        YjRkIl0sICJmaWxlbmFtZSI6ICJiemlwMi1saWJzLTEuMC41LTcuZWw2XzAu
+        eDg2XzY0LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUi
+        LCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAieDg2XzY0In1dLCAi
+        bmFtZSI6ICJSZWQgSGF0IEVudGVycHJpc2UgTGludXggU2VydmVyICh2LiA2
+        IGZvciA2NC1iaXQgeDg2XzY0KSIsICJzaG9ydCI6ICJyaGVsLXg4Nl82NC1z
+        ZXJ2ZXItNiJ9XSwgInN0YXR1cyI6ICJmaW5hbCIsICJ1cGRhdGVkIjogIjIw
+        MTAtMTEtMTAgMDA6MDA6MDAiLCAiZGVzY3JpcHRpb24iOiAiYnppcDIgaXMg
+        YSBmcmVlbHkgYXZhaWxhYmxlLCBoaWdoLXF1YWxpdHkgZGF0YSBjb21wcmVz
+        c29yLiBJdCBwcm92aWRlcyBib3RoXG5saWJiejIgbGlicmFyeSBtdXN0IGJl
+        IHJlc3RhcnRlZCBmb3IgdGhlIHVwZGF0ZSB0byB0YWtlIGVmZmVjdC4iLCAi
+        X2xhc3RfdXBkYXRlZCI6ICIyMDE4LTA3LTMwVDIwOjU1OjI0WiIsICJwdXNo
+        Y291bnQiOiAiIiwgInJpZ2h0cyI6ICJDb3B5cmlnaHQgMjAxMCBSZWQgSGF0
+        IEluYyIsICJzb2x1dGlvbiI6ICJCZWZvcmUgYXBwbHlpbmcgdGhpcyB1cGRh
+        dGUsIG1ha2Ugc3VyZSBhbGwgcHJldmlvdXNseS1yZWxlYXNlZCBlcnJhdGFc
+        bnJlbGV2YW50IHRvIHlvdXIgc3lzdGVtIGhhdmUgYmVlbiBhcHBsaWVkLlxu
+        XG5UaGlzIHVwZGF0ZSBpcyBhdmFpbGFibGUgdmlhIHRoZSBSZWQgSGF0IE5l
+        dHdvcmsuIERldGFpbHMgb24gaG93IHRvXG51c2UgdGhlIFJlZCBIYXQgTmV0
+        d29yayB0byBhcHBseSB0aGlzIHVwZGF0ZSBhcmUgYXZhaWxhYmxlIGF0XG5o
+        dHRwOi8va2Jhc2UucmVkaGF0LmNvbS9mYXEvZG9jcy9ET0MtMTEyNTkiLCAi
+        c3VtbWFyeSI6ICJVcGRhdGVkIGJ6aXAyIHBhY2thZ2VzIHRoYXQgZml4IG9u
+        ZSBzZWN1cml0eSBpc3N1ZSIsICJyZWxlYXNlIjogIiIsICJfaWQiOiAiMWJk
+        MGU2OWEtZmRkMi00OTgyLTllNzgtOTgzYjQxMjJkNTYzIn0sIHsicmVwb3Np
+        dG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVzdCJdLCAiX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvZXJyYXR1bS82ZWMyNzgz
+        Yy01OWZiLTQwYzQtOGQzMi1hYjkxYjRmN2Y2YzIvIiwgImlzc3VlZCI6ICIy
+        MDEwLTAxLTAxIDAxOjAxOjAxIiwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBf
+        dXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJh
+        dHVtIiwgImlkIjogIlJIRUEtMjAxMDowMDAyIiwgImZyb20iOiAibHphcCtw
+        dWJAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAiT25l
+        IHBhY2thZ2UgZXJyYXRhIiwgImNoaWxkcmVuIjoge30sICJ2ZXJzaW9uIjog
+        IjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1
+        cml0eSIsICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0
+        cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIsICJuYW1lIjogImVsZXBoYW50
+        IiwgInN1bSI6IG51bGwsICJmaWxlbmFtZSI6ICJlbGVwaGFudC0wLjMtMC44
+        Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiBudWxsLCAidmVyc2lvbiI6ICIwLjMi
+        LCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1l
+        IjogIjEiLCAic2hvcnQiOiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIsICJ1
+        cGRhdGVkIjogIiIsICJkZXNjcmlwdGlvbiI6ICJPbmUgcGFja2FnZSBlcnJh
+        dGEiLCAiX2xhc3RfdXBkYXRlZCI6ICIyMDE4LTA3LTMwVDIwOjU1OjI0WiIs
+        ICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAi
+        IiwgInN1bW1hcnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiNmVj
+        Mjc4M2MtNTlmYi00MGM0LThkMzItYWI5MWI0ZjdmNmMyIn0sIHsicmVwb3Np
+        dG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVzdCJdLCAiX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvZXJyYXR1bS9iNzMyNTI0
+        OS00NWE0LTQ2OWYtYTQ0ZS03OTNmNTYwYWM1ZjMvIiwgImlzc3VlZCI6ICIy
+        MDEwLTAxLTAxIDAxOjAxOjAxIiwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBf
+        dXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJh
+        dHVtIiwgImlkIjogIlJIRUEtMjAxMDowMDAxIiwgImZyb20iOiAibHphcCtw
+        dWJAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAiRW1w
+        dHkgZXJyYXRhIiwgImNoaWxkcmVuIjoge30sICJ2ZXJzaW9uIjogIjEiLCAi
+        cmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIs
+        ICJwa2dsaXN0IjogW10sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQi
+        OiAiIiwgImRlc2NyaXB0aW9uIjogIkVtcHR5IGVycmF0YSIsICJfbGFzdF91
+        cGRhdGVkIjogIjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgInB1c2hjb3VudCI6
+        ICIiLCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6
+        ICIiLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJiNzMyNTI0OS00NWE0LTQ2
+        OWYtYTQ0ZS03OTNmNTYwYWM1ZjMifV0=
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: post
+    uri: https://alpha.partello.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwYWNrYWdlX2dyb3VwIl0sImZp
+        ZWxkcyI6eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '90'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '458'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIwYjEyMzEwNi1kYTYyLTQ2ZjAtYTJh
+        My1hYzA0OWY4YTU0ZDMiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNrYWdl
+        X2dyb3VwIn0sICJfaWQiOiB7IiRvaWQiOiAiNWI1ZjdiM2MyZjVlYTIyODhm
+        NmY0ODVhIn0sICJ1bml0X2lkIjogIjBiMTIzMTA2LWRhNjItNDZmMC1hMmEz
+        LWFjMDQ5ZjhhNTRkMyIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91
+        cCJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNTE2N2Q0Y2UtODA0YS00NDM2
+        LWIxYzYtMWNmNjFiNzRjZjVlIiwgIl9jb250ZW50X3R5cGVfaWQiOiAicGFj
+        a2FnZV9ncm91cCJ9LCAiX2lkIjogeyIkb2lkIjogIjViNWY3YjNjMmY1ZWEy
+        Mjg4ZjZmNDg1YiJ9LCAidW5pdF9pZCI6ICI1MTY3ZDRjZS04MDRhLTQ0MzYt
+        YjFjNi0xY2Y2MWI3NGNmNWUiLCAidW5pdF90eXBlX2lkIjogInBhY2thZ2Vf
+        Z3JvdXAifV0=
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: post
+    uri: https://alpha.partello.example.com/pulp/api/v2/content/units/package_group/search/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJsaW1pdCI6Miwic2tpcCI6MCwiZmlsdGVycyI6eyJf
+        aWQiOnsiJGluIjpbIjBiMTIzMTA2LWRhNjItNDZmMC1hMmEzLWFjMDQ5Zjhh
+        NTRkMyIsIjUxNjdkNGNlLTgwNGEtNDQzNi1iMWM2LTFjZjYxYjc0Y2Y1ZSJd
+        fX19LCJpbmNsdWRlX3JlcG9zIjp0cnVlfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '160'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1288'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVzdCJd
+        LCAibWFuZGF0b3J5X3BhY2thZ2VfbmFtZXMiOiBbInBlbmd1aW4iXSwgInJl
+        cG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJuYW1lIjogImJpcmQiLCAidXNl
+        cl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAiX2xhc3RfdXBk
+        YXRlZCI6ICIyMDE4LTA3LTMwVDIwOjU1OjI0WiIsICJjaGlsZHJlbiI6IHt9
+        LCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdLCAidHJhbnNsYXRlZF9u
+        YW1lIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0
+        cy9wYWNrYWdlX2dyb3VwLzBiMTIzMTA2LWRhNjItNDZmMC1hMmEzLWFjMDQ5
+        ZjhhNTRkMy8iLCAidHJhbnNsYXRlZF9kZXNjcmlwdGlvbiI6IHt9LCAicHVs
+        cF91c2VyX21ldGFkYXRhIjoge30sICJkZWZhdWx0X3BhY2thZ2VfbmFtZXMi
+        OiBbXSwgIl9jb250ZW50X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJp
+        ZCI6ICJiaXJkIiwgIl9pZCI6ICIwYjEyMzEwNi1kYTYyLTQ2ZjAtYTJhMy1h
+        YzA0OWY4YTU0ZDMiLCAiZGlzcGxheV9vcmRlciI6IDEwMjQsICJjb25kaXRp
+        b25hbF9wYWNrYWdlX25hbWVzIjogW119LCB7InJlcG9zaXRvcnlfbWVtYmVy
+        c2hpcHMiOiBbInNjZW5hcmlvX3Rlc3QiXSwgIm1hbmRhdG9yeV9wYWNrYWdl
+        X25hbWVzIjogWyJlbGVwaGFudCxnaXJhZmZlLGNoZWV0YWgsbGlvbixtb25r
+        ZXkscGVuZ3VpbixzcXVpcnJlbCx3YWxydXMiLCAicGVuZ3VpbiJdLCAicmVw
+        b19pZCI6ICJzY2VuYXJpb190ZXN0IiwgIm5hbWUiOiAibWFtbWFsIiwgInVz
+        ZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9sYXN0X3Vw
+        ZGF0ZWQiOiAiMjAxOC0wNy0zMFQyMDo1NToyNFoiLCAiY2hpbGRyZW4iOiB7
+        fSwgIm9wdGlvbmFsX3BhY2thZ2VfbmFtZXMiOiBbXSwgInRyYW5zbGF0ZWRf
+        bmFtZSI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5p
+        dHMvcGFja2FnZV9ncm91cC81MTY3ZDRjZS04MDRhLTQ0MzYtYjFjNi0xY2Y2
+        MWI3NGNmNWUvIiwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgInB1
+        bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNrYWdlX25hbWVz
+        IjogW10sICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAi
+        aWQiOiAibWFtbWFsIiwgIl9pZCI6ICI1MTY3ZDRjZS04MDRhLTQ0MzYtYjFj
+        Ni0xY2Y2MWI3NGNmNWUiLCAiZGlzcGxheV9vcmRlciI6IDEwMjQsICJjb25k
+        aXRpb25hbF9wYWNrYWdlX25hbWVzIjogW119XQ==
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: post
+    uri: https://alpha.partello.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkaXN0cmlidXRpb24iXX19
+
+'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '42'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:24 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1201'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7ImZpbGVzIjogW3sicmVsYXRpdmVwYXRoIjogImlt
+        YWdlcy90ZXN0Mi5pbWciLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiIsICJj
+        aGVja3N1bSI6ICJlM2IwYzQ0Mjk4ZmMxYzE0OWFmYmY0Yzg5OTZmYjkyNDI3
+        YWU0MWU0NjQ5YjkzNGNhNDk1OTkxYjc4NTJiODU1In0sIHsicmVsYXRpdmVw
+        YXRoIjogImVtcHR5LmlzbyIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2Iiwg
+        ImNoZWNrc3VtIjogImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0
+        MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifSwgeyJyZWxhdGl2
+        ZXBhdGgiOiAiaW1hZ2VzL3Rlc3QxLmltZyIsICJjaGVja3N1bXR5cGUiOiAi
+        c2hhMjU2IiwgImNoZWNrc3VtIjogImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRj
+        ODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifV0s
+        ICJfc3RvcmFnZV9wYXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0
+        cy9kaXN0cmlidXRpb24vOWIvODMxMjU2YTEyNDcxOGJmMzkxNjZiNTY0ZDhl
+        Njg5OTU0ZmYwYThmMGY0NzliYTI0Y2ZhMjYzNTAxMDliYzUiLCAiZmFtaWx5
+        IjogIlRlc3QgRmFtaWx5IiwgImRvd25sb2FkZWQiOiB0cnVlLCAidGltZXN0
+        YW1wIjogMTMyMzExMjE1My4wOSwgIl9sYXN0X3VwZGF0ZWQiOiAxNTMyOTg0
+        MTI0LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJkaXN0cmlidXRpb24iLCAidmFy
+        aWFudCI6ICJUZXN0VmFyaWFudCIsICJpZCI6ICJrcy1UZXN0IEZhbWlseS1U
+        ZXN0VmFyaWFudC0xNi14ODZfNjQiLCAidmVyc2lvbiI6ICIxNiIsICJ2ZXJz
+        aW9uX3NvcnRfaW5kZXgiOiAiMDItMTYiLCAicHVscF91c2VyX21ldGFkYXRh
+        Ijoge30sICJwYWNrYWdlZGlyIjogIiIsICJfaWQiOiAiZDU4OWJiZTQtNWY1
+        ZC00ZDE2LWFkMDgtZmU4N2Y2NDRmOTYwIiwgImFyY2giOiAieDg2XzY0Iiwg
+        Il9ucyI6ICJ1bml0c19kaXN0cmlidXRpb24ifSwgInVwZGF0ZWQiOiAiMjAx
+        OC0wNy0zMFQyMDo1NToyNFoiLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0
+        IiwgImNyZWF0ZWQiOiAiMjAxOC0wNy0zMFQyMDo1NToyNFoiLCAidW5pdF90
+        eXBlX2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogImQ1ODliYmU0
+        LTVmNWQtNGQxNi1hZDA4LWZlODdmNjQ0Zjk2MCIsICJfaWQiOiB7IiRvaWQi
+        OiAiNWI1ZjdiM2MyZjVlYTIyODhmNmY0ODU2In19XQ==
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:24 GMT
+- request:
+    method: post
+    uri: https://alpha.partello.example.com/pulp/api/v2/repositories/actions/content/regenerate_applicability//
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwYXJhbGxlbCI6dHJ1ZSwicmVwb19jcml0ZXJpYSI6eyJmaWx0ZXJzIjp7
+        ImlkIjp7IiRpbiI6WyJzY2VuYXJpb190ZXN0Il19fX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '78'
+  response:
+    status:
+      code: 202
+      message: ACCEPTED
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:25 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJncm91cF9pZCI6ICIwOTVjOTRlNC03OGVjLTQ5NzAtYTY3Ni05ZDMyZjBj
+        NWIyOTMiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tfZ3JvdXBzLzA5
+        NWM5NGU0LTc4ZWMtNDk3MC1hNjc2LTlkMzJmMGM1YjI5My8ifQ==
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:25 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/task_groups/095c94e4-78ec-4970-a676-9d32f0c5b293/state_summary/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:25 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJhY2NlcHRlZCI6IDAsICJmaW5pc2hlZCI6IDAsICJydW5uaW5nIjogMCwg
+        ImNhbmNlbGVkIjogMCwgIndhaXRpbmciOiAwLCAic2tpcHBlZCI6IDAsICJz
+        dXNwZW5kZWQiOiAwLCAiZXJyb3IiOiAwLCAidG90YWwiOiAwfQ==
+    http_version: 
+  recorded_at: Mon, 30 Jul 2018 20:55:25 GMT
+- request:
+    method: get
+    uri: https://alpha.partello.example.com/pulp/api/v2/repositories/scenario_test/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jul 2018 20:55:25 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
       - '2545'
-      Connection:
-      - close
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2863,60 +5373,60 @@ http_interactions:
         eyJzY3JhdGNocGFkIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiJ9LCAi
         ZGlzcGxheV9uYW1lIjogIlNjZW5hcmlvIHl1bSBwcm9kdWN0IiwgImRlc2Ny
         aXB0aW9uIjogbnVsbCwgImRpc3RyaWJ1dG9ycyI6IFt7InJlcG9faWQiOiAi
-        c2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOC0wNi0wN1Qx
-        Mzo1ODoyNFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
+        c2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOC0wNy0zMFQy
+        MDo1NTowMloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
         cy9zY2VuYXJpb190ZXN0L2Rpc3RyaWJ1dG9ycy9zY2VuYXJpb190ZXN0X2Ns
         b25lLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJs
         aXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Nsb25l
         X2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRj
         aHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6
-        IHsiJG9pZCI6ICI1YjE5M2EwMDQxOGE4YTA0YzkxMTIxYmQifSwgImNvbmZp
+        IHsiJG9pZCI6ICI1YjVmN2IyNmQ2Y2MwNjQ3MjUwOGE5NjEifSwgImNvbmZp
         ZyI6IHsiZGVzdGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiAic2NlbmFyaW9f
         dGVzdCJ9LCAiaWQiOiAic2NlbmFyaW9fdGVzdF9jbG9uZSJ9LCB7InJlcG9f
         aWQiOiAic2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOC0w
-        Ni0wN1QxMzo1ODo0NloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9z
+        Ny0zMFQyMDo1NToyNFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9z
         aXRvcmllcy9zY2VuYXJpb190ZXN0L2Rpc3RyaWJ1dG9ycy9zY2VuYXJpb190
         ZXN0LyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJs
-        aXNoIjogIjIwMTgtMDYtMDdUMTM6NTg6NDZaIiwgImRpc3RyaWJ1dG9yX3R5
+        aXNoIjogIjIwMTgtMDctMzBUMjA6NTU6MjRaIiwgImRpc3RyaWJ1dG9yX3R5
         cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IHRy
         dWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRv
-        cnMiLCAiX2lkIjogeyIkb2lkIjogIjViMTkzYTAwNDE4YThhMDRjOTExMjFi
-        YiJ9LCAiY29uZmlnIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiIsICJw
+        cnMiLCAiX2lkIjogeyIkb2lkIjogIjViNWY3YjI2ZDZjYzA2NDcyNTA4YTk1
+        ZiJ9LCAiY29uZmlnIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiIsICJw
         cm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6IGZhbHNlLCAiaHR0cHMiOiB0cnVl
         LCAicmVsYXRpdmVfdXJsIjogInNjZW5hcmlvX3Rlc3QifSwgImlkIjogInNj
         ZW5hcmlvX3Rlc3QifSwgeyJyZXBvX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAi
-        bGFzdF91cGRhdGVkIjogIjIwMTgtMDYtMDdUMTM6NTg6MjRaIiwgIl9ocmVm
+        bGFzdF91cGRhdGVkIjogIjIwMTgtMDctMzBUMjA6NTU6MDJaIiwgIl9ocmVm
         IjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvc2NlbmFyaW9fdGVzdC9k
         aXN0cmlidXRvcnMvZXhwb3J0X2Rpc3RyaWJ1dG9yLyIsICJsYXN0X292ZXJy
         aWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3Ry
         aWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIiwgImF1dG9f
         cHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJl
-        cG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1YjE5M2EwMDQx
-        OGE4YTA0YzkxMTIxYmMifSwgImNvbmZpZyI6IHsiaHR0cCI6IGZhbHNlLCAi
+        cG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1YjVmN2IyNmQ2
+        Y2MwNjQ3MjUwOGE5NjAifSwgImNvbmZpZyI6IHsiaHR0cCI6IGZhbHNlLCAi
         cmVsYXRpdmVfdXJsIjogInNjZW5hcmlvX3Rlc3QiLCAiaHR0cHMiOiBmYWxz
         ZX0sICJpZCI6ICJleHBvcnRfZGlzdHJpYnV0b3IifV0sICJsYXN0X3VuaXRf
-        YWRkZWQiOiAiMjAxOC0wNi0wN1QxMzo1ODo0NloiLCAibm90ZXMiOiB7Il9y
+        YWRkZWQiOiAiMjAxOC0wNy0zMFQyMDo1NToyNFoiLCAibm90ZXMiOiB7Il9y
         ZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwgImxhc3RfdW5pdF9yZW1vdmVkIjog
         bnVsbCwgImNvbnRlbnRfdW5pdF9jb3VudHMiOiB7InBhY2thZ2VfZ3JvdXAi
         OiAyLCAiZGlzdHJpYnV0aW9uIjogMSwgInBhY2thZ2VfY2F0ZWdvcnkiOiAx
         LCAicnBtIjogOCwgImVycmF0dW0iOiAzfSwgIl9ucyI6ICJyZXBvcyIsICJp
         bXBvcnRlcnMiOiBbeyJyZXBvX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAibGFz
-        dF91cGRhdGVkIjogIjIwMTgtMDYtMDdUMTM6NTg6MjRaIiwgIl9ocmVmIjog
+        dF91cGRhdGVkIjogIjIwMTgtMDctMzBUMjA6NTU6MDJaIiwgIl9ocmVmIjog
         Ii9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvc2NlbmFyaW9fdGVzdC9pbXBv
         cnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBvcnRlcnMi
         LCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAibGFzdF9v
         dmVycmlkZV9jb25maWciOiB7Im51bV90aHJlYWRzIjogNCwgInZhbGlkYXRl
-        IjogdHJ1ZX0sICJsYXN0X3N5bmMiOiAiMjAxOC0wNi0wN1QxMzo1ODo0Nloi
+        IjogdHJ1ZX0sICJsYXN0X3N5bmMiOiAiMjAxOC0wNy0zMFQyMDo1NToyNFoi
         LCAic2NyYXRjaHBhZCI6IHsicmVwb21kX3JldmlzaW9uIjogMTMyMTg5Mzgw
-        MH0sICJfaWQiOiB7IiRvaWQiOiAiNWIxOTNhMDA0MThhOGEwNGM5MTEyMWJh
+        MH0sICJfaWQiOiB7IiRvaWQiOiAiNWI1ZjdiMjZkNmNjMDY0NzI1MDhhOTVl
         In0sICJjb25maWciOiB7ImZlZWQiOiAiZmlsZTovLy92YXIvd3d3L3Rlc3Rf
         cmVwb3Mvem9vIiwgInNzbF92YWxpZGF0aW9uIjogdHJ1ZSwgInJlbW92ZV9t
         aXNzaW5nIjogdHJ1ZSwgImRvd25sb2FkX3BvbGljeSI6ICJpbW1lZGlhdGUi
         fSwgImlkIjogInl1bV9pbXBvcnRlciJ9XSwgImxvY2FsbHlfc3RvcmVkX3Vu
-        aXRzIjogMTUsICJfaWQiOiB7IiRvaWQiOiAiNWIxOTNhMDA0MThhOGEwNGM5
-        MTEyMWI5In0sICJ0b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMTUsICJpZCI6
+        aXRzIjogMTUsICJfaWQiOiB7IiRvaWQiOiAiNWI1ZjdiMjZkNmNjMDY0NzI1
+        MDhhOTVkIn0sICJ0b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMTUsICJpZCI6
         ICJzY2VuYXJpb190ZXN0IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBv
         c2l0b3JpZXMvc2NlbmFyaW9fdGVzdC8ifQ==
     http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:47 GMT
+  recorded_at: Mon, 30 Jul 2018 20:55:25 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/support/destroy_org_if_exists.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/support/destroy_org_if_exists.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test
+    uri: https://alpha.partello.example.com:8443/candlepin/owners/scenario_test
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -14,9 +14,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111
       Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="QcLuU6UugUVqdAxvQKnLDk7UInGNM3BgkI7hOq6c",
-        oauth_signature="NtsnoYpm6zODILRiseQlXgtyEdQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1528379901", oauth_version="1.0"
+      - OAuth oauth_consumer_key="f3SrjSXwpnyQJkiNLCAuePYsZU5UbVUw", oauth_nonce="EWRM2DZViSdeyXPFVLqwxG68X6fb37yetTrKk3ZQ",
+        oauth_signature="eKjbfE89eYtn1hOLk1VLbnpvrt4%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1532984100", oauth_version="1.0"
       Cp-User:
       - foreman_admin
   response:
@@ -27,22 +27,22 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 4b27b65d-0d8d-4c2a-8502-92a206fdb5be
+      - 2021452b-7ed7-4506-bb21-145cea540bba
       X-Version:
-      - 2.3.8-1
-      - 2.3.8-1
+      - 2.4.5-1
+      - 2.4.5-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 07 Jun 2018 13:58:21 GMT
+      - Mon, 30 Jul 2018 20:55:00 GMT
     body:
       encoding: UTF-8
       base64_string: |
         eyJkaXNwbGF5TWVzc2FnZSI6Ik9yZ2FuaXphdGlvbiB3aXRoIGlkIHNjZW5h
         cmlvX3Rlc3QgY291bGQgbm90IGJlIGZvdW5kLiIsInJlcXVlc3RVdWlkIjoi
-        NGIyN2I2NWQtMGQ4ZC00YzJhLTg1MDItOTJhMjA2ZmRiNWJlIn0=
+        MjAyMTQ1MmItN2VkNy00NTA2LWJiMjEtMTQ1Y2VhNTQwYmJhIn0=
     http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:21 GMT
+  recorded_at: Mon, 30 Jul 2018 20:55:00 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/support/destroy_repo_if_exists.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/support/destroy_repo_if_exists.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/
+    uri: https://alpha.partello.example.com/pulp/api/v2/repositories/scenario_test/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -18,18 +18,14 @@ http_interactions:
   response:
     status:
       code: 404
-      message: Not Found
+      message: NOT FOUND
     headers:
       Date:
-      - Thu, 07 Jun 2018 13:58:23 GMT
+      - Mon, 30 Jul 2018 20:55:02 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '422'
-      Etag:
-      - '"5ac546ec21028925462ba3914390e451"'
-      Connection:
-      - close
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -46,5 +42,5 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         InNjZW5hcmlvX3Rlc3QifX0=
     http_version: 
-  recorded_at: Thu, 07 Jun 2018 13:58:24 GMT
+  recorded_at: Mon, 30 Jul 2018 20:55:02 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
When indexing pool to subscription facet association, use
a new api that only returns the consumer uuids