### PR TITLE
Fixes #24499 - Fix javascript dependencies for Sync Status

### DIFF
--- a/app/assets/javascripts/katello/common/index.js
+++ b/app/assets/javascripts/katello/common/index.js
@@ -1,3 +1,4 @@
+//= require bastion/lodash/lodash
 //= require "katello/common/katello.global"
 //= require "katello/common/katello.common.js"
 //= require "katello/common/katello"

--- a/app/assets/javascripts/katello/sync_management/index.js
+++ b/app/assets/javascripts/katello/sync_management/index.js
@@ -1,2 +1,3 @@
 //= require "katello/jquery.treeTable"
+//= require "katello/common/katello.common.js"
 //= require "katello/sync_management/sync_management"


### PR DESCRIPTION
To test:

Navigate to Sync Status page, then ensure there are no JS console errors and normal functionality works fine, including the "Active Only" checkbox.