### PR TITLE
Fixes #24915 - Process system purpose compliance event

### DIFF
--- a/app/lib/actions/candlepin/import_pool_handler.rb
+++ b/app/lib/actions/candlepin/import_pool_handler.rb
@@ -1,6 +1,8 @@
 module Actions
   module Candlepin
     class ImportPoolHandler
+      attr_reader :message_handler
+
       def initialize(logger)
         @logger = logger
       end
@@ -11,7 +13,7 @@ module Actions
 
         ::User.current = ::User.anonymous_admin
 
-        message_handler = ::Katello::Candlepin::MessageHandler.new(message)
+        @message_handler = ::Katello::Candlepin::MessageHandler.new(message)
 
         case message_handler.subject
         when /entitlement\.created/
@@ -24,26 +26,49 @@ module Actions
           message_handler.import_pool
         when /pool\.deleted/
           message_handler.import_pool
-        when /compliance\.created/
-          reindex_consumer(message_handler)
+        when /^compliance\.created/
+          reindex_subscription_status
+        when /system_purpose_compliance\.created/
+          reindex_purpose_status
         end
       end
 
       private
 
-      def reindex_consumer(message_handler)
-        subscription_facet = message_handler.subscription_facet
-        sub_status = message_handler.sub_status
-        uuid = message_handler.consumer_uuid
-        if subscription_facet && sub_status
-          @logger.debug "re-indexing content host #{subscription_facet.host.name}"
-          subscription_facet.update_subscription_status(sub_status)
-          subscription_facet.update_compliance_reasons(message_handler.consumer_reasons)
-        elsif subscription_facet.nil?
-          @logger.debug "skip re-indexing of non-existent content host #{uuid}"
-        elsif sub_status.nil?
-          @logger.debug "skip re-indexing of empty subscription status #{uuid}"
+      def subscription_facet
+        message_handler.subscription_facet
+      end
+
+      def reindex_subscription_status
+        if message_handler.status.nil?
+          @logger.debug "skip re-indexing of empty #{message_handler.subject} status #{message_handler.consumer_uuid}"
+          return
         end
+
+        reindex_consumer do
+          subscription_facet.update_subscription_status(message_handler.status)
+          subscription_facet.update_compliance_reasons(message_handler.reasons)
+        end
+      end
+
+      def reindex_purpose_status
+        reindex_consumer do
+          subscription_facet.update_purpose_status(valid_role: message_handler.compliant_role?,
+                                                   valid_usage: message_handler.compliant_usage?,
+                                                   valid_addons: message_handler.compliant_addons?,
+                                                   valid_sla: message_handler.compliant_sla?)
+        end
+      end
+
+      def reindex_consumer
+        if subscription_facet.nil?
+          @logger.debug "skip re-indexing of non-existent content host #{message_handler.consumer_uuid}"
+          return
+        end
+
+        @logger.debug "re-indexing content host #{subscription_facet.host.name}"
+
+        yield
       end
     end
   end

--- a/app/lib/katello/resources/candlepin/consumer.rb
+++ b/app/lib/katello/resources/candlepin/consumer.rb
@@ -167,6 +167,13 @@ module Katello
             end
           end
 
+          def purpose_compliance(uuid)
+            response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'purpose_compliance'), self.default_headers(uuid)).body
+            if response.present?
+              JSON.parse(response).with_indifferent_access
+            end
+          end
+
           def events(uuid)
             response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'events'), self.default_headers).body
             if response.present?

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -163,6 +163,46 @@ module Katello
         @errata_status_label ||= get_status(::Katello::ErrataStatus).to_label(options)
       end
 
