### PR TITLE
Fixes #23989: fix new sync plan modal css.

### DIFF
--- a/engines/bastion_katello/app/assets/stylesheets/bastion_katello/bastion_katello.scss
+++ b/engines/bastion_katello/app/assets/stylesheets/bastion_katello/bastion_katello.scss
@@ -38,3 +38,8 @@
 .bottom-padded-content {
   padding-bottom: 10%;
 }
+
+.modal-body .uib-time input {
+  width: 100%;
+  padding-right: 6px;
+}


### PR DESCRIPTION
Fix the styling on the new sync plan modal such that the hour and
minute are displayed properly.

http://projects.theforeman.org/issues/23989