### PR TITLE
Fixes #24818 - Save button refresh on error

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/new/new-sync-plan.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/new/new-sync-plan.controller.js
@@ -19,16 +19,17 @@ angular.module('Bastion.sync-plans').controller('NewSyncPlanController',
             $scope.syncPlan = new SyncPlan();
             $scope.syncPlan.interval = $scope.intervals[0].id;
             $scope.syncPlan.startDate = new Date();
-            $scope.working = false;
+            $scope.isWorking = false;
 
             function success(syncPlan) {
+                $scope.isWorking = false;
                 $scope.$state.go('sync-plan.info', {syncPlanId: syncPlan.id});
                 Notification.setSuccessMessage(translate('New sync plan successfully created.'));
             }
 
             function error(response) {
                 var form = SyncPlanHelper.getForm();
-                $scope.working = false;
+                $scope.isWorking = false;
                 angular.forEach(response.data.errors, function (errors, field) {
                     if (form[field]) {
                         form[field].$setValidity('server', false);
@@ -40,6 +41,7 @@ angular.module('Bastion.sync-plans').controller('NewSyncPlanController',
             }
 
             $scope.createSyncPlan = function (syncPlan) {
+                $scope.isWorking = true;
                 SyncPlanHelper.createSyncPlan(syncPlan, success, error);
             };
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/new/views/new-sync-plan-form.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/new/views/new-sync-plan-form.html
@@ -68,10 +68,10 @@
   <div ng-init="setForm(syncPlanForm);"></div>
 
   <div ng-show="isState('sync-plans.new')">
-    <div bst-form-buttons
+    <div bst-save-control
          on-cancel="transitionBack()"
          on-save="createSyncPlan(syncPlan)"
-         working="working">
+         working="isWorking">
     </div>
   </div>
 </div>

--- a/engines/bastion_katello/test/sync-plans/new-sync-plan.controller.test.js
+++ b/engines/bastion_katello/test/sync-plans/new-sync-plan.controller.test.js
@@ -78,7 +78,7 @@ describe('Controller: NewSyncPlanController', function() {
 
             $scope.createSyncPlan(syncPlan);
 
-            expect($scope.working).toBe(false);
+            expect($scope.isWorking).toBe(false);
             expect(Notification.setSuccessMessage).toHaveBeenCalled();
             expect($scope.$state.go).toHaveBeenCalledWith('sync-plan.info', {syncPlanId: syncPlan.id});
         });
@@ -101,7 +101,7 @@ describe('Controller: NewSyncPlanController', function() {
 
             $scope.createSyncPlan(syncPlan);
 
-            expect($scope.working).toBe(false);
+            expect($scope.isWorking).toBe(false);
             expect($scope.$state.go).not.toHaveBeenCalled();
             expect(form.name.$setValidity).toHaveBeenCalledWith('server', false);
             expect(form.name.$error.messages).toBe('has already been taken');


### PR DESCRIPTION
### Steps to reproduce:
Go to sync plan > Create New
Create an invalid sync plan (ex: try duplicate name, invalid cron expression etc..)

**Actual:** Save button is stuck in working mode.
**Expected:** Save button should get enabled after error.