### PR TITLE
Fixes #24427 - Modules available to a Host

### DIFF
--- a/app/controllers/katello/api/v2/module_streams_controller.rb
+++ b/app/controllers/katello/api/v2/module_streams_controller.rb
@@ -1,10 +1,34 @@
 module Katello
   class Api::V2::ModuleStreamsController < Api::V2::ApiController
+    extend ::Apipie::DSL::Concern
     apipie_concern_subst(:a_resource => N_("a module stream"), :resource => "module_streams")
     include Katello::Concerns::Api::V2::RepositoryContentController
 
+    before_action :check_hosts, :only => :index
+
+    update_api(:index) do
+      param :host_ids, Array, :desc => N_("List of host id to list available module streams for")
+    end
+
+    def custom_index_relation(collection)
+      if params[:host_ids]
+        collection.available_for_hosts(params[:host_ids])
+      else
+        collection
+      end
+    end
+
     def default_sort
       %w(name asc)
+    end
+
+    private
+
+    def check_hosts
+      if params[:host_ids] &&
+        ::Host::Managed.authorized("view_hosts").where(:id => params[:host_ids]).count != params[:host_ids].count
+        fail HttpErrors::NotFound, _('One or more hosts not found')
+      end
     end
   end
 end

--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -727,6 +727,7 @@ module Katello
         Rpm.copy_repository_associations(base_repo, self)
         Erratum.copy_repository_associations(base_repo, self)
         PackageGroup.copy_repository_associations(base_repo, self)
