### PR TITLE
Fixes #25147 - Host details status icons missing

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
@@ -11,14 +11,17 @@
  * @requires MenuExpander
  * @requires ApiErrorHandler
  * @requires deleteHostOnUnregister
+ * @requires ContentHostsHelper
  *
  * @description
  *   Provides the functionality for the content host details action pane.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostDetailsController',
-    ['$scope', '$state', '$q', 'translate', 'Host', 'HostSubscription', 'Organization', 'CurrentOrganization', 'Notification', 'MenuExpander', 'ApiErrorHandler', 'deleteHostOnUnregister',
-    function ($scope, $state, $q, translate, Host, HostSubscription, Organization, CurrentOrganization, Notification, MenuExpander, ApiErrorHandler, deleteHostOnUnregister) {
+    ['$scope', '$state', '$q', 'translate', 'Host', 'HostSubscription', 'Organization', 'CurrentOrganization', 'Notification', 'MenuExpander', 'ApiErrorHandler', 'deleteHostOnUnregister', 'ContentHostsHelper',
+    function ($scope, $state, $q, translate, Host, HostSubscription, Organization, CurrentOrganization, Notification, MenuExpander, ApiErrorHandler, deleteHostOnUnregister, ContentHostsHelper) {
         $scope.menuExpander = MenuExpander;
+
+        $scope.getHostStatusIcon = ContentHostsHelper.getHostStatusIcon;
 
         $scope.purposeAddonsList = [];
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -33,11 +33,11 @@
         </dt>
         <dd bst-feature-flag="remote_actions">
           <span ng-show="host.content_facet_attributes.katello_agent_installed">
-            <span class="{{ table.getHostStatusIcon(0) }}"></span>
+            <span class="{{ getHostStatusIcon(0) }}"></span>
             <span translate>Installed</span>
           </span>
           <span ng-hide="host.content_facet_attributes.katello_agent_installed">
-            <span class="{{ table.getHostStatusIcon(1) }}"></span>
+            <span class="{{ getHostStatusIcon(1) }}"></span>
             <span translate>Not installed</span>
           </span>
         </dd>
@@ -67,7 +67,7 @@
       <dl class="dl-horizontal dl-horizontal-left">
         <dt translate>Subscription Status</dt>
         <dd>
-          <i ng-class="table.getHostStatusIcon(host.subscription_global_status)"></i>
+          <i ng-class="getHostStatusIcon(host.subscription_global_status)"></i>
           {{ host.subscription_status_label }}
         </dd>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-provisioning-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-provisioning-info.html
@@ -14,7 +14,7 @@
 
       <dt translate>Status</dt>
       <dd>
-        <i ng-class="table.getHostStatusIcon(host.global_status)"></i>
+        <i ng-class="getHostStatusIcon(host.global_status)"></i>
         {{ host.global_status_label | translate }}
       </dd>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-subscriptions.html
@@ -12,7 +12,7 @@
       <dl class="dl-horizontal dl-horizontal-left">
         <dt translate>Status</dt>
         <dd>
-          <i ng-class="table.getHostStatusIcon(host.subscription_global_status)"></i>
+          <i ng-class="getHostStatusIcon(host.subscription_global_status)"></i>
           {{ host.subscription_status_label | translate }}
         </dd>
 


### PR DESCRIPTION
The icons that should appear next to subscription & provisioning status across Details, Provisioning Details, and Subscriptions tabs are not showing.

Not sure what went missing (maybe a Bastion change?) but this fixes it!
