### PR TITLE
Fixes #24916 - Content host details system purpose status

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts-helper.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts-helper.service.js
@@ -23,10 +23,6 @@ angular.module('Bastion.content-hosts').service('ContentHostsHelper',
         this.getHostStatusIcon = function (globalStatus) {
             var icons;
             var colors = {
-                // we can remove 'valid', 'partial', and 'invalid' when http://projects.theforeman.org/issues/15347 is fixed
-                'valid': 'green',
-                'partial': 'yellow',
-                'invalid': 'red',
                 0: 'green',
                 1: 'yellow',
                 2: 'red'
@@ -40,6 +36,14 @@ angular.module('Bastion.content-hosts').service('ContentHostsHelper',
             };
 
             return icons[globalStatus];
+        };
+
+        this.getHostPurposeStatusIcon = function (statusCode) {
+            if (parseInt(statusCode) === 0) {
+                return 'pficon pficon-ok';
+            }
+
+            return 'pficon pficon-warning-triangle-o';
         };
     }
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
@@ -22,6 +22,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsController
         $scope.menuExpander = MenuExpander;
 
         $scope.getHostStatusIcon = ContentHostsHelper.getHostStatusIcon;
+        $scope.getHostPurposeStatusIcon = ContentHostsHelper.getHostPurposeStatusIcon;
 
         $scope.purposeAddonsList = [];
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -92,9 +92,16 @@
       <h4 translate>System Purpose</h4>
 
       <dl class="dl-horizontal dl-horizontal-left">
+        <dt translate>System Purpose Status</dt>
+        <dd>
+          <i ng-class="getHostPurposeStatusIcon(host.purpose_status)"></i>
+          {{ host.purpose_status_label }}
+        </dd>
         <dt translate>Service Level (SLA)</dt>
         <dd bst-edit-select="host.subscription_facet_attributes.service_level"
             readonly="denied('edit_hosts', host)"
+            icon-class="getHostPurposeStatusIcon(host.purpose_sla_status)"
+            icon-show="host.purpose_sla_status > 0"
             selector="host.subscription_facet_attributes.service_level"
             options="serviceLevels()"
             options-format="option for option in options"
@@ -106,6 +113,8 @@
         <dt translate>Usage Type</dt>
         <dd bst-edit-select="host.subscription_facet_attributes.purpose_usage"
             readonly="denied('edit_hosts', host)"
+            icon-class="getHostPurposeStatusIcon(host.purpose_usage_status)"
+            icon-show="host.purpose_usage_status > 0"
             selector="host.subscription_facet_attributes.purpose_usage"
             options="purposeUsages()"
             options-format="option for option in options"
@@ -117,6 +126,8 @@
         <dt translate>Role</dt>
         <dd bst-edit-select="host.subscription_facet_attributes.purpose_role"
             readonly="denied('edit_hosts', host)"
+            icon-class="getHostPurposeStatusIcon(host.purpose_role_status)"
+            icon-show="host.purpose_role_status > 0"
             selector="host.subscription_facet_attributes.purpose_role"
             options="purposeRoles()"
             options-format="option for option in options"
@@ -128,6 +139,8 @@
         <dt translate>Add ons</dt>
         <dd bst-edit-multiselect="host.subscription_facet_attributes.purpose_addons"
             readonly="denied('edit_hosts', host)"
+            icon-class="getHostPurposeStatusIcon(host.purpose_addons_status)"
+            icon-show="host.purpose_addons_status > 0"
             formatter="arrayToString"
             deletable="true"
             on-delete="clearAddOns()"

--- a/engines/bastion_katello/test/content-hosts/content-hosts-helper.service.test.js
+++ b/engines/bastion_katello/test/content-hosts/content-hosts-helper.service.test.js
@@ -10,10 +10,9 @@ describe('Controller: ContentHostsController', function() {
         ContentHostsHelper = $injector.get('ContentHostsHelper');
     }));
 
-    it("provides a way to get the status color for the content host.", function() {
-        expect(ContentHostsHelper.getHostStatusIcon("valid")).toBe(greenStatus);
-        expect(ContentHostsHelper.getHostStatusIcon("partial")).toBe(yellowStatus);
-        expect(ContentHostsHelper.getHostStatusIcon("error")).toBe(redStatus);
+    it("provides a way to get the status icon for system purpose on a host.", function() {
+        expect(ContentHostsHelper.getHostPurposeStatusIcon(0)).toBe("pficon pficon-ok");
+        expect(ContentHostsHelper.getHostPurposeStatusIcon(1)).toBe("pficon pficon-warning-triangle-o");
     });
 
     it("provides a way to get the global status color.", function() {


### PR DESCRIPTION
Testing steps in #7734 also apply here. You'll want to ensure that your environment (foreman, candlepin) are up to date as this requires very recent changes.

The change enables nice display of the system purpose on the content host details pages:

![syspurpose_matched](https://user-images.githubusercontent.com/1979598/46680842-f7b3a780-cbb7-11e8-89e9-0ac0ac53412c.png)

![syspurpose_mismatched](https://user-images.githubusercontent.com/1979598/46680858-013d0f80-cbb8-11e8-81e4-06fe6c76c517.png)
