### PR TITLE
Fixes #25143: properly show composite ids in API

### DIFF
--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -40,6 +40,7 @@ module Katello
              :class_name => "Katello::ContentViewVersionComponent"
     has_many :composites, :through => :content_view_version_composites, :source => :composite_version,
              :class_name => "Katello::ContentViewVersion", :inverse_of => :components
+    has_many :published_in_composite_content_views, through: :composites, source: :content_view
 
     delegate :default, :default?, to: :content_view
 

--- a/app/views/katello/api/v2/content_view_versions/base.json.rabl
+++ b/app/views/katello/api/v2/content_view_versions/base.json.rabl
@@ -5,6 +5,7 @@ extends 'katello/api/v2/common/identifier'
 
 attributes :version, :major, :minor
 attributes :composite_content_view_ids
+attributes :published_in_composite_content_view_ids
 attributes :content_view_id
 attributes :default
 attributes :description
@@ -28,7 +29,15 @@ child :content_view => :content_view do
   attributes :id, :name, :label
 end
 
-child :composite_content_views do
+child :composite_content_views => :composite_content_views do
+  attributes :id, :name, :label
+end
+
+child :composites => :composite_content_view_versions do
+  attributes :id, :content_view_id, :version
+end
+
+child :published_in_composite_content_views => :published_in_composite_content_views do
   attributes :id, :name, :label
 end
 


### PR DESCRIPTION
To test:

- create a composite content view
- create a non-composite content view
- publish a content view version in the non-composite CV
- add the 'latest' version to the composite CV (do not publish!)
- `GET /katello/api/v2/content_views/2/content_view_versions`
- `GET /katello/api/v2/content_view_versions/8`
- publish your composite CV
- `GET /katello/api/v2/content_views/2/content_view_versions`
- `GET /katello/api/v2/content_view_versions/8`

Look for the 'composite_content_view_ids' and 'published_in_composite_content_view_ids' fields.