+      def purpose_status
+        @purpose_status ||= get_status(::Katello::PurposeStatus).status
+      end
+
+      def purpose_status_label(options = {})
+        @purpose_status_label ||= get_status(::Katello::PurposeStatus).to_label(options)
+      end
+
+      def purpose_sla_status
+        @purpose_sla_status ||= get_status(::Katello::PurposeSlaStatus).status
+      end
+
+      def purpose_sla_status_label(options = {})
+        @purpose_sla_status_label ||= get_status(::Katello::PurposeSlaStatus).to_label(options)
+      end
+
+      def purpose_role_status
+        @purpose_role_status ||= get_status(::Katello::PurposeRoleStatus).status
+      end
+
+      def purpose_role_status_label(options = {})
+        @purpose_role_status_label ||= get_status(::Katello::PurposeRoleStatus).to_label(options)
+      end
+
+      def purpose_usage_status
+        @purpose_usage_status ||= get_status(::Katello::PurposeUsageStatus).status
+      end
+
+      def purpose_usage_status_label(options = {})
+        @purpose_usage_status_label ||= get_status(::Katello::PurposeUsageStatus).to_label(options)
+      end
+
+      def purpose_addons_status
+        @purpose_addons_status ||= get_status(::Katello::PurposeAddonsStatus).status
+      end
+
+      def purpose_addons_status_label(options = {})
+        @purpose_addons_status_label ||= get_status(::Katello::PurposeAddonsStatus).to_label(options)
+      end
+
       def valid_content_override_label?(content_label)
         available_content = subscription_facet.candlepin_consumer.available_product_content
         available_content.map(&:content).any? { |content| content.label == content_label }

--- a/app/models/katello/concerns/subscription_facet_host_extensions.rb
+++ b/app/models/katello/concerns/subscription_facet_host_extensions.rb
@@ -14,6 +14,31 @@ module Katello
           :unsubscribed_hypervisor => Katello::SubscriptionStatus::UNSUBSCRIBED_HYPERVISOR
         }.freeze
 
+        SLA_STATUS_MAP = {
+          :valid => Katello::PurposeSlaStatus::VALID,
+          :invalid => Katello::PurposeSlaStatus::INVALID
+        }.freeze
+
+        USAGE_STATUS_MAP = {
+          :valid => Katello::PurposeUsageStatus::VALID,
+          :invalid => Katello::PurposeUsageStatus::INVALID
+        }.freeze
+
+        ROLE_STATUS_MAP = {
+          :valid => Katello::PurposeRoleStatus::VALID,
+          :invalid => Katello::PurposeRoleStatus::INVALID
+        }.freeze
+
+        ADDONS_STATUS_MAP = {
+          :valid => Katello::PurposeAddonsStatus::VALID,
+          :invalid => Katello::PurposeAddonsStatus::INVALID
+        }.freeze
+
+        PURPOSE_STATUS_MAP = {
+          :valid => Katello::PurposeStatus::VALID,
+          :invalid => Katello::PurposeStatus::INVALID
+        }.freeze
+
         prepend ForemanTasks::Concerns::ActionTriggering
 
         module Prepended
@@ -32,10 +57,21 @@ module Katello
         has_many :pools, :through => :subscription_facet
         has_many :subscriptions, :through => :pools
         has_one :subscription_status_object, :class_name => 'Katello::SubscriptionStatus', :foreign_key => 'host_id', :dependent => :destroy
+        has_one :purpose_sla_status_object, :class_name => 'Katello::PurposeSlaStatus', :foreign_key => 'host_id', :dependent => :destroy
+        has_one :purpose_role_status_object, :class_name => 'Katello::PurposeRoleStatus', :foreign_key => 'host_id', :dependent => :destroy
+        has_one :purpose_usage_status_object, :class_name => 'Katello::PurposeUsageStatus', :foreign_key => 'host_id', :dependent => :destroy
+        has_one :purpose_addons_status_object, :class_name => 'Katello::PurposeAddonsStatus', :foreign_key => 'host_id', :dependent => :destroy
+        has_one :purpose_status_object, :class_name => 'Katello::PurposeStatus', :foreign_key => 'host_id', :dependent => :destroy
         has_one :hypervisor_host, :through => :subscription_facet
 
         scoped_search :on => :status, :relation => :subscription_status_object, :rename => :subscription_status,
                       :complete_value => SUBSCRIPTION_STATUS_MAP
