### PR TITLE
fixes #25420 - add host_ids to host-collection create results

### DIFF
--- a/app/views/katello/api/v2/host_collections/create.json.rabl
+++ b/app/views/katello/api/v2/host_collections/create.json.rabl
@@ -1,3 +1,3 @@
 object @host_collection
 
-extends "katello/api/v2/host_collections/base"
+extends "katello/api/v2/host_collections/show"


### PR DESCRIPTION
Currently, an API call to create a host-collection returns json that does not include associated host-ids. This is a regression, and host-ids should be shown on the host collection object.

To test:
* create a host collection by making an API call to `POST katello/api/v2/host_collections`
* verify that `host_ids` field shows, even if empty.