### PR TITLE
Fixes #25142 - fix extending module_streams api docs

### DIFF
--- a/app/controllers/katello/api/v2/module_streams_controller.rb
+++ b/app/controllers/katello/api/v2/module_streams_controller.rb
@@ -6,7 +6,8 @@ module Katello
 
     before_action :check_params, :only => :index
 
-    update_api(:index) do
+    # updating params inherited from Katello::Concerns::Api::V2::RepositoryContentController
+    apipie_update_params([:index]) do
       param :host_ids, Array, :desc => N_("List of host id to list available module streams for")
       param :name_stream_only, :boolean, :desc => N_("Return name and stream information only)")
     end

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "qpid_messaging"
   gem.add_dependency "gettext_i18n_rails"
-  gem.add_dependency "apipie-rails", ">= 0.5.4"
+  gem.add_dependency "apipie-rails", ">= 0.5.14"
 
   # Pulp
   gem.add_dependency "runcible", ">= 2.9.0", "< 3.0.0"


### PR DESCRIPTION
- [x] - new apipie release with required change https://github.com/Apipie/apipie-rails/pull/642

`update_api` is only usable from within a concern. When extending an API
inside controller that's coming from concern, `apipie_update_params` should be
used instead.

Also, there has been an issue on apipie side, that prevented merging top-level
params (see https://github.com/Apipie/apipie-rails/pull/642).

Both changes are needed in order for this issue to be resolved.