### PR TITLE
fixes #25023 - disallow docker push by default

### DIFF
--- a/config/katello.yaml.example
+++ b/config/katello.yaml.example
@@ -73,6 +73,7 @@
   :container_image_registry:
     :crane_url: https://localhost:5000
     :crane_ca_cert_file: /etc/pki/katello/certs/katello-server-ca.crt
+    :allow_push: false  # default false if omitted
 
 # Logging configuration can be changed by uncommenting the loggers
 # section and the logger configuration desired.


### PR DESCRIPTION
To test:
```
$ docker push devel.example.com/alpine:abcdef
The push refers to a repository [devel.example.com/alpine]
df64d3292fd6: Preparing 
error parsing HTTP 404 response body: no error details found in HTTP response body: "{\n  \"error\": {\"message\":\"Registry push not supported\"}\n}\n"
```
Add _:allow_push:true_ manually to _katello.yaml_:
```
  :container_image_registry:
    :crane_url: https://devel.example.com:5000
    :crane_ca_cert_file: /etc/pki/katello/certs/katello-default-ca.crt
    :allow_push: true
```
Then retry _docker push_:
```
$ docker push devel.example.com/alpine:abcdef
The push refers to a repository [devel.example.com/alpine]
df64d3292fd6: Pushing [==================================================>] 4.672 MB
```
Note: Push fails on my devel setup, hence the need to fence it off.