### PR TITLE
Refs #24902 - apipie fixup for new CV publish api

### DIFF
--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -83,10 +83,8 @@ module Katello
     param :minor, :number, :desc => N_("Override the minor version number"), :required => false
 
     param :repos_units, Array, :desc => N_("Specify the list of units in each repo"), :required => false do
-      param :repo_units, Hash, :desc => N_("a hash containing a repo label and list of units"), :required => true do
-        param :label, String, :desc => N_("repo label"), :required => true
-        param :rpm_filenames, Array, :desc => N_("list of rpm filename strings to include in published version"), :required => true
-      end
+      param :label, String, :desc => N_("repo label"), :required => true
+      param :rpm_filenames, Array, of: String, :desc => N_("list of rpm filename strings to include in published version"), :required => true
     end
     def publish
       if params[:repos_units].present? && @view.composite?


### PR DESCRIPTION
The previous apipie definition was incorrect and caused problems with
hammer.

The Hash definition is implicit and only the keys inside need to be
defined.