### PR TITLE
Fixes #24765 - ensure reschedule notification on error

### DIFF
--- a/app/jobs/create_pulp_disk_space_notifications.rb
+++ b/app/jobs/create_pulp_disk_space_notifications.rb
@@ -1,10 +1,8 @@
 class CreatePulpDiskSpaceNotifications < ApplicationJob
-  after_perform do
-    self.class.set(:wait => 12.hours).perform_later
-  end
-
   def perform
     Katello::UINotifications::Pulp::ProxyDiskSpace.deliver!
+  ensure
+    self.class.set(:wait => 12.hours).perform_later
   end
 
   def humanized_name

--- a/app/jobs/send_expire_soon_notifications.rb
+++ b/app/jobs/send_expire_soon_notifications.rb
@@ -1,10 +1,8 @@
 class SendExpireSoonNotifications < ApplicationJob
-  after_perform do
-    self.class.set(:wait => 12.hours).perform_later
-  end
-
   def perform
     Katello::UINotifications::Subscriptions::ExpireSoon.deliver!
+  ensure
+    self.class.set(:wait => 12.hours).perform_later
   end
 
   def humanized_name


### PR DESCRIPTION
ActiveJob's after_perform doesn't run on any error: the rescue_from is
run after the callbacks. Also, the rescue_from is hiding the errors from
the task details when foreman-tasks is present: re-raising the error
after logging should be better.