### PR TITLE
Fixes #25371 - do not fall back to master smart proxy

### DIFF
--- a/app/lib/actions/pulp/abstract.rb
+++ b/app/lib/actions/pulp/abstract.rb
@@ -12,8 +12,8 @@ module Actions
         capsule_content(capsule_id).extensions
       end
 
-      def smart_proxy(capsule_id = nil)
-        capsule_id ? SmartProxy.unscoped.find(capsule_id || input[:capsule_id]) : SmartProxy.default_capsule
+      def smart_proxy(id)
+        SmartProxy.unscoped.find(id)
       end
 
       private

--- a/app/lib/actions/pulp/repository/create.rb
+++ b/app/lib/actions/pulp/repository/create.rb
@@ -6,6 +6,7 @@ module Actions
 
         input_format do
           param :repository_id
+          param :capsule_id
         end
 
         def plan(repository, smart_proxy = SmartProxy.pulp_master!)
@@ -23,7 +24,7 @@ module Actions
             repo = ::Katello::ContentViewPuppetEnvironment.find(input[:content_view_puppet_environment_id]).nonpersisted_repository
           end
 
-          output[:response] = repo.backend_service(smart_proxy).create
+          output[:response] = repo.backend_service(smart_proxy(input[:capsule_id])).create
         rescue RestClient::Conflict
           Rails.logger.warn("Tried to add repository #{input[:pulp_id]} that already exists.")
           []

--- a/app/lib/actions/pulp/repository/create_in_plan.rb
+++ b/app/lib/actions/pulp/repository/create_in_plan.rb
@@ -5,7 +5,7 @@ module Actions
         alias_method :perform_run, :run
 
         def plan(repository)
-          input[:response] = repository.backend_service(smart_proxy).create
+          input[:response] = repository.backend_service(SmartProxy.pulp_master).create
         rescue RestClient::Conflict
           Rails.logger.warn("Tried to add repository #{input[:pulp_id]} that already exists.")
         end

--- a/app/lib/actions/pulp/repository/sync.rb
+++ b/app/lib/actions/pulp/repository/sync.rb
@@ -21,7 +21,7 @@ module Actions
             overrides[:validate] = !(SETTINGS[:katello][:pulp][:skip_checksum_validation])
             overrides[:options] = input[:options] if input[:options]
             repo = ::Katello::Repository.find_by(:pulp_id => input[:pulp_id])
-            output[:pulp_tasks] = repo.backend_service(smart_proxy).sync(overrides)
+            output[:pulp_tasks] = repo.backend_service(::SmartProxy.pulp_master).sync(overrides)
           end
         end
 

--- a/test/actions/pulp/repository/sync_progress_test.rb
+++ b/test/actions/pulp/repository/sync_progress_test.rb
@@ -6,12 +6,11 @@ module ::Actions::Pulp::Repository
     let(:action_class) { ::Actions::Pulp::Repository::Sync }
 
     before do
-      stub_remote_user
+      stub_remote_user(true)
       @repo = Katello::Repository.find(katello_repositories(:fedora_17_x86_64).id)
       pulp_response = { 'spawned_tasks' => [{'task_id' => 'other' }]}
       Runcible::Resources::Repository.any_instance.stubs(:sync).returns pulp_response
-      proxy = SmartProxy.new(:url => 'http://foo.com/foo')
-      SmartProxy.stubs(:default_capsule).returns(proxy)
+      FactoryBot.create(:smart_proxy, :default_smart_proxy)
     end
 
     it 'runs' do
@@ -19,6 +18,7 @@ module ::Actions::Pulp::Repository
       task1         = task_base.merge('tags' => ['pulp:action:sync'])
       task2         = task1.merge(task_progress_hash(6, 8))
       task3         = task1.merge(task_progress_hash(0, 8)).merge(task_finished_hash)
+
       plan_action action, pulp_id: @repo.pulp_id
       action = run_action action do |actn|
         stub_task_poll actn, task1, task2, task3

--- a/test/actions/pulp/repository/sync_test.rb
+++ b/test/actions/pulp/repository/sync_test.rb
@@ -4,8 +4,7 @@ require_relative 'test_base.rb'
 module ::Actions::Pulp::Repository
   class SyncTest < VCRTestBase
     def setup
-      proxy = SmartProxy.new(:url => 'http://foo.com/foo')
-      SmartProxy.stubs(:default_capsule).returns(proxy)
+      FactoryBot.create(:smart_proxy, :default_smart_proxy)
     end
 
     def test_sync
@@ -17,8 +16,7 @@ module ::Actions::Pulp::Repository
   class BackgroundSyncTest < VCRTestBase
     let(:repo) { katello_repositories(:rhel_7_x86_64) }
     def setup
-      proxy = SmartProxy.new(:url => 'http://foo.com/foo')
-      SmartProxy.stubs(:default_capsule).returns(proxy)
+      FactoryBot.create(:smart_proxy, :default_smart_proxy)
     end
 
     def test_sync


### PR DESCRIPTION
in our smart proxy lookup code, we default to the master
server if nothing was passed in.  We should be explicit about
this.

This also fixes smart proxy sync, where the repos were
trying to be created on the master.