+
+        scoped_search on: :status, relation: :purpose_sla_status_object, rename: :sla_status, complete_value: SLA_STATUS_MAP
+        scoped_search on: :status, relation: :purpose_role_status_object, rename: :role_status, complete_value: ROLE_STATUS_MAP
+        scoped_search on: :status, relation: :purpose_usage_status_object, rename: :usage_status, complete_value: USAGE_STATUS_MAP
+        scoped_search on: :status, relation: :purpose_addons_status_object, rename: :addons_status, complete_value: ADDONS_STATUS_MAP
+        scoped_search on: :status, relation: :purpose_status_object, rename: :purpose_status, complete_value: PURPOSE_STATUS_MAP
 
         scoped_search :on => :release_version, :relation => :subscription_facet, :complete_value => true, :only_explicit => true
         scoped_search :on => :autoheal, :relation => :subscription_facet, :complete_value => true, :only_explicit => true

--- a/app/models/katello/purpose_addons_status.rb
+++ b/app/models/katello/purpose_addons_status.rb
@@ -1,0 +1,50 @@
+module Katello
+  class PurposeAddonsStatus < HostStatus::Status
+    VALID = 0
+    INVALID = 1
+    UNKNOWN = 2
+
+    def self.status_name
+      N_('Addons')
+    end
+
+    def self.humanized_name
+      'purpose_addons'
+    end
+
+    def to_label(_options = {})
+      case status
+      when VALID
+        N_('Matched')
+      when INVALID
+        N_('Mismatched')
+      else
+        N_('Unknown')
+      end
+    end
+
+    def to_status(options = {})
+      return UNKNOWN unless relevant?
+
+      status_override = options[:status_override]
+
+      return INVALID if status_override == false
+
+      return VALID if status_override || consumer.compliant_addons?
+
+      INVALID
+    end
+
+    def relevant?(_options = {})
+      host.subscription_facet.try(:uuid)
+    end
+
+    def substatus?(_options = {})
+      true
+    end
+
+    def consumer
+      Katello::Candlepin::Consumer.new(host.subscription_facet.uuid, host.organization.label)
+    end
+  end
+end

--- a/app/models/katello/purpose_role_status.rb
+++ b/app/models/katello/purpose_role_status.rb
@@ -1,0 +1,50 @@
+module Katello
+  class PurposeRoleStatus < HostStatus::Status
+    VALID = 0
+    INVALID = 1
+    UNKNOWN = 2
+
+    def self.status_name
+      N_('Role')
+    end
+
+    def self.humanized_name
+      'purpose_role'
+    end
+
+    def to_label(_options = {})
+      case status
+      when VALID
+        N_('Matched')
+      when INVALID
+        N_('Mismatched')
+      else
+        N_('Unknown')
+      end
+    end
+
+    def to_status(options = {})
+      return UNKNOWN unless relevant?
+
+      status_override = options[:status_override]
+
+      return INVALID if status_override == false
+
+      return VALID if status_override || consumer.compliant_role?
+
+      INVALID
+    end
+
+    def relevant?(_options = {})
+      host.subscription_facet.try(:uuid)
+    end
+
+    def substatus?(_options = {})
+      true
+    end
+
+    def consumer
+      Katello::Candlepin::Consumer.new(host.subscription_facet.uuid, host.organization.label)
+    end
+  end
+end

