### PR TITLE
Fixes #24576 - improve Event Queue performance

### DIFF
--- a/app/lib/actions/katello/event_queue/poller_thread.rb
+++ b/app/lib/actions/katello/event_queue/poller_thread.rb
@@ -3,6 +3,7 @@ module Actions
     module EventQueue
       class PollerThread
         SLEEP_INTERVAL = 2
+        COUNT_UPDATE_INTERVAL = 250
         cattr_accessor :instance
 
         def self.initialize(logger)
@@ -22,16 +23,38 @@ module Actions
           @thread.kill if @thread
         end
 
+        def run_event(event)
+          @logger.debug("event_queue_event: #{event.event_type}, #{event.object_id}")
+          ::User.as_anonymous_admin do
+            ::Katello::EventQueue.event_class(event.event_type).new(event.object_id).run
+          end
+        rescue => e
+          @logger.error("event_queue_error: #{event.event_type}, #{event.object_id}")
+          @logger.error(e.message)
+          @logger.error(e.backtrace.join("\n"))
+        ensure
+          ::Katello::EventQueue.clear_events(event.event_type, event.object_id, event.created_at)
+        end
+
         def poll_for_events(suspended_action)
           @thread.kill if @thread
           @thread = Thread.new do
             loop do
               Rails.application.executor.wrap do
                 begin
+                  count = 0
+
                   until (event = ::Katello::EventQueue.next_event).nil?
-                    suspended_action.notify_queue_item(event.event_type, event.object_id, event.created_at) if event
+                    run_event(event)
+                    count += 1
+
+                    if count > COUNT_UPDATE_INTERVAL
+                      suspended_action.notify_count(count)
+                      count = 0
+                    end
                   end
 
+                  suspended_action.notify_count(count) if count > 0
                   sleep SLEEP_INTERVAL
                 rescue => e
                   suspended_action.notify_fatal(e)

--- a/app/lib/actions/katello/event_queue/suspended_action.rb
+++ b/app/lib/actions/katello/event_queue/suspended_action.rb
@@ -6,8 +6,8 @@ module Actions
           @suspended_action = suspended_action
         end
 
-        def notify_queue_item(event_type, object_id, created_at)
-          @suspended_action << Monitor::Event[event_type, object_id, created_at]
+        def notify_count(processed_count)
+          @suspended_action << Monitor::Count[processed_count, Time.now]
         end
 
         def notify_ready

--- a/test/actions/katello/event_queue_monitor_test.rb
+++ b/test/actions/katello/event_queue_monitor_test.rb
@@ -22,17 +22,14 @@ class Actions::Katello::EventQueueMonitorTest < ActiveSupport::TestCase
       action.run(action_class::Ready)
     end
 
-    it 'should process events' do
-      host = FactoryBot.create(:host)
+    it 'should process counts' do
       action_class.any_instance.stubs(:suspend).yields(nil)
-      ::Katello::EventQueue.push_event(::Katello::Events::ImportHostApplicability::EVENT_TYPE, host.id)
-      event = Katello::EventQueue.next_event
 
       suspended_class.any_instance.expects(:notify_ready).once
-      Katello::Events::ImportHostApplicability.any_instance.expects(:run).once
 
       action = run_action planned_action
-      action.run(action_class::Event[event.event_type, event.object_id, event.created_at.to_time])
+      action.run(action_class::Count[5, Time.now])
+      assert_equal 5, action.output[:count]
     end
   end
 end


### PR DESCRIPTION
previosly the event was processed in the task, requiring the task
to be notified for each and every event.  With a lot of hosts,
this could be 10s of thousands of events.  The act of notifying
the task, ends up reducing performance for not much benefit.
This changes it to process the event within the poller thread,
rather than the main task