### PR TITLE
Fixes #25212 - computed_ostree_upstream_sync_depth missing from repository API 

### DIFF
--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -21,7 +21,8 @@ glue(@resource.root) do
   attributes :product_type
   attributes :ostree_branch_names => :ostree_branches
   attributes :upstream_username
-  attributes :ostree_upstream_sync_policy, :ostree_upstream_sync_depth, :compute_ostree_upstream_sync_depth => :computed_ostree_upstream_sync_depth
+  attributes :ostree_upstream_sync_policy, :ostree_upstream_sync_depth
+  attributes :compute_ostree_upstream_sync_depth => :computed_ostree_upstream_sync_depth
   attributes :deb_releases, :deb_components, :deb_architectures
   attributes :ignore_global_proxy
   attributes :ignorable_content


### PR DESCRIPTION
Given an ostree repo, look at it's output in the API: https://{{hostname}}/katello/api/v2/repositories/22/?organization_id=1

Note that the attribute `computed_ostree_upstream_sync_depth` is missing. This PR puts it back, but I have no idea why this fixes it. Either this never worked (attribute aliasing needs to happen on their own call to `attributes`) or this is regression in rabl.