### PR TITLE
Fixes #24948 - Fix pulp_deb repo listing

### DIFF
--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -703,7 +703,7 @@ module Katello
       elsif ostree?
         "#{scheme}://#{pulp_uri.host.downcase}/pulp/ostree/web/#{relative_path}"
       elsif deb?
-        "#{scheme}://#{pulp_uri.host.downcase}/pulp/deb/#{relative_path}"
+        "#{scheme}://#{pulp_uri.host.downcase}/pulp/deb/#{relative_path}/"
       else
         "#{scheme}://#{pulp_uri.host.downcase}/pulp/repos/#{relative_path}/"
       end


### PR DESCRIPTION
A missing '/' lead to strange behaviour when browsing debian type
repositories in the Browser.