### PR TITLE
Fixes #24809 - 'Enabled Products' now 'Product Content'

### DIFF
--- a/webpack/scenes/Subscriptions/Details/SubscriptionDetailProductContent.js
+++ b/webpack/scenes/Subscriptions/Details/SubscriptionDetailProductContent.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { Col, ListView } from 'patternfly-react';
 import SubscriptionDetailProduct from './SubscriptionDetailProduct';
 
-const SubscriptionDetailEnabledProducts = ({ enabledProducts }) => {
-  const listItems = enabledProducts.results.map(product => ({
+const SubscriptionDetailProductContent = ({ productContent }) => {
+  const listItems = productContent.results.map(product => ({
     index: product.id,
     title: product.name,
     availableContent: (
@@ -47,8 +47,8 @@ const SubscriptionDetailEnabledProducts = ({ enabledProducts }) => {
   );
 };
 
-SubscriptionDetailEnabledProducts.propTypes = {
-  enabledProducts: PropTypes.shape({}).isRequired,
+SubscriptionDetailProductContent.propTypes = {
+  productContent: PropTypes.shape({}).isRequired,
 };
 
-export default SubscriptionDetailEnabledProducts;
+export default SubscriptionDetailProductContent;

--- a/webpack/scenes/Subscriptions/Details/SubscriptionDetailReducer.js
+++ b/webpack/scenes/Subscriptions/Details/SubscriptionDetailReducer.js
@@ -12,7 +12,7 @@ import {
 
 const initialState = Immutable({
   loading: false,
-  enabledProducts: {
+  productContent: {
     results: [],
     total: 0,
   },
@@ -38,10 +38,10 @@ export default (state = initialState, action) => {
     }
 
     case PRODUCTS_SUCCESS: {
-      const enabledProducts = { enabledProducts: action.response };
+      const productContent = { productContent: action.response };
 
       return state.merge({
-        ...enabledProducts,
+        ...productContent,
         loading: false,
       });
     }

--- a/webpack/scenes/Subscriptions/Details/SubscriptionDetails.js
+++ b/webpack/scenes/Subscriptions/Details/SubscriptionDetails.js
@@ -5,7 +5,7 @@ import BreadcrumbsBar from 'foremanReact/components/BreadcrumbBar';
 import SubscriptionDetailInfo from './SubscriptionDetailInfo';
 import SubscriptionDetailAssociations from './SubscriptionDetailAssociations';
 import SubscriptionDetailProducts from './SubscriptionDetailProducts';
-import SubscriptionDetailEnabledProducts from './SubscriptionDetailEnabledProducts';
+import SubscriptionDetailProductContent from './SubscriptionDetailProductContent';
 import { LoadingState } from '../../../move_to_pf/LoadingState';
 import { notify } from '../../../move_to_foreman/foreman_toast_notifications';
 import api, { orgId } from '../../../services/api';
@@ -85,7 +85,7 @@ class SubscriptionDetails extends Component {
                   <div>{__('Details')}</div>
                 </NavItem>
                 <NavItem eventKey={2}>
-                  <div>{__('Enabled Products')}</div>
+                  <div>{__('Product Content')}</div>
                 </NavItem>
               </Nav>
               <Grid bsClass="container-fluid">
@@ -114,8 +114,8 @@ class SubscriptionDetails extends Component {
                     <div>
                       <Row>
                         <Col sm={12}>
-                          <SubscriptionDetailEnabledProducts
-                            enabledProducts={subscriptionDetails.enabledProducts}
+                          <SubscriptionDetailProductContent
+                            productContent={subscriptionDetails.productContent}
                           />
                         </Col>
                       </Row>

--- a/webpack/scenes/Subscriptions/Details/__tests__/SubscriptionDetailProductContent.test.js
+++ b/webpack/scenes/Subscriptions/Details/__tests__/SubscriptionDetailProductContent.test.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
 import { ListView } from 'patternfly-react';
-import SubscriptionDetailEnabledProducts from '../SubscriptionDetailEnabledProducts';
+import SubscriptionDetailProductContent from '../SubscriptionDetailProductContent';
 import { availableContent, product } from '../../../Products/__tests__/products.fixtures.js';
 
-describe('subscription detail enabled products page', () => {
+describe('subscription detail product content page', () => {
   it('renders correctly', () => {
     const testRenderer = TestRenderer
-      .create(<SubscriptionDetailEnabledProducts
-        enabledProducts={{ results: [product([availableContent])] }}
+      .create(<SubscriptionDetailProductContent
+        productContent={{ results: [product([availableContent])] }}
       />);
     const testInstance = testRenderer.root;
 

--- a/webpack/scenes/Subscriptions/Details/__tests__/SubscriptionDetails.test.js
+++ b/webpack/scenes/Subscriptions/Details/__tests__/SubscriptionDetails.test.js
@@ -5,7 +5,7 @@ import SubscriptionDetails from '../SubscriptionDetails';
 import SubscriptionDetailAssociations from '../SubscriptionDetailAssociations';
 import SubscriptionDetailInfo from '../SubscriptionDetailInfo';
 import SubscriptionDetailProducts from '../SubscriptionDetailProducts';
-import SubscriptionDetailEnabledProducts from '../SubscriptionDetailEnabledProducts';
+import SubscriptionDetailProductContent from '../SubscriptionDetailProductContent';
 import { loadSubscriptionDetails } from '../SubscriptionDetailActions';
 import { loadProducts } from '../../../Products/ProductActions';
 import { successState } from './subscriptionDetails.fixtures';
@@ -27,7 +27,7 @@ describe('subscriptions details page', () => {
     expect(wrapper.find(SubscriptionDetailAssociations)).toHaveLength(1);
     expect(wrapper.find(SubscriptionDetailInfo)).toHaveLength(1);
     expect(wrapper.find(SubscriptionDetailProducts)).toHaveLength(1);
-    expect(wrapper.find(SubscriptionDetailEnabledProducts)).toHaveLength(1);
+    expect(wrapper.find(SubscriptionDetailProductContent)).toHaveLength(1);
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 });

--- a/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetailProductContent.test.js.snap
+++ b/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetailProductContent.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`subscription detail enabled products page renders correctly 1`] = `
+exports[`subscription detail product content page renders correctly 1`] = `
 <div
   className="list-group list-view-pf list-view-pf-view"
 >

--- a/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetails.test.js.snap
+++ b/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetails.test.js.snap
@@ -56,7 +56,7 @@ exports[`subscriptions details page should render and contain appropiate compone
             eventKey={2}
           >
             <div>
-              Enabled Products
+              Product Content
             </div>
           </NavItem>
         </Nav>
@@ -98,10 +98,6 @@ exports[`subscriptions details page should render and contain appropiate compone
                           "cores": 4,
                           "cp_id": "4028f92a6317cfbd0163b419377f3bee",
                           "description": "OpenShift Enterprise",
-                          "enabledProducts": Object {
-                            "results": Array [],
-                            "total": 0,
-                          },
                           "end_date": "2021-12-31 23:59:59 -0500",
                           "error": null,
                           "host_count": 0,
@@ -110,6 +106,10 @@ exports[`subscriptions details page should render and contain appropiate compone
                           "loading": false,
                           "multi_entitlement": true,
                           "name": "OpenShift Employee Subscription",
+                          "productContent": Object {
+                            "results": Array [],
+                            "total": 0,
+                          },
                           "product_id": "SER0421",
                           "product_name": "OpenShift Employee Subscription",
                           "provided_products": Array [
@@ -236,10 +236,6 @@ exports[`subscriptions details page should render and contain appropiate compone
                           "cores": 4,
                           "cp_id": "4028f92a6317cfbd0163b419377f3bee",
                           "description": "OpenShift Enterprise",
-                          "enabledProducts": Object {
-                            "results": Array [],
-                            "total": 0,
-                          },
                           "end_date": "2021-12-31 23:59:59 -0500",
                           "error": null,
                           "host_count": 0,
@@ -248,6 +244,10 @@ exports[`subscriptions details page should render and contain appropiate compone
                           "loading": false,
                           "multi_entitlement": true,
                           "name": "OpenShift Employee Subscription",
+                          "productContent": Object {
+                            "results": Array [],
+                            "total": 0,
+                          },
                           "product_id": "SER0421",
                           "product_name": "OpenShift Employee Subscription",
                           "provided_products": Array [
@@ -368,10 +368,6 @@ exports[`subscriptions details page should render and contain appropiate compone
                           "cores": 4,
                           "cp_id": "4028f92a6317cfbd0163b419377f3bee",
                           "description": "OpenShift Enterprise",
-                          "enabledProducts": Object {
-                            "results": Array [],
-                            "total": 0,
-                          },
                           "end_date": "2021-12-31 23:59:59 -0500",
                           "error": null,
                           "host_count": 0,
@@ -380,6 +376,10 @@ exports[`subscriptions details page should render and contain appropiate compone
                           "loading": false,
                           "multi_entitlement": true,
                           "name": "OpenShift Employee Subscription",
+                          "productContent": Object {
+                            "results": Array [],
+                            "total": 0,
+                          },
                           "product_id": "SER0421",
                           "product_name": "OpenShift Employee Subscription",
                           "provided_products": Array [
@@ -506,8 +506,8 @@ exports[`subscriptions details page should render and contain appropiate compone
                     componentClass="div"
                     sm={12}
                   >
-                    <SubscriptionDetailEnabledProducts
-                      enabledProducts={
+                    <SubscriptionDetailProductContent
+                      productContent={
                         Object {
                           "results": Array [],
                           "total": 0,

--- a/webpack/scenes/Subscriptions/Details/__tests__/subscriptionDetails.fixtures.js
+++ b/webpack/scenes/Subscriptions/Details/__tests__/subscriptionDetails.fixtures.js
@@ -3,7 +3,7 @@ import { toastErrorAction, failureAction } from '../../../../services/api/testHe
 
 export const initialState = Immutable({
   loading: false,
-  enabledProducts: {
+  productContent: {
     results: [],
     total: 0,
   },


### PR DESCRIPTION
As part of Bug 1603239, Product Content tab on Subscription details page has been renamed to Enabled Products.

Each product on that page has "Enabled?" field. As a result, "Enabled Products" tab can list products that are not enabled, leading to confusion.

This steams from "Enabled" having two distinct meanings on that page. "Enabled Products" in tab title means products that has been selected (enabled) on Red Hat Repositories page. "Enabled?" in product details refer to "enabled" flag of product. It affects whether repository will be enabled by default on host consuming that subscription, and default values when setting up Activation Key.

Steps to reproduce:
1. Upload manifest with RHEL product
2. Content -> Red Hat Repositories -> Enable rhel-7-server-rpms and rhel-7-server-kickstart
3. Content -> Subscriptions -> Subscription with RHEL product -> Enabled Products -> expand Red Hat Enterprise Linux Server

**Fix: Tab renamed "Product Content" and all variables and files have been renamed to avoid confusion.**