### PR TITLE
added test for invalid cron expression

### DIFF
--- a/test/models/sync_plan_test.rb
+++ b/test/models/sync_plan_test.rb
@@ -250,6 +250,16 @@ module Katello
       Time.parse(@plan.next_sync).must_equal(Time.new(2012, 11, 17, 9, 26, 0, "+00:00"))
     end
 
+    def test_invalid_custom_cron_expression
+      @plan.interval = 'custom cron'
+      @plan.sync_date = '1999-11-17 09:00:00 UTC'
+      @plan.cron_expression = "15 5 5a * *" #Wrong Cron Expression
+      exception = assert_raises Exception do
+        @plan.save_with_logic!
+      end
+      assert_equal('Cron expression is not valid!', exception.message)
+    end
+
     def test_update
       @plan.save!
       p = SyncPlan.find_by_name('Norman Rockwell')


### PR DESCRIPTION
Added test for invalid cron expression 
```
Run options: --name=test_invalid_custom_cron_expression --seed 5536

# Running:

.

Finished in 0.777028s, 1.2870 runs/s, 2.5739 assertions/s.
1 runs, 2 assertions, 0 failures, 0 errors, 0 skips
Coverage report Rcov style generated for Unit Tests to /home/vagrant/foreman/coverage/rcov
Coverage report generated for Unit Tests to /home/vagrant/foreman/coverage. 0.0 / 0.0 LOC (100.0%) covered.
```
