### PR TITLE
Fixes #24428,#24424 - UI Modularity streams - Host

### DIFF
--- a/app/controllers/katello/api/v2/module_streams_controller.rb
+++ b/app/controllers/katello/api/v2/module_streams_controller.rb
@@ -4,15 +4,26 @@ module Katello
     apipie_concern_subst(:a_resource => N_("a module stream"), :resource => "module_streams")
     include Katello::Concerns::Api::V2::RepositoryContentController
 
-    before_action :check_hosts, :only => :index
+    before_action :check_params, :only => :index
 
     update_api(:index) do
       param :host_ids, Array, :desc => N_("List of host id to list available module streams for")
+      param :name_stream_only, :boolean, :desc => N_("Return name and stream information only)")
+    end
+    def index
+      if @name_stream_only
+        sort_by, sort_order, options = sort_options
+        options[:group] = [:name, :stream]
+        respond(:collection => scoped_search(index_relation, sort_by, sort_order, options),
+                :template => 'name_streams')
+      else
+        super
+      end
     end
 
     def custom_index_relation(collection)
-      if params[:host_ids]
-        collection.available_for_hosts(params[:host_ids])
+      if @host_ids
+        collection.available_for_hosts(@host_ids)
       else
         collection
       end
@@ -24,10 +35,14 @@ module Katello
 
     private
 
-    def check_hosts
-      if params[:host_ids] &&
-        ::Host::Managed.authorized("view_hosts").where(:id => params[:host_ids]).count != params[:host_ids].count
-        fail HttpErrors::NotFound, _('One or more hosts not found')
+    def check_params
+      @name_stream_only = ::Foreman::Cast.to_bool(params[:name_stream_only])
+
+      if params[:host_ids]
+        @host_ids = params[:host_ids].is_a?(Array) ? params[:host_ids] : params[:host_ids].split(",")
+        if ::Host::Managed.authorized("view_hosts").where(:id => @host_ids).count != @host_ids.count
+          fail HttpErrors::NotFound, _('One or more hosts not found')
+        end
       end
     end
   end

--- a/app/controllers/katello/remote_execution_controller.rb
+++ b/app/controllers/katello/remote_execution_controller.rb
@@ -40,6 +40,12 @@ module Katello
           { :errata => params[:name] }
         elsif feature_name == 'katello_service_restart'
           { :helper => params[:name] }
+        elsif feature_name == 'katello_module_stream_action'
+          fail HttpErrors::NotFound, _('module streams not found') if params[:module_spec].blank?
+          fail HttpErrors::NotFound, _('actions not found') if params[:module_stream_action].blank?
+          inputs = { :module_spec => params[:module_spec], :action => params[:module_stream_action] }
+          inputs[:options] = params[:options] if params[:options]
+          inputs
         else
           { :package => params[:name] }
         end

--- a/app/views/katello/api/v2/module_streams/base.json.rabl
+++ b/app/views/katello/api/v2/module_streams/base.json.rabl
@@ -1,4 +1,4 @@
 object @resource
 
 attributes :id, :name, :uuid, :version, :context, :stream,
-           :arch, :description, :summary
+           :arch, :description, :summary, :module_spec

--- a/app/views/katello/api/v2/module_streams/name_stream.json.rabl
+++ b/app/views/katello/api/v2/module_streams/name_stream.json.rabl
@@ -1,0 +1,3 @@
+object @object
+
+attributes :name, :stream, :module_spec

--- a/app/views/katello/api/v2/module_streams/name_streams.json.rabl
+++ b/app/views/katello/api/v2/module_streams/name_streams.json.rabl
@@ -1,0 +1,7 @@
+object false
+
+extends "katello/api/v2/common/metadata"
+
+child @collection[:results] => :results do |_results|
+  extends 'katello/api/v2/module_streams/name_stream'
+end

