### PR TITLE
fixes #18282 - select all filtered table

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
@@ -17,8 +17,8 @@
  *   Provides the functionality for the repo discovery action pane.
  */
 angular.module('Bastion.products').controller('DiscoveryController',
-    ['$scope', '$q', '$timeout', '$http', 'Notification', 'Task', 'Organization', 'CurrentOrganization', 'DiscoveryRepositories', 'translate',
-    function ($scope, $q, $timeout, $http, Notification, Task, Organization, CurrentOrganization, DiscoveryRepositories, translate) {
+    ['$scope', '$q', '$timeout', '$http', '$filter', 'Notification', 'Task', 'Organization', 'CurrentOrganization', 'DiscoveryRepositories', 'translate',
+    function ($scope, $q, $timeout, $http, $filter, Notification, Task, Organization, CurrentOrganization, DiscoveryRepositories, translate) {
         var transformRows, setDiscoveryDetails;
 
         $scope.discovery = {
@@ -48,6 +48,21 @@ angular.module('Bastion.products').controller('DiscoveryController',
             $scope.table.rows = transformRows(task.output);
             $scope.table.resource.total = $scope.table.rows.length;
             $scope.table.resource.subtotal = $scope.table.resource.total;
+        };
+
+        $scope.filteredRows = function (filter) {
+            var rows, idx;
+            angular.forEach($scope.table.rows, function (row) {
+                row.unselectable = true;
+            });
+            rows = $filter('filter')($scope.table.rows.slice(), filter);
+            angular.forEach(rows, function (row) {
+                idx = $scope.table.rows.indexOf(row);
+                $scope.table.rows[idx].unselectable = false;
+            });
+            $scope.table.getSelected();
+
+            return (rows);
         };
 
         $scope.setupSelected = function () {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
@@ -101,7 +101,7 @@
       </thead>
 
       <tbody>
-        <tr bst-table-row ng-repeat="urlRow in table.rows | filter:tableFilter" row-select="urlRow">
+        <tr bst-table-row ng-repeat="urlRow in filteredRows(tableFilter)" row-select="urlRow">
           <td bst-table-cell style="white-space:nowrap">{{ urlRow.path }}</td>
         </tr>
       </tbody>


### PR DESCRIPTION
This correctly updates the selected rows when the "select all" checkbox is used at the same time as a filter value is there.

To test, repo discover _https://yum.theforeman.org/releases/nightly_, enter a filter like "source", select all, clear filter and note that just the source repos were selected.

Outside the scope of this PR:
- Existing issue when a filter matches no results a message should be shown.
- Existing issue that the displayed number of selected can be wrong at times (somewhat alleviated by the call to _$scope.table.getSelected()_.