### PR TITLE
Fixes #25010 - show clear error message with viewer role

### DIFF
--- a/webpack/mockRequest.js
+++ b/webpack/mockRequest.js
@@ -24,7 +24,7 @@ export const mockErrorRequest = ({
   status = 500,
   ...options
 }) => mockRequest({
-  response: errorResponse(`Request failed with status code ${status}`),
+  response: { message: `Error ${status}`, details: 'oh no, something went wrong' },
   status,
   ...options,
 });

--- a/webpack/move_to_foreman/common/helpers.js
+++ b/webpack/move_to_foreman/common/helpers.js
@@ -81,7 +81,7 @@ export const sendErrorNotifications = messages => (dispatch) => {
   messages.forEach((msg) => {
     dispatch(addToast({
       type: 'error',
-      message: msg,
+      message: `${msg.message}: ${msg.details}`,
       sticky: true,
     }));
   });

--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -45,6 +45,10 @@ class SubscriptionsPage extends Component {
     this.props.resetTasks();
     this.props.loadSetting('content_disconnected');
     this.props.loadSubscriptions();
+    this.props.loadTables().then(() => {
+      const { subscriptionTableSettings, loadTableColumns } = this.props;
+      loadTableColumns(subscriptionTableSettings);
+    });
   }
 
   componentDidUpdate(prevProps) {
@@ -84,7 +88,8 @@ class SubscriptionsPage extends Component {
       }
     }
 
-    if (!isEqual(organization.owner_details, prevProps.organization.owner_details)) {
+    if (prevProps.organization.owner_details &&
+       !isEqual(organization.owner_details, prevProps.organization.owner_details)) {
       this.pollTasks();
     }
   }

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsPage.js
@@ -25,6 +25,12 @@ class UpstreamSubscriptionsPage extends Component {
     this.loadData();
   }
 
+  componentDidUpdate() {
+    if (this.props.error.length > 0) {
+      this.props.history.push('/subscriptions');
+    }
+  }
+
   onChange = (value, rowData) => {
     const { selectedRows } = this.state;
     const pool = {
@@ -265,6 +271,11 @@ UpstreamSubscriptionsPage.propTypes = {
     task: PropTypes.shape({}),
   }).isRequired,
   history: PropTypes.shape({ push: PropTypes.func.isRequired }).isRequired,
+  error: PropTypes.shape([PropTypes.shape({})]),
+};
+
+UpstreamSubscriptionsPage.defaultProps = {
+  error: {},
 };
 
 export default UpstreamSubscriptionsPage;

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsReducer.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsReducer.js
@@ -38,7 +38,7 @@ export default (state = initialState, action) => {
 
     case UPSTREAM_SUBSCRIPTIONS_FAILURE:
       return state.merge({
-        error: action.payload.message,
+        error: action.payload.messages,
         loading: false,
       });
 

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/index.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/index.js
@@ -8,7 +8,10 @@ import reducer from './UpstreamSubscriptionsReducer';
 import UpstreamSubscriptionsPage from './UpstreamSubscriptionsPage';
 
 // map state to props
-const mapStateToProps = state => ({ upstreamSubscriptions: state.katello.upstreamSubscriptions });
+const mapStateToProps = state => ({
+  upstreamSubscriptions: state.katello.upstreamSubscriptions,
+  error: state.katello.upstreamSubscriptions.error,
+});
 
 // map action dispatchers to props
 const mapDispatchToProps = dispatch => bindActionCreators(actions, dispatch);

--- a/webpack/services/api/testHelpers.js
+++ b/webpack/services/api/testHelpers.js
@@ -9,7 +9,7 @@ export const failureAction = (type, message = 'Request failed with status code 4
   }
 );
 
-export const toastErrorAction = (message = 'Request failed with status code 422') => (
+export const toastErrorAction = (message = 'Error 422: oh no, something went wrong') => (
   {
     payload: {
       message: {


### PR DESCRIPTION
When user with Viewer role accesses Content -> Subscriptions page for organization with manifest, error with unhelpful message appears: "[object Object]".
