### PR TITLE
Fixes #25380 - DRY up applicability code

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -48,6 +48,10 @@ module Katello
       RepositoryErratum
     end
 
+    def self.content_facet_association_class
+      ContentFacetErratum
+    end
+
     def self.applicable_to_hosts(hosts)
       # Note: ContentFacetErrata actually holds the "Applicable Errata" to that host
       # It is not the errata "belonging" to the host. Its rather the errata that is "applicable"

--- a/app/models/katello/rpm.rb
+++ b/app/models/katello/rpm.rb
@@ -31,6 +31,10 @@ module Katello
       RepositoryRpm
     end
 
+    def self.content_facet_association_class
+      ContentFacetApplicableRpm
+    end
+
     def self.scoped_search_version(_key, operator, value)
       self.scoped_search_sortable('version', operator, value)
     end

--- a/app/services/katello/applicable_content_importer.rb
+++ b/app/services/katello/applicable_content_importer.rb
@@ -1,0 +1,73 @@
+module Katello
+  class ApplicableContentImporter
+    attr_accessor :content_facet, :content_unit_class
+
+    def initialize(content_facet, content_unit_class)
+      self.content_facet = content_facet
+      self.content_unit_class = content_unit_class
+    end
+
+    def import(partial)
+      to_add, to_remove = applicable_differences(partial)
+      content_facet_association_class.where(:content_facet_id => content_facet.id).delete_all unless partial
+      ActiveRecord::Base.transaction do
+        insert(to_add) unless to_add.blank?
+        remove(to_remove) unless to_remove.blank?
+      end
+    end
+
+    def installable(env = nil, content_view = nil)
+      repos = if env && content_view
+                Katello::Repository.in_environment(env).in_content_views([content_view])
+              else
+                content_facet.bound_repositories.pluck(:id)
+              end
+      content_facet.send(applicable_units).in_repositories(repos)
+    end
+
+    private
+
+    def applicable_units
+      "applicable_#{content_unit_class.name.demodulize.pluralize.underscore}"
+    end
+
+    def content_unit_association_id
+      "#{content_unit_class.name.demodulize.underscore}_id"
+    end
+
+    def content_type
+      content_unit_class.const_get(:CONTENT_TYPE)
+    end
+
+    def content_facet_association_class
+      self.content_unit_class.content_facet_association_class
+    end
+
+    def applicable_differences(partial)
+      content_uuids = ::Katello::Pulp::Consumer.new(content_facet.uuid).applicable_ids(content_type)
+      if partial
+        consumer_uuids = content_facet.send(applicable_units).pluck("#{content_unit_class.table_name}.uuid")
+        to_remove = consumer_uuids - content_uuids
+        to_add = content_uuids - consumer_uuids
+      else
+        to_add = content_uuids
+        to_remove = nil
+      end
+      [to_add, to_remove]
+    end
+
+    def insert(uuids)
+      applicable_ids = content_unit_class.where(:uuid => uuids).pluck(:id)
+      unless applicable_ids.empty?
+        inserts = applicable_ids.map { |applicable_id| "(#{applicable_id.to_i}, #{content_facet.id.to_i})" }
+        sql = "INSERT INTO #{content_facet_association_class.table_name} (#{content_unit_association_id}, content_facet_id) VALUES #{inserts.join(', ')}"
+        ActiveRecord::Base.connection.execute(sql)
+      end
+    end
+
+    def remove(uuids)
+      applicable_ids = content_unit_class.where(:uuid => uuids).pluck(:id)
+      content_facet_association_class.where(:content_facet_id => content_facet.id, content_unit_association_id => applicable_ids).delete_all
+    end
+  end
+end

--- a/app/services/katello/pulp/consumer.rb
+++ b/app/services/katello/pulp/consumer.rb
@@ -20,16 +20,14 @@ module Katello
         Katello.pulp_server.extensions.consumer.upload_profile(self.uuid, 'rpm', profile)
       end
 
