### PR TITLE
fixes #25231 - fixes default order field in content view history

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/histories/content-view-history.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/histories/content-view-history.controller.js
@@ -16,7 +16,7 @@ angular.module('Bastion.content-views').controller('ContentViewHistoryController
 
         nutupane = new Nutupane(ContentViewHistory, {
             contentViewId: $scope.$stateParams.contentViewId,
-            'sort_by': 'created_at',
+            'sort_by': 'content_view_version_id',
             'sort_order': 'DESC'
         });
         $scope.controllerName = 'katello_content_views';


### PR DESCRIPTION
Different fields in content views were altered, leaving the histories tab on content views unable to render. This corrects the `sort_by` field to return the content view history in the order in which they were created.

To test:
* create and publish and/or promote a content view
* navigate to the History tabs

Bug: returned an empty page with notification that `created_by` was not a valid search field
Fix: returns the content view's history without error.