### PR TITLE
Fixes #24221: disable deletion of custom subscriptions.

### DIFF
--- a/webpack/move_to_foreman/components/common/table/formatters/selectionCellFormatter.js
+++ b/webpack/move_to_foreman/components/common/table/formatters/selectionCellFormatter.js
@@ -13,5 +13,6 @@ export default (
     onChange={() => selectionController.selectRow(additionalData)}
     before={before}
     after={after}
+    disabled={additionalData.disabled}
   />
 );

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTableSchema.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTableSchema.js
@@ -25,12 +25,16 @@ export const createSubscriptionsTableSchema = (
     },
     cell: {
       formatters: [
-        (value, additionalData) =>
-          collapseableAndSelectionCellFormatter(
+        (value, additionalData) => {
+          // eslint-disable-next-line no-param-reassign
+          additionalData.disabled = additionalData.rowData.available === -1;
+
+          return collapseableAndSelectionCellFormatter(
             groupingController,
             selectionController,
             additionalData,
-          ),
+          );
+        },
       ],
     },
   },

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/SubscriptionsTable.test.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/SubscriptionsTable.test.js
@@ -37,6 +37,24 @@ describe('subscriptions table', () => {
     expect(toJson(page)).toMatchSnapshot();
   });
 
+  it('should disable checkboxes for custom subscriptions', async () => {
+    /* eslint-disable react/jsx-indent */
+    const page = render(<MemoryRouter>
+      <SubscriptionsTable
+        subscriptions={successState}
+        loadSubscriptions={loadSubscriptions}
+        tableColumns={tableColumns}
+        updateQuantity={updateQuantity}
+        subscriptionDeleteModalOpen={false}
+        onSubscriptionDeleteModalClose={() => { }}
+        onDeleteSubscriptions={() => {}}
+        toggleDeleteButton={() => {}}
+        emptyState={{}}
+      />
+                        </MemoryRouter>);
+    expect(page.find('#select1').is('[disabled]')).toBe(true);
+  });
+
   it('should render an empty state', async () => {
     const emptyStateData = {
       header: __('Yay empty state'),

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
@@ -175,6 +175,7 @@ exports[`subscriptions table should render a table 1`] = `
             Select row
           </label>
           <input
+            disabled=""
             id="select1"
             type="checkbox"
           />


### PR DESCRIPTION
Ensure that we don't delete custom subscriptions by disabling the
checkbox on custom subscription rows.

https://projects.theforeman.org/issues/24221