--- a/app/models/katello/purpose_sla_status.rb
+++ b/app/models/katello/purpose_sla_status.rb
@@ -1,0 +1,48 @@
+module Katello
+  class PurposeSlaStatus < HostStatus::Status
+    VALID = 0
+    INVALID = 1
+    UNKNOWN = 2
+
+    def self.status_name
+      N_('Service Level')
+    end
+
+    def self.humanized_name
+      'purpose_sla'
+    end
+
+    def to_label(_options = {})
+      case status
+      when VALID
+        N_('Matched')
+      when INVALID
+        N_('Mismatched')
+      else
+        N_('Unknown')
+      end
+    end
+
+    def to_status(options = {})
+      return UNKNOWN unless relevant?
+
+      return INVALID if options[:status_override] == false
+
+      return VALID if options[:status_override] || consumer.compliant_sla?
+
+      INVALID
+    end
+
+    def relevant?(_options = {})
+      host.subscription_facet.try(:uuid)
+    end
+
+    def substatus?(_options = {})
+      true
+    end
+
+    def consumer
+      Katello::Candlepin::Consumer.new(host.subscription_facet.uuid, host.organization.label)
+    end
+  end
+end

--- a/app/models/katello/purpose_status.rb
+++ b/app/models/katello/purpose_status.rb
@@ -1,0 +1,56 @@
+module Katello
+  class PurposeStatus < HostStatus::Status
+    VALID = 0
+    INVALID = 1
+    UNKNOWN = 2
+
+    SUBSTATUSES = [
+      Katello::PurposeSlaStatus,
+      Katello::PurposeRoleStatus,
+      Katello::PurposeUsageStatus,
+      Katello::PurposeAddonsStatus
+    ].freeze
+
+    def self.status_name
+      N_('System Purpose')
+    end
+
+    def self.humanized_name
+      'purpose'
+    end
+
+    def to_label(_options = {})
+      case status
+      when VALID
+        N_('Matched')
+      when INVALID
+        N_('Mismatched')
+      else
+        N_('Unknown')
+      end
+    end
+
+    def to_global(_options = {})
+      case status
+      when VALID
+        ::HostStatus::Global::OK
+      else
+        ::HostStatus::Global::WARN
+      end
+    end
+
+    def to_status(_options = {})
+      return UNKNOWN unless relevant?
+
+      SUBSTATUSES.each do |status_class|
+        return INVALID if host.get_status(status_class).status != status_class::VALID
+      end
+
+      VALID
+    end
+
+    def relevant?(_options = {})
+      host.subscription_facet.try(:uuid)
+    end
+  end
+end

--- a/app/models/katello/purpose_usage_status.rb
+++ b/app/models/katello/purpose_usage_status.rb
@@ -1,0 +1,50 @@
+module Katello
+  class PurposeUsageStatus < HostStatus::Status
+    VALID = 0
+    INVALID = 1
+    UNKNOWN = 2
+
+    def self.status_name
+      N_('Usage')
+    end
+
+    def self.humanized_name
+      'purpose_usage'
+    end
+
+    def to_label(_options = {})
+      case status
+      when VALID
+        N_('Matched')
+      when INVALID
+        N_('Mismatched')
+      else
+        N_('Unknown')
+      end
+    end
+
+    def to_status(options = {})
+      return UNKNOWN unless relevant?
+
+      status_override = options[:status_override]
+
+      return INVALID if status_override == false
+
+      return VALID if status_override || consumer.compliant_usage?
+
+      INVALID
+    end
+
+    def relevant?(_options = {})
+      host.subscription_facet.try(:uuid)
+    end
+
+    def substatus?(_options = {})
+      true
+    end
+
+    def consumer
+      Katello::Candlepin::Consumer.new(host.subscription_facet.uuid, host.organization.label)
+    end
+  end
+end

--- a/app/services/katello/candlepin/consumer.rb
+++ b/app/services/katello/candlepin/consumer.rb
@@ -23,6 +23,7 @@ module Katello
                                                              ::Katello::ContentOverride.from_entitlement_hash(override)
                                                            end
                                                          end)
+      lazy_accessor :purpose_compliance, :initializer => lambda { |_s| Resources::Candlepin::Consumer.purpose_compliance(uuid) }
 
       attr_accessor :uuid, :owner_label
 
