### PR TITLE
Fixes #24680 - RPM filter should not contain Beta repos

### DIFF
--- a/webpack/redux/actions/RedHatRepositories/helpers.js
+++ b/webpack/redux/actions/RedHatRepositories/helpers.js
@@ -1,5 +1,5 @@
 const repoTypeSearchQueryMap = {
-  rpm: '(name !~ source rpm) and (name !~ debug rpm) and (content_type = yum)',
+  rpm: '(name !~ source rpm) and (name !~ debug rpm) and (content_type = yum) and (name !~ beta) and (product_name !~ beta)',
   sourceRpm: '(name ~ source rpm) and (content_type = yum)',
   debugRpm: '(name ~ debug rpm) and (content_type = yum)',
   kickstart: 'content_type = kickstart',


### PR DESCRIPTION
Description of problem:

When we filter out "RPM" repos,  we can see Beta repositories on Red Hat Repositories page. We have a separate filter for "Beta" repos and unless user use it, those beta repos should not be listed. 

Example: On Red Hat Repositories page, Click on "Nothing Selected" -> Select only "RPM" , You will see many Beta repositories also listed.

Fix:

We filter out any repo with a name that contains "beta" and we filter out any repo that belongs to a product with a name that contains "beta".