### PR TITLE
Fixes #25026 - format uuids on hypervisor checkin

### DIFF
--- a/app/lib/actions/katello/host/hypervisors_update.rb
+++ b/app/lib/actions/katello/host/hypervisors_update.rb
@@ -34,7 +34,7 @@ module Actions
           load_hosts_by_duplicate_name
           create_missing_hosts
 
-          candlepin_data = ::Katello::Resources::Candlepin::Consumer.get(uuid: @hosts.keys)
+          candlepin_data = ::Katello::Resources::Candlepin::Consumer.get(:uuid => @hosts.keys, :include_only => [:uuid])
           @candlepin_attributes = candlepin_data.map { |consumer| [consumer[:uuid], consumer] }.to_h
         end
 

--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -201,7 +201,11 @@ module Katello
       def hash_to_query(query_parameters)
         query_parameters.inject("?") do |so_far, current|
           so_far << "&" unless so_far == "?"
-          so_far << "#{current[0].to_s}=#{url_encode(current[1])}"
+          if current[1].is_a?(Array)
+            so_far << current[1].map { |attr| "#{current[0]}=#{attr}" }.join('&')
+          else
+            so_far << "#{current[0].to_s}=#{url_encode(current[1])}"
+          end
         end
       end
     end


### PR DESCRIPTION
The previous code was incorrectly UUID encoding a list of
uuids instead of passing each as a GET param.