### PR TITLE
Fixes #25348 - CV filter API displays correctly

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filter_rules_controller.rb
@@ -107,7 +107,7 @@ module Katello
 
     def find_rule
       rule_clazz = ContentViewFilter.rule_class_for(@filter)
-      @rule = rule_clazz.find(params[:id])
+      @rule = rule_clazz.where(content_view_filter_id: @filter.id).find(params[:id])
     end
 
     def rule_params

--- a/test/controllers/api/v2/content_view_filter_rules_controller_test.rb
+++ b/test/controllers/api/v2/content_view_filter_rules_controller_test.rb
@@ -6,7 +6,8 @@ module Katello
   class Api::V2::ContentViewFilterRulesControllerTest < ActionController::TestCase
     def models
       @filter = katello_content_view_filters(:simple_filter)
-      @rule = katello_content_view_package_filter_rules(:package_rule)
+      @rule = katello_content_view_package_filter_rules(:test_package)
+      @rule_for_different_filter = katello_content_view_package_filter_rules(:package_rule)
     end
 
     def permissions
@@ -45,8 +46,8 @@ module Katello
 
       assert_template :layout => 'katello/api/v2/layouts/resource'
       assert_template 'katello/api/v2/common/create'
-      assert_equal @filter.reload.package_rules.first.name, "testpkg"
-      assert_equal @filter.package_rules.first.version, "10.0"
+      assert_equal @filter.reload.package_rules.second.name, "testpkg"
+      assert_equal @filter.package_rules.second.version, "10.0"
     end
 
     def test_create_with_name_array
@@ -56,8 +57,8 @@ module Katello
 
       assert_template layout: 'katello/api/v2/layouts/collection'
       assert_template 'katello/api/v2/content_view_filter_rules/index'
-      assert_equal @filter.reload.package_rules.sort.map(&:name), %w(testpkg testpkg2)
-      assert_equal @filter.package_rules.map(&:version), %w(10.0 10.0)
+      assert_equal @filter.reload.package_rules.sort.map(&:name), %w(package\ def testpkg testpkg2)
+      assert_equal @filter.package_rules.map(&:version), %w(1.0 10.0 10.0)
     end
 
     def test_create_protected
@@ -74,6 +75,12 @@ module Katello
 
       assert_response :success
       assert_template 'api/v2/content_view_filter_rules/show'
+    end
+
+    def test_mismatched_filter_and_rule
+      get :show, params: { :content_view_filter_id => @filter.id, :id => @rule_for_different_filter.id }
+
+      assert_response 404
     end
 
     def test_show_protected

--- a/test/fixtures/models/katello_content_view_package_filter_rules.yml
+++ b/test/fixtures/models/katello_content_view_package_filter_rules.yml
@@ -4,3 +4,10 @@ package_rule:
   content_view_filter_id:  <%= ActiveRecord::FixtureSet.identify(:populated_package_filter) %>
   created_at:              <%= Time.now %>
   updated_at:              <%= Time.now %>
+
+test_package:
+  name:                    package def
+  version:                 1.0
+  content_view_filter_id:  <%= ActiveRecord::FixtureSet.identify(:simple_filter) %>
+  created_at:              <%= Time.now %>
+  updated_at:              <%= Time.now %>


### PR DESCRIPTION
This pull request fixes the issue with incorrectly displaying a rule id that does not exist in the content view filter id provided in the api call. Please check the output and make sure we are ok with the display message as-is:

{
    "displayMessage": "Couldn't find Katello::ContentViewErratumFilterRule with 'id'=1 [WHERE \"katello_content_view_erratum_filter_rules\".\"content_view_filter_id\" = $1]",
    "errors": [
        "Couldn't find Katello::ContentViewErratumFilterRule with 'id'=1 [WHERE \"katello_content_view_erratum_filter_rules\".\"content_view_filter_id\" = $1]"
    ]
}

**_Also had to fix some issues with the test file. We were using a rule that didn't belong to the filter in the same test. I changed that and then created a new rule that we could use to test for this bug._**

**Description of problem:**
API request to fetch the CV filter rules for a particular content-view can display filter rule information of another CV filter. 

**Affected api:**
GET /katello/api/content_view_filters/:content_view_filter_id/rules/:id 	Show filter rule info

**Steps to Reproduce:**
1. Create 2 CVs testcv1 and testcv2 to keep it simple.
2. Add some repo on them and create one filter a piece on the CVs with "erratum by ID"
3. Include some errata in the filters, publish a cv version

**Additional info:**
Lets assume that the testcv1 has a filter with content_view_filter_id=1, testcv2 has a filter with  content_view_filter_id=1

**Filter1:**
-------------------
[root ~]# curl -s -u admin:redhat -k "-H Content-Type: application/json" "-d{\"per_page\":9999999}" -X GET https://centos7.localhost.example.com/katello/api/v2/content_view_filters/1/rules/  | python -m json.tool 

**Filter 2:**
-------------------
root ~]# curl -s -u admin:redhat -k "-H Content-Type: application/json" "-d{\"per_page\":9999999}" -X GET https://centos7.localhost.example.com/katello/api/v2/content_view_filters/2/rules/  | python -m json.tool


---------------------
If you see the above output then the filter 2 does not have any rules with id "1". So ideally filter 2 should not display any information for GET request for rules with that id. But that's not the case, because same GET request results into the information of rule with id 1 from the filter 1 which is not ideal.


**Actual Result:**

[root ~]# curl -s -u admin:redhat -k "-H Content-Type: application/json" "-d{\"per_page\":9999999}" -X GET https://centos7.localhost.example.com/katello/api/v2/content_view_filters/2/rules/1  | python -m json.tool
{
    "content_view_filter_id": 1,
    "created_at": "2018-08-28 13:43:14 UTC",
    "date_type": "updated",
    "errata_id": "RHBA-2017:2804",
    "id": 1,
    "updated_at": "2018-08-28 13:43:14 UTC"
}


**Expected result:**

[root ~]# curl -s -u admin:redhat -k "-H Content-Type: application/json" "-d{\"per_page\":9999999}" -X GET https://centos7.localhost.example.com/katello/api/v2/content_view_filters/2/rules/1  | python -m json.tool
{
    "displayMessage": "Couldn't find Katello::ContentViewErratumFilterRule with 'id'=1",
    "errors": [
        "Couldn't find Katello::ContentViewErratumFilterRule with 'id'=1"
    ]
}