### PR TITLE
Fixes #24420 - CV Publish for modules

### DIFF
--- a/app/lib/actions/katello/repository/clear.rb
+++ b/app/lib/actions/katello/repository/clear.rb
@@ -8,6 +8,8 @@ module Actions
            Pulp::Repository::RemovePackageGroup,
            Pulp::Repository::RemoveDistribution,
            Pulp::Repository::RemoveYumMetadataFile,
+           Pulp::Repository::RemoveModuleDefault,
+           Pulp::Repository::RemoveModuleStream,
            Pulp::Repository::RemoveFile,
            Pulp::Repository::RemovePuppetModule,
            Pulp::Repository::RemoveDockerManifest,

--- a/app/lib/actions/katello/repository/clone_yum_content.rb
+++ b/app/lib/actions/katello/repository/clone_yum_content.rb
@@ -39,6 +39,8 @@ module Actions
             end
             plan_copy(Pulp::Repository::CopyYumMetadataFile, source_repo, target_repo)
             plan_copy(Pulp::Repository::CopyDistribution, source_repo, target_repo)
+            plan_copy(Pulp::Repository::CopyModuleStream, source_repo, target_repo, nil)
+            plan_copy(Pulp::Repository::CopyModuleDefault, source_repo, target_repo)
 
             # Check for matching content before indexing happens, the content in pulp is
             # actually updated, but it is not reflected in the database yet.

--- a/app/lib/actions/katello/repository/index_module_streams.rb
+++ b/app/lib/actions/katello/repository/index_module_streams.rb
@@ -1,0 +1,16 @@
+module Actions
+  module Katello
+    module Repository
+      class IndexModuleStreams < Actions::EntryAction
+        def plan(repository)
+          plan_self(:user_id => ::User.current.id, :id => repository.id)
+        end
+
+        def run
+          repo = ::Katello::Repository.find(input[:id])
+          ::Katello::ModuleStream.import_for_repository(repo)
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp/repository/copy_module_default.rb
+++ b/app/lib/actions/pulp/repository/copy_module_default.rb
@@ -1,0 +1,11 @@
+module Actions
+  module Pulp
+    module Repository
+      class CopyModuleDefault < Pulp::Repository::AbstractCopyContent
+        def content_extension
+          pulp_extensions.module_default
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp/repository/copy_module_stream.rb
+++ b/app/lib/actions/pulp/repository/copy_module_stream.rb
@@ -1,0 +1,11 @@
+module Actions
+  module Pulp
+    module Repository
+      class CopyModuleStream < Pulp::Repository::AbstractCopyContent
+        def content_extension
+          pulp_extensions.module
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp/repository/remove_module_default.rb
+++ b/app/lib/actions/pulp/repository/remove_module_default.rb
@@ -1,0 +1,11 @@
+module Actions
+  module Pulp
+    module Repository
+      class RemoveModuleDefault < Pulp::Repository::AbstractRemoveContent
+        def content_extension
+          pulp_extensions.module_default
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp/repository/remove_module_stream.rb
+++ b/app/lib/actions/pulp/repository/remove_module_stream.rb
@@ -1,0 +1,11 @@
+module Actions
+  module Pulp
+    module Repository
+      class RemoveModuleStream < Pulp::Repository::AbstractRemoveContent
+        def content_extension
+          pulp_extensions.module
+        end
+      end
+    end
+  end
+end

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -264,6 +264,10 @@ module Katello
       Katello::Rpm.in_repositories(self.repositories.archived).count
     end
 
+    def module_stream_count
+      Katello::ModuleStream.in_repositories(self.repositories.archived).count
+    end
+
     def file_count
       Katello::FileUnit.in_repositories(self.repositories.archived).count
     end

--- a/app/models/katello/module_stream.rb
+++ b/app/models/katello/module_stream.rb
@@ -7,7 +7,9 @@ module Katello
     has_many :profiles, class_name: "Katello::ModuleProfile", dependent: :destroy
     has_many :artifacts, class_name: "Katello::ModuleStreamArtifact", dependent: :destroy
 
-    CONTENT_TYPE = 'modulemd'.freeze
+    CONTENT_TYPE = Pulp::ModuleStream::CONTENT_TYPE
+
+    MODULE_STREAM_DEFAULT_CONTENT_TYPE = "modulemd_defaults".freeze
 
     def self.default_sort
       order(:name)

--- a/app/views/katello/api/v2/content_view_versions/base.json.rabl
+++ b/app/views/katello/api/v2/content_view_versions/base.json.rabl
@@ -9,6 +9,7 @@ attributes :content_view_id
 attributes :default
 attributes :description
 attributes :package_count
+attributes :module_stream_count
 attributes :srpm_count
 attributes :file_count
 attributes :package_group_count

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-versions.html
@@ -62,6 +62,9 @@
               <span translate>{{ version.errata_counts.total }} Errata</span>
               (<span errata-counts="version.errata_counts"></span>)
             </div>
+            <div translate ng-if="version.module_stream_count && version.module_stream_count > 0">
+              {{ version.module_stream_count }} Module Streams
+            </div>
             <div translate ng-if="version.puppet_module_count && version.puppet_module_count > 0">
               {{ version.puppet_module_count }} Puppet Modules
             </div>

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "apipie-rails", ">= 0.5.4"
 
   # Pulp
-  gem.add_dependency "runcible", ">= 2.8.1", "< 3.0.0"
+  gem.add_dependency "runcible", ">= 2.9.0", "< 3.0.0"
   gem.add_dependency "anemone"
 
   # UI


### PR DESCRIPTION
This commit provides the ability to publish content views on
repositories holding module streams and defaults. The main complication
is the implicit filtering on module streams. i.e. We do not copy module
streams that do not have any packages associated to them.

More details:
The publish algorithm works as follows
1) Packages are first filtered
2) Module Streams are copied over from source repo to destination
3) Module Streams without any packages/artifacts in the
destination repo are purged.
4) Only modulemd defaults belonging to the existing module streams are
copied over.