### PR TITLE
Fixes # 22498 - Improve error messages for content views

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -24,7 +24,7 @@ module Katello
     # component_composites -> Bottom Up, given I am a component CV get the associated composites that I belong to
     #
     has_many :content_view_components, :class_name => "Katello::ContentViewComponent", :dependent => :destroy,
-             :inverse_of => :composite_content_view, :foreign_key => :composite_content_view_id
+             :inverse_of => :composite_content_view, :foreign_key => :composite_content_view_id, autosave: true
 
     has_many :component_composites, :class_name => "Katello::ContentViewComponent",
              :dependent => :destroy, :inverse_of => :content_view, :foreign_key => :content_view_id

--- a/app/models/katello/content_view_component.rb
+++ b/app/models/katello/content_view_component.rb
@@ -43,7 +43,7 @@ module Katello
       end
 
       if attached_content_view_ids.include?(view.id)
-        errors.add(:base, _("Duplicate Content View. Another component already includes this view"))
+        errors.add(:base, _("Another component already includes content view with ID %s" % view.id))
       end
     end
 

--- a/test/models/content_view_component_test.rb
+++ b/test/models/content_view_component_test.rb
@@ -109,12 +109,12 @@ module Katello
       @composite = @composite.reload
       component = ContentViewComponent.create(:composite_content_view => @composite,
                                               :content_view => view1, :latest => true)
-      refute_with_error(component, /^Duplicate Content View. Another component already includes this view/)
+      refute_with_error(component, /^Another component already includes content view with ID/)
 
       component = ContentViewComponent.create(:composite_content_view => @composite,
                                               :content_view_version => version1, :latest => false)
       refute_with_error(component,
-                             /^Duplicate Content View. Another component already includes this view/)
+                             /^Another component already includes content view with ID/)
     end
 
     def test_latest_versions


### PR DESCRIPTION
The specific error was being caught in the content view component but
the error was being rescued in the content view model, so the CV error
took precedence over the component CV error. Used validates_associated
to combine the error messages for more specification.

I also added a call to the specific content view that holds the error.
And I added periods to the end of the error statements to make them
more readable.

There is still the issue with the error message showing up twice. Both
the content view that's already in the CCV and the CV attempting to be
passed in are getting the error messages. Perhaps we have some
suggestions on how to group the error messages together so it only
gets printed once?