### PR TITLE
[WIP] Fixes #24592 - Repository sets not displayed correctly

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-repository-sets.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-repository-sets.controller.js
@@ -35,8 +35,8 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyRepositorySet
             contentAccessModeEnv: false
         };
         $scope.toggleFilters = function () {
-            $scope.nutupane.table.params['content_access_mode_env'] = $scope.contentAccessModes.contentAccessModeEnv;
-            $scope.nutupane.table.params['content_access_mode_all'] = $scope.contentAccessModes.contentAccessModeAll;
+            $scope.nutupane.params['content_access_mode_env'] = $scope.contentAccessModes.contentAccessModeEnv;
+            $scope.nutupane.params['content_access_mode_all'] = $scope.contentAccessModes.contentAccessModeAll;
             $scope.nutupane.refresh();
         };
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-repository-sets.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-repository-sets.controller.js
@@ -35,8 +35,8 @@ angular.module('Bastion.content-hosts').controller('ContentHostRepositorySetsCon
             contentAccessModeEnv: false
         };
         $scope.toggleFilters = function () {
-            $scope.nutupane.table.params['content_access_mode_all'] = $scope.contentAccessModes.contentAccessModeAll;
-            $scope.nutupane.table.params['content_access_mode_env'] = $scope.contentAccessModes.contentAccessModeEnv;
+            $scope.nutupane.params['content_access_mode_all'] = $scope.contentAccessModes.contentAccessModeAll;
+            $scope.nutupane.params['content_access_mode_env'] = $scope.contentAccessModes.contentAccessModeEnv;
             $scope.nutupane.refresh();
         };
 


### PR DESCRIPTION
### Description:

The method `toggleFilters` does not work as the param is set on `nutupane.table`. Changing it to `nutupane`.

### Steps to reproduce:
1. Create an activation key.
2. Remove all subscriptions.
3. Go to repository-sets tab.
4. Show All checkbox doesn't show all repository sets.

**Expected Result:**
Show all checkbox should display all repository sets.

**The same behavior can be seen on content hosts page.**