--- a/db/seeds.d/150-module_job_templates.rb
+++ b/db/seeds.d/150-module_job_templates.rb
@@ -1,0 +1,12 @@
+if Katello.with_remote_execution?
+  User.as_anonymous_admin do
+    JobTemplate.without_auditing do
+      module_template = JobTemplate.find_by(name: 'Module Action - SSH Default')
+      if module_template
+        module_template.sync_feature('katello_module_stream_action')
+        module_template.organizations << Organization.unscoped.all if module_template.organizations.empty?
+        module_template.locations << Location.unscoped.all if module_template.locations.empty?
+      end
+    end
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.routes.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.routes.js
@@ -247,5 +247,19 @@ angular.module('Bastion.content-hosts').config(['$stateProvider', function ($sta
             label: "{{ 'Traces' | translate }}",
             parent: 'content-host.info'
         }
+    })
+    .state('content-host.module-streams', {
+        abstract: true,
+        controller: 'ContentHostModuleStreamsController',
+        template: '<div ui-view></div>'
+    })
+    .state('content-host.module-streams.index', {
+        url: '/module-streams',
+        permission: 'view_hosts',
+        templateUrl: 'content-hosts/content/views/content-host-module-streams.html',
+        ncyBreadcrumb: {
+            label: "{{ 'Module Streams' | translate }}",
+            parent: 'content-host.info'
+        }
     });
 }]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-module-streams.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-module-streams.controller.js
@@ -20,9 +20,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostModuleStreamsCont
             { action: 'disable', description: translate("Disable")},
             { action: 'install', description: translate("Install")},
             { action: 'update', description: translate("Update")},
