### PR TITLE
Fixes #24730: checksum_type comes from scratchpad

### DIFF
--- a/app/lib/actions/katello/repository/correct_checksum.rb
+++ b/app/lib/actions/katello/repository/correct_checksum.rb
@@ -9,10 +9,10 @@ module Actions
         def finalize
           ::User.current = ::User.anonymous_admin
           repo = ::Katello::Repository.find(input[:repo_id])
-          found_checksum = repo.pulp_checksum_type
 
-          if found_checksum && repo.checksum_type != found_checksum
-            repo.checksum_type = found_checksum
+          if repo.pulp_scratchpad_checksum_type &&
+              repo.pulp_scratchpad_checksum_type != repo.source_repo_checksum_type
+            repo.source_repo_checksum_type = repo.pulp_scratchpad_checksum_type
             repo.save!
           end
         ensure

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -97,8 +97,8 @@ module Katello
         pulp_repo_facts.merge(as_json).merge(:sync_state => sync_state)
       end
 
-      def pulp_checksum_type
-        find_distributor['config']['checksum_type'] if self.try(:yum?) && find_distributor
+      def pulp_scratchpad_checksum_type
+        pulp_repo_facts&.dig('scratchpad', 'checksum_type')
       end
 
       def pulp_counts_differ?

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -259,6 +259,10 @@ module Katello
       content_view_version && content_view_version.default_content_view?
     end
 
+    def on_demand?
+      download_policy == Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND
+    end
+
     def self.in_environments_products(env_ids, product_ids)
       in_environment(env_ids).in_product(product_ids)
     end
@@ -475,11 +479,11 @@ module Katello
                      :content_id => self.content_id,
                      :content_view_version => to_version,
                      :content_type => self.content_type,
+                     :checksum_type => checksum_type || source_repo_checksum_type,
                      :docker_upstream_name => self.docker_upstream_name,
                      :docker_tags_whitelist => self.docker_tags_whitelist,
                      :download_policy => download_policy,
                      :unprotected => self.unprotected) do |clone|
-        clone.checksum_type = self.checksum_type
         options = {
           :repository => self,
           :environment => to_env,

--- a/db/migrate/20180917173645_add_source_repo_checksum_type_to_katello_repositories.rb
+++ b/db/migrate/20180917173645_add_source_repo_checksum_type_to_katello_repositories.rb
@@ -1,0 +1,5 @@
+class AddSourceRepoChecksumTypeToKatelloRepositories < ActiveRecord::Migration[5.2]
+  def change
+    add_column :katello_repositories, :source_repo_checksum_type, :string
+  end
+end

--- a/db/seeds.d/111-upgrade_tasks.rb
+++ b/db/seeds.d/111-upgrade_tasks.rb
@@ -3,6 +3,7 @@ UpgradeTask.define_tasks(:katello) do
     {:name => 'katello:correct_repositories', :long_running => true, :skip_failure => true, :always_run => true},
     {:name => 'katello:correct_puppet_environments', :long_running => true, :skip_failure => true, :always_run => true},
     {:name => 'katello:clean_backend_objects', :long_running => true, :skip_failure => true, :always_run => true},
+    {:name => 'katello:upgrades:3.8:clear_checksum_type'},
     {:name => 'katello:upgrades:3.9:migrate_sync_plans'}
   ]
 end

