### PR TITLE
Fixes #25087 - Import module inventory from subman

### DIFF
--- a/app/controllers/katello/api/v2/host_module_streams_controller.rb
+++ b/app/controllers/katello/api/v2/host_module_streams_controller.rb
@@ -1,0 +1,37 @@
+module Katello
+  class Api::V2::HostModuleStreamsController < Api::V2::ApiController
+    include Katello::Concerns::FilteredAutoCompleteSearch
+
+    before_action :find_host
+
+    resource_description do
+      api_version 'v2'
+      api_base_url "/api"
+    end
+
+    api :GET, "/hosts/:host_id/module_streams", N_("List module streams available to the host")
+    param :host_id, :number, :required => true, :desc => N_("ID of the host")
+    param :status, ::Katello::HostAvailableModuleStream::API_STATES.keys, :desc => N_("Streams based on the host based on their status")
+    param_group :search, Api::V2::ApiController
+    def index
+      collection = scoped_search(index_relation, :name, :asc, :resource_class => ::Katello::HostAvailableModuleStream)
+      respond_for_index(:collection => collection)
+    end
+
+    def index_relation
+      rel = @host.host_available_module_streams
+      return rel if params[:status].blank?
+      rel.send(::Katello::HostAvailableModuleStream::API_STATES[params[:status]])
+    end
+
+    def resource_class
+      Katello::HostAvailableModuleStream
+    end
+
+    private
+
+    def find_host
+      @host = resource_finder(::Host::Managed.authorized(:view_hosts, ::Host::Managed), params[:host_id])
+    end
+  end
+end

--- a/app/lib/actions/katello/host/upload_profiles.rb
+++ b/app/lib/actions/katello/host/upload_profiles.rb
@@ -46,6 +46,8 @@ module Actions
                 UploadPackageProfile.upload(input[:host_id], payload)
               when "enabled_repos"
                 host.import_enabled_repositories(payload)
+              else
+                host.import_module_streams(payload)
               end
             end
           end

--- a/app/models/katello/available_module_stream.rb
+++ b/app/models/katello/available_module_stream.rb
@@ -1,0 +1,11 @@
+module Katello
+  class AvailableModuleStream < Katello::Model
+    has_many :hosts, :through => :host_available_module_streams, :class_name => "::Host"
+    has_many :host_available_module_streams, :class_name => "Katello::HostAvailableModuleStream", :dependent => :destroy, :inverse_of => :available_module_stream
+    serialize :profiles
+
+    def module_spec
+      "#{name}:#{stream}"
+    end
+  end
+end

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -129,7 +129,6 @@ module Katello
       end
 
       def import_module_streams(module_streams)
-        # TODO: Implement this when module stream support is added
         streams = {}
         module_streams.each do |module_stream|
           stream = AvailableModuleStream.where(name: module_stream["name"],
@@ -152,9 +151,9 @@ module Katello
         new_ids.each do |new_id|
           module_stream = new_available_module_streams[new_id]
           self.host_available_module_streams.create!(host_id: self.id,
-                                          available_module_stream_id: new_id,
-                                          installed_profiles: module_stream["installed_profiles"],
-                                          status: module_stream["status"])
+                                                     available_module_stream_id: new_id,
+                                                     installed_profiles: module_stream["installed_profiles"],
+                                                     status: module_stream["status"])
         end
 
         updatable_streams.each do |hams|

--- a/app/models/katello/host_available_module_stream.rb
+++ b/app/models/katello/host_available_module_stream.rb
@@ -1,0 +1,30 @@
+module Katello
+  class HostAvailableModuleStream < Katello::Model
+    belongs_to :host, :inverse_of => :host_available_module_streams, :class_name => '::Host::Managed'
+    belongs_to :available_module_stream, :inverse_of => :host_available_module_streams, :class_name => 'Katello::AvailableModuleStream'
+    serialize :installed_profiles
+
+    scope :installed, -> { enabled.where.not(installed_profiles: []) }
+    scope :enabled, -> { where(status: ENABLED) }
+    scope :disabled, -> { where(status: DISABLED) }
+    scope :unknown, -> { where(status: UNKNOWN) }
+
+    ENABLED = "enabled".freeze
+    DISABLED = "disabled".freeze
+    UNKNOWN = "unknown".freeze
+    INSTALLED = "installed".freeze
+
+    STATUS = [ENABLED, DISABLED, UNKNOWN].freeze
+
+    API_STATES = {
+      ENABLED => :enabled,
+      DISABLED => :disabled,
+      UNKNOWN => :unknown,
+      INSTALLED => :installed
+    }.with_indifferent_access
+
+    scoped_search :on => :name, :relation => :available_module_stream, :complete_value => true
+    scoped_search :on => :stream, :relation => :available_module_stream, :complete_value => false
+    scoped_search :on => :status, :complete_value => STATUS
+  end
+end

