### PR TITLE
Fixes #24523 - Parse action input for RPMs into pulp units

### DIFF
--- a/app/lib/actions/pulp/consumer/abstract_content_action.rb
+++ b/app/lib/actions/pulp/consumer/abstract_content_action.rb
@@ -44,6 +44,18 @@ module Actions
           messages
         end
 
+        # by default runcible puts whatever we pass into a hash under the 'name' key
+        # here we can make the unit hash more precise
+        def parse_units_for_type
+          if input[:type] == 'rpm'
+            input[:args].collect do |unit|
+              ::Katello::Util::Package.parse_nvrea_nvre(unit) || unit
+            end
+          else
+            input[:args]
+          end
+        end
+
         def presenter
           Consumer::ContentPresenter.new(self)
         end

--- a/app/lib/actions/pulp/consumer/content_install.rb
+++ b/app/lib/actions/pulp/consumer/content_install.rb
@@ -14,7 +14,7 @@ module Actions
         def invoke_external_task
           task = pulp_extensions.consumer.install_content(input[:consumer_uuid],
                                                    input[:type],
-                                                   input[:args],
+                                                   parse_units_for_type,
                                                     "importkeys" => true)
           schedule_timeout(Setting['content_action_accept_timeout'])
           task

--- a/app/lib/actions/pulp/consumer/content_uninstall.rb
+++ b/app/lib/actions/pulp/consumer/content_uninstall.rb
@@ -14,7 +14,7 @@ module Actions
         def invoke_external_task
           pulp_extensions.consumer.uninstall_content(input[:consumer_uuid],
                                                      input[:type],
-                                                     input[:args])
+                                                     parse_units_for_type)
         end
 
         def presenter

--- a/app/lib/actions/pulp/consumer/content_update.rb
+++ b/app/lib/actions/pulp/consumer/content_update.rb
@@ -17,7 +17,7 @@ module Actions
 
           pulp_extensions.consumer.update_content(input[:consumer_uuid],
                                                   input[:type],
-                                                  input[:args],
+                                                  parse_units_for_type,
                                                   options)
         end
 

--- a/test/actions/pulp/consumer_test.rb
+++ b/test/actions/pulp/consumer_test.rb
@@ -10,7 +10,15 @@ module ::Actions::Pulp
     let(:uuid) { 'uuid' }
     let(:consumer_name) { 'gregor' }
     let(:type) { 'rpm' }
-    let(:args) { %w(vim vi) }
+    let(:args) { %w(vim walrus-0.71-1.noarch) }
+    let(:expected_extension_params) do
+      [
+        "uuid",
+        "rpm",
+        ["vim", {:name => "walrus", :version => "0.71", :release => "1", :arch => "noarch"}],
+        {"importkeys" => true}
+      ]
+    end
 
     def setup
       set_user
@@ -46,17 +54,24 @@ module ::Actions::Pulp
 
     def test_install_content
       action = plan_consumer_action(::Actions::Pulp::Consumer::ContentInstall)
-      it_runs(action, :extensions, :consumer, :install_content)
+      it_runs(action, :extensions, :consumer, :install_content) do |expectation|
+        expectation.with(*expected_extension_params)
+      end
     end
 
     def test_update_content
       action = plan_consumer_action(::Actions::Pulp::Consumer::ContentUpdate)
-      it_runs(action, :extensions, :consumer, :update_content)
+      it_runs(action, :extensions, :consumer, :update_content) do |expectation|
+        expectation.with(*expected_extension_params)
+      end
     end
 
     def test_uninstall_content
       action = plan_consumer_action(::Actions::Pulp::Consumer::ContentUninstall)
-      it_runs(action, :extensions, :consumer, :uninstall_content)
+      expected_extension_params.pop
+      it_runs(action, :extensions, :consumer, :uninstall_content) do |expectation|
+        expectation.with(*expected_extension_params)
+      end
     end
 
     def test_regenerate_applicability


### PR DESCRIPTION
I'm not sure that package actions have ever worked when given input like 'walrus-0.71-1.noarch' vs just the package name - would be interested to hear otherwise.

This'll be easier tested with #7634 since you'll want to test the removal scenario too.

To reproduce per the reported issue:
- set up a content host w/ katello-agent running
- install a package which has an applicable update
- in the applicable packages section for the content host, select the update and install it
- observe the failure reported by katello agent

I've updated package install, update, and removal. For RPMs , given an input from the UI like `walrus-0.71-1.noarch` the code now attempts to create a hash like this: `{ name: walrus, version: '0.71', release: '1', arch: 'noarch'}` if possible, otherwise it falls back to default behavior and passes the input straight through to pulp.