### PR TITLE
Fixes #25379 - Kickstart repo seems not available in promoted CV

### DIFF
--- a/app/lib/katello/validators/hostgroup_kickstart_repository_validator.rb
+++ b/app/lib/katello/validators/hostgroup_kickstart_repository_validator.rb
@@ -18,7 +18,7 @@ module Katello
                 _("Kickstart repositories can only be assigned to hosts in the Red Hat family")
               elsif hostgroup.architecture.blank?
                 _("Please select an architecture before assigning a kickstart repository")
-              elsif hostgroup.operatingsystem.kickstart_repos(hostgroup).none? { |repo| repo[:id] == hostgroup.kickstart_repository_id }
+              elsif !hostgroup.matching_kickstart_repository?
                 _("The selected kickstart repository is not part of the assigned content view, lifecycle environment,
                   content source, operating system, and architecture")
               end

--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -30,6 +30,12 @@ module Katello
         elsif kickstart_repository && medium
           self.medium = nil
         end
+
+        unless matching_kickstart_repository?
+          if (equivalent = equivalent_kickstart_repository)
+            self.kickstart_repository_id = equivalent[:id]
+          end
+        end
       end
 
       def content_view
@@ -79,6 +85,17 @@ module Katello
       def content_and_puppet_match?
         self.content_view && self.lifecycle_environment && self.content_view == self.environment.try(:content_view) &&
             self.lifecycle_environment == self.environment.try(:lifecycle_environment)
+      end
+
+      def equivalent_kickstart_repository
+        return unless operatingsystem && kickstart_repository
+        ks_repos = operatingsystem.kickstart_repos(self)
+        ks_repos.find { |repo| repo[:name] == kickstart_repository.label }
+      end
+
+      def matching_kickstart_repository?
+        return true unless operatingsystem
+        operatingsystem.kickstart_repos(self).any? { |repo| repo[:id] == kickstart_repository_id }
       end
 
       private

--- a/app/models/katello/concerns/redhat_extensions.rb
+++ b/app/models/katello/concerns/redhat_extensions.rb
@@ -41,7 +41,11 @@ module Katello
       end
 
       def kickstart_repos(host)
-        distros = distribution_repositories(host).where(distribution_bootable: true)
+        distribution_repos = distribution_repositories(host)
+
+        return [] if distribution_repos.empty?
+
+        distros = distribution_repos.where(distribution_bootable: true)
         if distros && host.content_source
           distros.map { |distro| distro.to_hash(host.content_source) }
         else

--- a/app/views/overrides/activation_keys/_host_synced_content_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_synced_content_select.html.erb
@@ -1,4 +1,3 @@
-<%= javascript "katello/hosts/host_and_hostgroup_edit" %>
 <%
 kickstart_repo_id = using_hostgroups_page? ? kickstart_repository_id(@hostgroup) : kickstart_repository_id(@host, :selected_host_group => @hostgroup)
 host = using_hostgroups_page? ? @hostgroup : @host

--- a/test/actions/katello/capsule_content_test.rb
+++ b/test/actions/katello/capsule_content_test.rb
@@ -67,7 +67,7 @@ module ::Actions::Katello::CapsuleContent
       capsule_content_sync = plan_action(action, capsule_content.capsule, :environment_id => dev_environment.id)
       synced_repos = synced_repos(capsule_content_sync, capsule_content.repos_available_to_capsule)
 
-      assert_equal synced_repos.uniq.count, 8
+      assert_equal 9, synced_repos.uniq.count
     end
 
     it 'fails when trying to sync to the default capsule' do

--- a/test/controllers/api/v2/products_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/products_bulk_actions_controller_test.rb
@@ -55,7 +55,7 @@ module Katello
     def test_sync
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
         action_class.must_equal ::Actions::Katello::Repository::Sync
-        repos.size.must_equal 5
+        repos.size.must_equal 6
       end
 
       put :sync_products, params: { :ids => @products.collect(&:id), :organization_id => @organization.id }

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -96,7 +96,7 @@ module Katello
 
       assert_response :success
       assert_template 'api/v2/repositories/index'
-      assert_equal response_ids.sort, ids.sort
+      assert_equal ids.sort, response_ids.sort
     end
 
     def test_index_with_environment_id
@@ -207,12 +207,12 @@ module Katello
     end
 
     def test_index_with_name
-      id = RootRepository.find_by(:name => katello_repositories(:fedora_17_x86_64).name).library_instance.id
+      ids = RootRepository.find_by(:name => katello_repositories(:fedora_17_x86_64).name).repositories.where(content_view_version: @organization.default_content_view.versions.first).pluck(:id)
       response = get :index, params: { :name => katello_repositories(:fedora_17_x86_64).name, :organization_id => @organization.id }
 
       assert_response :success
       assert_template 'api/v2/repositories/index'
-      assert_response_ids response, [id]
+      assert_response_ids response, ids
     end
 
     def test_index_protected

--- a/test/fixtures/models/katello_content_view_environments.yml
+++ b/test/fixtures/models/katello_content_view_environments.yml
@@ -88,3 +88,13 @@ library_composite_view:
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:composite_view_version_1) %>
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
+
+library_dev_view_acme:
+  name:           Published acme view dev environment
+  label:          'published_acme_view_dev'
+  cp_id:          13
+  environment_id: <%= ActiveRecord::FixtureSet.identify(:dev) %>
+  content_view_id: <%= ActiveRecord::FixtureSet.identify(:acme_default) %>
+  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_dev_view_version) %>
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -11,6 +11,19 @@ fedora_17_x86_64:
   distribution_bootable: true
   distribution_uuid: 'xyz123'
 
