### PR TITLE
Fixes #25196 - Correct broken default sort for some scoped_search queries

### DIFF
--- a/app/controllers/katello/api/v2/content_view_histories_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_histories_controller.rb
@@ -7,7 +7,7 @@ module Katello
     api :GET, "/content_views/:id/history", N_("Show a content view's history")
     param :id, :number, :desc => N_("content view numeric identifier"), :required => true
     def index
-      respond_for_index :collection => scoped_search(index_relation.distinct, :katello_content_view_version_id, :asc, :resource_class => ContentViewHistory)
+      respond_for_index :collection => scoped_search(index_relation.distinct, :content_view_version_id, :asc, :resource_class => ContentViewHistory)
     end
 
     def index_relation

--- a/app/models/katello/concerns/content_view_filter_rule_common.rb
+++ b/app/models/katello/concerns/content_view_filter_rule_common.rb
@@ -4,6 +4,7 @@ module Katello
       extend ActiveSupport::Concern
 
       included do
+        scoped_search on: :id
         scoped_search on: :name
 
         validates_lengths_from_database

--- a/app/models/katello/content_view_history.rb
+++ b/app/models/katello/content_view_history.rb
@@ -25,6 +25,7 @@ module Katello
     alias_method :version, :content_view_version
     alias_attribute :description, :notes
 
+    scoped_search :on => :id, :relation => :content_view_version, :rename => :content_view_version_id
     scoped_search :on => :name, :relation => :environment, :rename => :environment, :complete_value => true
 
     enum action: {

--- a/test/controllers/api/v2/content_credentials_controller_test.rb
+++ b/test/controllers/api/v2/content_credentials_controller_test.rb
@@ -44,7 +44,6 @@ module Katello
 
     def test_content
       get :content, params: { :id => @gpg_key.id }
-      assert_response :success
       assert_equal @response.body, @gpg_key.content
     end
 

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -153,6 +153,18 @@ class ActionController::TestCase
     @auth_permissions = [@read_permission]
     @unauth_permissions = [@create_permission, @update_permission, @destroy_permission, @sync_permission]
   end
+
+  def assert_response(type, message = nil)
+    if type == :success
+      if response.body.present? && /json/.match(response.headers['Content-Type'])
+        json_body = JSON.parse(response.body)
+        if json_body.is_a?(Hash)
+          assert_nil json_body['error']
+        end
+      end
+    end
+    super(type, message)
+  end
 end
 
 class ActiveSupport::TestCase


### PR DESCRIPTION
I fixed the errors and provided a way to catch them sooner. Could use some feedback on the approach I took - I opted to add the missing scoped_search definitions, but I could see us just changing the attribute used for the default sort with something already defined.