### PR TITLE
Fixes #25146 - SuccessMessage call sends link

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/product-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/product-repositories.controller.js
@@ -65,11 +65,10 @@ angular.module('Bastion.products').controller('ProductRepositoriesController',
             var success, error, params = getParams(), removalPromise;
 
             success = function (response) {
-                var message = translate('Removal of selected repositories initiated successfully. ');
-
-                message += translate('<a href="/foreman_tasks/tasks/%taskId">Click here to check the status of the task.</a>').
-                    replace('%taskId', response.task.id);
-                Notification.setSuccessMessage(message);
+                var message = translate('Removal of selected repositories initiated successfully.');
+                var link = ("/foreman_tasks/tasks/%taskId").replace('%taskId', response.task.id);
+                var alertBody = { children: translate("Click to view task"), href: link };
+                Notification.setSuccessMessage(message, {link: alertBody});
             };
 
             error = function (response) {


### PR DESCRIPTION
This fix requires approval and merge of bastion fix (https://github.com/Katello/bastion/pull/233). Change in Foreman requires we send link separately from message to properly populate link in notification message. This fix ensures we send properly to bastion before sending to Foreman.

With up-to-date bastion branch, deleting multiple repositories from product at one time will populate a notification message with a link to the foreman task to view progress. Without fixes, the window will populate, but will include html code that doesn't link to task.