### PR TITLE
Fixes #25135 - use i18n from webpack

### DIFF
--- a/webpack/__mocks__/foremanReact/common/I18n.js
+++ b/webpack/__mocks__/foremanReact/common/I18n.js
@@ -1,0 +1,5 @@
+export { sprintf } from 'jed';
+
+export const translate = s => s;
+
+export const ngettext = s => s;

--- a/webpack/components/MultiSelect/index.js
+++ b/webpack/components/MultiSelect/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
+import { translate as __ } from 'foremanReact/common/I18n';
 import { FormGroup, ControlLabel } from 'react-bootstrap';
 import BootstrapSelect from '../../move_to_pf/react-bootstrap-select';
 

--- a/webpack/components/Search/index.js
+++ b/webpack/components/Search/index.js
@@ -2,7 +2,7 @@
 import React, { Component } from 'react';
 import { ControlLabel } from 'react-bootstrap';
 import PropTypes from 'prop-types';
-
+import { translate as __ } from 'foremanReact/common/I18n';
 import TypeAhead from '../../move_to_pf/TypeAhead/TypeAhead';
 import api from '../../services/api';
 import { stringIncludes } from './helpers';

--- a/webpack/components/SelectOrg/SetOrganization.js
+++ b/webpack/components/SelectOrg/SetOrganization.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
 import { Form, Button } from 'patternfly-react';
 import { withRouter } from 'react-router';
 import { bindActionCreators } from 'redux';

--- a/webpack/components/WithOrganization/withOrganization.js
+++ b/webpack/components/WithOrganization/withOrganization.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
 import { get } from 'lodash';
 import SetOrganization from '../SelectOrg/SetOrganization';
 import titleWithCaret from '../../helpers/caret';

--- a/webpack/containers/Application/config.js
+++ b/webpack/containers/Application/config.js
@@ -1,3 +1,4 @@
+import { translate as __ } from 'foremanReact/common/I18n';
 import Repos from '../../scenes/RedHatRepositories';
 import Subscriptions from '../../scenes/Subscriptions';
 import UpstreamSubscriptions from '../../scenes/Subscriptions/UpstreamSubscriptions/index';

--- a/webpack/move_to_foreman/common/helpers.js
+++ b/webpack/move_to_foreman/common/helpers.js
@@ -1,3 +1,4 @@
+import { translate as __ } from 'foremanReact/common/I18n';
 import { addToast } from 'foremanReact/redux/actions/toasts';
 import { SUBSCRIPTIONS_QUANTITIES_FAILURE } from '../../scenes/Subscriptions/SubscriptionConstants';
 

--- a/webpack/move_to_foreman/components/common/ConfirmDialog/ConfirmDialog.js
+++ b/webpack/move_to_foreman/components/common/ConfirmDialog/ConfirmDialog.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
 import { Button } from 'patternfly-react';
 import Dialog from '../Dialog';
 

