### PR TITLE
Fixes #24519 - Sync Plan saved with incorrect date/time

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/sync-plan-helper.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/sync-plan-helper.service.js
@@ -48,8 +48,7 @@
          * @returns $resource sync plan
          */
         this.createSyncPlan = function (syncPlan, success, error) {
-            var GMT_OFFSET_MILLISECONDS = syncPlan.startDate.getTimezoneOffset() * 60000,
-                syncDate = new Date(syncPlan.startDate.getTime() + GMT_OFFSET_MILLISECONDS),
+            var syncDate = new Date(syncPlan.startDate.getTime()),
                 syncTime = new Date(syncPlan.startTime || new Date());
             syncDate.setHours(syncTime.getHours());
             syncDate.setMinutes(syncTime.getMinutes());


### PR DESCRIPTION
### Steps to Reproduce:

Go to Sync Plans > New 
Enter a date and time for the new sync plan

**Actual Behavior:** The saved sync plan has a different time than what was set by the user

**Expected Behavior:** The dates should be correct