### PR TITLE
Fixes #24243 - Recommended repositories toggle is too close to the "Available Repositories" header on narrow displays

### DIFF
--- a/webpack/scenes/RedHatRepositories/index.scss
+++ b/webpack/scenes/RedHatRepositories/index.scss
@@ -46,6 +46,7 @@
 
       h2 {
         margin: 0;
+        margin-right: 40px;
       }
     }
   }


### PR DESCRIPTION
Recommended repositories toggle is too close
to the "Available Repositories" header on narrow displays