### PR TITLE
Fixes #25258 - Host collection mod stream fix

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-host-bulk-module-streams-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-host-bulk-module-streams-modal.html
@@ -9,7 +9,7 @@
       <input type="hidden" name="remote_action" ng-value="moduleStreamActionFormValues.remoteAction"/>
       <input type="hidden" name="module_stream_action" ng-value="moduleStreamActionFormValues.moduleStreamAction"/>
       <input type="hidden" name="module_spec" ng-value="moduleStreamActionFormValues.moduleSpec"/>
-      <input type="hidden" name="scoped_search" ng-value="errataActionFormValues.search"/>
+      <input type="hidden" name="scoped_search" ng-value="moduleStreamActionFormValues.search"/>
       <input type="hidden" name="host_ids" ng-value="moduleStreamActionFormValues.hostIds"/>
       <input type="hidden" name="customize" ng-value="moduleStreamActionFormValues.customize"/>
       <input type="hidden" name="authenticity_token" ng-value="moduleStreamActionFormValues.authenticityToken"/>


### PR DESCRIPTION
Host collections should only submit their own hosts. Due
to the typo, they were submitting all the hosts in the org
when sending a remote action. To test, go to host collection
page and perform a module stream action. Ensure no hosts
outside the host collection are affected. These actions
are perfomed by remote execution.