### PR TITLE
Fixes #24902 - pass in list of packages when publishing CV

### DIFF
--- a/app/lib/actions/katello/content_view_version/incremental_update.rb
+++ b/app/lib/actions/katello/content_view_version/incremental_update.rb
@@ -66,7 +66,7 @@ module Actions
         def copy_repos(source_repos, new_version, content, dep_solve)
           copy_output = []
           sequence do
-            new_repo = plan_action(Repository::CloneToVersion, source_repos, new_version, true).new_repository
+            new_repo = plan_action(Repository::CloneToVersion, source_repos, new_version, :incremental => true).new_repository
             copy_output = copy_yum_content(new_repo, dep_solve, content[:package_ids], content[:errata_ids])
 
             plan_action(Katello::Repository::MetadataGenerate, new_repo)

--- a/app/lib/actions/katello/repository/export.rb
+++ b/app/lib/actions/katello/repository/export.rb
@@ -71,7 +71,7 @@ module Actions
               sequence do
                 if repo.link?
                   plan_action(Katello::Repository::Clear, repo)
-                  plan_action(Katello::Repository::CloneYumContent, repo.target_repository, repo, [], false,
+                  plan_action(Katello::Repository::CloneYumContent, repo.target_repository, repo, [], :purge_empty_units => false,
                               :generate_metadata => false, :index_content => false)
                 end
               end

--- a/test/actions/katello/repository/clone_to_version_test.rb
+++ b/test/actions/katello/repository/clone_to_version_test.rb
@@ -22,12 +22,13 @@ module Actions
       action = create_action(action_class)
       cloned_repo.expects(:link?).returns(false)
       yum_repo.expects(:build_clone).returns(cloned_repo)
+      options = {}
 
-      plan_action(action, [yum_repo], version)
+      plan_action(action, [yum_repo], version, options)
 
       assert_action_planed_with(action, Actions::Katello::Repository::CloneYumContent,
-                                yum_repo, cloned_repo, [], true, :generate_metadata => true,
-                                :index_content => true, :simple_clone => false)
+                                yum_repo, cloned_repo, [], :purge_empty_units => true, :generate_metadata => true,
+                                :index_content => true, :simple_clone => false, :rpm_filenames => nil)
     end
 
     it 'plans to clone yum metadata' do
@@ -35,10 +36,11 @@ module Actions
 
       action = create_action(action_class)
       cloned_repo.expects(:link?).returns(true)
+      options = {}
 
       yum_repo.expects(:build_clone).returns(cloned_repo)
 
-      plan_action(action, [yum_repo], version)
+      plan_action(action, [yum_repo], version, options)
 
       assert_action_planed_with(action, Actions::Katello::Repository::CloneYumMetadata,
                                 yum_repo, cloned_repo, :force_yum_metadata_regeneration => true)
@@ -50,8 +52,9 @@ module Actions
 
       action = create_action(action_class)
       docker_repo.expects(:build_clone).returns(cloned_repo)
+      options = {}
 
-      plan_action(action, [docker_repo], version)
+      plan_action(action, [docker_repo], version, options)
 
       assert_action_planed_with(action, Actions::Katello::Repository::CloneDockerContent,
                                 docker_repo, cloned_repo, [])
@@ -62,8 +65,9 @@ module Actions
                                             version: version)
       action = create_action(action_class)
       file_repo.expects(:build_clone).returns(cloned_repo)
+      options = {}
 
-      plan_action(action, [file_repo], version)
+      plan_action(action, [file_repo], version, options)
 
       assert_action_planed_with(action, Actions::Katello::Repository::CloneFileContent,
                                 file_repo, cloned_repo)

