### PR TITLE
Fixes #25226 - Export Content host search filter

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-hosts.controller.js
@@ -37,7 +37,10 @@ angular.module('Bastion.content-hosts').controller('ContentHostsController',
             'sort_order': 'ASC'
         };
 
-        $scope.csvQuery = $httpParamSerializer(params);
+        $scope.csvQuery = function () {
+            return $httpParamSerializer(params);
+        };
+
         nutupane = new Nutupane(Host, params);
         $scope.controllerName = 'hosts';
         nutupane.masterOnly = true;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
@@ -7,7 +7,7 @@
   </div>
 
   <div data-block="list-actions">
-    <a href="/hosts/content_hosts.csv?{{csvQuery}}" class="btn btn-default" target="_self">
+    <a href="/hosts/content_hosts.csv?{{csvQuery()}}" class="btn btn-default" target="_self">
       <span translate>Export</span>
     </a>
     <button class="btn btn-default"


### PR DESCRIPTION
Steps to reproduce
**** 
Go to UI > Host> Content Host > Put a search query
Click on export

**Result:** 
Only the filtered results should be exported in the csv