### PR TITLE
Fixes #24772 - test ensures 'parameters' included in GET HG api

### DIFF
--- a/test/controllers/api/v2/hostgroups_controller_test.rb
+++ b/test/controllers/api/v2/hostgroups_controller_test.rb
@@ -11,6 +11,14 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
     @hostgroup = hostgroups(:common)
   end
 
+  def test_parameters_included_in_hostgroup_show
+    get :show, params: { :id => hostgroups(:common).to_param }
+    assert_response :success
+    assert_template 'katello/api/v2/hostgroups_extensions/show'
+    response = JSON.parse(@response.body)
+    assert response.key?('parameters')
+  end
+
   test_attributes :pid => '70fe5df8-8917-4a46-b37a-708f449fe749'
   def test_show_content_attributes
     content_fields = %w[


### PR DESCRIPTION
Added one test here as well to ensure parameters included in GET hostgroup api i.e for show action.
The main change added on foreman side i.e [PR-6003](https://github.com/theforeman/foreman/pull/6003) where using `before_action`  filter, it sets `parameters` flag to `true` for actions `show/create/update` .

Note - please merge it after [PR-6003](https://github.com/theforeman/foreman/pull/6003).