### PR TITLE
Fixes #25422 - switch to link locking so we queue conflicting actions

### DIFF
--- a/app/lib/actions/katello/host/update.rb
+++ b/app/lib/actions/katello/host/update.rb
@@ -45,7 +45,11 @@ module Actions
         end
 
         def resource_locks
-          :update
+          if Setting[:host_update_lock]
+            :link
+          else
+            :update
+          end
         end
 
         def rescue_strategy

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -100,6 +100,8 @@ class Setting::Content < Setting
                  N_('Default Location where new Puppet content will be put upon Content View publish'),
                  nil, N_('Default Location Puppet content'), nil,
                  :collection => proc { Hash[Location.unscoped.all.map { |loc| [loc[:title], loc[:title]] }] }),
+        self.set('host_update_lock', N_("Allow multiple concurrent Actions::Katello::Host::Update calls for one host to be processed at the same time."),
+                 false, N_('Concurrent Actions::Katello::Host::Update allowed')),
         self.set('expire_soon_days', N_('The number of days remaining in a subscription before you will be reminded about renewing it.'),
                  120, N_('Expire soon days'))
       ].each { |s| self.create! s.update(:category => "Setting::Content") }

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -18,6 +18,14 @@ module Katello
       assert setting.valid?
     end
 
+    def test_host_update_lock_setting
+      setting = Setting.where(:name => "host_update_lock").first
+      setting.value = "invalid"
+      refute setting.valid?
+      setting.value = true
+      assert setting.valid?
+    end
+
     def test_recalculate_errata_status
       ForemanTasks.expects(:async_task).with(::Actions::Katello::Host::RecalculateErrataStatus)
       setting = Setting.where(:name => "errata_status_installable").first


### PR DESCRIPTION
:link will queue conflicting actions and process the Host updates in
the order they were received. Tasks will sit in planned:pending until
the running task is completed. This will reduce the error rate and
prevent clients from receiving errors because sequential API calls error
immediately while one is processing.

