### PR TITLE
Fixes #24757 - fix audit searching by user

### DIFF
--- a/app/models/katello/concerns/audit_search.rb
+++ b/app/models/katello/concerns/audit_search.rb
@@ -1,0 +1,13 @@
+module Katello
+  module Concerns
+    module AuditSearch
+      extend ActiveSupport::Concern
+
+      # since this class makes User class STI, we need to provide alias for auditable_type to re-enable searching
+      # audits by type = user
+      def auditable_type_complete_values
+        super.merge(:user => 'User')
+      end
+    end
+  end
+end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -221,6 +221,8 @@ module Katello
         helper Katello::Concerns::HostsAndHostgroupsHelperExtensions
       end
 
+      ::AuditSearch::ClassMethods.prepend Katello::Concerns::AuditSearch
+
       load 'katello/repository_types.rb'
       load 'katello/scheduled_jobs.rb'
     end


### PR DESCRIPTION
to test:

1) run foreman + katello in production mode
2) go to audits
3) try searching by query "type = user"

the problem is that Foreman creates the list dynamically but "ignores" STI classes, user in core is not STI-ed but Katello changes this, there it has also to add it to the explicit mapping list