### PR TITLE
Fixes #25210 - Manifest refresh broken when ostree content enabled

### DIFF
--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -160,7 +160,7 @@ module Katello
           Runcible::Models::DockerImporter.new(importer_connection_options(capsule).merge(options))
         when Repository::OSTREE_TYPE
           options = importer_connection_options(capsule)
-          options[:depth] = capsule.default_capsule? ? compute_ostree_upstream_sync_depth : ostree_capsule_sync_depth
+          options[:depth] = capsule.default_capsule? ? root.compute_ostree_upstream_sync_depth : ostree_capsule_sync_depth
           options[:feed] = self.importer_feed_url(capsule)
           Runcible::Models::OstreeImporter.new(options)
         when Repository::DEB_TYPE

--- a/test/glue/pulp/repository_test.rb
+++ b/test/glue/pulp/repository_test.rb
@@ -226,7 +226,7 @@ module Katello
     def test_importer_ostree
       ostree_repo = katello_repositories(:ostree)
       depth = 100
-      ostree_repo.expects(:compute_ostree_upstream_sync_depth).returns(depth)
+      ostree_repo.root.expects(:compute_ostree_upstream_sync_depth).returns(depth)
       importer = ostree_repo.generate_importer
       assert_equal depth, importer.depth
     end
@@ -236,7 +236,7 @@ module Katello
       capsule = FactoryBot.build(:bmc_smart_proxy)
       depth = 100
       ostree_repo = katello_repositories(:ostree)
-      ostree_repo.expects(:compute_ostree_upstream_sync_depth).never
+      ostree_repo.root.expects(:compute_ostree_upstream_sync_depth).never
       ostree_repo.expects(:ostree_capsule_sync_depth).returns(depth)
       importer = ostree_repo.generate_importer(capsule)
       assert_equal depth, importer.depth


### PR DESCRIPTION
If you currently have a manifest imported that provides ostree content  *and* one or more ostree repos are enabled, refreshing the manifest will fail:

```
undefined local variable or method `compute_ostree_upstream_sync_depth' for #<Katello::Repository:0x00007fd23e277d20>
```

Applying this PR fixes that!