### PR TITLE
Fixes #24813 - extend smart_proxy API to return download_policy

### DIFF
--- a/app/views/katello/api/v2/smart_proxies/download_policy.json.rabl
+++ b/app/views/katello/api/v2/smart_proxies/download_policy.json.rabl
@@ -1,0 +1,1 @@
+attributes :download_policy

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -240,6 +240,8 @@ Foreman::Plugin.register :katello do
   register_custom_status(Katello::SubscriptionStatus)
   register_custom_status(Katello::TraceStatus)
 
+  extend_rabl_template 'api/v2/smart_proxies/main', 'katello/api/v2/smart_proxies/download_policy'
+
   extend_page "smart_proxies/show" do |cx|
     cx.add_pagelet :details_content,
                    :name => _('Storage'),


### PR DESCRIPTION
This works with both `/api/v2/smart_proxies` and `api/v2/smart_proxies/:id`

```
[sokeeffe@sean foreman-ansible-modules] (tasks)$ curl https://admin:changeme@centos7-devel.sean.example.com/api/v2/smart_proxies -qk | jq
{ 
  "total": 1,
  "subtotal": 1,
  "page": 1,
  "per_page": 20,
  "search": null,
  "sort": { 
    "by": null,
    "order": null
  },
  "results": [
    {
      "created_at": "2018-08-15 09:40:06 UTC",
      "updated_at": "2018-08-15 09:40:07 UTC",
      "name": "centos7-devel.sean.example.com",
      "id": 1,
      "url": "https://centos7-devel.sean.example.com:9090",
      "download_policy": "on_demand",
      "features": [
        {
          "name": "Templates",
          "id": 1
        },
        {
          "name": "Pulp",
          "id": 2
        },
        {
          "name": "TFTP",
          "id": 4
        },
        {
          "name": "Puppet",
          "id": 7
        },
        {
          "name": "Puppet CA",
          "id": 8
        },
        {
          "name": "Logs",
          "id": 12 
        },
        {
          "name": "DNS",
          "id": 5
        }
      ]
    }
  ]
} 
[sokeeffe@sean foreman-ansible-modules] (tasks)$ curl https://admin:changeme@centos7-devel.sean.example.com/api/v2/smart_proxies/1 -k | jq
{
  "created_at": "2018-08-15 09:40:06 UTC",
  "updated_at": "2018-08-15 09:40:07 UTC",
  "name": "centos7-devel.sean.example.com",
  "id": 1,
  "url": "https://centos7-devel.sean.example.com:9090",
  "download_policy": "on_demand",
  "features": [
    {
      "name": "Templates",
      "id": 1
    },
    {
      "name": "Pulp",
      "id": 2
    },
    {
      "name": "TFTP",
      "id": 4
    },
    {
      "name": "DNS",
      "id": 5
    },
    {
      "name": "Puppet",
      "id": 7
    },
    {
      "name": "Puppet CA",
      "id": 8
    },
    {
      "name": "Logs",
      "id": 12
    }
  ],
  "locations": [
    {
      "id": 2,
      "name": "Default Location",
      "title": "Default Location",
      "description": null
    }
  ],
  "organizations": [
    {
      "id": 1,
      "name": "Default Organization",
      "title": "Default Organization",
      "description": null
    }
  ]
}
