### PR TITLE
Fixes #24876 - Move repository sync to service class

### DIFF
--- a/app/lib/actions/pulp/abstract.rb
+++ b/app/lib/actions/pulp/abstract.rb
@@ -5,9 +5,9 @@ module Actions
       middleware.use Actions::Middleware::PulpServicesCheck
 
       def pulp_resources(capsule_id = nil)
-        capsule_id ||= input["capsule_id"]
+        capsule_id ||= input.try(:[], "capsule_id")
         if capsule_id
-          capsule_content = ::Katello::CapsuleContent.new(SmartProxy.unscoped.find(capsule_id))
+          capsule_content = ::Katello::CapsuleContent.new(smart_proxy(capsule_id))
           capsule_content.pulp_server.resources
         else
           ::Katello.pulp_server.resources
@@ -22,6 +22,11 @@ module Actions
         else
           ::Katello.pulp_server.extensions
         end
+      end
+
+      def smart_proxy(capsule_id = nil)
+        smart_proxy = capsule_id ? SmartProxy.unscoped.find(capsule_id) : SmartProxy.default_capsule
+        smart_proxy
       end
     end
   end

--- a/app/services/katello/pulp/repository.rb
+++ b/app/services/katello/pulp/repository.rb
@@ -1,0 +1,22 @@
+module Katello
+  module Pulp
+    class Repository < ::Actions::Pulp::Abstract
+      attr_accessor :repo
+
+      def initialize(repo, smart_proxy = nil)
+        @repo = repo
+        @smart_proxy = smart_proxy
+      end
+
+      def sync(overrides = {})
+        sync_options = {}
+        sync_options[:max_speed] = SETTINGS.dig(:katello, :pulp, :sync_KBlimit)
+        sync_options[:num_threads] = SETTINGS.dig(:katello, :pulp, :sync_threads)
+        sync_options[:feed] = overrides[:source_url] if overrides[:source_url]
+        sync_options[:validate] = !SETTINGS.dig(:katello, :pulp, :skip_checksum_validation)
+        sync_options.merge!(overrides[:options]) if overrides[:options]
+        [::Katello::CapsuleContent.new(@smart_proxy).pulp_server.resources.repository.sync(@repo.pulp_id, override_config: sync_options.compact!)]
+      end
+    end
+  end
+end

--- a/test/actions/pulp/repository/sync_test.rb
+++ b/test/actions/pulp/repository/sync_test.rb
@@ -3,6 +3,11 @@ require_relative 'test_base.rb'
 
 module ::Actions::Pulp::Repository
   class SyncTest < VCRTestBase
+    def setup
+      proxy = SmartProxy.new(:url => 'http://foo.com/foo')
+      SmartProxy.stubs(:default_capsule).returns(proxy)
+    end
+
     def test_sync
       ForemanTasks.sync_task(::Actions::Pulp::Repository::Sync, :pulp_id => repo.pulp_id).main_action
       assert_equal 8, ::Katello::Pulp::Rpm.ids_for_repository(repo.pulp_id).length
@@ -11,6 +16,10 @@ module ::Actions::Pulp::Repository
 
   class BackgroundSyncTest < VCRTestBase
     let(:repo) { katello_repositories(:rhel_7_x86_64) }
+    def setup
+      proxy = SmartProxy.new(:url => 'http://foo.com/foo')
+      SmartProxy.stubs(:default_capsule).returns(proxy)
+    end
 
     def test_sync
       output = ForemanTasks.sync_task(::Actions::Pulp::Repository::Sync, :pulp_id => repo.pulp_id).output

--- a/test/scenarios/scenario_test.rb
+++ b/test/scenarios/scenario_test.rb
@@ -8,7 +8,7 @@ module Scenarios
     include ForemanTasks::TestHelpers::WithInThreadExecutor
 
     def setup
-      default_capsule = mock
+      default_capsule = SmartProxy.new(:url => 'http://foo.com/foo')
       default_capsule.stubs(:default_capsule?).returns(true)
       SmartProxy.stubs(:default_capsule).returns(default_capsule)
     end

--- a/test/support/pulp/repository_support.rb
+++ b/test/support/pulp/repository_support.rb
@@ -7,6 +7,7 @@ module Katello
     @repo_url = "file:///var/www/test_repos/zoo"
     @puppet_repo_url = "http://davidd.fedorapeople.org/repos/random_puppet/"
     @repo = nil
+    @proxy = SmartProxy.new(:url => 'http://foo.com/foo')
 
     def self.repo_id
       @repo.id
@@ -51,6 +52,7 @@ module Katello
     end
 
     def self.sync_repo
+      SmartProxy.stubs(:default_capsule).returns(@proxy)
       ::ForemanTasks.sync_task(::Actions::Pulp::Repository::Sync,
                                pulp_id: @repo.pulp_id
                               )


### PR DESCRIPTION
To test run rake db:migrate and then test normal flows.