--- a/test/actions/katello/repository/clone_yum_content_test.rb
+++ b/test/actions/katello/repository/clone_yum_content_test.rb
@@ -1,0 +1,43 @@
+require 'katello_test_helper'
+
+module Actions
+  describe Katello::Repository::CloneYumContent do
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include FactoryBot::Syntax::Methods
+
+    let(:action_class) { ::Actions::Katello::Repository::CloneYumContent }
+    let(:source_repo) { katello_repositories(:rhel_6_x86_64_dev_archive) }
+    let(:target_repo) { katello_repositories(:rhel_6_x86_64_dev) }
+
+    it 'plans to copy rpms' do
+      action = create_action(action_class)
+      source_repo = katello_repositories(:rhel_6_x86_64_dev_archive)
+      target_repo = katello_repositories(:rhel_6_x86_64_dev)
+
+      plan_action(action, source_repo, target_repo, [], :purge_empty_units => false)
+      assert_action_planed_with(action, ::Actions::Pulp::Repository::CopySrpm, :source_pulp_id => source_repo.pulp_id, :target_pulp_id => target_repo.pulp_id, :clauses => nil)
+      assert_action_planed_with(action, ::Actions::Pulp::Repository::CopyRpm, :source_pulp_id => source_repo.pulp_id, :target_pulp_id => target_repo.pulp_id, :clauses => nil)
+      assert_action_planed_with(action, ::Actions::Pulp::Repository::CopyYumMetadataFile, :source_pulp_id => source_repo.pulp_id, :target_pulp_id => target_repo.pulp_id, :clauses => nil)
+      assert_action_planed_with(action, ::Actions::Pulp::Repository::CopyDistribution, :source_pulp_id => source_repo.pulp_id, :target_pulp_id => target_repo.pulp_id, :clauses => nil)
+      assert_action_planed_with(action, ::Actions::Pulp::Repository::CopyModuleStream, :source_pulp_id => source_repo.pulp_id, :target_pulp_id => target_repo.pulp_id, :clauses => nil)
+      assert_action_planed_with(action, ::Actions::Pulp::Repository::CopyModuleDefault, :source_pulp_id => source_repo.pulp_id, :target_pulp_id => target_repo.pulp_id, :clauses => nil)
+    end
+
+    it 'plans to copy rpms with rpm_filenames' do
+      action = create_action(action_class)
+      source_repo = katello_repositories(:rhel_6_x86_64_dev_archive)
+      source_repo.stubs(:rpms).returns([{ :filename => "rpm1.rpm" }, { :filename => "rpm2.rpm" }])
+      target_repo = katello_repositories(:rhel_6_x86_64_dev)
+
+      plan_action(action, source_repo, target_repo, [], :purge_empty_units => false, :rpm_filenames => ["rpm1.rpm", "rpm2.rpm"])
+
+      assert_action_planed_with(action, ::Actions::Pulp::Repository::CopySrpm, :source_pulp_id => source_repo.pulp_id, :target_pulp_id => target_repo.pulp_id, :clauses => nil)
+      assert_action_planed_with(action, ::Actions::Pulp::Repository::CopyRpm, :source_pulp_id => source_repo.pulp_id, :target_pulp_id => target_repo.pulp_id, :clauses => {"filename" => {"$in" => ["rpm1.rpm", "rpm2.rpm"]}})
+      assert_action_planed_with(action, ::Actions::Pulp::Repository::CopyYumMetadataFile, :source_pulp_id => source_repo.pulp_id, :target_pulp_id => target_repo.pulp_id, :clauses => nil)
+      assert_action_planed_with(action, ::Actions::Pulp::Repository::CopyDistribution, :source_pulp_id => source_repo.pulp_id, :target_pulp_id => target_repo.pulp_id, :clauses => nil)
+      assert_action_planed_with(action, ::Actions::Pulp::Repository::CopyModuleStream, :source_pulp_id => source_repo.pulp_id, :target_pulp_id => target_repo.pulp_id, :clauses => nil)
+      assert_action_planed_with(action, ::Actions::Pulp::Repository::CopyModuleDefault, :source_pulp_id => source_repo.pulp_id, :target_pulp_id => target_repo.pulp_id, :clauses => nil)
+    end
+  end
+end

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -561,7 +561,7 @@ module ::Actions::Katello::Repository
       plan_action(action, [repository], false, nil, 0, "8")
       assert_action_planed_with(action, ::Actions::Katello::Repository::Clear,
                                 repository)
-      assert_action_planed_with(action, ::Actions::Katello::Repository::CloneYumContent, custom_repository, repository, [], false,
+      assert_action_planed_with(action, ::Actions::Katello::Repository::CloneYumContent, custom_repository, repository, [], :purge_empty_units => false,
                                     :generate_metadata => false, :index_content => false)
     end
 

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -196,13 +196,13 @@ module Katello
 
     def test_duplicate_component_error_message
       view = katello_content_views(:library_view)
-      view_version = create(:katello_content_view_version, :content_view => view)
+      view_version = create(:katello_content_view_version, :content_view => view, :major => 8999)
 
       composite = katello_content_views(:composite_view)
       ContentViewComponent.create!(:composite_content_view => composite,
                                    :content_view_version => view_version, :latest => false)
 
-      view_version2 = create(:katello_content_view_version, :content_view => view)
+      view_version2 = create(:katello_content_view_version, :content_view => view, :major => 9001)
 
       put :update, params: { id: composite.id, content_view: { component_ids: [view_version.id, view_version2.id] } }
       display_message = JSON.parse(response.body)['displayMessage']
@@ -305,6 +305,12 @@ module Katello
       post :publish, params: { :id => view.id }
       assert_response 400
       assert_equal version_count, view.versions.reload.count
+    end
+
+    def test_publish_composite_with_repos_units
+      composite = ContentView.find(katello_content_views(:composite_view).id)
+      post :publish, params: { :id => composite.id, :repos_units => "{\"hello\": 1}" }
+      assert_response 400
     end
 
     test_attributes :pid => 'd582f1b3-8118-4e78-a639-237c6f9d27c6'


### PR DESCRIPTION
Previously, the only way to control which packages land in content
view version was by using filters, or by managing the contents of the
Library versions of the repos.

This commit lets you optionally specify the exact package set you want
in your repository. It will look at the Library version of each repo,
and copy the list of packages into the CV version.

Example value for `repos_units` when calling
`/katello/api/v2/content_views/2/publish`:

```json
[
    {
        "repo_label": "zoo",
        "rpm_filenames": [
            "walrus-5.21-1.noarch.rpm",
            "gorilla-0.62-1.noarch.rpm"
        ]
    },
    {
        "repo_label": "a_longer_label",
        "rpm_filenames": [
            "facter-2.4.6-3.el7sat.x86_64.rpm",
            "pulp-rpm-handlers-2.13.4.9-1.el7sat.noarch.rpm"
        ]
    }
]
```

This works the same for custom and RH repos.

When used with #7594, you can
set the CV version number as well as the list of packages in each
repo. This is useful for cloning a CV version from one Katello to
another.