### PR TITLE
fixes #24498 - fix compare for some content types

### DIFF
--- a/app/controllers/katello/api/v2/puppet_modules_controller.rb
+++ b/app/controllers/katello/api/v2/puppet_modules_controller.rb
@@ -10,5 +10,10 @@ module Katello
       end
       collection
     end
+
+    def custom_collection_by_content_view_version(versions)
+      resource_class.joins(:content_view_puppet_environments)
+        .where("#{Katello::ContentViewPuppetEnvironment.table_name}.content_view_version_id" => versions)
+    end
   end
 end

--- a/app/presenters/katello/content_view_version_compare_presenter.rb
+++ b/app/presenters/katello/content_view_version_compare_presenter.rb
@@ -7,8 +7,13 @@ module Katello
     end
 
     def comparison
-      item_repos = @item.repositories
-      item_repos.where(:library_instance_id => @repository.id) if @repository
+      if @item.is_a?(::Katello::PuppetModule)
+        item_repos = @item.content_view_puppet_environments
+      else
+        item_repos = @item.repositories
+        item_repos.where(:library_instance_id => @repository.id) if @repository
+      end
+
       item_repos.map(&:content_view_version_id) & @versions.map(&:id)
     end
 

--- a/app/views/katello/api/v2/debs/compare.json.rabl
+++ b/app/views/katello/api/v2/debs/compare.json.rabl
@@ -1,0 +1,10 @@
+object false
+
+extends "katello/api/v2/common/metadata"
+
+child @collection[:results] => :results do
+  extends 'katello/api/v2/debs/base'
+  node :comparison do |result|
+    result.comparison
+  end
+end

--- a/app/views/katello/api/v2/docker_manifest_lists/compare.json.rabl
+++ b/app/views/katello/api/v2/docker_manifest_lists/compare.json.rabl
@@ -1,0 +1,10 @@
+object false
+
+extends "katello/api/v2/common/metadata"
+
+child @collection[:results] => :results do
+  extends 'katello/api/v2/docker_manifest_lists/show'
+  node :comparison do |result|
+    result.comparison
+  end
+end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -132,6 +132,7 @@ Katello::Engine.routes.draw do
         api_resources :debs, :only => [:index, :show] do
           collection do
             get :auto_complete_search
+            get :compare
           end
         end
 
@@ -145,6 +146,7 @@ Katello::Engine.routes.draw do
         api_resources :docker_manifest_lists, :only => [:index, :show] do
           collection do
             get :auto_complete_search
+            get :compare
           end
         end
 

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -249,7 +249,7 @@ module Katello
                            'katello/api/v2/products' => [:index, :show, :auto_complete_search],
                            'katello/api/v2/repositories' => [:index, :show, :repository_types, :auto_complete_search, :cancel],
                            'katello/api/v2/packages' => [:index, :show, :auto_complete_search, :auto_complete_name, :auto_complete_arch, :compare],
-                           'katello/api/v2/debs' => [:index, :show, :auto_complete_search],
+                           'katello/api/v2/debs' => [:index, :show, :auto_complete_search, :compare],
                            'katello/api/v2/package_groups' => [:index, :show, :auto_complete_search, :compare],
                            'katello/api/v2/docker_manifests' => [:index, :show, :auto_complete_search, :compare],
                            'katello/api/v2/docker_manifest_lists' => [:index, :show, :auto_complete_search, :compare],

--- a/test/fixtures/models/katello_content_view_puppet_environment_puppet_modules.yml
+++ b/test/fixtures/models/katello_content_view_puppet_environment_puppet_modules.yml
@@ -1,3 +1,11 @@
 dev_view_puppet_environment_dhcp_puppet_module:
   content_view_puppet_environment_id: <%= ActiveRecord::FixtureSet.identify(:dev_view_puppet_environment) %>
   puppet_module_id: <%= ActiveRecord::FixtureSet.identify(:dhcp) %>
+
+library_view_puppet_environment_dhcp_puppet_module:
+  content_view_puppet_environment_id: <%= ActiveRecord::FixtureSet.identify(:library_view_puppet_environment) %>
+  puppet_module_id: <%= ActiveRecord::FixtureSet.identify(:dhcp) %>
+
+library_view_puppet_environment_abrt_puppet_module:
+  content_view_puppet_environment_id: <%= ActiveRecord::FixtureSet.identify(:library_view_puppet_environment) %>
+  puppet_module_id: <%= ActiveRecord::FixtureSet.identify(:abrt) %>

--- a/test/presenters/content_view_version_compare_presenter_test.rb
+++ b/test/presenters/content_view_version_compare_presenter_test.rb
@@ -1,7 +1,7 @@
 require 'katello_test_helper'
 
 module Katello
-  class ContentVIewVersionComparePresenterTest < ActiveSupport::TestCase
+  class ContentViewVersionComparePresenterTest < ActiveSupport::TestCase
     def setup
       @complete_version = katello_content_view_versions(:library_default_version)
       @incomplete_version = katello_content_view_versions(:library_view_version_1)
@@ -31,6 +31,31 @@ module Katello
       present = ContentViewVersionComparePresenter.new(@complete_version, @versions, @fedora_repo)
       assert_includes present.comparison, @complete_version.id
       refute_includes present.comparison, @incomplete_version.id
+      assert_equal 1, present.comparison.size
+    end
+  end
+
+  class ContentViewVersionComparePresenterPuppetTest < ActiveSupport::TestCase
+    def setup
+      @complete_version = katello_content_view_versions(:library_view_version_1)
+      @incomplete_version = katello_content_view_versions(:library_view_version_2)
+      @versions = [@complete_version, @incomplete_version]
+
+      @complete_module = katello_puppet_modules(:dhcp)
+      @incomplete_module = katello_puppet_modules(:abrt)
+    end
+
+    test "both views match" do
+      present = ContentViewVersionComparePresenter.new(@complete_module, @versions, nil)
+      assert_includes present.comparison, @complete_version.id
+      assert_includes present.comparison, @incomplete_version.id
+      assert_equal 2, present.comparison.size
+    end
+
+    test "only one view matches" do
+      present = ContentViewVersionComparePresenter.new(@incomplete_module, @versions, nil)
+      assert_includes present.comparison, @incomplete_version.id
+      refute_includes present.comparison, @complete_version.id
       assert_equal 1, present.comparison.size
     end
   end


### PR DESCRIPTION
Debs and docker manifest lists were missing the API RABL view, and Puppet module comparisons weren't working because their container is a content view puppet environment, not a repository.
