### PR TITLE
Fixes #24507: fix networking section of CH details.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -263,36 +263,36 @@
         <dt translate>Last Checkin</dt>
         <dd>{{ (host.subscription_facet_attributes.last_checkin | date:'short') || ("Never checked in" | translate) }}</dd>
       </dl>
-    </div>
 
-    <div class="divider"></div>
+      <div class="divider"></div>
 
-    <h4 translate>Networking</h4>
+      <h4 translate>Networking</h4>
 
-    <dl class="dl-horizontal dl-horizontal-left">
-      <dt translate>Hostname</dt>
-      <dd>{{ host.name }}</dd>
+      <dl class="dl-horizontal dl-horizontal-left">
+        <dt translate>Hostname</dt>
+        <dd>{{ host.name }}</dd>
 
-      <dt translate>IPv4 Address</dt>
-      <dd>{{ host.facts["network::ipv4_address"] }}</dd>
+        <dt translate>IPv4 Address</dt>
+        <dd>{{ host.facts["network::ipv4_address"] }}</dd>
 
-      <dt translate>IPv6 Address</dt>
-      <dd>{{ host.facts["network::ipv6_address"] }}</dd>
+        <dt translate>IPv6 Address</dt>
+        <dd>{{ host.facts["network::ipv6_address"] }}</dd>
 
-      <dt translate>Interfaces</dt>
-      <dd>
-        <div ng-repeat="(interfaceName, interface) in hostFactsAsObject.net.interface" >
-          <i ng-class="{'fa fa-plus': !expanded, 'fa fa-minus': expanded}" class="expand-icon"
-             ng-hide="editMode" ng-click="expanded = !expanded"></i>
-          {{ interfaceName }}
-          <div class="sub-detail" ng-show="expanded">
-            <div ng-repeat="(key, value) in interface">
-              <span class="info-sub-label">{{ key.replace("_", " ") }}:</span>
-              <span class="info-sub-value">{{ value }}</span>
+        <dt translate>Interfaces</dt>
+        <dd>
+          <div ng-repeat="(interfaceName, interface) in hostFactsAsObject.net.interface" >
+            <i ng-class="{'fa fa-plus': !expanded, 'fa fa-minus': expanded}" class="expand-icon"
+               ng-hide="editMode" ng-click="expanded = !expanded"></i>
+            {{ interfaceName }}
+            <div class="sub-detail" ng-show="expanded">
+              <div ng-repeat="(key, value) in interface">
+                <span class="info-sub-label">{{ key.replace("_", " ") }}:</span>
+                <span class="info-sub-value">{{ value }}</span>
+              </div>
             </div>
           </div>
-        </div>
-      </dd>
-    </dl>
+        </dd>
+      </dl>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
The networking section on the content host details page was not
displaying due to it not being included in the left or right
sections of the page.  This commit moves the network section into
the right section of the page.

https://projects.theforeman.org/issues/24507