### PR TITLE
fixes #24892 - clean up bad hypervisor assoc before add fk

### DIFF
--- a/db/migrate/20180612163403_add_foreign_key_to_hypervisor_id.rb
+++ b/db/migrate/20180612163403_add_foreign_key_to_hypervisor_id.rb
@@ -1,5 +1,8 @@
 class AddForeignKeyToHypervisorId < ActiveRecord::Migration[5.1]
   def up
+    # Update all pools that have a hypervisor reference that's not a host before we add the FK
+    ::Katello::Pool.where.not(hypervisor_id: nil).where.not(hypervisor_id: Host::Managed.all).update_all(hypervisor_id: nil)
+
     add_foreign_key(:katello_pools, :hosts,
                     :name => 'katello_pools_hypervisor_fk', :column => 'hypervisor_id')
   end


### PR DESCRIPTION
If the user has bad data, adding the FK now will fail. We have to remove
the bad associations first.