### PR TITLE
Fixes #24727 - Include Deb packages in incremental updates

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -133,6 +133,7 @@ module Katello
     param :add_content, Hash do
       param :errata_ids, Array, :desc => "Errata ids or uuids to copy into the new versions"
       param :package_ids, Array, :desc => "Package ids or uuids to copy into the new versions"
+      param :deb_ids, Array, :desc => "Deb Package ids or uuids to copy into the new versions"
       param :puppet_module_ids, Array, :desc => "Puppet Module ids or uuids to copy into the new versions"
     end
     param :update_hosts, Hash, :desc => N_("After generating the incremental update, apply the changes to the specified hosts.  Only Errata are supported currently.") do
@@ -275,6 +276,10 @@ module Katello
 
       if content[:package_ids]
         fail _("package_ids is not an array") unless content[:package_ids].is_a?(Array)
+      end
+
+      if content[:deb_ids]
+        fail _("deb_ids is not an array") unless content[:deb_ids].is_a?(Array)
       end
 
       if content[:puppet_module_ids]

--- a/app/lib/actions/katello/repository/clone_to_version.rb
+++ b/app/lib/actions/katello/repository/clone_to_version.rb
@@ -2,7 +2,7 @@ module Actions
   module Katello
     module Repository
       class CloneToVersion < Actions::Base
-        # allows accessing the build object from the superior action
+        # allows accessing the built object from the superior action
         attr_accessor :new_repository
 
         def plan(repositories, content_view_version, options = {})

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -299,6 +299,19 @@ module Katello
       assert_response :success
     end
 
+    def test_incremental_update_with_deb
+      version = @library_dev_staging_view.versions.first
+      errata_id = Katello::Erratum.first.uuid
+      deb_id = Katello::Deb.first.id
+      @controller.expects(:async_task).with(::Actions::Katello::ContentView::IncrementalUpdates,
+                                            [{:content_view_version => version, :environments => [@beta]}], [],
+                                            {'errata_ids' => [errata_id], 'deb_ids' => [deb_id]}, true, [], nil).returns({})
+
+      put :incremental_update, params: { :content_view_version_environments => [{:content_view_version_id => version.id, :environment_ids => [@beta.id]}], :add_content => {:errata_ids => [errata_id], :deb_ids => [deb_id]}, :resolve_dependencies => true }
+
+      assert_response :success
+    end
+
     def test_incremental_update_without_env
       version = @library_dev_staging_view.versions.first
       errata_id = Katello::Erratum.first.uuid

--- a/test/fixtures/models/katello_debs.yml
+++ b/test/fixtures/models/katello_debs.yml
@@ -1,0 +1,6 @@
+one:
+  name:         uno
+  uuid:         uno-uuid
+  version:      1.0-1
+  architecture: amd64
+  filename:     uno_1.0-1_amd64.deb


### PR DESCRIPTION
This is only touching the API, since there seem to be no generic GUI for creating incremental content view versions.