+fedora_17_x86_64_acme_dev:
+  root_id:              <%= ActiveRecord::FixtureSet.identify(:fedora_17_x86_64_root) %>
+  pulp_id:              fedora_17_acme_dev
+  relative_path:        'ACME_Corporation/dev/fedora_17_dev_label'
+  environment_id:       <%= ActiveRecord::FixtureSet.identify(:dev) %>
+  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
+  distribution_arch: "x86_64"
+  distribution_version: "17.0"
+  distribution_family: "Test Family"
+  distribution_variant: "TestVariant"
+  distribution_bootable: true
+  distribution_uuid: 'xyz123'
+
 fedora_17_x86_64_dev:
   library_instance:     fedora_17_x86_64
   root_id:              <%= ActiveRecord::FixtureSet.identify(:fedora_17_x86_64_root) %>

--- a/test/models/concerns/redhat_extensions_test.rb
+++ b/test/models/concerns/redhat_extensions_test.rb
@@ -117,6 +117,7 @@ module Katello
       distro_repos = mock('distribution_repos').tap do |mock|
         mock.expects(:where).returns([@repo_with_distro])
       end
+      distro_repos.expects(:empty?)
       @os.expects(:distribution_repositories).with(@host).returns(distro_repos)
       @host.content_facet.content_source = nil
       assert_empty @os.kickstart_repos(@host)
@@ -126,6 +127,7 @@ module Katello
       distro_repos = mock('distribution_repos').tap do |mock|
         mock.expects(:where).returns([@repo_with_distro])
       end
+      distro_repos.expects(:empty?)
       @os.expects(:distribution_repositories).with(@host).returns(distro_repos)
       repos = @os.kickstart_repos(@host)
       refute_empty repos

--- a/test/presenters/repository_presenter_test.rb
+++ b/test/presenters/repository_presenter_test.rb
@@ -9,7 +9,7 @@ module Katello
     def test_content_view_environments
       content_view_environments = @presenter.content_view_environments
 
-      assert_equal content_view_environments.length, 4
+      assert_equal 5, content_view_environments.length
     end
   end
 end


### PR DESCRIPTION
Changing the environment of a hostgroup or creating a child hostgroup with a different environment than its parent could raise a validation error: "The selected kickstart repository is not part of the assigned content view, lifecycle environment, content source, operating system, and architecture"

The error is valid but not a great experience for the user. I've changed to code in two main ways to make it better:

- On the UI side changing the environment will refresh the list of CVs and the Synced Content (kickstarts) dropdown so that the options there are valid ones.

- On the server side, given a mismatched kickstart repo ID for the env/cv/os/arch will trigger the validator to search for an equivalent based on the repo label. If not found a new but similar validation error will be raised.

#### Testing

- Create a CV with a kickstart repo, and promote it to Dev and Library envs for example
- Create a hostgroup in one of the environments and select CV you created as well as the kickstart repo on the Operating System tab
- Create another hostgroup in the opposite environment and attempt to save.

Without this patch, you'll get the validation error described. With the patch you'll see that the equivalent kickstart repo was located and assigned to the child HG