### PR TITLE
Fixes #24411: List module_streams in an environment

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/content.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/content.service.js
@@ -59,6 +59,11 @@
                 resource: 'OstreeBranch',
                 display: translate('OSTree Branches'),
                 repositoryType: 'ostree'
+            }, {
+                state: 'module-streams',
+                resource: 'ModuleStream',
+                display: translate('Module Streams'),
+                repositoryType: 'yum'
             }
         ];
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-module-streams.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-module-streams.html
@@ -1,0 +1,34 @@
+<div data-extend-template="layouts/partials/table.html">
+  <div data-block="search-filter">
+    <select class="form-control" ng-model="contentView" ng-change="contentViewSelected(contentView)" ng-options="contentView.name for (id, contentView) in contentViews"></select>
+    <select class="form-control" ng-model="repository" ng-change="repositorySelected(repository)" ng-options="repository.name for (id, repository) in repositories"></select>
+  </div>
+
+  <span data-block="no-rows-message" translate>
+    There are no module streams that match the criteria.
+  </span>
+
+  <span data-block="no-search-results-message" translate>
+    Your search returned zero module streams.
+  </span>
+
+  <table data-block="table" class="table table-striped table-bordered">
+    <thead>
+      <tr bst-table-head>
+        <th bst-table-column translate>Name</th>
+        <th bst-table-column translate>Version</th>
+        <th bst-table-column translate>Release</th>
+        <th bst-table-column translate>Arch</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <tr bst-table-row ng-repeat="module_stream in table.rows">
+        <td bst-table-cell>{{ module_stream.name }}</td>
+        <td bst-table-cell>{{ module_stream.version }}</td>
+        <td bst-table-cell>{{ module_stream.stream }}</td>
+        <td bst-table-cell>{{ module_stream.arch }}</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/environments.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/environments.routes.js
@@ -87,6 +87,17 @@ angular.module('Bastion.environments').config(['$stateProvider', function ($stat
             parent: 'environment.details'
         }
     })
+    .state('environment.module-streams', {
+        url: '/module-streams?repositoryId&contentViewId',
+        reloadOnSearch: false,
+        permission: 'view_lifecycle_environments',
+        controller: 'EnvironmentContentController',
+        templateUrl: 'environments/details/views/environment-module-streams.html',
+        ncyBreadcrumb: {
+            label: '{{ "Module Streams" | translate }}',
+            parent: 'environment.details'
+        }
+    })
     .state('environment.puppet-modules', {
         url: '/puppet-modules?contentViewId',
         reloadOnSearch: false,

--- a/engines/bastion_katello/test/environments/content.service.test.js
+++ b/engines/bastion_katello/test/environments/content.service.test.js
@@ -1,37 +1,59 @@
 describe('Service: ContentService', function() {
-    var ContentService, Package;
+    var ContentService, Package, ModuleStream, $state;
 
     beforeEach(module('Bastion.environments', 'Bastion.test-mocks'));
 
     beforeEach(inject(function ($injector) {
-        var $state = $injector.get('$state');
-
-        $state.current = {name: 'environment.packages'};
-        Package = $injector.get('Package');
+        $state = $injector.get('$state');
         ContentService = $injector.get('ContentService');
     }));
 
     it("should expose the list of content types", function() {
-        expect(ContentService.contentTypes.length).toBe(7);
-    });
-
-    it("should expose a method to get the repository type for an object", function() {
-        expect(ContentService.getRepositoryType()).toBe('yum');
-    });
-
-    it("should provide a method to build a nutupane based on the current state", function () {
-        var nutupane = ContentService.buildNutupane();
-
-        expect(nutupane).toBeDefined();
-        expect(nutupane.table.resource).toBe(Package);
+        expect(ContentService.contentTypes.length).toBe(8);
     });
 
     it("should provide a method to build a nutupane based on params", function () {
+        $state.current = {name: 'environment.packages'};
         var nutupane = ContentService.buildNutupane({environmentId: 1});
 
         expect(nutupane).toBeDefined();
         expect(nutupane.getParams()['environmentId']).toBe(1);
     });
 
+    describe ('Package', function() {
+        beforeEach(inject(function ($injector) {
+            $state.current = {name: 'environment.packages'};
+            Package = $injector.get('Package');
+        }));
+
+        it("should expose a method to get the repository type for an object", function() {
+            expect(ContentService.getRepositoryType()).toBe('yum');
+        });
+
+        it("should provide a method to build a nutupane based on the current state", function () {
+            var nutupane = ContentService.buildNutupane();
+
+            expect(nutupane).toBeDefined();
+            expect(nutupane.table.resource).toBe(Package);
+        });
+    });
+
+    describe ('ModuleStream', function() {
+        beforeEach(inject(function ($injector) {
+            $state.current = {name: 'environment.module-streams'};
+            ModuleStream = $injector.get('ModuleStream');
+        }));
+
+        it("should expose a method to get the repository type for an object", function() {
+            expect(ContentService.getRepositoryType()).toBe('yum');
+        });
+
+        it("should provide a method to build a nutupane based on the current state", function () {
+            var nutupane = ContentService.buildNutupane();
+
+            expect(nutupane).toBeDefined();
+            expect(nutupane.table.resource).toBe(ModuleStream);
+        });
+    });
 });
 


### PR DESCRIPTION
Adds the UI for listing module streams in an environment.

Content -> Lifecycle Environments -> Select Environment (i.e. Library) -> Module Streams tab