### PR TITLE
Fixes #25344 - subclass error with db:migrate

### DIFF
--- a/db/migrate/20141209103005_disown_foreman_templates.rb
+++ b/db/migrate/20141209103005_disown_foreman_templates.rb
@@ -19,11 +19,6 @@ class DisownForemanTemplates < ActiveRecord::Migration[4.2]
 
   def update_templates_attributes(attribute_hash)
     templates = ["puppet.conf", "freeipa_register", "Kickstart default iPXE", "Kickstart default PXELinux", "PXELinux global default"]
-
-    templates.each do |template|
-      if (template = FakeConfigTemplate.find_by(:name => template))
-        template.update_attributes(attribute_hash)
-      end
-    end
+    FakeConfigTemplate.where(name: templates).update_all(attribute_hash)
   end
 end


### PR DESCRIPTION
Without this, I get the error in the Redmine issue. Fix came from @tbrisker :+1: 