--- a/lib/katello/tasks/upgrades/3.8/clear_checksum_type.rake
+++ b/lib/katello/tasks/upgrades/3.8/clear_checksum_type.rake
@@ -1,0 +1,32 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '3.8' do
+      desc "Clear checksum type for on-demand repositories"
+      task :clear_checksum_type => %w(environment) do
+        User.current = User.anonymous_admin
+
+        Katello::Repository.yum_type.find_each do |repo|
+          repo.transaction do
+            begin
+              if repo.on_demand? && repo.url.present?
+                repo.update_attribute(:checksum_type, nil)
+
+                if repo.find_distributor[:config]&.delete(:checksum_type)
+                  Katello.pulp_server.resources.repository.update_distributor(
+                    repo.pulp_id, repo.find_distributor[:id], repo.find_distributor[:config])
+                end
+              end
+
+              if repo.library_instance?
+                repo.update_attributes!(
+                  source_repo_checksum_type: repo.pulp_scratchpad_checksum_type)
+              end
+            # rubocop:disable HandleExceptions
+            rescue RestClient::ResourceNotFound
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/vcr_cassettes/katello/glue_pulp_repo/pulp_scratchpad_checksum_type.yml
+++ b/test/fixtures/vcr_cassettes/katello/glue_pulp_repo/pulp_scratchpad_checksum_type.yml
@@ -1,0 +1,398 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://centos7-devel.virbr0.akofink-desktop/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
+        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
+        b3J0ZXJfY29uZmlnIjp7ImZlZWQiOiJmaWxlOi8vL3Zhci93d3cvdGVzdF9y
+        ZXBvcy96b28iLCJwcm94eV9ob3N0IjpudWxsLCJzc2xfY2FfY2VydCI6ImZv
+        byIsInNzbF9jbGllbnRfY2VydCI6ImZvbyIsInNzbF9jbGllbnRfa2V5Ijoi
+        Zm9vIiwic3NsX3ZhbGlkYXRpb24iOm51bGwsImRvd25sb2FkX3BvbGljeSI6
+        bnVsbCwicmVtb3ZlX21pc3NpbmciOm51bGx9LCJub3RlcyI6eyJfcmVwby10
+        eXBlIjoicnBtLXJlcG8ifSwiZGlzdHJpYnV0b3JzIjpbeyJkaXN0cmlidXRv
+        cl90eXBlX2lkIjoieXVtX2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29u
+        ZmlnIjp7InJlbGF0aXZlX3VybCI6InRlc3RfcGF0aC8iLCJodHRwIjpmYWxz
+        ZSwiaHR0cHMiOnRydWUsInByb3RlY3RlZCI6dHJ1ZX0sImF1dG9fcHVibGlz
+        aCI6dHJ1ZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSx7ImRpc3Ry
+        aWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3IiLCJkaXN0cmli
+        dXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBzIjpmYWxzZSwicmVs
+        YXRpdmVfdXJsIjoidGVzdF9wYXRoLyJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNl
+        LCJkaXN0cmlidXRvcl9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciJ9LHsiZGlz
+        dHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9jbG9uZV9kaXN0cmlidXRvciIsImRp
+        c3RyaWJ1dG9yX2NvbmZpZyI6eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9p
+        ZCI6IkZlZG9yYV8xNyJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmli
+        dXRvcl9pZCI6IkZlZG9yYV8xN19jbG9uZSJ9XX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.4p296
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '884'
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Wed, 19 Sep 2018 13:54:06 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '320'
+      Location:
+      - "/pulp/api/v2/repositories/Fedora_17/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
+        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWJhMjU0ZmVhMTliZjgyYjYxNWQzNjU2In0sICJpZCI6ICJGZWRvcmFfMTci
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
+        MTcvIn0=
+    http_version: 
+  recorded_at: Wed, 19 Sep 2018 13:54:06 GMT
+- request:
+    method: post
+    uri: https://centos7-devel.virbr0.akofink-desktop/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjkiLCJkaXNwbGF5X25hbWUiOiJSSEVMIDcgeDg2XzY0IiwiaW1w
+        b3J0ZXJfdHlwZV9pZCI6Inl1bV9pbXBvcnRlciIsImltcG9ydGVyX2NvbmZp
+        ZyI6eyJmZWVkIjoiaHR0cHM6Ly9jZG4uZXhhbXBsZS5jb20vcmhlbC83L29z
+        IiwicHJveHlfaG9zdCI6bnVsbCwic3NsX2NhX2NlcnQiOm51bGwsInNzbF9j
+        bGllbnRfY2VydCI6bnVsbCwic3NsX2NsaWVudF9rZXkiOm51bGwsInNzbF92
+        YWxpZGF0aW9uIjp0cnVlLCJkb3dubG9hZF9wb2xpY3kiOiJiYWNrZ3JvdW5k
+        IiwicmVtb3ZlX21pc3NpbmciOnRydWUsImJhc2ljX2F1dGhfdXNlcm5hbWUi
+        Om51bGwsImJhc2ljX2F1dGhfcGFzc3dvcmQiOm51bGx9LCJub3RlcyI6eyJf
+        cmVwby10eXBlIjoicnBtLXJlcG8ifSwiZGlzdHJpYnV0b3JzIjpbeyJkaXN0
+        cmlidXRvcl90eXBlX2lkIjoieXVtX2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0
+        b3JfY29uZmlnIjp7InJlbGF0aXZlX3VybCI6IkFDTUVfQ29ycG9yYXRpb24v
+        bGlicmFyeS9yaGVsXzdfbGFiZWwiLCJodHRwIjpmYWxzZSwiaHR0cHMiOnRy
+        dWUsInByb3RlY3RlZCI6dHJ1ZSwiY2hlY2tzdW1fdHlwZSI6bnVsbH0sImF1
+        dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3JfaWQiOiI5In0seyJkaXN0
+        cmlidXRvcl90eXBlX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIiwiZGlzdHJp
+        YnV0b3JfY29uZmlnIjp7Imh0dHAiOmZhbHNlLCJodHRwcyI6ZmFsc2UsInJl
+        bGF0aXZlX3VybCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9yaGVsXzdf
+        bGFiZWwifSwiYXV0b19wdWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQi
+        OiJleHBvcnRfZGlzdHJpYnV0b3IifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQi
+        OiJ5dW1fY2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWci
+        OnsiZGVzdGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiI5In0sImF1dG9fcHVi
+        bGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiOV9jbG9uZSJ9XX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.4p296
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '986'
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Wed, 19 Sep 2018 13:54:06 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '301'
+      Location:
+      - "/pulp/api/v2/repositories/9/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA3IHg4
+        Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQi
+        OiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwg
+        Imxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3Vu
+        dHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNWJh
+        MjU0ZmVhMTliZjgyYjYxNWQzNjViIn0sICJpZCI6ICI5IiwgIl9ocmVmIjog
+        Ii9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvOS8ifQ==
+    http_version: 
+  recorded_at: Wed, 19 Sep 2018 13:54:06 GMT
+- request:
+    method: get
+    uri: https://centos7-devel.virbr0.akofink-desktop/pulp/api/v2/repositories/9/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.4p296
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Sep 2018 13:54:06 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"f221c4f68bf77b44b23474b9df69c699-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2157'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA3IHg4
+        Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMiOiBb
+        eyJyZXBvX2lkIjogIjkiLCAibGFzdF91cGRhdGVkIjogIjIwMTgtMDktMTlU
+        MTM6NTQ6MDZaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3Jp
+        ZXMvOS9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3RyaWJ1dG9yLyIsICJsYXN0
+        X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwg
+        ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIiwg
+        ImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25z
+        IjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1YmEy
+        NTRmZWExOWJmODJiNjE1ZDM2NWUifSwgImNvbmZpZyI6IHsiaHR0cCI6IGZh
+        bHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29ycG9yYXRpb24vbGlicmFy
+        eS9yaGVsXzdfbGFiZWwiLCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6ICJleHBv
+        cnRfZGlzdHJpYnV0b3IifSwgeyJyZXBvX2lkIjogIjkiLCAibGFzdF91cGRh
+        dGVkIjogIjIwMTgtMDktMTlUMTM6NTQ6MDZaIiwgIl9ocmVmIjogIi9wdWxw
+        L2FwaS92Mi9yZXBvc2l0b3JpZXMvOS9kaXN0cmlidXRvcnMvOV9jbG9uZS8i
+        LCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlzaCI6
+        IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9jbG9uZV9kaXN0
+        cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hwYWQi
+        OiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7IiRv
+        aWQiOiAiNWJhMjU0ZmVhMTliZjgyYjYxNWQzNjVmIn0sICJjb25maWciOiB7
+        ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogIjkifSwgImlkIjogIjlf
+        Y2xvbmUifSwgeyJyZXBvX2lkIjogIjkiLCAibGFzdF91cGRhdGVkIjogIjIw
+        MTgtMDktMTlUMTM6NTQ6MDZaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        ZXBvc2l0b3JpZXMvOS9kaXN0cmlidXRvcnMvOS8iLCAibGFzdF9vdmVycmlk
+        ZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmli
+        dXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxp
+        c2giOiB0cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlz
+        dHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1YmEyNTRmZWExOWJmODJi
+        NjE1ZDM2NWQifSwgImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0
+        dHAiOiBmYWxzZSwgImh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJB
+        Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvcmhlbF83X2xhYmVsIn0sICJpZCI6
+        ICI5In1dLCAibGFzdF91bml0X2FkZGVkIjogbnVsbCwgIm5vdGVzIjogeyJf
+        cmVwby10eXBlIjogInJwbS1yZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6
+        IG51bGwsICJjb250ZW50X3VuaXRfY291bnRzIjoge30sICJfbnMiOiAicmVw
+        b3MiLCAiaW1wb3J0ZXJzIjogW3sicmVwb19pZCI6ICI5IiwgImxhc3RfdXBk
+        YXRlZCI6ICIyMDE4LTA5LTE5VDEzOjU0OjA2WiIsICJfaHJlZiI6ICIvcHVs
+        cC9hcGkvdjIvcmVwb3NpdG9yaWVzLzkvaW1wb3J0ZXJzL3l1bV9pbXBvcnRl
+        ci8iLCAiX25zIjogInJlcG9faW1wb3J0ZXJzIiwgImltcG9ydGVyX3R5cGVf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjog
+        e30sICJsYXN0X3N5bmMiOiBudWxsLCAic2NyYXRjaHBhZCI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNWJhMjU0ZmVhMTliZjgyYjYxNWQzNjVjIn0sICJj
+        b25maWciOiB7ImZlZWQiOiAiaHR0cHM6Ly9jZG4uZXhhbXBsZS5jb20vcmhl
+        bC83L29zIiwgInNzbF92YWxpZGF0aW9uIjogdHJ1ZSwgInJlbW92ZV9taXNz
+        aW5nIjogdHJ1ZSwgImRvd25sb2FkX3BvbGljeSI6ICJiYWNrZ3JvdW5kIn0s
+        ICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0sICJsb2NhbGx5X3N0b3JlZF91bml0
+        cyI6IDAsICJfaWQiOiB7IiRvaWQiOiAiNWJhMjU0ZmVhMTliZjgyYjYxNWQz
+        NjViIn0sICJ0b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMCwgImlkIjogIjki
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy85LyJ9
+    http_version: 
+  recorded_at: Wed, 19 Sep 2018 13:54:06 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel.virbr0.akofink-desktop/pulp/api/v2/repositories/9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.4p296
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Sep 2018 13:54:06 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzhlZGQyYmYzLTM2ZmQtNDgwMC04NTdjLTUxYTY0ZjllZDIyNC8iLCAi
+        dGFza19pZCI6ICI4ZWRkMmJmMy0zNmZkLTQ4MDAtODU3Yy01MWE2NGY5ZWQy
+        MjQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 19 Sep 2018 13:54:06 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel.virbr0.akofink-desktop/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.4p296
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 19 Sep 2018 13:54:07 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzMwOWM1MDQ3LWZlMDAtNGUwNC05MmIxLWFlZjc0NTViNDkyMy8iLCAi
+        dGFza19pZCI6ICIzMDljNTA0Ny1mZTAwLTRlMDQtOTJiMS1hZWY3NDU1YjQ5
+        MjMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 19 Sep 2018 13:54:07 GMT
+- request:
+    method: get
+    uri: https://centos7-devel.virbr0.akofink-desktop/pulp/api/v2/tasks/309c5047-fe00-4e04-92b1-aef7455b4923/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.4p296
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Sep 2018 13:54:07 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"eb6b7b54f0d6c113e8167a2709cce989-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '670'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMDljNTA0Ny1mZTAwLTRlMDQtOTJiMS1hZWY3NDU1YjQ5
+        MjMvIiwgInRhc2tfaWQiOiAiMzA5YzUwNDctZmUwMC00ZTA0LTkyYjEtYWVm
+        NzQ1NWI0OTIzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMkBjZW50b3M3LWRldmVsLnZpcmJyMC5ha29maW5rLWRlc2t0
+        b3AuZHEyIiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1kZXZlbC52aXJi
+        cjAuYWtvZmluay1kZXNrdG9wIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWJhMjU0ZmZjY2ZjYTQwNWM4YmYx
+        N2ZjIn0sICJpZCI6ICI1YmEyNTRmZmNjZmNhNDA1YzhiZjE3ZmMifQ==
+    http_version: 
+  recorded_at: Wed, 19 Sep 2018 13:54:07 GMT
+- request:
+    method: get
+    uri: https://centos7-devel.virbr0.akofink-desktop/pulp/api/v2/tasks/309c5047-fe00-4e04-92b1-aef7455b4923/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.4p296
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 19 Sep 2018 13:54:07 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"dac052f0fb5497f357c26230020a2594-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '707'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zMDljNTA0Ny1mZTAwLTRlMDQtOTJiMS1hZWY3NDU1YjQ5
+        MjMvIiwgInRhc2tfaWQiOiAiMzA5YzUwNDctZmUwMC00ZTA0LTkyYjEtYWVm
+        NzQ1NWI0OTIzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE4LTA5LTE5VDEzOjU0OjA3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE4LTA5LTE5VDEzOjU0OjA3WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MkBjZW50b3M3LWRldmVsLnZpcmJyMC5ha29maW5rLWRlc2t0b3AuZHEyIiwg
+        InN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVk
+        X3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczctZGV2ZWwudmlyYnIwLmFrb2Zp
+        bmstZGVza3RvcCIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjViYTI1NGZmY2NmY2E0MDVjOGJmMTdmYyJ9LCAi
+        aWQiOiAiNWJhMjU0ZmZjY2ZjYTQwNWM4YmYxN2ZjIn0=
+    http_version: 
+  recorded_at: Wed, 19 Sep 2018 13:54:07 GMT
+recorded_with: VCR 3.0.3

