### PR TITLE
Fixes #24675 - Update host name for Manifest refresh

### DIFF
--- a/app/models/katello/glue/provider.rb
+++ b/app/models/katello/glue/provider.rb
@@ -5,6 +5,8 @@ module Katello
     end
 
     module InstanceMethods
+      API_URL = 'https://subscription.rhsm.redhat.com/subscription/consumers/'.freeze
+
       def sync
         Rails.logger.debug "Syncing provider #{name}"
         syncs = self.products.collect do |p|
@@ -60,7 +62,7 @@ module Katello
         end
 
         # Default to Red Hat
-        url = upstream['apiUrl'] || 'https://subscription.rhn.redhat.com/subscription/consumers/'
+        url = upstream['apiUrl'] || API_URL
 
         # TODO: wait until ca_path is supported
         #       https://github.com/L2G/rest-client-fork/pull/8
@@ -83,7 +85,7 @@ module Katello
         end
 
         # Default to Red Hat
-        url = upstream['apiUrl'] || 'https://subscription.rhn.redhat.com/subscription/consumers/'
+        url = upstream['apiUrl'] || API_URL
 
         # TODO: wait until ca_path is supported
         #       https://github.com/L2G/rest-client-fork/pull/8

--- a/test/models/provider_test.rb
+++ b/test/models/provider_test.rb
@@ -1,0 +1,31 @@
+require 'katello_test_helper'
+
+module Katello
+  class ProviderTest < ActiveSupport::TestCase
+    class OwnerUpstreamUpdateTest < ActiveSupport::TestCase
+      let(:provider) { katello_providers(:redhat) }
+      let(:api_url) { 'http://theforeman.org' }
+      let(:expected_url) { api_url }
+
+      def setup
+        @upstream_params = { 'apiUrl' => api_url, 'idCert' => { 'key' => '', 'cert' => ''}}
+        @expected_params = [expected_url, "", "", nil, { :capabilities => [], :facts => { :distributor_version => "sat-6.3" } }]
+        Resources::Candlepin::UpstreamConsumer.expects(:update).with(*@expected_params)
+        Resources::Candlepin::CandlepinPing.stubs(:ping).returns('managerCapabilities' => [])
+      end
+
+      it 'calls the apiUrl in the manifest' do
+        provider.owner_upstream_update(@upstream_params, {})
+      end
+
+      context 'apiUrl missing from the manifest' do
+        let(:api_url) { nil }
+        let(:expected_url) { 'https://subscription.rhsm.redhat.com/subscription/consumers/' }
+
+        it 'falls back to the default' do
+          provider.owner_upstream_update(@upstream_params, {})
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Comments in redmine mention the need to update the hard-coded link in the file so it points to
https://subscription.rhsm.redhat.com/subscription/consumers/. This fixes the issue with updating
while the server is pointed to a proxy, but only covers up the root of the issue. The root of the issue
is that if an old manifest is refreshed, then the old host name will be accessed. The true fix is to
update the documentation to add https://subscription.rhn.redhat.com/subscription/consumers/ to the
whitelist hostnames.

This bug fix updates the file so that if no apiUrl is present, then it will default to the updated
host.