### PR TITLE
fixes #25284 - supply additional repos to anaconda if req'd

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -278,6 +278,10 @@ module Katello
       all_instances
     end
 
+    def to_hash(content_source = nil)
+      {id: id, name: label, url: full_path(content_source)}
+    end
+
     #is the repo cloned in the specified environment
     def cloned_in?(env)
       !get_clone(env).nil?

--- a/app/services/katello/managed_content_medium_provider.rb
+++ b/app/services/katello/managed_content_medium_provider.rb
@@ -14,6 +14,13 @@ module Katello
       URI.parse(url)
     end
 
+    # If there is an 'AppStream' variant, we need to make it
+    # available to Anaconda
+    def additional_media
+      appstream = entity.operatingsystem.variant_repo(entity, 'AppStream')
+      super + (appstream ? [appstream] : [])
+    end
+
     def unique_id
       @unique_id ||= begin
         "#{kickstart_repo.name.parameterize}-#{kickstart_repo.id}"

--- a/test/models/concerns/redhat_extensions_test.rb
+++ b/test/models/concerns/redhat_extensions_test.rb
@@ -114,16 +114,22 @@ module Katello
     end
 
     def test_kickstart_repos_with_no_content_source
-      @os.expects(:distribution_repositories).with(@host).returns([@repo_with_distro])
+      distro_repos = mock('distribution_repos').tap do |mock|
+        mock.expects(:where).returns([@repo_with_distro])
+      end
+      @os.expects(:distribution_repositories).with(@host).returns(distro_repos)
       @host.content_facet.content_source = nil
       assert_empty @os.kickstart_repos(@host)
     end
 
     def test_kickstart_repos_with_one_distro
-      @os.expects(:distribution_repositories).with(@host).returns([@repo_with_distro])
+      distro_repos = mock('distribution_repos').tap do |mock|
+        mock.expects(:where).returns([@repo_with_distro])
+      end
+      @os.expects(:distribution_repositories).with(@host).returns(distro_repos)
       repos = @os.kickstart_repos(@host)
       refute_empty repos
-      assert_equal @repo_with_distro.full_path(@content_source), repos.first[:path]
+      assert_equal @repo_with_distro.full_path(@content_source), repos.first[:url]
     end
   end
 end

--- a/test/services/katello/managed_content_medium_provider.rb
+++ b/test/services/katello/managed_content_medium_provider.rb
@@ -8,17 +8,32 @@ module Katello
     class ManagedContentMediumProvider < ManagedContentMediumProviderTestBase
       setup do
         @org = FactoryBot.create(:katello_organization)
-        @distro = FactoryBot.create(:katello_repository)
+        @distro = FactoryBot.create(:katello_repository,  :with_product)
+        @variant = FactoryBot.create(:katello_repository, :with_product)
       end
 
       def test_unique_id
-        host = ::Host::Managed.new(:name => 'foobar', :managed => false, :organization => @org)
+        host = FactoryBot.build(:host, :managed, :redhat, :with_content, organization: @org)
         host.content_facet.kickstart_repository = @distro
         host_group = ::Hostgroup.new(:name => 'bar')
         host_group.kickstart_repository = @distro
         assert_not_nil ::Katello::ManagedContentMediumProvider.new(host).unique_id
         assert_not_nil ::Katello::ManagedContentMediumProvider.new(host.content_facet).unique_id
         assert_not_nil ::Katello::ManagedContentMediumProvider.new(host_group).unique_id
+      end
+
+      def test_kickstart_repo
+        host = FactoryBot.build(:host, :managed, :redhat, :with_content, organization: @org)
+        host.content_facet.kickstart_repository = @distro
+        provider = ::Katello::ManagedContentMediumProvider.new(host)
+        assert_equal provider.kickstart_repo, @distro
+      end
+
+      def test_additional_media
+        host = FactoryBot.build(:host, :managed, :redhat, organization: @org)
+        Redhat.any_instance.expects(:variant_repo).with(host, 'AppStream').returns(@variant.to_hash)
+        provider = ::Katello::ManagedContentMediumProvider.new(host)
+        assert_includes provider.additional_media, @variant.to_hash
       end
     end
   end


### PR DESCRIPTION
Requires https://github.com/theforeman/foreman/pull/6166, https://github.com/theforeman/community-templates/pull/531

How to test this

1. Sync split content down from the CDN, e.g. a kickstart repo that has both base OS and appstream available (I have a manifest if you'd like)

2. Grab the foreman and the kickstart template out of the linked PR's above

3. Create a new host, configure it's kickstart repository to be the "base OS" bootable kickstart repo you previously synced

4. Preview the provisioning template, and notice you have two media sources defined for anaconda

```
url --url http://centos7-devel.zpm.example.com/pulp/repos/Default_Organization/Library/custom/Thing/BaseOS_x86_64_os/
repo --name AppStream_x86_64_os --baseurl http://centos7-devel.zpm.example.com/pulp/repos/Default_Organization/Library/custom/Thing/AppStream_x86_64_os/ 
```