### PR TITLE
Fixes #24542 - prop-types warning bootstrap-select

### DIFF
--- a/webpack/move_to_pf/react-bootstrap-select/index.js
+++ b/webpack/move_to_pf/react-bootstrap-select/index.js
@@ -53,13 +53,13 @@ class BootstrapSelect extends React.Component {
   render() {
     // TODO: these classes are required because foreman assumes that all selects should use select2 and jquery multiselect
     // TODO: see also http://projects.theforeman.org/issues/21952
-    const { noneSelectedText, defaultValue } = this.props;
+    const { noneSelectedText, ...props } = this.props;
 
-    return <FormControl {...this.props}
+    return <FormControl {...props}
                         data-none-selected-text={noneSelectedText}
                         data-selected-text-format="count>3"
                         data-count-selected-text={__('{0} items selected')}
-                        value={defaultValue}
+                        value={props.defaultValue}
                         componentClass="select"
                         className="without_select2 without_jquery_multiselect"
     />;


### PR DESCRIPTION
Fix prop-types warning about noneSelectedText in
move_to_pf/react-bootstrap-select/index.js

**The warning:**
```
warning.js:33 Warning: React does not recognize the `noneSelectedText` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `noneselectedtext` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in select (created by FormControl)
    in FormControl (created by BootstrapSelect)
    in BootstrapSelect (created by MultiSelect)
    in div (created by FormGroup)
    in FormGroup (created by MultiSelect)
    in MultiSelect (created by SearchBar)
    in form (created by Form)
    in Form (created by SearchBar)
    in SearchBar (created by Connect(SearchBar))
    in Connect(SearchBar) (created by RedHatRepositoriesPage)
    in div (created by Col)
    in Col (created by RedHatRepositoriesPage)
    in div (created by Row)
    in Row (created by RedHatRepositoriesPage)
    in div (created by Grid)
    in Grid (created by RedHatRepositoriesPage)
    in RedHatRepositoriesPage (created by Connect(RedHatRepositoriesPage))
    in Connect(RedHatRepositoriesPage) (created by CheckOrg)
    in CheckOrg (created by Route)
    in Route
    in div
    in Unknown (created by Application)
    in Router (created by BrowserRouter)
    in BrowserRouter (created by Application)
    in Application (created by Connect(Application))
    in Connect(Application)
    in Provider
```