### PR TITLE
Fixes #24651 - Cannot remove packages from content host UI

### DIFF
--- a/app/controllers/katello/api/v2/host_packages_controller.rb
+++ b/app/controllers/katello/api/v2/host_packages_controller.rb
@@ -102,13 +102,9 @@ module Katello
       @host = resource_finder(::Host::Managed.authorized(:view_hosts, ::Host::Managed), params[:host_id])
     end
 
-    def valid_package_name?(package_name)
-      package_name =~ /^[a-zA-Z0-9\-\.\_\+\,]+$/
-    end
-
     def validate_package_list_format(packages)
       packages.each do |package|
-        if !valid_package_name?(package) && !package.is_a?(Hash)
+        unless package.is_a?(String) && ::Katello::Util::Package.valid_package_name_format(package).nil?
           fail HttpErrors::BadRequest, _("%s is not a valid package name") % package
         end
       end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages-installed.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages-installed.controller.js
@@ -18,7 +18,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostPackagesInstalled
         var packagesNutupane;
 
         $scope.removeSelectedPackages = function () {
-            var selected = $scope.table.getSelected();
+            var selected = _.map($scope.table.getSelected(), 'name');
 
             if (!$scope.working) {
                 $scope.working = true;

--- a/engines/bastion_katello/test/content-hosts/content/content-host-packages-installed.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content/content-host-packages-installed.controller.test.js
@@ -66,7 +66,7 @@ describe('Controller: ContentHostPackagesInstalledController', function() {
 
         spyOn(HostPackage, 'remove');
         $scope.removeSelectedPackages();
-        expect(HostPackage.remove).toHaveBeenCalledWith({id: mockHost.id, packages: [mockPackageClone]},
+        expect(HostPackage.remove).toHaveBeenCalledWith({id: mockHost.id, packages: ['foo']},
                                                           jasmine.any(Function), jasmine.any(Function));
         expect($scope.working).toBe(true);
     });

--- a/test/controllers/api/v2/host_packages_controller_test.rb
+++ b/test/controllers/api/v2/host_packages_controller_test.rb
@@ -95,6 +95,18 @@ module Katello
       assert_response :success
     end
 
+    def test_invalid_package_input
+      methods = [:remove, :install, :upgrade]
+
+      methods.each do |method|
+        put method, params: { host_id: @host.id, packages: [{name: 'foo'}] }
+        assert_response 400
+
+        put method, params: { host_id: @host.id, packages: %w(*) }
+        assert_response 400
+      end
+    end
+
     def test_remove_group
       assert_async_task ::Actions::Katello::Host::PackageGroup::Remove do |host, groups|
         host.id == @host.id && groups == %w(blah)


### PR DESCRIPTION
To reproduce:

- Set up a content host with some installed packages
- From the installed package list on the host, select one or more & submit
- Observe error about invalid package name


Leaving some inline comments because I'm making some assumptions here...