### PR TITLE
Fixes #24664 - ensure not to use database during db preparation

### DIFF
--- a/engines/bastion_katello/lib/bastion_katello/engine.rb
+++ b/engines/bastion_katello/lib/bastion_katello/engine.rb
@@ -10,7 +10,7 @@ module BastionKatello
       consumer_cert_rpm = 'katello-ca-consumer-latest.noarch.rpm'
       consumer_cert_rpm = SETTINGS[:katello][:consumer_cert_rpm] if SETTINGS.key?(:katello)
 
-      db_migrated = ActiveRecord::Base.connection.table_exists?(Setting.table_name)
+      db_migrated = !Foreman.in_setup_db_rake? && ActiveRecord::Base.connection.table_exists?(Setting.table_name)
 
       Bastion.register_plugin(
         :name => 'bastion_katello',
@@ -40,7 +40,7 @@ module BastionKatello
           'consumerCertRPM' => consumer_cert_rpm,
           'defaultDownloadPolicy' => !Foreman.in_rake? && db_migrated && Setting['default_download_policy'],
           'remoteExecutionPresent' => ::Katello.with_remote_execution?,
-          'remoteExecutionByDefault' => ::Katello.with_remote_execution? && !Foreman.in_rake?('db:migrate') &&
+          'remoteExecutionByDefault' => ::Katello.with_remote_execution? &&
                                         db_migrated && Setting['remote_execution_by_default']
         }
       )


### PR DESCRIPTION
Rails 5.2 started initializing rails environment during
the db:create phase, leading the bastion initializtion code to fail with

    database "test_develop_pr_katello-0-dev" does not exist