@@ -118,6 +119,22 @@ module Katello
 
       def compliance_reasons
         self.class.friendly_compliance_reasons(Resources::Candlepin::Consumer.compliance(uuid)['reasons'])
+      end
+
+      def compliant_role?
+        purpose_compliance['nonCompliantRole'].nil?
+      end
+
+      def compliant_usage?
+        purpose_compliance['nonCompliantUsage'].nil?
+      end
+
+      def compliant_addons?
+        purpose_compliance['nonCompliantAddOns'].empty?
+      end
+
+      def compliant_sla?
+        purpose_compliance['nonCompliantSLA'].empty?
       end
 
       def entitlements?

--- a/app/services/katello/candlepin/message_handler.rb
+++ b/app/services/katello/candlepin/message_handler.rb
@@ -21,12 +21,28 @@ module Katello
         data ? JSON.parse(data) : {}
       end
 
-      def sub_status
+      def status
         event_data['status']
       end
 
-      def consumer_reasons
+      def reasons
         event_data['reasons']
+      end
+
+      def compliant_role?
+        reasons.none? { |reason| reason.match(/role/) }
+      end
+
+      def compliant_usage?
+        reasons.none? { |reason| reason.match(/usage/) }
+      end
+
+      def compliant_addons?
+        reasons.none? { |reason| reason.match(/add on/) }
+      end
+
+      def compliant_sla?
+        reasons.none? { |reason| reason.match(/sla/) }
       end
 
       def consumer_uuid

--- a/app/services/katello/registration_manager.rb
+++ b/app/services/katello/registration_manager.rb
@@ -192,6 +192,11 @@ module Katello
         end
 
         host.get_status(::Katello::ErrataStatus).destroy
+        host.get_status(::Katello::PurposeSlaStatus).destroy
+        host.get_status(::Katello::PurposeRoleStatus).destroy
+        host.get_status(::Katello::PurposeUsageStatus).destroy
+        host.get_status(::Katello::PurposeAddonsStatus).destroy
+        host.get_status(::Katello::PurposeStatus).destroy
         host.get_status(::Katello::SubscriptionStatus).destroy
         host.get_status(::Katello::TraceStatus).destroy
         host.installed_packages.delete_all

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -245,6 +245,11 @@ Foreman::Plugin.register :katello do
 
   register_custom_status(Katello::ErrataStatus)
   register_custom_status(Katello::SubscriptionStatus)
+  register_custom_status(Katello::PurposeSlaStatus)
+  register_custom_status(Katello::PurposeRoleStatus)
+  register_custom_status(Katello::PurposeUsageStatus)
+  register_custom_status(Katello::PurposeAddonsStatus)
+  register_custom_status(Katello::PurposeStatus)
   register_custom_status(Katello::TraceStatus)
 
   extend_rabl_template 'api/v2/smart_proxies/main', 'katello/api/v2/smart_proxies/download_policy'

--- a/test/fixtures/candlepin_messages/system_purpose_compliance.created.json
+++ b/test/fixtures/candlepin_messages/system_purpose_compliance.created.json
@@ -1,0 +1,19 @@
+{
+   "id":null,
+   "type":"CREATED",
+   "target":"SYSTEM_PURPOSE_COMPLIANCE",
+   "targetName":"dev.example.com",
+   "principalStore":"{\"type\":\"trusteduser\",\"name\":\"foreman_admin\"}",
+   "timestamp":1539144566445,
+   "entityId":"3b4823c3-ae91-4bad-a46e-3e1ecb5678be",
+   "ownerId":"4028f94a65f7979b0165f846c8c20000",
+   "consumerUuid":"3b4823c3-ae91-4bad-a46e-3e1ecb5678be",
+   "referenceId":null,
+   "referenceType":null,
+   "eventData":"{\"reasons\":[\"unsatisfied sla: Standard\",\"unsatisfied usage: Disaster Recovery\",\"unsatisfied role: Red Hat Satellite\",\"unsatisfied add on: EUS\"],\"status\":\"invalid\"}",
+   "messageText":null,
+   "principal":{
+      "type":"trusteduser",
+      "name":"foreman_admin"
+   }
+}