+        ModuleStream.copy_repository_associations(base_repo, self)
         self.update_attributes!(
           :distribution_version => base_repo.distribution_version,
           :distribution_arch => base_repo.distribution_arch,

--- a/app/models/katello/module_profile.rb
+++ b/app/models/katello/module_profile.rb
@@ -1,6 +1,6 @@
 module Katello
-  class ModuleProfile < ApplicationRecord
-    belongs_to :module_stream, class_name: "Katello::ModuleStream"
-    has_many :rpms, class_name: "Katello::ModuleProfileRpm", dependent: :destroy
+  class ModuleProfile < Katello::Model
+    belongs_to :module_stream, class_name: "Katello::ModuleStream", inverse_of: :profiles
+    has_many :rpms, class_name: "Katello::ModuleProfileRpm", dependent: :destroy, inverse_of: :module_profile
   end
 end

--- a/app/models/katello/module_profile_rpm.rb
+++ b/app/models/katello/module_profile_rpm.rb
@@ -1,5 +1,5 @@
 module Katello
-  class ModuleProfileRpm < ApplicationRecord
-    belongs_to :module_profile, class_name: "Katello::ModuleProfile"
+  class ModuleProfileRpm < Katello::Model
+    belongs_to :module_profile, class_name: "Katello::ModuleProfile", inverse_of: :rpms
   end
 end

--- a/app/models/katello/module_stream.rb
+++ b/app/models/katello/module_stream.rb
@@ -1,11 +1,11 @@
 module Katello
-  class ModuleStream < ApplicationRecord
+  class ModuleStream < Katello::Model
     include Concerns::PulpDatabaseUnit
     has_many :repository_module_streams, class_name: "Katello::RepositoryModuleStream",
       dependent: :destroy, inverse_of: :module_stream
     has_many :repositories, through: :repository_module_streams, class_name: "Katello::Repository"
-    has_many :profiles, class_name: "Katello::ModuleProfile", dependent: :destroy
-    has_many :artifacts, class_name: "Katello::ModuleStreamArtifact", dependent: :destroy
+    has_many :profiles, class_name: "Katello::ModuleProfile", dependent: :destroy, inverse_of: :module_stream
+    has_many :artifacts, class_name: "Katello::ModuleStreamArtifact", dependent: :destroy, inverse_of: :module_stream
 
     scoped_search on: :name, complete_value: true
     scoped_search on: :uuid, complete_value: true
@@ -48,6 +48,10 @@ module Katello
           profile.rpms.where(name: rpm).first_or_create!
         end
       end
+    end
+
+    def self.available_for_hosts(hosts)
+      joins(repositories: :content_facets).merge(Katello::Host::ContentFacet.where(host_id: hosts)).distinct
     end
   end
 end

--- a/app/models/katello/module_stream_artifact.rb
+++ b/app/models/katello/module_stream_artifact.rb
@@ -1,5 +1,5 @@
 module Katello
-  class ModuleStreamArtifact < ApplicationRecord
-    belongs_to :module_stream, class_name: "Katello::ModuleStream"
+  class ModuleStreamArtifact < Katello::Model
+    belongs_to :module_stream, class_name: "Katello::ModuleStream", inverse_of: :artifacts
   end
 end

--- a/app/models/katello/repository_module_stream.rb
+++ b/app/models/katello/repository_module_stream.rb
@@ -1,5 +1,6 @@
 module Katello
-  class RepositoryModuleStream < ApplicationRecord
+  class RepositoryModuleStream < Katello::Model
+    # Do not use active record callbacks in this join model.  Direct INSERTs and DELETEs are done
     belongs_to :repository, inverse_of: :repository_module_streams, class_name: 'Katello::Repository'
     belongs_to :module_stream, inverse_of: :repository_module_streams, class_name: 'Katello::ModuleStream'
   end

--- a/app/views/katello/api/v2/module_streams/base.json.rabl
+++ b/app/views/katello/api/v2/module_streams/base.json.rabl
@@ -2,7 +2,3 @@ object @resource
 
 attributes :id, :name, :uuid, :version, :context, :stream,
            :arch, :description, :summary
-
-child :repositories => :repositories do
-  attributes :id, :name
-end

--- a/db/migrate/20180920123913_drop_repo_module_streams_timestamp_not_null.rb
+++ b/db/migrate/20180920123913_drop_repo_module_streams_timestamp_not_null.rb
@@ -1,0 +1,7 @@
+class DropRepoModuleStreamsTimestampNotNull < ActiveRecord::Migration[5.2]
+  def change
+    change_column :katello_repository_module_streams, :created_at, :datetime, :null => true
+    change_column :katello_repository_module_streams, :updated_at, :datetime, :null => true
+    change_column :katello_repository_module_streams, :repository_id, :integer, :null => true
+  end
+end

--- a/lib/katello/tasks/reimport.rake
+++ b/lib/katello/tasks/reimport.rake
@@ -22,6 +22,7 @@ namespace :katello do
               Katello::PuppetModule,
               Katello::Rpm,
               Katello::Srpm,
+              Katello::ModuleStream,
               Katello::Deb,
               Katello::FileUnit,
               Katello::Subscription,

--- a/test/models/module_stream_test.rb
+++ b/test/models/module_stream_test.rb
@@ -69,6 +69,20 @@ module Katello
       assert_includes module_streams, @module_stream_river
     end
 
+    def test_available_hosts
+      content_view = katello_content_views(:library_dev_view)
+      environment = katello_environments(:library)
+      host = FactoryBot.create(:host, :with_content, :content_view => content_view,
+                                     :lifecycle_environment => environment)
+      content_facet = host.content_facet
+      content_facet.bound_repositories = [Katello::Repository.find(@fedora_repo.id)]
+      content_facet.save!
+
+      host_without_modules = hosts(:without_errata)
+      assert_empty ModuleStream.available_for_hosts([host_without_modules.id])
+      assert_includes ModuleStream.available_for_hosts([host.id]), @module_stream_river
+    end
+
     def pulp_module_data
       @pulp_module_data ||= {
         "repository_memberships" => [@fedora_repo.pulp_id],


### PR DESCRIPTION
Added API constructs to show modules that are available to a host based on the
enabled repositories in the host.