### PR TITLE
Fixes #24937: Never CVV auto_publish when not comp

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/new/content-view-new.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/new/content-view-new.controller.js
@@ -46,5 +46,12 @@ angular.module('Bastion.content-views').controller('NewContentViewController',
             }
         });
 
+        $scope.$watch('contentView.composite', function () {
+            if (!$scope.contentView.composite) {
+                /* eslint-disable camelcase */
+                $scope.contentView.auto_publish = false;
+                /* eslint-enable camelcase */
+            }
+        });
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/new/views/content-view-new.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/new/views/content-view-new.html
@@ -78,8 +78,7 @@
                    ng-model="contentView.auto_publish"
                    type="checkbox"
                    tabindex="5"
-                   ng-disabled="!contentView.composite"
-                   ng-checked="contentView.composite && 0"/>
+                   ng-disabled="!contentView.composite"/>
             <span translate>Auto Publish</span>
           </label>
         </div>


### PR DESCRIPTION
Ensure that auto_publish is unchecked and false when users uncheck the
composite checkbox while creating a content view.

Note, this may have been caused by the following, from the [Angular ngChecked docs](https://docs.angularjs.org/api/ng/directive/ngChecked):

> Note that this directive should not be used together with ngModel, as this can lead to unexpected behavior.