--- a/test/models/host/subscription_facet_test.rb
+++ b/test/models/host/subscription_facet_test.rb
@@ -69,6 +69,25 @@ module Katello
       assert_empty subscription_facet.purpose_usage
       assert_empty subscription_facet.purpose_addons
     end
+
+    def test_purpose_sla_status_search
+      status = Katello::PurposeSlaStatus.new(:host => host)
+      status.status = Katello::PurposeSlaStatus::INVALID
+      status.reported_at = Time.now
+      status.save!
+
+      assert_includes ::Host::Managed.search_for("sla_status = invalid"), host
+    end
+
+    def test_update_purpose_status
+      subscription_facet.update_purpose_status(valid_sla: true,
+                                               valid_role: true,
+                                               valid_usage: true,
+                                               valid_addons: true
+                                              )
+
+      assert_equal host.purpose_status, Katello::PurposeStatus::VALID
+    end
   end
 
   class SubscriptionFacetTest < SubscriptionFacetBase

--- a/test/models/purpose_addons_status_test.rb
+++ b/test/models/purpose_addons_status_test.rb
@@ -1,0 +1,28 @@
+require 'katello_test_helper'
+
+module Katello
+  class PurposeAddonsStatusTest < ActiveSupport::TestCase
+    let(:host) { FactoryBot.create(:host, :with_subscription) }
+    let(:status) { host.get_status(Katello::PurposeAddonsStatus) }
+
+    def test_status_valid
+      Katello::Candlepin::Consumer.any_instance.expects(:compliant_addons?).returns(true)
+
+      assert_equal Katello::PurposeAddonsStatus::VALID, status.to_status
+      assert_equal 'Matched', status.to_label
+    end
+
+    def test_status_invalid
+      Katello::Candlepin::Consumer.any_instance.expects(:compliant_addons?).returns(false)
+      status.status = status.to_status
+
+      assert_equal Katello::PurposeAddonsStatus::INVALID, status.status
+      assert_equal 'Mismatched', status.to_label
+    end
+
+    def test_status_override
+      assert_equal Katello::PurposeAddonsStatus::VALID, status.to_status(status_override: true)
+      assert_equal Katello::PurposeAddonsStatus::INVALID, status.to_status(status_override: false)
+    end
+  end
+end

--- a/test/models/purpose_role_status_test.rb
+++ b/test/models/purpose_role_status_test.rb
@@ -1,0 +1,28 @@
+require 'katello_test_helper'
+
+module Katello
+  class PurposeRoleStatusTest < ActiveSupport::TestCase
+    let(:host) { FactoryBot.create(:host, :with_subscription) }
+    let(:status) { host.get_status(Katello::PurposeRoleStatus) }
+
+    def test_status_valid
+      Katello::Candlepin::Consumer.any_instance.expects(:compliant_role?).returns(true)
+
+      assert_equal Katello::PurposeRoleStatus::VALID, status.to_status
+      assert_equal 'Matched', status.to_label
+    end
+
+    def test_status_invalid
+      Katello::Candlepin::Consumer.any_instance.expects(:compliant_role?).returns(false)
+      status.status = status.to_status
+
+      assert_equal Katello::PurposeRoleStatus::INVALID, status.status
+      assert_equal 'Mismatched', status.to_label
+    end
+
+    def test_status_override
+      assert_equal Katello::PurposeRoleStatus::VALID, status.to_status(status_override: true)
+      assert_equal Katello::PurposeRoleStatus::INVALID, status.to_status(status_override: false)
+    end
+  end
+end

