### PR TITLE
Fixes #18341 - Documented sort parameters

### DIFF
--- a/app/controllers/katello/api/v2/api_controller.rb
+++ b/app/controllers/katello/api/v2/api_controller.rb
@@ -22,10 +22,8 @@ module Katello
       param :per_page, :number, :desc => N_("Number of results per page to return")
       param :order, String, :desc => N_("Sort field and order, eg. 'id DESC'")
       param :full_result, :bool, :desc => N_("Whether or not to show all results")
-      param :sort, Hash, :desc => N_("Hash version of 'order' param") do
-        param :by, String, :desc => N_("Field to sort the results on")
-        param :order, String, :desc => N_("How to order the sorted results (e.g. ASC for ascending)")
-      end
+      param :sort_by, String, :desc => N_("Field to sort the results on")
+      param :sort_order, String, :desc => N_("How to order the sorted results (e.g. ASC for ascending)")
     end
 
     param :object_root, String, :desc => N_("root-node of single-resource responses (optional)")


### PR DESCRIPTION
Param `sort[by|order]` should be deleted, since it doesn't seem to be used anyway. Also I guess the params `sort_by` and `sort_order` should be documented since they are used [silently](https://github.com/Katello/katello/blob/0ff1b88f3800c9064c1fd99a4d52a842973845b1/app/controllers/katello/api/v2/api_controller.rb#L64).