### PR TITLE
Fixes #24960 - Adds tests coverage via coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+
+language: node_js
+node_js:
+  - '6.14' # previous LTS, currently in EPEL
+  - '8' # current LTS
+  - '10' # future LTS
+script: ./travis_run_js_tests.sh

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "npm run format && npm run lint",
     "lint": "eslint webpack/",
     "lint:fix": "eslint --fix webpack/",
-    "lint:test": "npm run lint && npm test"
+    "lint:test": "npm run lint && npm test",
+    "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },
   "repository": {
     "type": "git",
@@ -33,6 +34,7 @@
     "babel-preset-react": "^6.24.1",
     "enzyme": "^3.4.0",
     "enzyme-adapter-react-16": "^1.4.0",
+    "coveralls": "^3.0.0",
     "enzyme-to-json": "^3.1.2",
     "eslint": "^4.19.1",
     "eslint-config-airbnb": "^16.0.0",
@@ -74,6 +76,9 @@
     "seamless-immutable": "^7.1.2"
   },
   "jest": {
+    "collectCoverage": true,
+    "collectCoverageFrom": ["webpack/**/*.js", "!webpack/**/bundle*"],
+    "coverageReporters": ["lcov"],
     "testURL": "http://localhost/",
     "setupFiles": [
       "raf/polyfill",

--- a/travis_run_js_tests.sh
+++ b/travis_run_js_tests.sh
@@ -1,0 +1,3 @@
+set -ev
+  npm run test;
+  npm run coveralls;


### PR DESCRIPTION
react test coverage is poor (only 50%), therefore it would be great to have a tool for that such as `coveralls`
I've integrated it with travis for the [demonstration](https://github.com/amirfefer/katello/pull/2), but we can integrate it with Jenkins as well.
Personally I prefer travis. 
[Coveralls page](https://coveralls.io/builds/19038843)
