### PR TITLE
Fixes #24679 - Sorting repos Red Hat repos page

### DIFF
--- a/app/controllers/katello/api/v2/repository_sets_controller.rb
+++ b/app/controllers/katello/api/v2/repository_sets_controller.rb
@@ -52,11 +52,21 @@ module Katello
         end
       end
 
+      sorted_repos = repos.sort_by do |repo|
+        major, minor = repo[:substitutions][:releasever].nil? ? [1000, 1000] : repo[:substitutions][:releasever].split('.').map(&:to_i)
+        major = major == 0 ? 1000 : major
+        minor = minor.nil? ? 1000 : minor
+        arch = repo[:substitutions][:basearch].nil? ? "" : repo[:substitutions][:basearch]
+
+        [arch, major, minor]
+      end
+
       collection = {
-        :results  => repos,
+        :results => sorted_repos.reverse,
         :subtotal => repos.size,
         :total    => repos.size
       }
+
       respond_for_index :collection => collection
     end
 

--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepositories.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepositories.js
@@ -16,6 +16,37 @@ class RepositorySetRepositories extends Component {
     }
   }
 
+  sortedRepos = repos => [...repos.filter(({ enabled }) => !enabled)]
+    .sort((repo1, repo2) => {
+      const repo1YStream = yStream(repo1.releasever || '');
+      const repo2YStream = yStream(repo2.releasever || '');
+
+      if (repo1YStream < repo2YStream) {
+        return -1;
+      }
+
+      if (repo2YStream < repo1YStream) {
+        return 1;
+      }
+
+      if (repo1.arch === repo2.arch) {
+        const repo1MajorMinor = repo1.releasever.split('.');
+        const repo2MajorMinor = repo2.releasever.split('.');
+
+        const repo1Major = parseInt(repo1MajorMinor[0], 10);
+        const repo2Major = parseInt(repo2MajorMinor[0], 10);
+
+        if (repo1Major === repo2Major) {
+          const repo1Minor = parseInt(repo1MajorMinor[1], 10);
+          const repo2Minor = parseInt(repo2MajorMinor[1], 10);
+
+          if (repo1Minor === repo2Minor) {
+            return 0;
+          } return (repo1Minor > repo2Minor) ? -1 : 1;
+        } return (repo1Major > repo2Major) ? -1 : 1;
+      } return (repo1.arch > repo2.arch) ? -1 : 1;
+    });
+
   render() {
     const { data, type } = this.props;
 
@@ -27,11 +58,9 @@ class RepositorySetRepositories extends Component {
       );
     }
 
-    const availableRepos = [...data.repositories.filter(({ enabled }) => !enabled)]
-      .sort((repo1, repo2) => yStream(repo1.releasever || '') - yStream(repo2.releasever || ''))
-      .map(repo => (
-        <RepositorySetRepository key={repo.arch + repo.releasever} type={type} {...repo} />
-      ));
+    const availableRepos = this.sortedRepos(data.repositories).map(repo => (
+      <RepositorySetRepository key={repo.arch + repo.releasever} type={type} {...repo} />
+    ));
 
     const repoMessage = (data.repositories.length > 0 && availableRepos.length === 0 ?
       __('All available architectures for this repo are enabled.') : __('No repositories available.'));

--- a/webpack/scenes/RedHatRepositories/components/__tests__/RepositorySetRepositories.test.js
+++ b/webpack/scenes/RedHatRepositories/components/__tests__/RepositorySetRepositories.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import thunk from 'redux-thunk';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import configureMockStore from 'redux-mock-store';
+import RepositorySetRepositories from '../RepositorySetRepositories';
+
+const mockStore = configureMockStore([thunk]);
+const store = mockStore({ katello: { redHatRepositories: { repositorySetRepositories: [] } } });
+
+describe('RepositorySetRepositories Component', () => {
+  let shallowWrapper;
+  beforeEach(() => {
+    shallowWrapper = shallow(<RepositorySetRepositories
+      store={store}
+      contentId={1}
+      productId={2}
+      type="foo"
+    />);
+  });
+
+  it('sorts repos correctly', async () => {
+    const repos = [
+      { arch: 'x86_64', releasever: '5.11' },
+      { arch: 'x86_64', releasever: '7Server' },
+      { arch: 'x86_64', releasever: '7.10' },
+      { arch: 'x86_64', releasever: '7.1' },
+      { arch: 'i386', releasever: '5.11' },
+      { arch: 'i386', releasever: '5Workstation' },
+      { arch: 'x86_64', releasever: '7.11' }];
+
+    const result = shallowWrapper.dive().instance().sortedRepos(repos);
+
+    const expectedIndices = [1, 5, 6, 2, 3, 0, 4];
+
+    expectedIndices.forEach((expected, i) => {
+      expect(result[i]).toEqual(repos[expected]);
+    });
+  });
+
+  it('should render', async () => {
+    expect(toJson(shallowWrapper)).toMatchSnapshot();
+  });
+});

--- a/webpack/scenes/RedHatRepositories/components/__tests__/__snapshots__/RepositorySetRepositories.test.js.snap
+++ b/webpack/scenes/RedHatRepositories/components/__tests__/__snapshots__/RepositorySetRepositories.test.js.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RepositorySetRepositories Component should render 1`] = `
+<RepositorySetRepositories
+  contentId={1}
+  data={
+    Object {
+      "error": null,
+      "loading": true,
+      "repositories": Array [],
+    }
+  }
+  loadRepositorySetRepos={[Function]}
+  productId={2}
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+  storeSubscription={
+    Subscription {
+      "listeners": Object {
+        "clear": [Function],
+        "get": [Function],
+        "notify": [Function],
+        "subscribe": [Function],
+      },
+      "onStateChange": [Function],
+      "parentSub": undefined,
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "unsubscribe": [Function],
+    }
+  }
+  type="foo"
+/>
+`;


### PR DESCRIPTION
Description of problem: Sorting of available minor version repos is not consistent. **To test this bug, upload a manifest and expand the the products on the Red Hat Repositories page.**

Example: When we look for "Red Hat Enterprise Linux 7 Server (RPMs)" repos we see "x86_64 7Server" as a first entry. Whereas when we look for "Red Hat Enterprise Linux 6 Server (RPMs)" repos then we see "x86_64 6Server" as the last entry and the sorting is like: 

i386 6.1
x86_64 6.1
x86_64 6.10    <<<<  After 6.1 we should see 6.2 instead of 6.10 
i386 6.10
i386 6.2
x86_64 6.2
i386 6.3
...
...
...
x86_64 6Server
i386 6Server

6Server or 7Server are base repositories and these are most commonly used repos so those should be listed as a first entry.

Solution:

Repos are now grouped by architecture (i386, ia64, x86_64), and then ordered by base repositories first (Server, Workstation, etc.) and then in descending order (7.11, 7.10, 7.9, etc.).