### PR TITLE
Fixes #24839 - Legacy Subscriptions tab links

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/common/views/subscription-add-or-remove.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/common/views/subscription-add-or-remove.html
@@ -34,7 +34,7 @@
        </td>
        <td bst-table-cell ng-hide="contextAdd">{{ subscription.quantity_consumed }}</td>
        <td bst-table-cell>
-         <a ui-sref="subscription.info({subscriptionId: subscription.id})">
+         <a ng-href="/subscriptions/{{ subscription.id }}">
            {{ subscription | subscriptionConsumedFilter }}
          </a>
        </td>


### PR DESCRIPTION
#### Issue:
******
In Activation Key details page> Subscriptions tab> link in "Attached" column points to `/legacy_subscriptions/:id ` instead of `/subscriptions/:id`