--- a/test/models/purpose_sla_status_test.rb
+++ b/test/models/purpose_sla_status_test.rb
@@ -1,0 +1,28 @@
+require 'katello_test_helper'
+
+module Katello
+  class PurposeSlaStatusTest < ActiveSupport::TestCase
+    let(:host) { FactoryBot.create(:host, :with_subscription) }
+    let(:status) { host.get_status(Katello::PurposeSlaStatus) }
+
+    def test_status_valid
+      Katello::Candlepin::Consumer.any_instance.expects(:compliant_sla?).returns(true)
+
+      assert_equal Katello::PurposeSlaStatus::VALID, status.to_status
+      assert_equal 'Matched', status.to_label
+    end
+
+    def test_status_invalid
+      Katello::Candlepin::Consumer.any_instance.expects(:compliant_sla?).returns(false)
+      status.status = status.to_status
+
+      assert_equal Katello::PurposeSlaStatus::INVALID, status.status
+      assert_equal 'Mismatched', status.to_label
+    end
+
+    def test_status_override
+      assert_equal Katello::PurposeSlaStatus::INVALID, status.to_status(status_override: false)
+      assert_equal Katello::PurposeSlaStatus::VALID, status.to_status(status_override: true)
+    end
+  end
+end

--- a/test/models/purpose_status_test.rb
+++ b/test/models/purpose_status_test.rb
@@ -1,0 +1,40 @@
+require 'katello_test_helper'
+
+module Katello
+  class PurposeStatusTest < ActiveSupport::TestCase
+    let(:host) { FactoryBot.create(:host, :with_subscription) }
+    let(:status) { host.get_status(Katello::PurposeStatus) }
+
+    def test_status_valid
+      assert_equal Katello::PurposeStatus::VALID, status.to_status
+    end
+
+    def test_status_invalid_sla
+      sla_status = host.get_status(Katello::PurposeSlaStatus)
+      sla_status.status = Katello::PurposeSlaStatus::INVALID
+
+      assert_equal Katello::PurposeStatus::INVALID, status.to_status
+    end
+
+    def test_status_invalid_role
+      sla_status = host.get_status(Katello::PurposeRoleStatus)
+      sla_status.status = Katello::PurposeRoleStatus::INVALID
+
+      assert_equal Katello::PurposeStatus::INVALID, status.to_status
+    end
+
+    def test_status_invalid_usage
+      sla_status = host.get_status(Katello::PurposeUsageStatus)
+      sla_status.status = Katello::PurposeUsageStatus::INVALID
+
+      assert_equal Katello::PurposeStatus::INVALID, status.to_status
+    end
+
+    def test_status_invalid_addons
+      sla_status = host.get_status(Katello::PurposeAddonsStatus)
+      sla_status.status = Katello::PurposeAddonsStatus::INVALID
+
+      assert_equal Katello::PurposeStatus::INVALID, status.to_status
+    end
+  end
+end

--- a/test/models/purpose_usage_status_test.rb
+++ b/test/models/purpose_usage_status_test.rb
@@ -1,0 +1,28 @@
+require 'katello_test_helper'
+
+module Katello
+  class PurposeUsageStatusTest < ActiveSupport::TestCase
+    let(:host) { FactoryBot.create(:host, :with_subscription) }
+    let(:status) { host.get_status(Katello::PurposeUsageStatus) }
+
+    def test_status_valid
+      Katello::Candlepin::Consumer.any_instance.expects(:compliant_usage?).returns(true)
+
+      assert_equal Katello::PurposeUsageStatus::VALID, status.to_status
+      assert_equal 'Matched', status.to_label
+    end
+
+    def test_status_invalid
+      Katello::Candlepin::Consumer.any_instance.expects(:compliant_usage?).returns(false)
+      status.status = status.to_status
+
+      assert_equal Katello::PurposeUsageStatus::INVALID, status.status
+      assert_equal 'Mismatched', status.to_label
+    end
+
+    def test_status_override
+      assert_equal Katello::PurposeUsageStatus::VALID, status.to_status(status_override: true)
+      assert_equal Katello::PurposeUsageStatus::INVALID, status.to_status(status_override: false)
+    end
+  end
+end

