### PR TITLE
Fixes #24575 - Add system purpose attributes

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -417,7 +417,7 @@ module Katello
     end
 
     def rhsm_params
-      params.slice(:name, :type, :facts, :installedProducts, :autoheal, :releaseVer, :serviceLevel, :uuid, :capabilities, :guestIds, :lastCheckin).to_h
+      params.slice(:name, :type, :facts, :installedProducts, :autoheal, :releaseVer, :usage, :role, :addOns, :serviceLevel, :uuid, :capabilities, :guestIds, :lastCheckin).to_h
     end
 
     def logger

--- a/app/models/katello/concerns/subscription_facet_host_extensions.rb
+++ b/app/models/katello/concerns/subscription_facet_host_extensions.rb
@@ -29,6 +29,9 @@ module Katello
         accepts_nested_attributes_for :subscription_facet, :update_only => true, :reject_if => lambda { |attrs| attrs.values.compact.empty? }
 
         has_many :activation_keys, :through => :subscription_facet
+        has_many :purpose_addons, :through => :subscription_facet
+        has_one :purpose_role, :through => :subscription_facet
+        has_one :purpose_usage, :through => :subscription_facet
         has_many :pools, :through => :subscription_facet
         has_many :subscriptions, :through => :pools
         has_one :subscription_status_object, :class_name => 'Katello::SubscriptionStatus', :foreign_key => 'host_id', :dependent => :destroy
@@ -51,9 +54,30 @@ module Katello
         scoped_search :on => :name, :relation => :hypervisor_host, :complete_value => true, :rename => :hypervisor_host, :ext_method => :find_by_hypervisor_host
         scoped_search :on => :name, :relation => :subscriptions, :rename => :subscription_name, :complete_value => true, :ext_method => :find_by_subscription_name
         scoped_search :on => :id, :relation => :pools, :rename => :subscription_id, :complete_value => true, :ext_method => :find_by_subscription_id
+        scoped_search :on => :name, :rename => :addon, :relation => :purpose_addons, :ext_method => :find_by_addon_name, :complete_value => true
+        scoped_search :on => :name, :rename => :role, :relation => :purpose_role, :ext_method => :find_by_role_name, :complete_value => true
+        scoped_search :on => :name, :rename => :usage, :relation => :purpose_usage, :ext_method => :find_by_usage_name, :complete_value => true
       end
 
       module ClassMethods
+        def find_by_usage_name(_key, operator, value)
+          conditions = sanitize_sql_for_conditions(["#{Katello::PurposeUsage.table_name}.name #{operator} ?", value_to_sql(operator, value)])
+          hosts = ::Host::Managed.joins(:purpose_usage).where(conditions)
+          return_hosts(hosts)
+        end
+
+        def find_by_role_name(_key, operator, value)
+          conditions = sanitize_sql_for_conditions(["#{Katello::PurposeRole.table_name}.name #{operator} ?", value_to_sql(operator, value)])
+          hosts = ::Host::Managed.joins(:purpose_role).where(conditions)
+          return_hosts(hosts)
+        end
+
+        def find_by_addon_name(_key, operator, value)
+          conditions = sanitize_sql_for_conditions(["#{Katello::PurposeAddon.table_name}.name #{operator} ?", value_to_sql(operator, value)])
+          hosts = ::Host::Managed.joins(:purpose_addons).where(conditions)
+          return_hosts(hosts)
+        end
+
         def find_by_activation_key(_key, operator, value)
           conditions = sanitize_sql_for_conditions(["#{Katello::ActivationKey.table_name}.name #{operator} ?", value_to_sql(operator, value)])
           hosts = ::Host::Managed.joins(:activation_keys).where(conditions)

--- a/app/models/katello/purpose_addon.rb
+++ b/app/models/katello/purpose_addon.rb
@@ -1,0 +1,9 @@
+module Katello
+  class PurposeAddon < Katello::Model
+    self.table_name = 'katello_purpose_addons'
+
+    has_many :subscription_facet_purpose_addons, :class_name => "Katello::SubscriptionFacetPurposeAddon", :dependent => :destroy, :inverse_of => :purpose_addon
+
+    has_many :subscription_facets, :through => :subscription_facet_purpose_addons, :class_name => "Katello::Host::SubscriptionFacet"
+  end
+end

--- a/app/models/katello/purpose_role.rb
+++ b/app/models/katello/purpose_role.rb
@@ -1,0 +1,9 @@
+module Katello
+  class PurposeRole < Katello::Model
+    self.table_name = 'katello_purpose_roles'
+
+    has_many :subscription_facet_purpose_roles, :class_name => "Katello::SubscriptionFacetPurposeRole", :dependent => :destroy, :inverse_of => :purpose_role
+
+    has_many :subscription_facets, :through => :subscription_facet_purpose_addons, :class_name => "Katello::Host::SubscriptionFacet"
+  end
+end

--- a/app/models/katello/purpose_usage.rb
+++ b/app/models/katello/purpose_usage.rb
@@ -1,0 +1,9 @@
+module Katello
+  class PurposeUsage < Katello::Model
+    self.table_name = 'katello_purpose_usages'
+
+    has_many :subscription_facet_purpose_usages, :class_name => "Katello::SubscriptionFacetPurposeUsage", :dependent => :destroy, :inverse_of => :purpose_usage
+
+    has_many :subscription_facets, :through => :subscription_facet_purpose_usages, :class_name => "Katello::Host::SubscriptionFacet"
+  end
+end

