### PR TITLE
Fixes #24768 - do not validate model during count updates

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -83,13 +83,14 @@ module Katello
       end
 
       def update_applicability_counts
-        self.update_attributes!(
+        self.assign_attributes(
             :installable_security_errata_count => self.installable_errata.security.count,
             :installable_bugfix_errata_count => self.installable_errata.bugfix.count,
             :installable_enhancement_errata_count => self.installable_errata.enhancement.count,
             :applicable_rpm_count => self.content_facet_applicable_rpms.count,
             :upgradable_rpm_count => self.installable_rpms.count
         )
+        self.save!(:validate => false)
       end
 
       def import_rpm_applicability(partial)

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -194,6 +194,11 @@ module Katello
       assert_includes rpm_one.repositories, repo
       rpm_two.repositories = []
       host_one.content_facet.bound_repositories << repo
+
+      #shouldn't matter if facet is invalid
+      host_one.content_facet.lifecycle_environment = katello_environments(:qa_path2)
+      refute host_one.valid?
+
       host_one.content_facet.update_applicability_counts
 
       assert_equal 2, host_one.content_facet.applicable_rpm_count


### PR DESCRIPTION
It does not really matter if the content facet
is valid, we still should update the applicability
counts.