-            { action: 'remove', description: translate("Remove")},
-            { action: 'lock', description: translate("Lock")},
-            { action: 'unlock', description: translate("Unlock")}
+            { action: 'remove', description: translate("Remove")}
         ];
         $scope.working = false;
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-module-streams.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-module-streams.controller.js
@@ -1,0 +1,55 @@
+/**
+ * @ngdoc object
+ * @name  Bastion.content-hosts.controller:ContentHostModuleStreamsController
+ *
+ * @requires $scope
+ * @resource $timeout
+ * @resource $window
+ * @requires ModuleStream
+ * @requires translate
+ * @requires Nutupane
+ *
+ * @description
+ *   Provides the functionality for the content host module streams list and actions.
+ */
+angular.module('Bastion.content-hosts').controller('ContentHostModuleStreamsController',
+    ['$scope', '$timeout', '$window', 'ModuleStream', 'translate', 'Nutupane', 'BastionConfig',
+    function ($scope, $timeout, $window, ModuleStream, translate, Nutupane, BastionConfig) {
+        $scope.moduleStreamActions = [
+            { action: 'enable', description: translate("Enable")},
+            { action: 'disable', description: translate("Disable")},
+            { action: 'install', description: translate("Install")},
+            { action: 'update', description: translate("Update")},
+            { action: 'remove', description: translate("Remove")},
+            { action: 'lock', description: translate("Lock")},
+            { action: 'unlock', description: translate("Unlock")}
+        ];
+        $scope.working = false;
+
+        $scope.moduleStreamsNutupane = new Nutupane(ModuleStream, {
+            'host_ids': [$scope.$stateParams.hostId],
+            'name_stream_only': '1'
+        });
+
+        $scope.moduleStreamsNutupane.masterOnly = true;
+        $scope.table = $scope.moduleStreamsNutupane.table;
+
+        $scope.remoteExecutionPresent = BastionConfig.remoteExecutionPresent;
+        $scope.remoteExecutionByDefault = BastionConfig.remoteExecutionByDefault;
+        $scope.moduleStreamActionFormValues = {
+            authenticityToken: $window.AUTH_TOKEN.replace(/&quot;/g, ''),
+            remoteAction: 'module_stream_action'
+        };
+
+        $scope.performViaRemoteExecution = function(moduleSpec, actionType) {
+            $scope.working = true;
+            $scope.moduleStreamActionFormValues.moduleSpec = moduleSpec;
+            $scope.moduleStreamActionFormValues.moduleStreamAction = actionType;
+            $scope.moduleStreamActionFormValues.hostIds = $scope.host.id;
+
+            $timeout(function () {
+                angular.element('#moduleStreamActionForm').submit();
+            }, 0);
+        };
+    }
+]);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-module-streams.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-module-streams.html
@@ -1,0 +1,69 @@
+<span page-title ng-model="host">{{ 'Module Streams for: ' | translate }} {{ host.name }}</span>
+
+<div bst-feature-flag="remote_actions">
+  <h3 translate ng-hide="selectedModuleStreamOption === 'available'">Available Module Streams</h3>
+</div>
+
+<div ng-hide="host.hasContent()">
+  <div data-extend-template="common/views/registration.html"></div>
+</div>
+
+<div ng-if="host && host.hasContent()">
+  <form id="moduleStreamActionForm" method="post" action="/katello/remote_execution">
+    <input type="hidden" name="remote_action" ng-value="moduleStreamActionFormValues.remoteAction"/>
+    <input type="hidden" name="module_stream_action" ng-value="moduleStreamActionFormValues.moduleStreamAction"/>
+    <input type="hidden" name="module_spec" ng-value="moduleStreamActionFormValues.moduleSpec"/>
+    <input type="hidden" name="host_ids" ng-value="moduleStreamActionFormValues.hostIds"/>
+    <input type="hidden" name="customize" ng-value="moduleStreamActionFormValues.customize"/>
+    <input type="hidden" name="authenticity_token" ng-value="moduleStreamActionFormValues.authenticityToken"/>
+  </form>
+
+  <div data-extend-template="layouts/partials/table.html">
+
+    <span data-block="no-rows-message" translate>
+      There are no Module Streams to display.
+    </span>
+
+    <span data-block="no-search-results-message" translate>
+      Your search returned zero Module Streams.
+    </span>
+    <div data-block="table">
+      <table class="table table-striped table-bordered" ng-class="{'table-mask': table.working}">
+        <thead>
+          <tr bst-table-head>
+            <th bst-table-column translate>Name</th>
+            <th bst-table-column translate>Stream</th>
+            <th bst-table-column translate>Actions</th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <tr bst-table-row ng-repeat="module in table.rows">
+            <td bst-table-cell>
+              <a href="/module_streams?search=module_spec%3D{{ module.module_spec }}+and+host%3D{{ host.name }}">
+              {{ module.name }}</a></td>
+            <td bst-table-cell>{{ module.stream }}</td>
+            <td bst-table-cell>
+              <div class="dropdown" ng-hide="!remoteExecutionPresent || denied('edit_content_hosts', contentHost)">
+                <button class="btn btn-default dropdown-toggle" ng-disabled="$scope.working" type="button" id="dropdownMenu1" data-toggle="dropdown"> Actions
+                  <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu1">
+                  <li role="presentation">
+                    <label class="drop-down-check-box">
+                      <input id="customize" name="customize" ng-model="moduleStreamActionFormValues.customize" type="checkbox"/>
+                      <span translate>Customize</span>
+                    </label>
+                  </li>
+                  <li role="presentation" class="divider"></li>
+
+                  <li role="presentation" ng-repeat="action in moduleStreamActions"><a role="menuitem" tabindex="-1" ng-click="performViaRemoteExecution(module.module_spec, action.action)" href="#">{{ action.description}}</a></li>
+                </ul>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
@@ -129,6 +129,12 @@
           Errata
         </a>
       </li>
+      <li ng-class="{active: isState('content-host.module-streams.index')}">
+        <a translate
+           ui-sref="content-host.module-streams.index">
+          Module Streams
+        </a>
+      </li>
       <li ng-class="{active: isState('content-host.traces.index')}">
         <a translate
            ui-sref="content-host.traces.index">

