### PR TITLE
fixes #23507 - seed container image bookmarks

### DIFF
--- a/db/seeds.d/111-container-image-bookmarks.rb
+++ b/db/seeds.d/111-container-image-bookmarks.rb
@@ -1,0 +1,19 @@
+# This file should contain all the record creation needed to seed the database with its default values.
+# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
+#
+# !!! PLEASE KEEP THIS SCRIPT IDEMPOTENT !!!
+#
+
+User.as_anonymous_admin do
+  Bookmark.without_auditing do
+    bookmarks = [
+      {:name => "Without a Tag", :query => 'not has tag', :controller => "katello_docker_manifests"}
+    ]
+
+    bookmarks.each do |input|
+      next if SeedHelper.audit_modified? Bookmark, input[:name], :controller => input[:controller]
+      b = Bookmark.find_or_create_by({ :public => true }.merge(input))
+      fail "Unable to create bookmark: #{format_errors b}" if b.nil? || b.errors.any?
+    end
+  end
+end


### PR DESCRIPTION
To test: Seed db then note bookmark on product repository container image manifest page.

Requires this fix to test: https://github.com/Katello/katello/pull/7596