### PR TITLE
fixes #24115, #24534 - validate upstream auth on repository

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -142,6 +142,7 @@ module Katello
     validate :ensure_ostree_repo_protected, :if => :ostree?
     validate :ensure_compatible_download_policy, :if => :yum?
     validate :ensure_valid_ignorable_content
+    validate :ensure_valid_upstream_authorization
 
     before_validation :set_pulp_id
     before_validation :set_container_repository_name, :if => :docker?
@@ -899,6 +900,17 @@ module Katello
         errors.add(:ignorable_content, N_("Invalid value specified for ignorable content."))
       elsif ignorable_content.any? { |item| !IGNORABLE_CONTENT_UNIT_TYPES.include?(item) }
         errors.add(:ignorable_content, N_("Invalid value specified for ignorable content. Permissible values %s") % IGNORABLE_CONTENT_UNIT_TYPES.join(","))
+      end
+    end
+
+    def ensure_valid_upstream_authorization
+      return if (self.upstream_username.blank? && self.upstream_password.blank?)
+      if redhat?
+        errors.add(:base, N_("Upstream username and password may only be set on custom repositories."))
+      elsif self.upstream_username.blank?
+        errors.add(:base, N_("Upstream password requires upstream username be set."))
+      elsif !self.upstream_password
+        errors.add(:base, N_("Upstream username requires upstream password be set.")) # requirement of pulp
       end
     end
 

--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -64,6 +64,10 @@ node :upstream_password_exists do |repo|
   repo.upstream_password.present?
 end
 
+node :upstream_auth_exists do |repo|
+  repo.upstream_username.present? && repo.upstream_password.present?
+end
+
 if @object && @object.library_instance_id.nil?
 
   node :content_view_environments do |repository|

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
@@ -151,9 +151,10 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
             return DownloadPolicy.downloadPolicyName(downloadPolicy);
         };
 
