### PR TITLE
Fixes #24677 - Show Subscriptions menu link for Viewer role

### DIFF
--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -11,7 +11,7 @@ Foreman::Plugin.register :katello do
          :red_hat_subscriptions,
          :caption => N_('Subscriptions'),
          :url => '/subscriptions',
-         :url_hash => {:controller => 'katello/react',
+         :url_hash => {:controller => 'katello/api/v2/subscriptions',
                        :action => 'index'},
          :engine => Katello::Engine,
          :turbolinks => false

--- a/webpack/move_to_foreman/common/helpers.js
+++ b/webpack/move_to_foreman/common/helpers.js
@@ -14,7 +14,7 @@ const stringIsInteger = (value) => {
 
 export const getResponseErrorMsgs = ({ data }) => {
   if (data) {
-    const messages = (data.errors || data.displayMessage || data.message || data.error);
+    const messages = (data.errors || data.displayMessage || data.message || data.error.message);
     return (Array.isArray(messages) ? messages : [messages]);
   }
   return [];

--- a/webpack/scenes/Tasks/helpers.js
+++ b/webpack/scenes/Tasks/helpers.js
@@ -13,6 +13,8 @@ const getErrors = task => (
 );
 
 export const renderTaskStartedToast = (task) => {
+  if (!task) return;
+
   const message = (
     <span>
       <span>
@@ -32,6 +34,8 @@ export const renderTaskStartedToast = (task) => {
 };
 
 export const renderTaskFinishedToast = (task) => {
+  if (!task) return;
+
   const message = (
     <span>
       <span>


### PR DESCRIPTION
To test:

- create a user with only Viewer permission
- observe that there is no Content -> Subscriptions menu link (the defect)

- checkout this PR and restart rails server
- observe that the link is present and the user can navigate through it

Why? the url_hash needs a URL which has some permissions (https://github.com/Katello/katello/blob/master/lib/katello/permission_creator.rb)


https://github.com/theforeman/foreman/pull/5814 will give us a better way to disable UI components as needed per permissions