### PR TITLE
Fixes #24592 - Repository sets not displayed

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/components/content-view-composite-available-content-views.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/components/content-view-composite-available-content-views.controller.js
@@ -65,6 +65,7 @@ angular.module('Bastion.content-views').controller('ContentViewCompositeAvailabl
                                                     components: components}, function () {
                     var newContentIds = _.map(selectedRows, 'id');
                     $scope.saveSuccess();
+                    $scope.fetchContentView();
                     params['without[]'] = params["without[]"].concat(newContentIds);
                     nutupane.setParams(params);
                     nutupane.refresh();


### PR DESCRIPTION
### Steps to reproduce (In the master/3.8 branch):
**ISSUE 1:**
1. Go to activation key / Content Host
2. Go to Repository sets tab. (You should see records if there are subscriptions attached)
3. Click on show all.
4. All repository sets are not displayed, especially if you go to some other tab on the page and come back.

**ISSUE 2:**
1. Go to Content Views and create a composite CV. 
2. Add a CV to the composite CV.
3. Go to list tab and see the CV added.
4. Return to Add tab and you'll still see the CV you just added. 

### Test this along with the Bastion change https://github.com/Katello/bastion/pull/230