### PR TITLE
Fixes #24810 - align text in subscriptions details page

### DIFF
--- a/webpack/scenes/Subscriptions/Details/SubscriptionDetailProduct.js
+++ b/webpack/scenes/Subscriptions/Details/SubscriptionDetailProduct.js
@@ -5,20 +5,26 @@ import { Row, Col } from 'patternfly-react';
 const SubscriptionDetailProduct = ({ content }) => (
   <Row key={content.id}>
     <Col sm={12}>
-      <Row><u>{content.name}</u></Row>
+      <Row>
+        <u>{content.name}</u>
+      </Row>
     </Col>
-    <Col sm={3}>
-      <Row>{ __('Content Download URL') }</Row>
-      <Row>{ __('GPG Key URL') }</Row>
-      <Row>{ __('Repo Type') }</Row>
-      <Row>{ __('Enabled?') }</Row>
-    </Col>
-    <Col sm={9}>
-      <Row>{content.content_url}</Row>
-      <Row>{content.gpg_url}</Row>
-      <Row>{content.type}</Row>
-      <Row>{content.enabled ? __('yes') : __('no')}</Row>
-    </Col>
+    <Row>
+      <Col sm={3}>{__('Content Download URL')}</Col>
+      <Col sm={9}>{content.content_url} </Col>
+    </Row>
+    <Row>
+      <Col sm={3}>{__('GPG Key URL')}</Col>
+      <Col sm={9}>{content.gpg_url} </Col>
+    </Row>
+    <Row>
+      <Col sm={3}>{__('Repo Type')}</Col>
+      <Col sm={9}>{content.type} </Col>
+    </Row>
+    <Row>
+      <Col sm={3}>{__('Enabled')}</Col>
+      <Col sm={9}>{content.enabled ? __('yes') : __('no')} </Col>
+    </Row>
   </Row>
 );
 

--- a/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetailProduct.test.js.snap
+++ b/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetailProduct.test.js.snap
@@ -16,51 +16,63 @@ exports[`subscription detail enabled product component renders correctly 1`] = `
     </div>
   </div>
   <div
-    className="col-sm-3"
+    className="row"
   >
     <div
-      className="row"
+      className="col-sm-3"
     >
       Content Download URL
     </div>
     <div
-      className="row"
+      className="col-sm-9"
+    >
+      /content/dist/rhel/server/7/$releasever/$basearch/os
+       
+    </div>
+  </div>
+  <div
+    className="row"
+  >
+    <div
+      className="col-sm-3"
     >
       GPG Key URL
     </div>
     <div
-      className="row"
+      className="col-sm-9"
+    >
+      file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+       
+    </div>
+  </div>
+  <div
+    className="row"
+  >
+    <div
+      className="col-sm-3"
     >
       Repo Type
     </div>
     <div
-      className="row"
+      className="col-sm-9"
     >
-      Enabled?
+      yum
+       
     </div>
   </div>
   <div
-    className="col-sm-9"
+    className="row"
   >
     <div
-      className="row"
+      className="col-sm-3"
     >
-      /content/dist/rhel/server/7/$releasever/$basearch/os
+      Enabled
     </div>
     <div
-      className="row"
-    >
-      file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-    </div>
-    <div
-      className="row"
-    >
-      yum
-    </div>
-    <div
-      className="row"
+      className="col-sm-9"
     >
       no
+       
     </div>
   </div>
 </div>


### PR DESCRIPTION
On Subscription details page, there are 4 values displayed for each product: Content Download URL, GPG Key URL, Repo Type and Enabled?. If one value is missing, it causes subsequent values to shift up and not align with their labels. 