--- a/test/services/candlepin/message_handler_test.rb
+++ b/test/services/candlepin/message_handler_test.rb
@@ -26,6 +26,29 @@ module Katello
     end
   end
 
+  class SystemPurposeComplianceCreatedTest < MessageHandlerTestBase
+    def setup
+      super
+      @handler = load_handler('system_purpose_compliance.created')
+    end
+
+    def test_compliant_role
+      assert_equal false, @handler.compliant_role?
+    end
+
+    def test_compliant_usage
+      assert_equal false, @handler.compliant_usage?
+    end
+
+    def test_compliant_addons
+      assert_equal false, @handler.compliant_addons?
+    end
+
+    def test_compliant_sla
+      assert_equal false, @handler.compliant_sla?
+    end
+  end
+
   class ComplianceCreatedTest < MessageHandlerTestBase
     def setup
       super
@@ -37,12 +60,12 @@ module Katello
     end
 
     def test_reasons
-      assert_equal 1, @handler.consumer_reasons.count
-      assert_equal 'Red Hat Enterprise Linux Server', @handler.consumer_reasons[0]['productName']
+      assert_equal 1, @handler.reasons.count
+      assert_equal 'Red Hat Enterprise Linux Server', @handler.reasons[0]['productName']
     end
 
     def test_status
-      assert_equal 'invalid', @handler.sub_status
+      assert_equal 'invalid', @handler.status
     end
 
     def test_subscription_facet


### PR DESCRIPTION
**What this PR Does**

- Handles the system_purpose_compliance event from Candlepin received when subscriptions are changed. I have a BZ open against candlepin to also send the event when syspurpose attrs are changed on a host

- 4 new (sub)statuses + master status for system purpose
- Status info is present in the content host details API
- Status info is searchable
- Parent (SystemPurposeStatus) only puts the host global status into WARN when there is a mismatch

**Status Organization**

Syspurpose status is really the combination of 4 other statuses: role, usage, addon, and service level. Using a new mechanism in Foreman, these 4 are considered 'substatus' and are not shown individually on the Host (not Content Host) details, nor do they affect the global status for a host.

**Naming**
Let me know if you have any issues with how I've named everything. I've thrown the 'Purpose' word around a lot and I'm not sure it's necessary.

**Testing**

You'll need a dev env provisioning with the latest installer code - or you can run the following manually so that your box can pick up the syspurpose compliance event:

```
qpid-config --ssl-certificate /etc/pki/katello/certs/java-client.crt --ssl-key /etc/pki/katello/private/java-client.key -b 'amqps://localhost:5671' bind event katello_event_queue system_purpose_compliance.created
```

You will also need this foreman PR: https://github.com/theforeman/foreman/pull/6109

Data setup involves connecting to postgres and running some queries against the candlepin database:

```
insert into cp2_product_attributes(name, value, product_uuid) values ('addons', 'Test Addon1,Test Addon2', 'REPLACEME');
insert into cp2_product_attributes(name, value, product_uuid) values ('role', 'Test Role', 'REPLACEME');
insert into cp2_product_attributes(name, value, product_uuid) values ('usage', 'Development', 'REPLACEME');
```

The product_uuid can be taken from some product in the cp2_products table.

At this point you can use the UI to assign and clear the purpose attributes from the content host details page. Removing and re-adding the product subscription with the attributes will trigger the calculation via the event queue. You can also manually force recalculation:

```
::Host.find(5).subscription_facet.update_purpose_status
```

**Future**

This is ultimately how these statuses will manifest in the UI but the UI will follow in another PR

![syspurpose_mismatched](https://user-images.githubusercontent.com/1979598/46419273-88434100-c6fb-11e8-8405-9c51eda6aac4.png)


