### PR TITLE
Fixes #24827 - Show Repo Label on Enabled repos

### DIFF
--- a/webpack/redux/reducers/RedHatRepositories/enabled.js
+++ b/webpack/redux/reducers/RedHatRepositories/enabled.js
@@ -17,12 +17,14 @@ const mapRepo = (repo) => {
     id,
     name,
     minor,
+    cp_label: label,
   } = repo;
 
   return ({
     arch,
     id,
     name,
+    label,
     releasever: minor,
     type: repo.content_type,
     orphaned: repo.product.orphaned,

--- a/webpack/scenes/RedHatRepositories/components/EnabledRepository.js
+++ b/webpack/scenes/RedHatRepositories/components/EnabledRepository.js
@@ -65,8 +65,9 @@ class EnabledRepository extends Component {
 
   render() {
     const {
-      arch, name, id, type, releasever, orphaned,
+      name, id, type, orphaned, label,
     } = this.props;
+
     return (
       <ListView.Item
         key={id}
@@ -79,7 +80,7 @@ class EnabledRepository extends Component {
         }
         leftContent={<RepositoryTypeIcon id={id} type={type} />}
         heading={`${name} ${orphaned ? __('(Orphaned)') : ''}`}
-        description={`${arch} ${releasever || ''}`}
+        description={label}
         stacked
       />
     );
@@ -90,6 +91,7 @@ EnabledRepository.propTypes = {
   id: PropTypes.number.isRequired,
   contentId: PropTypes.number.isRequired,
   productId: PropTypes.number.isRequired,
+  label: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
   arch: PropTypes.string.isRequired,

--- a/webpack/scenes/RedHatRepositories/components/RepositorySet.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySet.js
@@ -18,7 +18,7 @@ const RepositorySet = ({
     actions={recommended ? <Icon type="fa" name="star" className="recommended-repository-set-icon" /> : ''}
     hideCloseIcon
   >
-    <RepositorySetRepositories contentId={id} productId={product.id} type={type} />
+    <RepositorySetRepositories contentId={id} productId={product.id} type={type} label={label} />
   </ListView.Item>
 );
 

--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepository.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepository.js
@@ -24,7 +24,7 @@ class RepositorySetRepository extends Component {
       const { data: { output: { repository: { id, name, content_type: type } } } } = response;
 
       const {
-        productId, contentId, arch, releasever,
+        productId, contentId, arch, releasever, label,
       } = this.props;
 
       const enabledRepo = {
@@ -35,6 +35,7 @@ class RepositorySetRepository extends Component {
         type,
         arch,
         releasever,
+        label,
       };
 
       this.props.setRepositoryEnabled(enabledRepo);
@@ -136,6 +137,7 @@ RepositorySetRepository.propTypes = {
   arch: PropTypes.string,
   releasever: PropTypes.string,
   type: PropTypes.string,
+  label: PropTypes.string,
   setRepositoryEnabled: PropTypes.func.isRequired,
 };
 
@@ -143,6 +145,7 @@ RepositorySetRepository.defaultProps = {
   releasever: '',
   arch: __(UNSPECIFIED_ARCH),
   type: '',
+  label: '',
 };
 
 export default connect(null, { setRepositoryEnabled })(RepositorySetRepository);

--- a/webpack/scenes/RedHatRepositories/components/__tests__/EnabledRepository.test.js
+++ b/webpack/scenes/RedHatRepositories/components/__tests__/EnabledRepository.test.js
@@ -23,6 +23,7 @@ describe('Enabled Repositories Component', () => {
       type="foo"
       arch="foo"
       releaseVer="1.1.1"
+      label="some label"
       setRepositoryDisabled={() => {}}
     />);
   });

--- a/webpack/scenes/RedHatRepositories/components/__tests__/RepositorySetRepository.test.js
+++ b/webpack/scenes/RedHatRepositories/components/__tests__/RepositorySetRepository.test.js
@@ -17,6 +17,7 @@ describe('RepositorySetRepository Component', () => {
       store={store}
       contentId={1}
       productId={1}
+      label="some label"
       arch="foo"
       releaseVer="1.1.1"
       type="foo"

--- a/webpack/scenes/RedHatRepositories/components/__tests__/__snapshots__/EnabledRepository.test.js.snap
+++ b/webpack/scenes/RedHatRepositories/components/__tests__/__snapshots__/EnabledRepository.test.js.snap
@@ -5,6 +5,7 @@ exports[`Enabled Repositories Component should render 1`] = `
   arch="foo"
   contentId={1}
   id={1}
+  label="some label"
   name="foo"
   orphaned={false}
   productId={1}

--- a/webpack/scenes/RedHatRepositories/components/__tests__/__snapshots__/RepositorySetRepository.test.js.snap
+++ b/webpack/scenes/RedHatRepositories/components/__tests__/__snapshots__/RepositorySetRepository.test.js.snap
@@ -4,6 +4,7 @@ exports[`RepositorySetRepository Component should render 1`] = `
 <RepositorySetRepository
   arch="foo"
   contentId={1}
+  label="some label"
   productId={1}
   releaseVer="1.1.1"
   releasever=""


### PR DESCRIPTION
Display the repo label on the enabled repos results

![https centos7 luna devel sharvits fedora book example com redhat_repositories](https://user-images.githubusercontent.com/1262502/45103375-73917e80-b138-11e8-824b-1839884ff451.png)

@tstrachota suggested to remove the `x86_64` label so we have only one line.

@rohoover, what is your opinion about this issue?