-        $scope.clearUpstreamPassword = function () {
+        $scope.clearUpstreamAuth = function () {
             $scope.repository['upstream_password'] = null;
-            $scope.repository['upstream_password_exists'] = false;
+            $scope.repository['upstream_auth_exists'] = false;
+            $scope.repository['upstream_username'] = null;
             $scope.save($scope.repository);
         };
     }]

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.filter.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.filter.js
@@ -22,8 +22,8 @@ angular.module('Bastion.components.formatters').filter('ostreeUpstreamSyncPolicy
 
 angular.module('Bastion.components.formatters').filter('upstreamPasswordFilter', [function () {
     return function (displayValue, repository) {
-        if (repository["upstream_password_exists"]) {
-            return "******";
+        if (repository["upstream_auth_exists"]) {
+            return '%(username) / ********'.replace('%(username)', repository["upstream_username"]);
         }
         return null;
     };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -82,27 +82,28 @@
           readonly="denied('edit_products', product)">
       </dd>
 
-      <dt translate>Upstream Username</dt>
-      <dd bst-edit-text="repository.upstream_username"
-          on-save="save(repository)"
-          readonly="product.redhat || denied('edit_products', product)">
-      </dd>
-
-      <dt translate>Upstream Password</dt>
-      <dd bst-edit-custom="repository.upstream_password_exists"
-          readonly="denied('edit_products', product)"
-          on-save="save(repository)"
-          formatter="upstreamPasswordFilter"
-          formatter-options="repository"
-          deletable="repository.upstream_password_exists"
-          on-delete="clearUpstreamPassword()"
-          >
+      <span ng-show="!product.redhat">
+        <dt translate>Upstream Authorization</dt>
+        <dd bst-edit-custom="repository.upstream_auth_exists"
+            readonly="denied('edit_products', product)"
+            on-save="save(repository)"
+            formatter="upstreamPasswordFilter"
+            formatter-options="repository"
+            deletable="repository.upstream_auth_exists"
+            on-delete="clearUpstreamAuth()">
+          <div translate>Upstream Username</div>
+          <input id="upstream_username"
+                 name="upstream_username"
+                 type="name"
+                 ng-model="repository.upstream_username"/>
+          <div translate>Upstream Password</div>
           <input id="upstream_password"
-            name="upstream_password"
-            type="password"
-            ng-model="repository.upstream_password"/>
-      </dd>
-
+                 name="upstream_password"
+                 type="password"
+                 ng-model="repository.upstream_password"/>
+        </dd>
+      </span>
+ 
       <span ng-show="repository.content_type === 'yum'">
         <dt translate>Yum Metadata Checksum</dt>
         <dd bst-edit-select="checksumTypeDisplay(repository.checksum_type)"

--- a/engines/bastion_katello/test/products/details/repositories/details/repository-details-info.controller.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/details/repository-details-info.controller.test.js
@@ -81,12 +81,13 @@ describe('Controller: RepositoryDetailsInfoController', function() {
         expect(promise.then).toBeDefined();
     });
 
-    it('should clear the repo upstream password and save on clearUpstreamPassword', function() {
+    it('should clear the repo upstream password and username on clearUpstreamAuth', function() {
         spyOn($scope, 'save');
-        $scope.clearUpstreamPassword($scope.repository);
+        $scope.clearUpstreamAuth($scope.repository);
         expect($scope.save).toHaveBeenCalledWith($scope.repository);
         expect($scope.repository["upstream_password"]).toBe(null);
-        expect($scope.repository["upstream_password_exists"]).toBe(false);
+        expect($scope.repository["upstream_username"]).toBe(null);
+        expect($scope.repository["upstream_auth_exists"]).toBe(false);
     });
 
     it('should save the repository successfully', function() {

--- a/engines/bastion_katello/test/products/details/repositories/details/repository-details-info.filter.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/details/repository-details-info.filter.test.js
@@ -7,16 +7,17 @@ describe('Filter:upstreamPasswordFilter', function() {
         filter = $filter('upstreamPasswordFilter');
     }));
 
-    it("returns *** for upstream_password_exists = true", function() {
+    it("returns username/*** for upstream_auth_exists = true", function() {
         repository = {
-            "upstream_password_exists" : true
+            "upstream_auth_exists" : true,
+            "upstream_username" : "test_user"
         }
-        expect(filter("", repository)).toBe('******');
+        expect(filter("", repository)).toBe('test_user / ********'); 
     });
 
-    it("returns null for upstream_password_exists = false", function() {
+    it("returns null for upstream_auth_exists = false", function() {
         repository = {
-            "upstream_password_exists" : false
+            "upstream_auth_exists" : false
         }
         expect(filter("", repository)).toBe(null);
     });

--- a/test/glue/pulp/repository_test.rb
+++ b/test/glue/pulp/repository_test.rb
@@ -256,10 +256,11 @@ module Katello
       refute @fedora_17_x86_64.importer_matches?({'importer_type_id' => Runcible::Models::YumImporter::ID, 'config' => yum_config}, capsule)
     end
 
-    def test_pulp_update_needed_with_upstream_name_passwd?
+    def test_pulp_update_needed_with_upstream_auth_change?
       repo = katello_repositories(:fedora_17_x86_64)
       refute repo.pulp_update_needed?
       repo.upstream_username = 'amazing'
+      repo.upstream_password = 'super-secret'
       repo.save!
       assert repo.pulp_update_needed?
 

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -712,6 +712,29 @@ module Katello
       assert_equal sync_depth, @repo.compute_ostree_upstream_sync_depth
     end
 
+    def test_invalid_upstream_password_update
+      @repo.upstream_password = "password"
+      refute @repo.save
+    end
+
+    def test_invalid_upstream_username_update
+      @repo.upstream_password = "username"
+      refute @repo.save
+    end
+
+    def test_valid_upstream_authorization
+      @repo.upstream_password = "password"
+      @repo.upstream_username = "username"
+      assert @repo.save
+    end
+
+    def test_invalid_upstream_authorization
+      rhel_6 = katello_repositories(:rhel_6_x86_64)
+      rhel_6.upstream_password = "password"
+      rhel_6.upstream_username = "username"
+      refute rhel_6.save
+    end
+
     def test_master_link
       assert @puppet_forge.master?
 


### PR DESCRIPTION
This PR is the same as https://github.com/Katello/katello/pull/7584 but with one line changed. Error message escaping was requested in https://projects.theforeman.org/issues/24807 instead of being done in this PR. Authorship info on the original commit has been preserved.

Original text:


`upstream_username` and `upstream_password` should only be set on custom repos, and they must be set as a pair (no `upstream_username` without `upstream_password` and vice versa) or pulp fails silently while the attributes remain set on the repository.

To test (UI/Hammer/API):
- Go to Products -> Product -> Repositories -> Repository
- enter `upstream_username`/`upstream_password` on rh repo to fail
- enter `upstream_username` & `upstream_password` combo on custom repo to pass
- enter `upstream_username` XOR `upstream_password` on custom repo to fail

Issues in UI:
- When form opens, `upstream_username` is prefilled while `upstream_password` is not. Leave both blank in form or have prefilled with current (w/`upstream_password` encrypted)?
- If failure, `upstream_username` still shows in UI after throwing error (adding `upstream_username` without `upstream_password` throws error, but closing and reopening the form still shows the erroneous `upstream_username` pre-filled in the form).



![original](https://user-images.githubusercontent.com/5577256/43552528-d1c161a0-95b8-11e8-8fe0-18dd41b1fa48.png)
Current issues: cannot add/update/delete username. Cannot set username and password as a set.



![new blank](https://user-images.githubusercontent.com/5577256/43552682-7d9f7d04-95b9-11e8-95dc-b688a180d768.png)
New solution. Screen without `upstream_auth added`.



![new filled](https://user-images.githubusercontent.com/5577256/43552395-586f42cc-95b8-11e8-9974-efee9a24ca26.png)
Details screen with `upstream_auth` added.



![form blank](https://user-images.githubusercontent.com/5577256/43552316-107c0e14-95b8-11e8-8264-f867ad2f3958.png)
Blank form when adding username/password combo.



![form filled](https://user-images.githubusercontent.com/5577256/43552369-3d64673c-95b8-11e8-9008-a3dabd2a0b54.png)
Filled form.