### PR TITLE
Fixes #24543 - Link to errata view doesn't work

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
@@ -17,7 +17,7 @@
         Content View and Lifecycle Environment.  In order to apply such Errata an Incremental Update is required.
       </span>
 
-      <a ui-sref="errata.index" translate>Click here to select Errata for an Incremental Update.</a>
+      <a ui-sref="errata" translate>Click here to select Errata for an Incremental Update.</a>
     </p>
   </div>
 


### PR DESCRIPTION
The link in "Click here to select Errata for an Incremental Update." to the errata view doesn't work as errata.index was removed some versions before.