### PR TITLE
Fixes #25321 - Correct environment count on CV delete

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-versions.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-versions.controller.js
@@ -170,7 +170,9 @@ angular.module('Bastion.content-views').controller('ContentViewVersionsControlle
 
         $scope.status = function (version) {
             var taskTypes = $scope.taskTypes,
-                deletionEvents = findTaskTypes(version['active_history'], taskTypes.deletion),
+                deletionEvents = _.filter(findTaskTypes(version['active_history'], taskTypes.deletion), function(history) {
+                    return history.environment != null;
+                }),
                 promotionEvents = findTaskTypes(version['active_history'], taskTypes.promotion),
                 publishEvents = findTaskTypes(version['active_history'], taskTypes.publish),
                 messages = "";

--- a/engines/bastion_katello/test/content-views/details/content-view-versions.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/content-view-versions.controller.test.js
@@ -15,7 +15,8 @@ describe('Controller: ContentViewVersionsController', function() {
         $scope.reloadVersions = function () {};
         $scope.taskTypes = {
             promotion: "promotion",
-            publish: "publish"
+            publish: "publish",
+            deletion: "deletion"
         };
 
         $scope.transitionTo = function(){};
@@ -106,5 +107,20 @@ describe('Controller: ContentViewVersionsController', function() {
 
         version.last_event.task.label = $scope.taskTypes.publish;
         expect($scope.historyText(version)).toBe("Published");
+    });
+
+    it("displays correct number of environments", function() {
+        var version = {active_history: [ {task: {label: "promotion"}} ],
+            environments: []
+        };
+        expect($scope.status(version)).toBe("Promoting to 1 environment.");
+
+        version = {active_history: [ {task: {label: "publish"}} ] };
+        expect($scope.status(version)).toBe("Publishing and promoting to 1 environment.");
+
+        version = {active_history: [ {environment: {name: "test"}, task: {label: "deletion"} }, {environment: null, task: {label: "deletion"} } ],
+            environments: [ {name: "test"} ]
+        };
+        expect($scope.status(version)).toBe("Deleting from 1 environment.");
     });
 });


### PR DESCRIPTION
Description of problem:

When I delete a content view version using the UI, it tells me that I'm deleting from 1 more environment than I actually am.

How reproducible: Every time.

Steps to Reproduce:
1. Delete a content view using the "Completely remove version?" checkbox

Actual results:
Message: Deleting from X environments will show 1 more than actual environments the view is being deleted from.

Expected results:
Message: Deleting from X environments will show the proper number of environments the view is being deleted from.