### PR TITLE
fixes #24585 - update setting callback for rails deprecation

### DIFF
--- a/app/models/katello/concerns/setting_extensions.rb
+++ b/app/models/katello/concerns/setting_extensions.rb
@@ -11,7 +11,7 @@ module Katello
       end
 
       def recalculate_errata_status
-        ForemanTasks.async_task(Actions::Katello::Host::RecalculateErrataStatus) if value_changed? && name == 'errata_status_installable'
+        ForemanTasks.async_task(Actions::Katello::Host::RecalculateErrataStatus) if saved_change_to_value? && name == 'errata_status_installable'
       end
     end
   end


### PR DESCRIPTION
This is showing up in the logs now:


2018-08-10T16:47:56 [W|app|] DEPRECATION WARNING: The behavior of `attribute_changed?` inside of after callbacks will be changing in the next version of Rails. The new return value will reflect the behavior of calling the method after `save` returned (e.g. the opposite of what it returns now). To maintain the current behavior, use `saved_change_to_attribute?` instead. (called from recalculate_errata_status at /home/vagrant/git/katello/app/models/katello/concerns/setting_extensions.rb:14)


See https://blog.toshima.ru/2017/04/06/saved-change-to-attribute.html