### PR TITLE
Fixes #25400 - remove CV force metadata gen option

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -54,13 +54,10 @@ module Katello
     param :environment_id, :number, :deprecated => true, :desc => N_("LifeCycle Environment identifier")
     param :environment_ids, Array, :desc => N_("Identifiers for Lifecycle Environment")
     param :description, String, :desc => N_("The description for the content view version promotion")
-    param :force_yum_metadata_regeneration, :bool, :desc => N_("Force metadata regeneration on the repositories " \
-                                                           "in the content view version")
     def promote
       is_force = ::Foreman::Cast.to_bool(params[:force])
       task = async_task(::Actions::Katello::ContentView::Promote,
-                        @version, @environments, is_force, params[:description],
-                        :force_yum_metadata_regeneration => params[:force_yum_metadata_regeneration])
+                        @version, @environments, is_force, params[:description])
       respond_for_async :resource => task
     end
 

--- a/app/controllers/katello/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/api/v2/content_views_controller.rb
@@ -77,8 +77,6 @@ module Katello
     api :POST, "/content_views/:id/publish", N_("Publish a content view")
     param :id, :number, :desc => N_("Content view identifier"), :required => true
     param :description, String, :desc => N_("Description for the new published content view version")
-    param :force_yum_metadata_regeneration, :bool, :desc => N_("Force yum metadata regeneration on the repositories " \
-                                                           "in the content view version")
     param :major, :number, :desc => N_("Override the major version number"), :required => false
     param :minor, :number, :desc => N_("Override the minor version number"), :required => false
 
@@ -92,7 +90,6 @@ module Katello
                                      "update the components, then re-publish the composite.")
       end
       task = async_task(::Actions::Katello::ContentView::Publish, @view, params[:description],
-                        :force_yum_metadata_regeneration => params[:force_yum_metadata_regeneration],
                         :major => params[:major],
                         :minor => params[:minor],
                         :repos_units => params[:repos_units])

--- a/app/lib/actions/katello/content_view/promote.rb
+++ b/app/lib/actions/katello/content_view/promote.rb
@@ -4,7 +4,7 @@ module Actions
       class Promote < Actions::EntryAction
         middleware.use Actions::Middleware::KeepCurrentUser
 
-        def plan(version, environments, is_force = false, description = nil, options = {})
+        def plan(version, environments, is_force = false, description = nil)
           action_subject(version.content_view)
           version.check_ready_to_promote!(environments)
 
@@ -15,8 +15,7 @@ module Actions
           environments.each do |environment|
             sequence do
               plan_action(Katello::ContentViewVersion::BeforePromoteHook, :id => version.id)
-              plan_action(ContentView::PromoteToEnvironment, version, environment, description,
-                          :force_yum_metadata_regeneration => options[:force_yum_metadata_regeneration])
+              plan_action(ContentView::PromoteToEnvironment, version, environment, description)
               plan_action(Katello::ContentViewVersion::AfterPromoteHook, :id => version.id)
             end
           end

--- a/app/lib/actions/katello/content_view/promote_to_environment.rb
+++ b/app/lib/actions/katello/content_view/promote_to_environment.rb
@@ -5,7 +5,7 @@ module Actions
       class PromoteToEnvironment < Actions::EntryAction
         middleware.use Actions::Middleware::KeepCurrentUser
 