-      def applicable_errata_ids
-        response = Katello.pulp_server.extensions.consumer.applicable_errata([self.uuid])
+      def applicable_ids(content_unit_type)
+        consumer_method = :applicable_rpms
+        if content_unit_type == ::Katello::Erratum::CONTENT_TYPE
+          consumer_method = :applicable_errata
+        end
+        response = Katello.pulp_server.extensions.consumer.send(consumer_method, [self.uuid])
         return [] if response.empty?
-        response[0]['applicability']['erratum'] || []
-      end
-
-      def applicable_rpm_ids
-        response = Katello.pulp_server.extensions.consumer.applicable_rpms([self.uuid])
-        return [] if response.empty?
-        response[0]['applicability']['rpm'] || []
+        response[0]['applicability'][content_unit_type] || []
       end
 
       def bind_yum_repositories(ids)

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -224,7 +224,7 @@ module Katello
     def test_partial_import
       refute_includes host.content_facet.applicable_errata, enhancement_errata
 
-      ::Katello::Pulp::Consumer.any_instance.stubs(:applicable_errata_ids).returns([enhancement_errata.uuid])
+      ::Katello::Pulp::Consumer.any_instance.stubs(:applicable_ids).returns([enhancement_errata.uuid])
       content_facet.import_errata_applicability(true)
 
       assert_equal [enhancement_errata], content_facet.reload.applicable_errata
@@ -233,14 +233,14 @@ module Katello
     def test_partial_import_empty
       content_facet.applicable_errata << enhancement_errata
 
-      ::Katello::Pulp::Consumer.any_instance.stubs(:applicable_errata_ids).returns([])
+      ::Katello::Pulp::Consumer.any_instance.stubs(:applicable_ids).returns([])
       content_facet.import_errata_applicability(true)
 
       assert_empty content_facet.reload.applicable_errata
     end
 
     def test_full_import
-      ::Katello::Pulp::Consumer.any_instance.stubs(:applicable_errata_ids).returns([enhancement_errata.uuid])
+      ::Katello::Pulp::Consumer.any_instance.stubs(:applicable_ids).returns([enhancement_errata.uuid])
       content_facet.import_errata_applicability(false)
 
       assert_equal [enhancement_errata], content_facet.reload.applicable_errata
@@ -267,7 +267,7 @@ module Katello
     def test_partial_import
       refute_includes host.content_facet.applicable_rpms, rpm
 
-      ::Katello::Pulp::Consumer.any_instance.stubs(:applicable_rpm_ids).returns([rpm.uuid])
+      ::Katello::Pulp::Consumer.any_instance.stubs(:applicable_ids).returns([rpm.uuid])
       content_facet.import_rpm_applicability(true)
 
       assert_equal [rpm], content_facet.reload.applicable_rpms
@@ -276,14 +276,14 @@ module Katello
     def test_partial_import_empty
       content_facet.applicable_rpms << rpm
 
-      ::Katello::Pulp::Consumer.any_instance.stubs(:applicable_rpm_ids).returns([])
+      ::Katello::Pulp::Consumer.any_instance.stubs(:applicable_ids).returns([])
       content_facet.import_rpm_applicability(true)
 
       assert_empty content_facet.reload.applicable_rpms
     end
 
     def test_full_import
-      ::Katello::Pulp::Consumer.any_instance.stubs(:applicable_rpm_ids).returns([rpm.uuid])
+      ::Katello::Pulp::Consumer.any_instance.stubs(:applicable_ids).returns([rpm.uuid])
       content_facet.import_rpm_applicability(false)
 
       assert_equal [rpm], content_facet.reload.applicable_rpms


### PR DESCRIPTION
This commit attempts to dry up applicability related code in the content
facet object. Main idea here is to delegate the applicability import
related code to the ApplicableContentImporter service class. This code
will become particularly handy when modules come into play cutting a lot
of duplicate logic.