### PR TITLE
Fixes #24617 - add subscription type column

### DIFF
--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionTypeFormatter.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionTypeFormatter.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import helpers from '../../../../move_to_foreman/common/helpers';
+
+export const subscriptionTypeFormatter = (value, { rowData }) => {
+  let cellContent;
+
+  if (rowData.virt_only === false) {
+    cellContent = __('Physical');
+  } else if (rowData.hypervisor) {
+    cellContent = (
+      <span>
+        {__('Guests of')}
+        {' '}
+        <Link to={helpers.urlBuilder('content_hosts', '', rowData.hypervisor.id)}>{rowData.hypervisor.name}</Link>
+      </span>
+    );
+  } else if (rowData.unmapped_guest) {
+    cellContent = __('Temporary');
+  } else {
+    cellContent = __('Virtual');
+  }
+
+  return (
+    <td>
+      {cellContent}
+    </td>
+  );
+};
+
+export default subscriptionTypeFormatter;

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTableSchema.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTableSchema.js
@@ -4,6 +4,7 @@ import { Icon } from 'patternfly-react';
 import { Link } from 'react-router-dom';
 import helpers from '../../../../move_to_foreman/common/helpers';
 import { entitlementsInlineEditFormatter } from './EntitlementsInlineEditFormatter';
+import { subscriptionTypeFormatter } from './SubscriptionTypeFormatter';
 import {
   headerFormatter,
   cellFormatter,
@@ -47,6 +48,16 @@ export const createSubscriptionsTableSchema = (
           </td>
         ),
       ],
+    },
+  },
+  {
+    property: 'type',
+    header: {
+      label: __('Type'),
+      formatters: [headerFormatter],
+    },
+    cell: {
+      formatters: [subscriptionTypeFormatter],
     },
   },
   {

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/SubscriptionTypeFormatter.test.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/SubscriptionTypeFormatter.test.js
@@ -1,0 +1,33 @@
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import { subscriptionTypeFormatter } from '../SubscriptionTypeFormatter';
+
+describe('subscriptionTypeFormatter', () => {
+  const data = rowData => ({
+    rowData,
+  });
+
+  it('renders physical subscriptions', async () => {
+    const formatter = subscriptionTypeFormatter(null, data({ virt_only: false }));
+
+    expect(toJson(shallow(formatter))).toMatchSnapshot();
+  });
+
+  it('renders temporary subscriptions', async () => {
+    const formatter = subscriptionTypeFormatter(null, data({ unmapped_guest: true }));
+
+    expect(toJson(shallow(formatter))).toMatchSnapshot();
+  });
+
+  it('renders virtual subscriptions', async () => {
+    const formatter = subscriptionTypeFormatter(null, data({}));
+
+    expect(toJson(shallow(formatter))).toMatchSnapshot();
+  });
+
+  it('renders link to a host', async () => {
+    const formatter = subscriptionTypeFormatter(null, data({ hypervisor: { name: 'host.example.com', id: 83 } }));
+
+    expect(toJson(shallow(formatter))).toMatchSnapshot();
+  });
+});

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionTypeFormatter.test.js.snap
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionTypeFormatter.test.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`subscriptionTypeFormatter renders link to a host 1`] = `
+<td>
+  <span>
+    Guests of
+     
+    <Link
+      replace={false}
+      to="/content_hosts/83/"
+    >
+      host.example.com
+    </Link>
+  </span>
+</td>
+`;
+
+exports[`subscriptionTypeFormatter renders physical subscriptions 1`] = `
+<td>
+  Physical
+</td>
+`;
+
+exports[`subscriptionTypeFormatter renders temporary subscriptions 1`] = `
+<td>
+  Temporary
+</td>
+`;
+
+exports[`subscriptionTypeFormatter renders virtual subscriptions 1`] = `
+<td>
+  Virtual
+</td>
+`;

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
@@ -88,6 +88,11 @@ exports[`subscriptions table should render a table 1`] = `
         <th
           class=""
         >
+          Type
+        </th>
+        <th
+          class=""
+        >
           SKU
         </th>
         <th
@@ -147,6 +152,9 @@ exports[`subscriptions table should render a table 1`] = `
             zoo
           </a>
         </td>
+        <td>
+          Physical
+        </td>
         <td
           class=""
         >
@@ -203,6 +211,9 @@ exports[`subscriptions table should render a table 1`] = `
           >
             hsdfhsdh
           </a>
+        </td>
+        <td>
+          Physical
         </td>
         <td
           class=""


### PR DESCRIPTION
Adds equivalent of a [subscription type column](https://github.com/Katello/katello/blob/8def2f53052a7516a3d3409465d855d33b511454/engines/bastion_katello/app/assets/javascripts/bastion_katello/subscriptions/views/subscription-type.html) from the angular UI onto the new subscriptions page.