--- a/app/views/katello/api/v2/host_module_streams/base.json.rabl
+++ b/app/views/katello/api/v2/host_module_streams/base.json.rabl
@@ -1,0 +1,7 @@
+object @resource
+
+attributes :status, :installed_profiles
+
+glue(@object.available_module_stream) do
+  attributes :name, :stream, :module_spec
+end

--- a/app/views/katello/api/v2/host_module_streams/index.json.rabl
+++ b/app/views/katello/api/v2/host_module_streams/index.json.rabl
@@ -1,0 +1,7 @@
+object false
+
+extends "katello/api/v2/common/metadata"
+
+child @collection[:results] => :results do
+  extends 'katello/api/v2/host_module_streams/base'
+end

--- a/config/routes/overrides.rb
+++ b/config/routes/overrides.rb
@@ -92,6 +92,10 @@ Foreman::Application.routes.draw do
             end
           end
 
+          resources :module_streams, :only => [:index], :controller => :host_module_streams do
+            get :auto_complete_search, :on => :collection
+          end
+
           resources :subscriptions, :only => [:index], :controller => :host_subscriptions do
             collection do
               put :auto_attach

--- a/db/migrate/20181017181806_available_module_streams.rb
+++ b/db/migrate/20181017181806_available_module_streams.rb
@@ -1,0 +1,34 @@
+class AvailableModuleStreams < ActiveRecord::Migration[5.2]
+  def up
+    create_table :katello_available_module_streams do |t|
+      t.string :name
+      t.string :stream
+    end
+
+    create_table :katello_host_available_module_streams do |t|
+      t.references :host, :null => false, :index => true
+      t.references :available_module_stream, :null => false, :index => false
+      t.text :installed_profiles
+      t.string :status
+    end
+
+    add_index :katello_available_module_streams, [:name, :stream], :unique => true, :name => :katello_available_module_streams_name_stream
+
+    add_foreign_key :katello_host_available_module_streams, :hosts,
+                    :name => :katello_hems_host_id_fk, :column => :host_id
+
+    add_foreign_key :katello_host_available_module_streams, :katello_available_module_streams,
+                    :name => :katello_hems_available_module_stream_id_fk, :column => :available_module_stream_id
+
+    add_index :katello_host_available_module_streams, :available_module_stream_id,
+              name: :index_katello_hems_available_module_stream_id
+  end
+
+  def down
+    remove_foreign_key :katello_host_available_module_streams, name: :katello_hems_host_id_fk
+    remove_foreign_key :katello_host_available_module_streams, name: :katello_hems_available_module_stream_id_fk
+
+    drop_table :katello_host_available_module_streams
+    drop_table :katello_available_module_streams
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/common/module-stream-actions.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/common/module-stream-actions.service.js
@@ -16,7 +16,8 @@
                 { action: 'disable', description: translate("Disable")},
                 { action: 'install', description: translate("Install")},
                 { action: 'update', description: translate("Update")},
-                { action: 'remove', description: translate("Remove")}
+                { action: 'remove', description: translate("Remove")},
+                { action: 'reset', description: translate("Reset")}
             ];
         };
     }

