### PR TITLE
Fixes #24485 - add floating pagination in repo page

### DIFF
--- a/webpack/scenes/RedHatRepositories/helpers.js
+++ b/webpack/scenes/RedHatRepositories/helpers.js
@@ -32,12 +32,14 @@ export const getSetsComponent = (repoSetsState, onPaginationChange) => {
   }
   return (
     <ListView>
-      <PaginationRow
-        viewType="list"
-        itemCount={itemCount}
-        pagination={pagination}
-        onChange={onPaginationChange}
-      />
+      <div className="sticky-pagination">
+        <PaginationRow
+          viewType="list"
+          itemCount={itemCount}
+          pagination={pagination}
+          onChange={onPaginationChange}
+        />
+      </div>
       {results.map(set => <RepositorySet id={set.id} key={set.id} {...set} />)}
     </ListView>
   );
@@ -60,12 +62,14 @@ export const getEnabledComponent = (enabledReposState, onPaginationChange) => {
 
   return (
     <ListView>
-      <PaginationRow
-        viewType="list"
-        itemCount={itemCount}
-        pagination={pagination}
-        onChange={onPaginationChange}
-      />
+      <div className="sticky-pagination sticky-pagination-grey">
+        <PaginationRow
+          viewType="list"
+          itemCount={itemCount}
+          pagination={pagination}
+          onChange={onPaginationChange}
+        />
+      </div>
       {repositories.map(repo => <EnabledRepository key={repo.id} {...repo} />)}
     </ListView>
   );

--- a/webpack/scenes/RedHatRepositories/index.scss
+++ b/webpack/scenes/RedHatRepositories/index.scss
@@ -73,3 +73,15 @@
     }
   }
 }
+
+.sticky-pagination {
+  position: sticky;
+  top: 60px;
+  z-index: 2;
+  background-color: white;
+  padding-top: 10px;
+}
+
+.sticky-pagination-grey {
+  background-color: $color-pf-black-200;
+}


### PR DESCRIPTION
On Red Hat Repositories page, the next/previous page option is available only on the top side of the "Available Repositories" page, which might be an issue when scrolling 50 or more items.

Instead of adding a pagination row at the bottom, the pagination row can float:
![192 168 121 17_3000_redhat_repositories 2](https://user-images.githubusercontent.com/11807069/43531057-a5751f0c-95b7-11e8-9259-63903d7e2648.gif)
 