### PR TITLE
Fixes #24549 - Add rendering extension tests

### DIFF
--- a/app/lib/katello/concerns/base_template_scope_extensions.rb
+++ b/app/lib/katello/concerns/base_template_scope_extensions.rb
@@ -1,6 +1,6 @@
 module Katello
   module Concerns
-    module InputTemplateScopeExtensions
+    module BaseTemplateScopeExtensions
       extend ActiveSupport::Concern
 
       module Overrides
@@ -14,7 +14,7 @@ module Katello
       end
 
       def errata(id)
-        Katello::Erratum.with_identifiers(id).map(&:attributes).first.slice!('created_at', 'updated_at')
+        Katello::Erratum.in_repositories(Katello::Repository.readable).with_identifiers(id).map(&:attributes).first.slice!('created_at', 'updated_at')
       end
     end
   end

--- a/app/lib/katello/concerns/renderer_extensions.rb
+++ b/app/lib/katello/concerns/renderer_extensions.rb
@@ -7,10 +7,12 @@ module Katello
         def kickstart_attributes
           super
 
+          medium_provider = Katello::ManagedContentMediumProvider.new(host.content_facet)
           content_view = host.try(:content_facet).try(:content_view) || host.try(:content_view)
+
           if content_view && host.operatingsystem.is_a?(Redhat) &&
                   host.operatingsystem.kickstart_repos(host).first.present?
-            @mediapath ||= host.operatingsystem.mediumpath(host)
+            @mediapath ||= host.operatingsystem.mediumpath(medium_provider)
           end
         end
       end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -135,9 +135,7 @@ module Katello
 
       # Lib Extensions
       ::Foreman::Renderer::Scope::Variables::Base.send :include, Katello::Concerns::RendererExtensions
-      if Katello.with_remote_execution?
-        ::ForemanRemoteExecution::Renderer::Scope::Input.send :include, Katello::Concerns::InputTemplateScopeExtensions
-      end
+      ::Foreman::Renderer::Scope::Base.send :include, Katello::Concerns::BaseTemplateScopeExtensions
 
       # Model extensions
       ::Environment.send :include, Katello::Concerns::EnvironmentExtensions

--- a/test/fixtures/models/hosts.yml
+++ b/test/fixtures/models/hosts.yml
@@ -3,6 +3,7 @@ one:
   location_id: <%= ActiveRecord::FixtureSet.identify(:location1) %>
   name: "Host1.example.com"
   type: 'Host::Managed'
+  architecture_id: <%= ActiveRecord::FixtureSet.identify(:x86_64) %>
 
 two:
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -166,7 +166,7 @@ rhel_6_x86_64:
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
   url:                 'https://cdn.example.com/rhel/6/os'
   distribution_arch: "x86_64"
-  distribution_version: "2.1"
+  distribution_version: "6.1"
   distribution_family: "Other Family"
   distribution_variant: "TestVariant"
   distribution_bootable: true

--- a/test/lib/concerns/base_template_scope_extensions_test.rb
+++ b/test/lib/concerns/base_template_scope_extensions_test.rb
@@ -1,0 +1,23 @@
+require 'katello_test_helper'
+require 'foreman/renderer'
+require 'foreman/renderer/source/string'
+
+module Katello
+  class BaseTemplateScopeExtensionsTest < ActiveSupport::TestCase
+    def setup
+      @errata = katello_errata(:security)
+    end
+
+    def test_errata
+      source = ::Foreman::Renderer::Source::String.new(
+        name: 'Parameter',
+        content: "<%= errata('#{@errata.errata_id}')['id'] %>"
+      )
+      scope = ::Foreman::Renderer.get_scope(host: ::Host.first)
+      id = ::Foreman::Renderer.render(source, scope)
+
+      refute id.empty?
+      assert_equal @errata.id.to_s, id
+    end
+  end
+end

--- a/test/lib/concerns/renderer_extensions_test.rb
+++ b/test/lib/concerns/renderer_extensions_test.rb
@@ -1,0 +1,22 @@
+require 'katello_test_helper'
+require 'foreman/renderer/scope/provisioning'
+
+module Katello
+  class RendererExtensionsTest < ActiveSupport::TestCase
+    def setup
+      @repo = katello_repositories(:rhel_6_x86_64)
+      @host = hosts(:one)
+      @host.content_facet.content_source = smart_proxies(:one)
+      @host.operatingsystem = operatingsystems(:redhat)
+      @host.content_facet.kickstart_repository = @repo
+      @host.content_facet.content_view = @repo.content_view
+    end
+
+    def test_render
+      scope = ::Foreman::Renderer::Scope::Provisioning.new(host: @host, source: Template.first)
+
+      assert_include scope.allowed_variables.keys, :mediapath
+      assert_include scope.allowed_variables[:mediapath], @repo.relative_path
+    end
+  end
+end


### PR DESCRIPTION
and fix a few issues with those extensions.  The
errata id helper did not take permissions into account,
the kickstart_attributes method was not using the new
medium provider and thus would not work.  This also
moves the errata helper to the base input scope instead
of on a REX class for easier testing.