### PR TITLE
Fixes #24559: validate hostgroup content_source_id

### DIFF
--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -13,6 +13,7 @@ module Katello
 
         validates_with Katello::Validators::ContentViewEnvironmentValidator
         validates_with Katello::Validators::HostgroupKickstartRepositoryValidator
+        validates_with ::AssociationExistsValidator, attributes: [:content_source]
 
         scoped_search :relation => :content_source, :on => :name, :complete_value => true, :rename => :content_source, :only_explicit => true
         scoped_search :relation => :content_view, :on => :name, :complete_value => true, :rename => :content_view, :only_explicit => true

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -21,7 +21,7 @@ module Katello
 
       validates :content_view, :presence => true, :allow_blank => false
       validates :lifecycle_environment, :presence => true, :allow_blank => false
-      validates_with Validators::AssociationExistsValidator, attributes: [:content_source]
+      validates_with ::AssociationExistsValidator, attributes: [:content_source]
       validates :host, :presence => true, :allow_blank => false
       validates_with Validators::ContentViewEnvironmentValidator
 


### PR DESCRIPTION
Test:

```sh
hammer hostgroup create --name potato --content-source-id 92 # does not exist
```