--- a/webpack/move_to_foreman/components/common/Dialog/Dialog.js
+++ b/webpack/move_to_foreman/components/common/Dialog/Dialog.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
 import { Button, Modal, Icon } from 'patternfly-react';
 
 const Dialog = (props) => {

--- a/webpack/move_to_foreman/components/common/EmptyState/index.js
+++ b/webpack/move_to_foreman/components/common/EmptyState/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 import React from 'react';
 import { EmptyState as PfEmptyState, Button } from 'patternfly-react';
+import { translate as __ } from 'foremanReact/common/I18n';
 import { LinkContainer } from 'react-router-bootstrap';
 
 const EmptyState = (props) => {

--- a/webpack/move_to_foreman/components/common/ModalProgressBar/ModalProgressBar.js
+++ b/webpack/move_to_foreman/components/common/ModalProgressBar/ModalProgressBar.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Modal, ProgressBar } from 'patternfly-react';
-import { sprintf } from 'jed';
+import { sprintf } from 'foremanReact/common/I18n';
 
 const ModalProgressBar = (props) => {
   const { show, container, task } = props;

--- a/webpack/scenes/RedHatRepositories/components/EnabledRepository/EnabledRepository.js
+++ b/webpack/scenes/RedHatRepositories/components/EnabledRepository/EnabledRepository.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { ListView } from 'patternfly-react';
-import { sprintf } from 'jed';
+import { sprintf } from 'foremanReact/common/I18n';
 
 import RepositoryTypeIcon from '../RepositoryTypeIcon';
 

--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepository/RepositorySetRepository.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepository/RepositorySetRepository.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { ListView, Spinner, OverlayTrigger, Tooltip, Icon, FieldLevelHelp } from 'patternfly-react';
 
-import { sprintf } from 'jed';
+import { sprintf } from 'foremanReact/common/I18n';
 import { yStream } from '../RepositorySetRepositoriesHelpers';
 import { notify } from '../../../../move_to_foreman/foreman_toast_notifications';
 import '../../index.scss';

--- a/webpack/scenes/RedHatRepositories/helpers.js
+++ b/webpack/scenes/RedHatRepositories/helpers.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ListView } from 'patternfly-react';
-import { sprintf } from 'jed';
+import { sprintf } from 'foremanReact/common/I18n';
 
 import PaginationRow from '../../components/PaginationRow/index';
 import RepositorySet from './components/RepositorySet';

--- a/webpack/scenes/Subscriptions/Details/SubscriptionAttributes.js
+++ b/webpack/scenes/Subscriptions/Details/SubscriptionAttributes.js
@@ -1,3 +1,5 @@
+import { translate as __ } from 'foremanReact/common/I18n';
+
 export default {
   name: __('Name'),
   description: __('Description'),

--- a/webpack/scenes/Subscriptions/Details/SubscriptionDetailAssociations.js
+++ b/webpack/scenes/Subscriptions/Details/SubscriptionDetailAssociations.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Table } from 'react-bootstrap';
+import { translate as __ } from 'foremanReact/common/I18n';
 import helpers from '../../../move_to_foreman/common/helpers.js';
 
 const SubscriptionDetailAssociations = ({ subscriptionDetails }) => {

--- a/webpack/scenes/Subscriptions/Details/SubscriptionDetailInfo.js
+++ b/webpack/scenes/Subscriptions/Details/SubscriptionDetailInfo.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Table } from 'react-bootstrap';
+import { translate as __ } from 'foremanReact/common/I18n';
 import subscriptionAttributes from './SubscriptionAttributes';
 
 const SubscriptionDetailInfo = ({ subscriptionDetails }) => {

--- a/webpack/scenes/Subscriptions/Details/SubscriptionDetailProduct.js
+++ b/webpack/scenes/Subscriptions/Details/SubscriptionDetailProduct.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Row, Col } from 'patternfly-react';
+import { translate as __ } from 'foremanReact/common/I18n';
 
 const SubscriptionDetailProduct = ({ content }) => (
   <Row key={content.id}>

--- a/webpack/scenes/Subscriptions/Details/SubscriptionDetails.js
+++ b/webpack/scenes/Subscriptions/Details/SubscriptionDetails.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
 import { Nav, NavItem, TabPane, TabContent, TabContainer, Grid, Row, Col } from 'patternfly-react';
 import BreadcrumbsBar from 'foremanReact/components/BreadcrumbBar';
 import SubscriptionDetailInfo from './SubscriptionDetailInfo';

--- a/webpack/scenes/Subscriptions/Manifest/DeleteManifestModalText.js
+++ b/webpack/scenes/Subscriptions/Manifest/DeleteManifestModalText.js
@@ -1,3 +1,5 @@
+import { translate as __ } from 'foremanReact/common/I18n';
+
 const question = __('Are you sure you want to delete the manifest?');
 const note = __(`Note: Deleting a subscription manifest is STRONGLY discouraged.
                  Deleting a manifest will:`);

--- a/webpack/scenes/Subscriptions/Manifest/ManifestHistoryTableSchema.js
+++ b/webpack/scenes/Subscriptions/Manifest/ManifestHistoryTableSchema.js
@@ -1,3 +1,4 @@
+import { translate as __ } from 'foremanReact/common/I18n';
 import { headerFormatter, cellFormatter } from '../../../move_to_foreman/components/common/table';
 
 export const columns = [

--- a/webpack/scenes/Subscriptions/SubscriptionConstants.js
+++ b/webpack/scenes/Subscriptions/SubscriptionConstants.js
@@ -1,3 +1,5 @@
+import { translate as __ } from 'foremanReact/common/I18n';
+
 export const SUBSCRIPTIONS_REQUEST = 'SUBSCRIPTIONS_REQUEST';
 export const SUBSCRIPTIONS_SUCCESS = 'SUBSCRIPTIONS_SUCCESS';
 export const SUBSCRIPTIONS_FAILURE = 'SUBSCRIPTIONS_FAILURE';

--- a/webpack/scenes/Subscriptions/SubscriptionValidations.js
+++ b/webpack/scenes/Subscriptions/SubscriptionValidations.js
@@ -1,3 +1,4 @@
+import { translate as __ } from 'foremanReact/common/I18n';
 import { filterRHSubscriptions } from './SubscriptionHelpers.js';
 
 export const validateQuantity = (quantity, availableQuantity) => {

--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Immutable from 'seamless-immutable';
+import { translate as __ } from 'foremanReact/common/I18n';
 import { isEmpty, isEqual } from 'lodash';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Grid, Row, Col, Form, FormGroup } from 'react-bootstrap';

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsPage.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import ReactDOMServer from 'react-dom/server';
 import _ from 'lodash';
+import { translate as __ } from 'foremanReact/common/I18n';
 import PropTypes from 'prop-types';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Grid, Row, Col } from 'react-bootstrap';

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsTableSchema.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsTableSchema.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FormGroup, FormControl, ControlLabel, HelpBlock } from 'react-bootstrap';
+import { translate as __ } from 'foremanReact/common/I18n';
 import helpers from '../../../move_to_foreman/common/helpers';
 import {
   headerFormatter,

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/EntitlementsInlineEditFormatter.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/EntitlementsInlineEditFormatter.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { sprintf } from 'jed';
+import { sprintf } from 'foremanReact/common/I18n';
 import { Table, FormControl, FormGroup, HelpBlock, Spinner } from 'patternfly-react';
 import { validateQuantity } from '../../SubscriptionValidations';
 import { KEY_CODES } from '../../../../move_to_foreman/common/helpers';

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTable.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTable.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { sprintf } from 'jed';
+import { sprintf } from 'foremanReact/common/I18n';
 import { cloneDeep, findIndex, isEqual } from 'lodash';
 import { Table } from 'patternfly-react';
 import { LoadingState } from '../../../../move_to_pf/LoadingState';

--- a/webpack/scenes/Tasks/helpers.js
+++ b/webpack/scenes/Tasks/helpers.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { translate as __ } from 'foremanReact/common/I18n';
 import helpers from '../../move_to_foreman/common/helpers';
 import { notify } from '../../move_to_foreman/foreman_toast_notifications';
 


### PR DESCRIPTION
i18n (jed) is moving to webpack in [foreman](https://github.com/theforeman/foreman/pull/5342)

`__()`, `sprintf()` and other functions should be imported