### PR TITLE
Fixes #23882: Deemphasize yStream repos

### DIFF
--- a/webpack/scenes/RedHatRepositories/components/RepositorySet.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySet.js
@@ -18,7 +18,7 @@ const RepositorySet = ({
     actions={recommended ? <Icon type="fa" name="star" className="recommended-repository-set-icon" /> : ''}
     hideCloseIcon
   >
-    <RepositorySetRepositories contentId={id} productId={product.id} />
+    <RepositorySetRepositories contentId={id} productId={product.id} type={type} />
   </ListView.Item>
 );
 

--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepositories.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepositories.js
@@ -5,6 +5,7 @@ import { Alert, Spinner } from 'patternfly-react';
 
 import loadRepositorySetRepos from '../../../redux/actions/RedHatRepositories/repositorySetRepositories';
 import RepositorySetRepository from './RepositorySetRepository';
+import { yStream } from '../helpers';
 
 class RepositorySetRepositories extends Component {
   componentDidMount() {
@@ -16,7 +17,7 @@ class RepositorySetRepositories extends Component {
   }
 
   render() {
-    const { data } = this.props;
+    const { data, type } = this.props;
 
     if (data.error) {
       return (
@@ -25,9 +26,12 @@ class RepositorySetRepositories extends Component {
         </Alert>
       );
     }
-    const availableRepos = data.repositories
-      .filter(({ enabled }) => !enabled)
-      .map(repo => <RepositorySetRepository key={repo.arch + repo.releasever} {...repo} />);
+
+    const availableRepos = [...data.repositories.filter(({ enabled }) => !enabled)]
+      .sort((repo1, repo2) => yStream(repo1.releasever || '') - yStream(repo2.releasever || ''))
+      .map(repo => (
+        <RepositorySetRepository key={repo.arch + repo.releasever} type={type} {...repo} />
+      ));
 
     const repoMessage = (data.repositories.length > 0 && availableRepos.length === 0 ?
       __('All available architectures for this repo are enabled.') : __('No repositories available.'));

--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepository.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepository.js
@@ -1,9 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { ListView, Spinner, OverlayTrigger, Tooltip, Icon } from 'patternfly-react';
+import { ListView, Spinner, OverlayTrigger, Tooltip, Icon, FieldLevelHelp } from 'patternfly-react';
 import { connect } from 'react-redux';
 
+
+import { yStream } from '../helpers';
 import { setRepositoryEnabled } from '../../../redux/actions/RedHatRepositories/repositorySetRepositories';
 import '../index.scss';
 import api from '../../../services/api';
@@ -64,12 +66,27 @@ class RepositorySetRepository extends Component {
   }
 
   render() {
-    const { arch, releasever } = this.props;
+    const { arch, releasever, type } = this.props;
+
+    const yStreamHelp = () => (
+      <span translate>
+        This repository is not suggested. Please see additional&nbsp;
+        <a href="https://access.redhat.com/articles/1586183">documentation</a>
+        &nbsp;prior to use.
+      </span>
+    );
+    const shouldDeemphasize = () => type !== 'kickstart' && yStream(releasever);
+    const repositoryHeading = () => (
+      <span>
+        {arch} {releasever}
+        {shouldDeemphasize() ? (<FieldLevelHelp content={yStreamHelp()} />) : null}
+      </span>
+    );
 
     return (
       <ListView.Item
-        heading={`${arch} ${releasever}`}
-        className="list-item-with-divider"
+        heading={repositoryHeading()}
+        className={`list-item-with-divider ${shouldDeemphasize() ? 'deemphasize' : ''}`}
         leftContent={
           this.state.error ? (
             <div className="list-error-danger">
@@ -118,12 +135,14 @@ RepositorySetRepository.propTypes = {
   productId: PropTypes.number.isRequired,
   arch: PropTypes.string,
   releasever: PropTypes.string,
+  type: PropTypes.string,
   setRepositoryEnabled: PropTypes.func.isRequired,
 };
 
 RepositorySetRepository.defaultProps = {
   releasever: '',
   arch: __(UNSPECIFIED_ARCH),
+  type: '',
 };
 
 export default connect(null, { setRepositoryEnabled })(RepositorySetRepository);

--- a/webpack/scenes/RedHatRepositories/components/__tests__/RepositorySetRepository.test.js
+++ b/webpack/scenes/RedHatRepositories/components/__tests__/RepositorySetRepository.test.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import thunk from 'redux-thunk';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import configureMockStore from 'redux-mock-store';
+import RepositorySetRepository from '../RepositorySetRepository';
+
+jest.mock('../../../../move_to_foreman/foreman_toast_notifications');
+
+const mockStore = configureMockStore([thunk]);
+const store = mockStore({});
+
+describe('RepositorySetRepository Component', () => {
+  let shallowWrapper;
+  beforeEach(() => {
+    shallowWrapper = shallow(<RepositorySetRepository
+      store={store}
+      contentId={1}
+      productId={1}
+      arch="foo"
+      releaseVer="1.1.1"
+      type="foo"
+      setRepositoryEnabled={() => {}}
+    />);
+  });
+
+  afterEach(() => {
+    store.clearActions();
+  });
+
+  it('should render', async () => {
+    expect(toJson(shallowWrapper)).toMatchSnapshot();
+  });
+});

--- a/webpack/scenes/RedHatRepositories/components/__tests__/__snapshots__/RepositorySetRepository.test.js.snap
+++ b/webpack/scenes/RedHatRepositories/components/__tests__/__snapshots__/RepositorySetRepository.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RepositorySetRepository Component should render 1`] = `
+<RepositorySetRepository
+  arch="foo"
+  contentId={1}
+  productId={1}
+  releaseVer="1.1.1"
+  releasever=""
+  setRepositoryEnabled={[Function]}
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+  type="foo"
+/>
+`;

--- a/webpack/scenes/RedHatRepositories/helpers.js
+++ b/webpack/scenes/RedHatRepositories/helpers.js
@@ -74,3 +74,6 @@ export const getEnabledComponent = (enabledReposState, onPaginationChange) => {
     </ListView>
   );
 };
+
+export const yStream = releasever => releasever.match(/^\d+\.\d+$/) != null;
+

--- a/webpack/scenes/RedHatRepositories/index.scss
+++ b/webpack/scenes/RedHatRepositories/index.scss
@@ -16,6 +16,10 @@
 }
 
 #redhatRepositoriesPage {
+  .deemphasize {
+    color: lightgray;
+  }
+
   .list-group-item-header .list-view-pf-description,
   .enabled-repositories-container .list-view-pf-description {
     width: 100%;


### PR DESCRIPTION
- [X] yStream repos are grayed out but still able to be enabled
- [X] Kickstart repos are not affected by this change
- [X] yStream repos are shown first in the list of repos
- [X] Info tooltip explaining why yStream repos are grayed out, with a link to documentation

![image](https://user-images.githubusercontent.com/761923/44400932-f56b9000-a51a-11e8-8ed3-d62245406613.png)