### PR TITLE
Fixes #24678: fix host repository sets modal.

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-repository-sets-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-repository-sets-modal.controller.js
@@ -28,14 +28,15 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkRepositorySe
         nutupaneParams = {
             'organization_id': CurrentOrganization,
             'offset': 0,
-            'sort_by': 'name',
-            'sort_order': 'ASC',
             'paged': true
         };
 
-        nutupane = new Nutupane(RepositorySet, nutupaneParams, 'queryPaged');
+        nutupane = new Nutupane(RepositorySet, nutupaneParams,
+          'queryPaged', {disableAutoLoad: true});
         $scope.controllerName = 'katello_repository_sets';
         nutupane.masterOnly = true;
+        nutupane.setSearchKey('repoSetsSearch');
+        nutupane.load();
 
         $scope.table = nutupane.table;
 

--- a/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-repository-sets-modal.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-repository-sets-modal.controller.test.js
@@ -17,6 +17,8 @@ describe('Controller: ContentHostsBulkRepositorySetsModalController', function()
             autoAttach: function() {}
         };
         Nutupane = function() {
+           this.load = function () {};
+           this.setSearchKey = function () {};
            this.getAllSelectedResults = function() {
                return {
                    included: { resources: repositorySetIds }


### PR DESCRIPTION
Fix the search error on the content host repository sets modal by
delaying the loading of the nutupane until the search key is set and
removing the incorrect sort_by specification.

https://projects.theforeman.org/issues/24678