-        def plan(version, environment, description, options = {})
+        def plan(version, environment, description)
           history = ::Katello::ContentViewHistory.create!(:content_view_version => version, :user => ::User.current.login,
                                                           :environment => environment, :task => self.task,
                                                           :status => ::Katello::ContentViewHistory::IN_PROGRESS,
@@ -17,8 +17,7 @@ module Actions
             concurrence do
               version.archived_repos.non_puppet.each do |repository|
                 sequence do
-                  plan_action(Repository::CloneToEnvironment, repository, environment,
-                              :force_yum_metadata_regeneration => options[:force_yum_metadata_regeneration])
+                  plan_action(Repository::CloneToEnvironment, repository, environment)
                 end
               end
 

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -45,8 +45,7 @@ module Actions
               content_view.publish_repositories do |repositories|
                 sequence do
                   clone_to_version = plan_action(Repository::CloneToVersion, repositories, version, :repos_units => options[:repos_units])
-                  plan_action(Repository::CloneToEnvironment, clone_to_version.new_repository, library,
-                              :force_yum_metadata_regeneration => options[:force_yum_metadata_regeneration])
+                  plan_action(Repository::CloneToEnvironment, clone_to_version.new_repository, library)
                 end
               end
 

--- a/app/lib/actions/katello/repository/clone_deb_content.rb
+++ b/app/lib/actions/katello/repository/clone_deb_content.rb
@@ -33,7 +33,7 @@ module Actions
             # Check for matching content before indexing happens, the content in pulp is
             # actually updated, but it is not reflected in the database yet.
             output = {}
-            if target_repo.environment && !options[:force_yum_metadata_regeneration]
+            if target_repo.environment
               output = plan_action(Katello::Repository::CheckMatchingContent,
                                    :source_repo_id => source_repo.id,
                                    :target_repo_id => target_repo.id).output

--- a/app/lib/actions/katello/repository/clone_to_environment.rb
+++ b/app/lib/actions/katello/repository/clone_to_environment.rb
@@ -4,7 +4,7 @@ module Actions
       # Clones the contnet of the repository into the environment
       # effectively promotion the repository to the environment
       class CloneToEnvironment < Actions::Base
-        def plan(repository, environment, options = {})
+        def plan(repository, environment)
           clone = find_or_build_environment_clone(repository, environment)
 
           sequence do
@@ -20,11 +20,9 @@ module Actions
             end
 
             if repository.yum?
-              plan_action(Repository::CloneYumMetadata, repository, clone,
-                          :force_yum_metadata_regeneration => options[:force_yum_metadata_regeneration])
+              plan_action(Repository::CloneYumMetadata, repository, clone)
             elsif repository.deb?
-              plan_action(Repository::CloneDebContent, repository, clone, [], false,
-                          :force_yum_metadata_regeneration => options[:force_yum_metadata_regeneration])
+              plan_action(Repository::CloneDebContent, repository, clone, [], false)
             elsif repository.docker?
               plan_action(Repository::CloneDockerContent, repository, clone, [])
             elsif repository.ostree?

--- a/app/lib/actions/katello/repository/clone_to_version.rb
+++ b/app/lib/actions/katello/repository/clone_to_version.rb
@@ -20,8 +20,7 @@ module Actions
 
             if new_repository.link?
               fail "Cannot clone metadata if more than one repository" if repositories.count > 1
-              plan_action(Repository::CloneYumMetadata, repositories[0], new_repository,
-                                                            :force_yum_metadata_regeneration => true)
+              plan_action(Repository::CloneYumMetadata, repositories[0], new_repository)
             else
               repositories.each do |repository|
                 if new_repository.yum?

--- a/app/lib/actions/katello/repository/clone_yum_content.rb
+++ b/app/lib/actions/katello/repository/clone_yum_content.rb
@@ -4,7 +4,6 @@ module Actions
       class CloneYumContent < Actions::Base
         # rubocop:disable MethodLength
         # rubocop:disable Metrics/CyclomaticComplexity TODO: refactor to push everything into options hash
-        # rubocop:disable Metrics/PerceivedComplexity
         def plan(source_repo, target_repo, filters, options = {})
           generate_metadata = options.fetch(:generate_metadata, true)
           index_content = options.fetch(:index_content, true)
@@ -62,7 +61,7 @@ module Actions
             # Check for matching content before indexing happens, the content in pulp is
             # actually updated, but it is not reflected in the database yet.
             output = {}
-            if target_repo.environment && !options[:force_yum_metadata_regeneration]
+            if target_repo.environment
               output = plan_action(Katello::Repository::CheckMatchingContent,
                                    :source_repo_id => source_repo.id,
                                    :target_repo_id => target_repo.id).output

--- a/app/lib/actions/katello/repository/clone_yum_metadata.rb
+++ b/app/lib/actions/katello/repository/clone_yum_metadata.rb
@@ -2,13 +2,13 @@ module Actions
   module Katello
     module Repository
       class CloneYumMetadata < Actions::Base
-        def plan(source_repo, target_repo, options = {})
+        def plan(source_repo, target_repo)
           sequence do
             # Check for matching content before indexing happens, the content in pulp is
             # actually updated, but it is not reflected in the database yet.
             output = {}
             if !target_repo.root.previous_changes.include?(:unprotected) &&
-                target_repo.environment && !options[:force_yum_metadata_regeneration]
+                target_repo.environment
               output = plan_action(Katello::Repository::CheckMatchingContent,
                                    :source_repo_id => source_repo.id,
                                    :target_repo_id => target_repo.id).output

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-promotion.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-promotion.controller.js
@@ -99,7 +99,6 @@ angular.module('Bastion.content-views').controller('ContentViewPromotionControll
             ContentViewVersion.promote({id: $scope.version.id,
                                         'environment_id': $scope.selectedEnvironment.id,
                                         'description': $scope.description,
-                                        'force_yum_metadata_regeneration': $scope.forceMetadataRegeneration,
                                         force: true},
                 success, failure);
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-publish.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-publish.controller.js
@@ -34,8 +34,7 @@ angular.module('Bastion.content-views').controller('ContentViewPublishController
 
         $scope.publish = function (contentView) {
             var description = $scope.version.description,
-                forceMetadataRegeneration = $scope.version.forceMetadataRegeneration,
-                data = {'id': contentView.id, 'description': description, 'force_yum_metadata_regeneration': forceMetadataRegeneration};
+                data = {'id': contentView.id, 'description': description};
             $scope.working = true;
             ContentView.publish(data, success, failure);
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-promotion.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-promotion.html
@@ -36,21 +36,6 @@
     </textarea>
   </div>
 
-  <div class="checkbox">
-    <label translate>
-      <input id="forceMetadataRegeneration"
-             name="forceMetadataRegeneration"
-             ng-model="forceMetadataRegeneration"
-             type="checkbox"/>
-      Force Yum Metadata Regeneration
-    </label>
-    <i class="fa fa-question-circle"
-       uib-tooltip="{{ 'Forces metadata regeneration on yum repos even if the contents of the repo have not changed' | translate }}"
-       tooltip-animation="false"
-       tooltip-append-to-body="true">
-    </i>
-  </div>
-
   <div>
     <button type="button" class="btn btn-primary btn-lg" ng-disabled="promoting || !selectedEnvironment" ng-click="verifySelection()" translate>
       Promote Version

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-publish.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-publish.html
@@ -39,20 +39,6 @@
     </textarea>
       </div>
 
-      <div class="checkbox">
-        <label translate>
-          <input id="forceMetadataRegeneration"
-                 name="forceMetadataRegeneration"
-                 ng-model="version.forceMetadataRegeneration"
-                 type="checkbox"/>
-          Force Yum Metadata Regeneration
-        </label>
-        <i class="fa fa-question-circle"
-           uib-tooltip="{{ 'Forces metadata regeneration on yum repos even if the contents of the repo have not changed' | translate }}"
-           tooltip-animation="false"
-           tooltip-append-to-body="true"></i>
-      </div>
-
       <div bst-form-buttons
            on-cancel="transitionTo('content-view.versions', {contentViewId: contentView.id})"
            on-save="publish(contentView)"

--- a/test/actions/katello/repository/clone_to_version_test.rb
+++ b/test/actions/katello/repository/clone_to_version_test.rb
@@ -44,7 +44,7 @@ module Actions
       plan_action(action, [yum_repo], version, options)
 
       assert_action_planed_with(action, Actions::Katello::Repository::CloneYumMetadata,
-                                yum_repo, cloned_repo, :force_yum_metadata_regeneration => true)
+                                yum_repo, cloned_repo)
     end
 
     it 'plans to clone docker units' do

--- a/test/actions/katello/repository/clone_yum_metadata_test.rb
+++ b/test/actions/katello/repository/clone_yum_metadata_test.rb
@@ -32,20 +32,6 @@ module Actions
                                 :matching_content => matching_action[0].output[:matching_content])
     end
 
-    it 'plans to clone the metadata with force_yum_metadata_regeneration' do
-      action = create_action(action_class)
-
-      plan_action(action, archive_repo, environment_repo, :force_yum_metadata_regeneration => true)
-
-      refute_action_planed(action, Katello::Repository::CheckMatchingContent)
-
-      assert_action_planed_with(action, Katello::Repository::IndexContent, :id => environment_repo.id)
-
-      assert_action_planed_with(action, Katello::Repository::MetadataGenerate, environment_repo,
-                                :source_repository => archive_repo,
-                                :matching_content => nil)
-    end
-
     it 'plans to clone the metadata if unprotected changed' do
       action = create_action(action_class)
       environment_repo.root.update_attributes!(:unprotected => !environment_repo.unprotected)

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -184,7 +184,7 @@ module Katello
 
     def test_promote
       version = @library_dev_staging_view.versions.first
-      @controller.expects(:async_task).with(::Actions::Katello::ContentView::Promote, version, [@dev], false, 'trystero', :force_yum_metadata_regeneration => nil).returns({})
+      @controller.expects(:async_task).with(::Actions::Katello::ContentView::Promote, version, [@dev], false, 'trystero').returns({})
       post :promote, params: { :id => version.id, :environment_ids => [@dev.id], :description => 'trystero' }
 
       assert_response :success
@@ -205,8 +205,8 @@ module Katello
 
     def test_bad_promote_out_of_sequence
       version = @library_dev_staging_view.versions.first
-      @controller.expects(:async_task).with(::Actions::Katello::ContentView::Promote, version, [@beta], false, nil,
-                                            :force_yum_metadata_regeneration => nil).raises(::Katello::HttpErrors::BadRequest)
+      @controller.expects(:async_task).with(::Actions::Katello::ContentView::Promote, version, [@beta], false, nil).
+          raises(::Katello::HttpErrors::BadRequest)
       post :promote, params: { :id => version.id, :environment_ids => [@beta.id] }
 
       assert_response 500
@@ -214,8 +214,7 @@ module Katello
 
     def test_promote_out_of_sequence_force
       version = @library_dev_staging_view.versions.first
-      @controller.expects(:async_task).with(::Actions::Katello::ContentView::Promote, version, [@beta], true, nil,
-                                            :force_yum_metadata_regeneration => nil).returns({})
+      @controller.expects(:async_task).with(::Actions::Katello::ContentView::Promote, version, [@beta], true, nil).returns({})
       post :promote, params: { :id => version.id, :environment_ids => [@beta.id], :force => 1 }
 
       assert_response :success
@@ -223,8 +222,7 @@ module Katello
 
     def test_promote_out_of_sequence_force_false
       version = @library_dev_staging_view.versions.first
-      @controller.expects(:async_task).with(::Actions::Katello::ContentView::Promote, version, [@beta], false, nil,
-                                            :force_yum_metadata_regeneration => nil).returns({})
+      @controller.expects(:async_task).with(::Actions::Katello::ContentView::Promote, version, [@beta], false, nil).returns({})
       post :promote, params: { :id => version.id, :environment_ids => [@beta.id], :force => 0 }
 
       assert_response :success


### PR DESCRIPTION
This removes the abiliy to ignore the optimization
for generation of yum metadata during cv publish
or promote.