--- a/test/glue/pulp/repository_test.rb
+++ b/test/glue/pulp/repository_test.rb
@@ -115,6 +115,9 @@ module Katello
   end
 
   class GluePulpNonVcrTests < GluePulpRepoTestBase
+    SHA1 = "sha1".freeze
+    SHA256 = "sha256".freeze
+
     def test_importer_feed_url
       proxy = SmartProxy.new(:url => 'http://foo.com/foo')
       pulp_host = URI.parse(SETTINGS[:katello][:pulp][:url]).host
@@ -285,6 +288,23 @@ module Katello
       ostree_repo.save!
       assert ostree_repo.pulp_update_needed?
     end
+
+    def test_pulp_scratchpad_checksum_type
+      repo = katello_repositories(:fedora_17_x86_64)
+
+      repo.stubs(:pulp_repo_facts)
+      repo.stubs(:distributors).
+        returns([{ "distributor_type_id" => Runcible::Models::YumDistributor.type_id }])
+
+      assert_nil repo.pulp_scratchpad_checksum_type
+
+      repo.stubs(:pulp_repo_facts).returns("scratchpad" => {"checksum_type" => SHA1})
+      repo.stubs(:distributors).
+        returns([{ "config" => {},
+                   "distributor_type_id" => Runcible::Models::YumDistributor.type_id }])
+
+      assert_equal repo.pulp_scratchpad_checksum_type, SHA1
+    end
   end
 
   class GluePulpRepoTestCreateDestroy < GluePulpRepoTestBase
@@ -364,6 +384,16 @@ module Katello
       @fedora_17_x86_64.url = 'https://www.yahoo.com'
       @fedora_17_x86_64.save!
       assert @fedora_17_x86_64.pulp_update_needed?
+    end
+
+    def test_pulp_scratchpad_checksum_type
+      repo = katello_repositories(:rhel_7_x86_64)
+      repo.create_pulp_repo
+
+      assert_nil repo.pulp_scratchpad_checksum_type
+
+      assert_nil ::Katello.pulp_server.extensions
+        .repository.delete(repo.pulp_id).parsed_body['error']
     end
   end
 


### PR DESCRIPTION
Instead of the checksum_type being on the distributor, it seems it has
moved to the repository itself, under the 'scratchpad' key. There doesn't appear to be any tests for the pulp_checksum_type method.

TODO:
- [x] create a test for pulp_checksum_type so if the API changes in the future, we can easily detect it