### PR TITLE
Fixes #24996 - eslint errors

### DIFF
--- a/test/models/concerns/redhat_extensions_test.rb
+++ b/test/models/concerns/redhat_extensions_test.rb
@@ -84,11 +84,11 @@ module Katello
       @host.medium = @os.media.first
       @host.content_facet.content_source = nil
       @host.content_facet.kickstart_repository = @repo_with_distro
-      assert_equal @os.media.first.path, @host.host_medium_provider.medium_uri.to_s
+      assert_equal @os.media.first.path, @host.medium_provider.medium_uri.to_s
 
       @host.content_facet.content_source = @content_source
       @host.content_facet.kickstart_repository = nil
-      assert_equal @os.media.first.path, @host.host_medium_provider.medium_uri.to_s
+      assert_equal @os.media.first.path, @host.medium_provider.medium_uri.to_s
     end
 
     def test_medium_uri_for_no_content_source_or_ks_repo_hg
@@ -96,21 +96,21 @@ module Katello
       @hostgroup.medium = @os.media.first
       @hostgroup.content_source = nil
       @hostgroup.kickstart_repository = @repo_with_distro
-      assert_equal @os.media.first.path, @hostgroup.host_medium_provider.medium_uri.to_s
+      assert_equal @os.media.first.path, @hostgroup.medium_provider.medium_uri.to_s
 
       @hostgroup.content_source = @content_source
       @hostgroup.kickstart_repository = nil
-      assert_equal @os.media.first.path, @hostgroup.host_medium_provider.medium_uri.to_s
+      assert_equal @os.media.first.path, @hostgroup.medium_provider.medium_uri.to_s
     end
 
     def test_medium_uri_with_a_kickstart_repo
       @host.content_facet.kickstart_repository = @repo_with_distro
-      assert_equal @repo_with_distro.full_path(@content_source), @host.host_medium_provider.medium_uri.to_s
+      assert_equal @repo_with_distro.full_path(@content_source), @host.medium_provider.medium_uri.to_s
     end
 
     def test_medium_uri_with_a_kickstart_repo_hg
       @hostgroup.kickstart_repository = @repo_with_distro
-      assert_equal @repo_with_distro.full_path(@content_source), @hostgroup.host_medium_provider.medium_uri.to_s
+      assert_equal @repo_with_distro.full_path(@content_source), @hostgroup.medium_provider.medium_uri.to_s
     end
 
     def test_kickstart_repos_with_no_content_source

--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -8,8 +8,6 @@ import { Button } from 'patternfly-react';
 import TooltipButton from 'react-bootstrap-tooltip-button';
 import { renderTaskFinishedToast } from '../Tasks/helpers';
 import OptionTooltip from '../../move_to_pf/OptionTooltip';
-import { notify } from '../../move_to_foreman/foreman_toast_notifications';
-import helpers from '../../move_to_foreman/common/helpers';
 import ModalProgressBar from '../../move_to_foreman/components/common/ModalProgressBar';
 import ManageManifestModal from './Manifest/';
 import { SubscriptionsTable } from './components/SubscriptionsTable';

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
@@ -99,11 +99,6 @@ exports[`subscriptions table should render a table 1`] = `
         <th
           class=""
         >
-          Type
-        </th>
-        <th
-          class=""
-        >
           SKU
         </th>
         <th
@@ -148,9 +143,6 @@ exports[`subscriptions table should render a table 1`] = `
             zoo
           </a>
         </td>
-        <td>
-          Physical
-        </td>
         <td
           class=""
         >
@@ -193,9 +185,6 @@ exports[`subscriptions table should render a table 1`] = `
           >
             hsdfhsdh
           </a>
-        </td>
-        <td>
-          Physical
         </td>
         <td
           class=""


### PR DESCRIPTION
This fixes broken eslint tests on master, but we really need to figure out why eslint keeps breaking on master. With the eslint job in jenkins, theoretically no unlinted code should get into master.