### PR TITLE
Fixes #25408 - Redefine max subscriptions

### DIFF
--- a/webpack/scenes/Subscriptions/SubscriptionValidations.js
+++ b/webpack/scenes/Subscriptions/SubscriptionValidations.js
@@ -1,7 +1,7 @@
 import { translate as __ } from 'foremanReact/common/I18n';
 import { filterRHSubscriptions } from './SubscriptionHelpers.js';
 
-export const validateQuantity = (quantity, availableQuantity) => {
+export const validateQuantity = (quantity, maxQuantity) => {
   let state;
   let message;
 
@@ -12,7 +12,7 @@ export const validateQuantity = (quantity, availableQuantity) => {
   } else if (numberValue <= 0) {
     state = 'error';
     message = __('Has to be > 0');
-  } else if (availableQuantity && availableQuantity >= 0 && numberValue > availableQuantity) {
+  } else if (maxQuantity && maxQuantity >= 0 && numberValue > maxQuantity) {
     state = 'error';
     message = __('Exceeds available quantity');
   }
@@ -23,4 +23,4 @@ export const validateQuantity = (quantity, availableQuantity) => {
 };
 
 export const recordsValid = rows =>
-  filterRHSubscriptions(rows).every(row => validateQuantity(row.quantity, row.availableQuantity).state !== 'error');
+  filterRHSubscriptions(rows).every(row => validateQuantity(row.quantity, row.maxQuantity).state !== 'error');

--- a/webpack/scenes/Subscriptions/__tests__/SubscriptionValidations.test.js
+++ b/webpack/scenes/Subscriptions/__tests__/SubscriptionValidations.test.js
@@ -44,6 +44,11 @@ describe('validateQuantity', () => {
     expect(validateQuantity(100))
       .toEqual(validResult);
   });
+
+  it('detects unlimited maxQuantity', () => {
+    expect(validateQuantity('500000', -1))
+      .toEqual(validResult);
+  });
 });
 
 describe('recordsValid', () => {
@@ -54,8 +59,8 @@ describe('recordsValid', () => {
   /* eslint-disable object-curly-newline */
   it('accepts valid array', () => {
     const rows = [
-      { quantity: 10, available: 10, availableQuantity: 100, upstream_pool_id: ' ' },
-      { quantity: 10, available: 10, availableQuantity: -1 },
+      { quantity: 10, available: 10, upstreamAvailable: 100, upstream_pool_id: ' ' },
+      { quantity: 10, available: 10, upstreamAvailable: -1 },
       { quantity: -1, available: -1 },
       { quantity: 10, available: 10, upstream_pool_id: ' ' },
     ];
@@ -66,8 +71,8 @@ describe('recordsValid', () => {
   it('detects invalid record', () => {
     /* eslint-disable object-curly-newline */
     const rows = [
-      { quantity: 10, available: 10, availableQuantity: 100, upstream_pool_id: ' ' },
-      { quantity: 10, available: 10, availableQuantity: 5, upstream_pool_id: ' ' },
+      { quantity: 10, available: 10, upstreamAvailable: 100, maxQuantity: 100, upstream_pool_id: ' ' },
+      { quantity: 10, available: 10, upstreamAvailable: 0, maxQuantity: 5, upstream_pool_id: ' ' },
     ];
     /* eslint-enable object-curly-newline */
     expect(recordsValid(rows)).toBe(false);

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/EntitlementsInlineEditFormatter.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/EntitlementsInlineEditFormatter.js
@@ -34,20 +34,22 @@ export const entitlementsInlineEditFormatter =
       );
     },
     renderEdit: (value, additionalData) => {
-      const { availableQuantity, availableQuantityLoaded } = additionalData.rowData;
+      const {
+        upstreamAvailable, upstreamAvailableLoaded, maxQuantity,
+      } = additionalData.rowData;
 
       const className = inlineEditController.hasChanged(additionalData)
         ? 'editable editing changed'
         : 'editable editing';
 
       let maxMessage;
-      if (availableQuantityLoaded && (availableQuantity !== undefined)) {
-        maxMessage = (availableQuantity < 1)
+      if (maxQuantity && upstreamAvailableLoaded && (upstreamAvailable !== undefined)) {
+        maxMessage = (upstreamAvailable < 0)
           ? __('Unlimited')
-          : sprintf(__('Max %(availableQuantity)s'), { availableQuantity });
+          : sprintf(__('Max %(maxQuantity)s'), { maxQuantity });
       }
 
-      const validation = validateQuantity(value, availableQuantity);
+      const validation = validateQuantity(value, maxQuantity);
 
       const formGroup = (
         // We have to block editing until available quantities are loaded.
@@ -58,7 +60,7 @@ export const entitlementsInlineEditFormatter =
         // The same issue prevents from correct switching inputs on TAB.
         // See the reactabular code for details:
         // https://github.com/reactabular/reactabular/blob/master/packages/reactabular-table/src/body-row.js#L58
-        <Spinner loading={!availableQuantityLoaded} size="xs">
+        <Spinner loading={!upstreamAvailableLoaded} size="xs">
           <FormGroup
             validationState={validation.state}
           >

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTableHelpers.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTableHelpers.js
@@ -1,23 +1,36 @@
+const getMaxQuantity = (subscription, upstreamAvailable) => {
+  if (upstreamAvailable === -1) {
+    return upstreamAvailable;
+  }
+  return upstreamAvailable + subscription.quantity;
+};
+
 const buildTableRow = (subscription, availableQuantities, updatedQuantity) => {
-  const availableQuantityLoaded = !!availableQuantities;
-  const availableQuantity = availableQuantityLoaded
+  const upstreamAvailableLoaded = !!availableQuantities;
+  const upstreamAvailable = upstreamAvailableLoaded
     ? availableQuantities[subscription.id]
     : null;
 
+  let maxQuantity;
+  if (upstreamAvailableLoaded) {
+    maxQuantity = getMaxQuantity(subscription, upstreamAvailable);
+  }
+
+  const baseSubscription = {
+    ...subscription,
+    upstreamAvailable,
+    upstreamAvailableLoaded,
+    maxQuantity,
+  };
+
   if (updatedQuantity[subscription.id]) {
     return {
-      ...subscription,
+      ...baseSubscription,
       entitlementsChanged: true,
       quantity: updatedQuantity[subscription.id],
-      availableQuantity,
-      availableQuantityLoaded,
     };
   }
-  return {
-    ...subscription,
-    availableQuantity,
-    availableQuantityLoaded,
-  };
+  return baseSubscription;
 };
 
 const buildTableRowsFromGroup = (subscriptionGroup, availableQuantities, updatedQuantity) => {
@@ -36,7 +49,6 @@ const buildTableRowsFromGroup = (subscriptionGroup, availableQuantities, updated
 
 export const buildTableRows = (groupedSubscriptions, availableQuantities, updatedQuantity) => {
   const rows = [];
-
   Object.values(groupedSubscriptions).forEach(subscriptionGroup =>
     rows.push(...buildTableRowsFromGroup(subscriptionGroup, availableQuantities, updatedQuantity)));
 

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/EntitlementsInlineEditFormatter.test.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/EntitlementsInlineEditFormatter.test.js
@@ -22,7 +22,7 @@ describe('EntitlementsInlineEditFormatter', () => {
         const controller = mockController();
         const value = 100;
         const formatter = editFormatter(controller)(value, data({
-          availableQuantityLoaded: false,
+          upstreamAvailableLoaded: false,
         }));
 
         expect(toJson(shallow(formatter))).toMatchSnapshot();
@@ -34,8 +34,9 @@ describe('EntitlementsInlineEditFormatter', () => {
         const controller = mockController();
         const value = 100;
         const formatter = editFormatter(controller)(value, data({
-          availableQuantityLoaded: true,
-          availableQuantity: 500,
+          upstreamAvailableLoaded: true,
+          upstreamAvailable: 500,
+          maxQuantity: 600,
         }));
 
         expect(toJson(shallow(formatter))).toMatchSnapshot();
@@ -45,8 +46,9 @@ describe('EntitlementsInlineEditFormatter', () => {
         const controller = mockController();
         const value = 100;
         const formatter = editFormatter(controller)(value, data({
-          availableQuantityLoaded: true,
-          availableQuantity: -1,
+          upstreamAvailableLoaded: true,
+          upstreamAvailable: -1,
+          maxQuantity: -1,
         }));
 
         expect(toJson(shallow(formatter))).toMatchSnapshot();
@@ -56,8 +58,9 @@ describe('EntitlementsInlineEditFormatter', () => {
         const controller = mockController();
         const value = 200;
         const formatter = editFormatter(controller)(value, data({
-          availableQuantityLoaded: true,
-          availableQuantity: 100,
+          upstreamAvailableLoaded: true,
+          upstreamAvailable: 100,
+          maxQuantity: 150,
         }));
 
         expect(toJson(shallow(formatter))).toMatchSnapshot();
@@ -67,8 +70,9 @@ describe('EntitlementsInlineEditFormatter', () => {
         const controller = mockController({ changed: true });
         const value = 100;
         const formatter = editFormatter(controller)(value, data({
-          availableQuantityLoaded: true,
-          availableQuantity: 200,
+          upstreamAvailableLoaded: true,
+          upstreamAvailable: 200,
+          maxQuantity: 300,
         }));
 
         expect(toJson(shallow(formatter))).toMatchSnapshot();
@@ -80,7 +84,7 @@ describe('EntitlementsInlineEditFormatter', () => {
         const controller = mockController();
         const value = 200;
         const formatter = editFormatter(controller)(value, data({
-          availableQuantityLoaded: true,
+          upstreamAvailableLoaded: true,
         }));
 
         expect(toJson(shallow(formatter))).toMatchSnapshot();

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/SubscriptionsTable.fixtures.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/SubscriptionsTable.fixtures.js
@@ -1,0 +1,105 @@
+import Immutable from 'seamless-immutable';
+
+const groupedSubscriptions = Immutable({
+  RH00001: {
+    open: false,
+    subscriptions: [
+      {
+        id: 1,
+        name: 'Alpha',
+        quantity: 10,
+        consumed: 0,
+        product_id: 'RH00001',
+      },
+      {
+        id: 2,
+        name: 'Alpha',
+        quantity: 15,
+        consumed: 5,
+        product_id: 'RH00001',
+      },
+    ],
+  },
+  RH00002: {
+    open: false,
+    subscriptions: [
+      {
+        id: 3,
+        name: 'Charlie',
+        quantity: 10,
+        consumed: 0,
+        product_id: 'RH00002',
+      },
+    ],
+  },
+  RH00003: {
+    open: false,
+    subscriptions: [
+      {
+        id: 4,
+        name: 'Bravo',
+        quantity: 100,
+        consumed: 0,
+        product_id: 'RH00003',
+      },
+    ],
+  },
+  RH00004: {
+    open: false,
+    subscriptions: [
+      {
+        id: 5,
+        name: 'Delta',
+        quantity: 15,
+        consumed: 5,
+        product_id: 'RH00004',
+      },
+    ],
+  },
+});
+
+export const subOne = Immutable({
+  consumed: 0,
+  id: 1,
+  maxQuantity: 60,
+  name: 'Alpha',
+  product_id: 'RH00001',
+  quantity: 10,
+  upstreamAvailable: 50,
+  upstreamAvailableLoaded: true,
+});
+
+export const subTwo = Immutable({
+  consumed: 0,
+  id: 3,
+  maxQuantity: -1,
+  name: 'Charlie',
+  product_id: 'RH00002',
+  quantity: 10,
+  upstreamAvailable: -1,
+  upstreamAvailableLoaded: true,
+});
+
+export const subThree = Immutable({
+  consumed: 0,
+  id: 4,
+  maxQuantity: 200,
+  name: 'Bravo',
+  product_id: 'RH00003',
+  quantity: 100,
+  upstreamAvailable: 100,
+  upstreamAvailableLoaded: true,
+});
+
+export const subFour = Immutable({
+  consumed: 5,
+  id: 5,
+  maxQuantity: 65,
+  name: 'Delta',
+  product_id: 'RH00004',
+  quantity: 15,
+  upstreamAvailable: 50,
+  upstreamAvailableLoaded: true,
+});
+
+export default groupedSubscriptions;

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/SubscriptionsTableHelpers.test.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/SubscriptionsTableHelpers.test.js
@@ -1,0 +1,44 @@
+import groupedSubscriptions, { subOne, subTwo, subThree, subFour } from './SubscriptionsTable.fixtures';
+import { buildTableRows } from '../SubscriptionsTableHelpers';
+
+describe('Build Table Rows', () => {
+  it('should display correct maxQuantity', () => {
+    const availableQuantities = {
+      1: 50,
+      2: 50,
+      3: -1,
+      4: 100,
+      5: 50,
+    };
+
+    const rows = [subOne, subTwo, subThree, subFour];
+
+    expect(buildTableRows(groupedSubscriptions, availableQuantities, {}))
+      .toEqual(rows);
+  });
+
+  it('should update quantities', () => {
+    const availableQuantities = {
+      1: 50,
+      2: 50,
+      3: -1,
+      4: 100,
+      5: 50,
+    };
+
+    const updatedQuantities = {
+      1: 20,
+      4: 150,
+    };
+
+    const rows = [
+      { ...subOne, entitlementsChanged: true, quantity: 20 },
+      subTwo,
+      { ...subThree, entitlementsChanged: true, quantity: 150 },
+      subFour,
+    ];
+
+    expect(buildTableRows(groupedSubscriptions, availableQuantities, updatedQuantities))
+      .toEqual(rows);
+  });
+});

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/EntitlementsInlineEditFormatter.test.js.snap
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/EntitlementsInlineEditFormatter.test.js.snap
@@ -57,7 +57,7 @@ exports[`EntitlementsInlineEditFormatter edit mode when available quantities are
       <HelpBlock
         bsClass="help-block"
       >
-        Max 200
+        Max 300
         <div
           className="validationMessages"
         />
@@ -91,7 +91,7 @@ exports[`EntitlementsInlineEditFormatter edit mode when available quantities are
       <HelpBlock
         bsClass="help-block"
       >
-        Max 500
+        Max 600
         <div
           className="validationMessages"
         />
@@ -160,7 +160,7 @@ exports[`EntitlementsInlineEditFormatter edit mode when available quantities are
       <HelpBlock
         bsClass="help-block"
       >
-        Max 100
+        Max 150
         <div
           className="validationMessages"
         >


### PR DESCRIPTION
The meaning of "max" is incorrect. When we try to edit the quantity of a subscription, the "max" represents the total available to add, but does not count what is already being used by the subscription. "Max" should represent the total amount available to the user to enter into the text box. Or, all available entitlements not currently being used by a different subscription other than the one we are editing.

For reviewer:
This should be done in the Red Hat Subscriptions page, not the "Add Subscriptions" page. If the quantities for entitlements are not showing up, add them by clicking the small window icon next to the filter bar and you can click to add those fields to the table.

As I understand the problem and solution, The "max" subscriptions to include in the text box should include all "available" plus whatever number is being used by that line item. If you have multiple subscriptions from the same upstream subscriptions, then the max would represent the total available, plus what number is being used in that line item, but would not include what is being used by the other subscription.