### PR TITLE
Fixes #23992: fix error on CH subscriptions modal.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-subscriptions-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-subscriptions-modal.controller.js
@@ -44,11 +44,14 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkSubscription
                 });
             };
 
-            $scope.contentNutupane = new Nutupane(Subscription, params);
+
+            $scope.contentNutupane = new Nutupane(Subscription, params,
+              'queryPaged', {disableAutoLoad: true});
             $scope.controllerName = 'katello_subscriptions';
             $scope.table = $scope.contentNutupane.table;
             $scope.contentNutupane.setSearchKey('subscriptionSearch');
             $scope.contentNutupane.masterOnly = true;
+            $scope.contentNutupane.load();
             $scope.groupedSubscriptions = {};
 
             $scope.$watch('table.rows', function (rows) {

--- a/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-subscriptions-modal.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-subscriptions-modal.controller.test.js
@@ -42,6 +42,7 @@ describe('Controller: ContentHostsBulkSubscriptionsModalController', function() 
             this.invalidate = function () {};
             this.setSearchKey = function () {};
             this.table = { };
+            this.load = function () {};
         };
 
         hostIds = {included: {ids: [1, 2, 3]}};


### PR DESCRIPTION
Fix the search error on the content host subscriptions modal by
delaying the loading of the nutupane until the search key is set.

http://projects.theforeman.org/issues/23992