### PR TITLE
Fixes #25287 - fix incorrect rails autoload

### DIFF
--- a/app/lib/katello/resources/candlepin/product.rb
+++ b/app/lib/katello/resources/candlepin/product.rb
@@ -9,7 +9,7 @@ module Katello
           end
 
           def find_for_stacking_id(owner_key, stacking_id)
-            Subscription.get_for_owner(owner_key).each do |subscription|
+            Resources::Candlepin::Subscription.get_for_owner(owner_key).each do |subscription|
               if subscription['product']['attributes'].any? { |attr| attr['name'] == 'stacking_id' && attr['value'] == stacking_id }
                 return subscription['product']
               end


### PR DESCRIPTION
under some conditions, in production this Subscription class
was being referenced and rails was loading the model, which
has the same method on it, returning different results