--- a/lib/katello/permissions/host_permissions.rb
+++ b/lib/katello/permissions/host_permissions.rb
@@ -41,6 +41,7 @@ Foreman::AccessControl.permission(:view_hosts).actions.concat [
   'katello/api/v2/host_errata/show',
   'katello/api/v2/host_errata/auto_complete_search',
   'katello/api/v2/host_module_streams/index',
+  'katello/api/v2/host_module_streams/auto_complete_search',
   'katello/api/v2/host_subscriptions/index',
   'katello/api/v2/host_subscriptions/events',
   'katello/api/v2/host_subscriptions/product_content',

--- a/lib/katello/permissions/host_permissions.rb
+++ b/lib/katello/permissions/host_permissions.rb
@@ -40,6 +40,7 @@ Foreman::AccessControl.permission(:view_hosts).actions.concat [
   'katello/api/v2/host_errata/index',
   'katello/api/v2/host_errata/show',
   'katello/api/v2/host_errata/auto_complete_search',
+  'katello/api/v2/host_module_streams/index',
   'katello/api/v2/host_subscriptions/index',
   'katello/api/v2/host_subscriptions/events',
   'katello/api/v2/host_subscriptions/product_content',

--- a/test/actions/katello/host/upload_profiles_test.rb
+++ b/test/actions/katello/host/upload_profiles_test.rb
@@ -47,6 +47,7 @@ module Katello::Host
           packages.map(&:nvra).must_equal(expected_packages.map(&:nvra))
         end
         @host.expects(:import_enabled_repositories).with(enabled_repos)
+        @host.expects(:import_module_streams).with(modumd_inventory)
 
         plan_action action, @host, profile.to_json
         run_action action
@@ -62,6 +63,7 @@ module Katello::Host
         ::Katello::Pulp::Consumer.expects(:new).returns(mock_consumer)
         @host.expects(:import_package_profile).with(any_parameters).never
         @host.expects(:import_enabled_repositories).with(enabled_repos)
+        @host.expects(:import_module_streams).with(modumd_inventory)
 
         plan_action action, @host, profile.to_json
         run_action action
@@ -100,7 +102,7 @@ module Katello::Host
         ::Katello::Pulp::Consumer.expects(:new).returns(mock_consumer)
         @host.expects(:import_package_profile).with(any_parameters).raises(ActiveRecord::InvalidForeignKey)
         @host.expects(:import_enabled_repositories).with(enabled_repos)
-
+        @host.expects(:import_module_streams).with(modumd_inventory)
         plan_action action, @host, profile.to_json
         run_action action
       end

--- a/test/controllers/api/v2/host_module_streams_controller_test.rb
+++ b/test/controllers/api/v2/host_module_streams_controller_test.rb
@@ -1,0 +1,53 @@
+# encoding: utf-8
+
+require "katello_test_helper"
+
+module Katello
+  class Api::V2::HostModuleStreamsControllerTest < ActionController::TestCase
+    include Support::ForemanTasks::Task
+    tests ::Katello::Api::V2::HostModuleStreamsController
+
+    def permissions
+      @view_permission = :view_hosts
+      @create_permission = :create_hosts
+      @update_permission = :edit_hosts
+      @destroy_permission = :destroy_hosts
+    end
+
+    def setup
+      setup_controller_defaults_api
+      login_user(users(:admin))
+      @request.env['HTTP_ACCEPT'] = 'application/json'
+
+      @host = hosts(:one)
+      @content_facet = katello_content_facets(:content_facet_one)
+      @host.content_facet = @content_facet
+
+      setup_foreman_routes
+      permissions
+    end
+
+    def test_index
+      get :index, params: { :host_id => @host.id }
+
+      assert_response :success
+    end
+
+    def test_view_permissions
+      good_perms = [@view_permission]
+      bad_perms = [@update_permission, @create_permission, @destroy_permission]
+
+      assert_protected_action(:index, good_perms, bad_perms) do
+        user = User.current
+        as_admin do
+          user.update_attribute(:organizations, [taxonomies(:organization1)])
+          @host.update_attribute(:organization, taxonomies(:organization1))
+          user.update_attribute(:locations, [taxonomies(:location1)])
+          @host.update_attribute(:location, taxonomies(:location1))
+        end
+
+        get :index, params: { :host_id => @host.id }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds code to import module inventory from subscription manager
This commit adds routing and api bindings to import the combined report
from subscription manager

Background:
Subscription Manager is going to consolidate
* Package Profiles
* Module MD Data
* Enabled Repository report
all in a single payload to a new end point
(candlepin/subscription-manager#1927)

As a user I would like Katello to accept the new payload from
Subscription Manager

This commit does the following
* Implements the module md inventory endpoint
* Adds the models and controller for Available and HostAvailable module
streams