--- a/engines/bastion_katello/app/assets/stylesheets/bastion_katello/bastion_katello.scss
+++ b/engines/bastion_katello/app/assets/stylesheets/bastion_katello/bastion_katello.scss
@@ -43,3 +43,7 @@
   width: 100%;
   padding-right: 6px;
 }
+
+.drop-down-check-box {
+  margin-left: 10px
+};

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -277,6 +277,9 @@ Foreman::Plugin.register :katello do
     RemoteExecutionFeature.register(:katello_group_remove, N_("Katello: Remove Package Group"), :description => N_("Remove package group via Katello interface"), :provided_inputs => ['package'])
     RemoteExecutionFeature.register(:katello_errata_install, N_("Katello: Install Errata"), :description => N_("Install errata via Katello interface"), :provided_inputs => ['errata'])
     RemoteExecutionFeature.register(:katello_service_restart, N_("Katello: Service Restart"), :description => N_("Restart Services via Katello interface"), :provided_inputs => ['helpers'])
+    RemoteExecutionFeature.register(:katello_module_stream_action, N_("Katello: Module Stream Actions"),
+                                    :description => N_("Perform a module stream action via Katello interface"),
+                                    :provided_inputs => ['action', 'module_spec', 'options'])
     allowed_template_helpers :errata
   end
 

--- a/test/controllers/api/v2/module_streams_controller_test.rb
+++ b/test/controllers/api/v2/module_streams_controller_test.rb
@@ -43,6 +43,20 @@ module Katello
       end
     end
 
+    def test_index_with_name_stream_only
+      get :index, params: { :name_stream_only => 1, :repository_id => @repo.id }
+
+      assert_response :success
+      assert_template "katello/api/v2/module_streams/name_streams"
+    end
+
+    def test_index_with_host_ids
+      get :index, params: { :host_ids => [hosts(:one).id, hosts(:two).id], :repository_id => @repo.id }
+
+      assert_response :success
+      assert_template "katello/api/v2/module_streams/index"
+    end
+
     def test_show
       get :show, params: { :id => @module_stream_river.id }
 

--- a/webpack/scenes/ModuleStreams/ModuleStreamsTableSchema.js
+++ b/webpack/scenes/ModuleStreams/ModuleStreamsTableSchema.js
@@ -16,9 +16,9 @@ const TableSchema = [
     },
   },
   {
-    property: 'version',
+    property: 'stream',
     header: {
-      label: __('Version'),
+      label: __('Stream'),
       formatters: [headerFormatter],
     },
     cell: {
@@ -26,9 +26,9 @@ const TableSchema = [
     },
   },
   {
-    property: 'stream',
+    property: 'version',
     header: {
-      label: __('Stream'),
+      label: __('Version'),
       formatters: [headerFormatter],
     },
     cell: {

--- a/webpack/scenes/ModuleStreams/__tests__/__snapshots__/ModuleStreamsTable.test.js.snap
+++ b/webpack/scenes/ModuleStreams/__tests__/__snapshots__/ModuleStreamsTable.test.js.snap
@@ -33,9 +33,9 @@ exports[`Module streams table should render and contain appropiate components 1`
             "formatters": Array [
               [Function],
             ],
-            "label": "Version",
+            "label": "Stream",
           },
-          "property": "version",
+          "property": "stream",
         },
         Object {
           "cell": Object {
@@ -47,9 +47,9 @@ exports[`Module streams table should render and contain appropiate components 1`
             "formatters": Array [
               [Function],
             ],
-            "label": "Stream",
+            "label": "Version",
           },
-          "property": "stream",
+          "property": "version",
         },
         Object {
           "cell": Object {


### PR DESCRIPTION
This commit contains the UI functionality to list and enable modularity
streams. It displays the list of available streams and provides remote
action templates to the user to enable/disable, install/remove and
lock/unlock streams.