### PR TITLE
Fixes #25443 - Include host name in task label

### DIFF
--- a/app/lib/actions/katello/host/update.rb
+++ b/app/lib/actions/katello/host/update.rb
@@ -5,6 +5,7 @@ module Actions
         middleware.use ::Actions::Middleware::RemoteAction
 
         def plan(host, consumer_params = nil)
+          input[:hostname] = host.name
           action_subject host
           sequence do
             host.content_facet.save! if host.content_facet


### PR DESCRIPTION
Before this fix, if a Host::Update action failed because of taken
locks, the task index would show just "Update for host". By saving
the hostname before checking for lock conflicts, we can get nice
task label even if the action fails.