--- a/app/models/katello/subscription_facet_purpose_addon.rb
+++ b/app/models/katello/subscription_facet_purpose_addon.rb
@@ -1,0 +1,6 @@
+module Katello
+  class SubscriptionFacetPurposeAddon < Katello::Model
+    belongs_to :subscription_facet, inverse_of: :subscription_facet_purpose_addons, class_name: 'Katello::Host::SubscriptionFacet'
+    belongs_to :purpose_addon, inverse_of: :subscription_facet_purpose_addons, class_name: 'Katello::PurposeAddon'
+  end
+end

--- a/app/models/katello/subscription_facet_purpose_role.rb
+++ b/app/models/katello/subscription_facet_purpose_role.rb
@@ -1,0 +1,6 @@
+module Katello
+  class SubscriptionFacetPurposeRole < Katello::Model
+    belongs_to :subscription_facet, inverse_of: :subscription_facet_purpose_role, class_name: 'Katello::Host::SubscriptionFacet'
+    belongs_to :purpose_role, inverse_of: :subscription_facet_purpose_roles, class_name: 'Katello::PurposeRole'
+  end
+end

--- a/app/models/katello/subscription_facet_purpose_usage.rb
+++ b/app/models/katello/subscription_facet_purpose_usage.rb
@@ -1,0 +1,6 @@
+module Katello
+  class SubscriptionFacetPurposeUsage < Katello::Model
+    belongs_to :subscription_facet, inverse_of: :subscription_facet_purpose_usage, class_name: 'Katello::Host::SubscriptionFacet'
+    belongs_to :purpose_usage, inverse_of: :subscription_facet_purpose_usages, class_name: 'Katello::PurposeUsage'
+  end
+end

--- a/db/migrate/20180808013432_add_system_purpose_attrs.rb
+++ b/db/migrate/20180808013432_add_system_purpose_attrs.rb
@@ -1,0 +1,39 @@
+class AddSystemPurposeAttrs < ActiveRecord::Migration[5.1]
+  def change
+    create_table :katello_purpose_addons do |t|
+      t.string :name, null: false
+    end
+
+    create_table :katello_purpose_roles do |t|
+      t.string :name, null: false
+    end
+
+    create_table :katello_purpose_usages do |t|
+      t.string :name, null: false
+    end
+
+    create_table :katello_subscription_facet_purpose_addons do |t|
+      t.references :purpose_addon, index: { name: :katello_sub_facet_purpose_addons_paid }
+      t.references :subscription_facet, index: { name: :katello_sub_facet_purpose_addons_sfid }
+    end
+
+    create_table :katello_subscription_facet_purpose_roles do |t|
+      t.references :purpose_role, index: { name: :katello_sub_facet_purpose_roles_prid }
+      t.references :subscription_facet, index: { name: :katello_sub_facet_purpose_roles_sfid }
+    end
+
+    create_table :katello_subscription_facet_purpose_usages do |t|
+      t.references :purpose_usage, index: { name: :katello_sub_facet_purpose_usages_puid }
+      t.references :subscription_facet, index: { name: :katello_sub_facet_purpose_usages_sfid }
+    end
+
+    add_foreign_key :katello_subscription_facet_purpose_addons, :katello_subscription_facets, column: :subscription_facet_id, name: :katello_sub_facet_purpose_addon_facet_id
+    add_foreign_key :katello_subscription_facet_purpose_addons, :katello_purpose_addons, column: :purpose_addon_id, name: :katello_sub_facet_purpose_addon_purpose_addon_id
+
+    add_foreign_key :katello_subscription_facet_purpose_roles, :katello_subscription_facets, column: :subscription_facet_id, name: :katello_sub_facet_purpose_role_facet_id
+    add_foreign_key :katello_subscription_facet_purpose_roles, :katello_purpose_roles, column: :purpose_role_id, name: :katello_sub_facet_purpose_role_purpose_role_id
+
+    add_foreign_key :katello_subscription_facet_purpose_usages, :katello_subscription_facets, column: :subscription_facet_id, name: :katello_sub_facet_purpose_usage_facet_id
+    add_foreign_key :katello_subscription_facet_purpose_usages, :katello_purpose_usages, column: :purpose_usage_id, name: :katello_sub_facet_purpose_usage_purpose_usage_id
+  end
+end


### PR DESCRIPTION
This is the first step in supporting system purpose. We don't have an official candlepin build with support yet, but this can still be tested. I also have a scratch build available with basic support for the purpose attributes on the consumer which can be used to test the data coming in and out of candlepin.

One way to test is to create a JSON that looks like this:

```
{
  "role": "party",
  "usage": "Disaster recovery",
  "addOns": ["EUS", "AUS"]
}
```

Then, on your client, simulate a checkin:

```
curl -X PUT -k https://devel.example.com/rhsm/consumers/:uuid -H 'Content-type: application/json' -u 'admin:changeme' -d @./update_consumer.json  
```

Following the update the subscription facet role, addons, and usage fields should match the JSON and candlepin should be updated (if you're testing with the right version).

The way I've modeled the data right now is very similar to candlepin. The role and usage live on the consumer (our facet) and the addons have their own table - but I've normalized it here.
