### PR TITLE
Fixes #24905: Add host_collections to hosts#show

### DIFF
--- a/app/views/katello/api/v2/content_facet/show.json.rabl
+++ b/app/views/katello/api/v2/content_facet/show.json.rabl
@@ -22,8 +22,4 @@ child :content_facet => :content_facet_attributes do
   end
 end
 
-child :host_collections => :host_collections do
-  attributes :id, :name
-end
-
 attributes :description, :facts

--- a/app/views/katello/api/v2/hosts/host_collections.json.rabl
+++ b/app/views/katello/api/v2/hosts/host_collections.json.rabl
@@ -1,0 +1,3 @@
+child :host_collections => :host_collections do
+  attributes :id, :name
+end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -241,6 +241,7 @@ Foreman::Plugin.register :katello do
   register_custom_status(Katello::TraceStatus)
 
   extend_rabl_template 'api/v2/smart_proxies/main', 'katello/api/v2/smart_proxies/download_policy'
+  extend_rabl_template 'api/v2/hosts/show', 'katello/api/v2/hosts/host_collections'
 
   extend_page "smart_proxies/show" do |cx|
     cx.add_pagelet :details_content,


### PR DESCRIPTION
If any attributes are in the `content_facet/show.json.rabl` and the host doesn't have a content facet, those attributes will not be sent in the response.