### PR TITLE
Fixes #25464: Handle non-unlimited guest subs

### DIFF
--- a/app/views/katello/api/v2/subscriptions/base.json.rabl
+++ b/app/views/katello/api/v2/subscriptions/base.json.rabl
@@ -17,6 +17,7 @@ attributes :unmapped_guest
 attributes :virt_only
 attributes :virt_who
 attributes :upstream? => :upstream
+attributes :upstream_pool_id
 
 node :hypervisor, :if => lambda { |sub| sub && sub.respond_to?(:hypervisor) && sub.hypervisor } do |subscription|
   {

--- a/webpack/scenes/Subscriptions/SubscriptionHelpers.js
+++ b/webpack/scenes/Subscriptions/SubscriptionHelpers.js
@@ -1,6 +1,7 @@
 // eslint-disable-next-line import/prefer-default-export
 export const filterRHSubscriptions = subscriptions =>
-  subscriptions.filter(sub => sub.available >= 0);
+  subscriptions.filter(sub =>
+    sub.available >= 0 && sub.upstream_pool_id);
 
 export const manifestExists = organization =>
   organization.owner_details && organization.owner_details.upstreamConsumer;

--- a/webpack/scenes/Subscriptions/__tests__/SubscriptionHelpers.test.js
+++ b/webpack/scenes/Subscriptions/__tests__/SubscriptionHelpers.test.js
@@ -9,23 +9,54 @@ import {
 } from '../SubscriptionHelpers';
 
 describe('Subscription helper', () => {
+  it('should filter subscriptions without upstream_pool_id', () => {
+    const subscriptions = [
+      {
+        key: 'sub-1',
+        available: 3,
+      },
+      {
+        key: 'sub-2',
+        available: 4,
+        upstream_pool_id: ' ',
+      },
+      {
+        key: 'sub-3',
+        available: -5,
+        upstream_pool_id: ' ',
+      },
+      {
+        key: 'sub-4',
+        available: -1,
+      },
+    ];
+
+    const filteredSubscriptions = filterRHSubscriptions(subscriptions);
+
+    expect(filteredSubscriptions).toMatchSnapshot();
+  });
+
   it('should filter redhat subscriptions', () => {
     const subscriptions = [
       {
         key: 'sub-1',
         available: 0,
+        upstream_pool_id: ' ',
       },
       {
         key: 'sub-2',
         available: 4,
+        upstream_pool_id: ' ',
       },
       {
         key: 'sub-3',
         available: -5,
+        upstream_pool_id: ' ',
       },
       {
         key: 'sub-4',
         available: 100,
+        upstream_pool_id: ' ',
       },
     ];
 

--- a/webpack/scenes/Subscriptions/__tests__/SubscriptionValidations.test.js
+++ b/webpack/scenes/Subscriptions/__tests__/SubscriptionValidations.test.js
@@ -51,21 +51,25 @@ describe('recordsValid', () => {
     expect(recordsValid([])).toBe(true);
   });
 
+  /* eslint-disable object-curly-newline */
   it('accepts valid array', () => {
     const rows = [
-      { quantity: 10, available: 10, availableQuantity: 100 },
+      { quantity: 10, available: 10, availableQuantity: 100, upstream_pool_id: ' ' },
       { quantity: 10, available: 10, availableQuantity: -1 },
       { quantity: -1, available: -1 },
-      { quantity: 10, available: 10 },
+      { quantity: 10, available: 10, upstream_pool_id: ' ' },
     ];
     expect(recordsValid(rows)).toBe(true);
   });
+  /* eslint-enable object-curly-newline */
 
   it('detects invalid record', () => {
+    /* eslint-disable object-curly-newline */
     const rows = [
-      { quantity: 10, available: 10, availableQuantity: 100 },
-      { quantity: 10, available: 10, availableQuantity: 5 },
+      { quantity: 10, available: 10, availableQuantity: 100, upstream_pool_id: ' ' },
+      { quantity: 10, available: 10, availableQuantity: 5, upstream_pool_id: ' ' },
     ];
+    /* eslint-enable object-curly-newline */
     expect(recordsValid(rows)).toBe(false);
   });
 });

--- a/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionHelpers.test.js.snap
+++ b/webpack/scenes/Subscriptions/__tests__/__snapshots__/SubscriptionHelpers.test.js.snap
@@ -5,14 +5,27 @@ Array [
   Object {
     "available": 0,
     "key": "sub-1",
+    "upstream_pool_id": " ",
   },
   Object {
     "available": 4,
     "key": "sub-2",
+    "upstream_pool_id": " ",
   },
   Object {
     "available": 100,
     "key": "sub-4",
+    "upstream_pool_id": " ",
+  },
+]
+`;
+
+exports[`Subscription helper should filter subscriptions without upstream_pool_id 1`] = `
+Array [
+  Object {
+    "available": 4,
+    "key": "sub-2",
+    "upstream_pool_id": " ",
   },
 ]
 `;

--- a/webpack/scenes/Subscriptions/__tests__/subscriptions.fixtures.js
+++ b/webpack/scenes/Subscriptions/__tests__/subscriptions.fixtures.js
@@ -133,6 +133,7 @@ export const requestSuccessResponseWithRHSubscriptions = Immutable({
       virt_only: false,
       virt_who: false,
       upstream: true,
+      upstream_pool_id: '8a85f98160f068060160f06e922a0201',
     },
   ],
 });

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/EntitlementsInlineEditFormatter.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/EntitlementsInlineEditFormatter.js
@@ -10,9 +10,9 @@ export const entitlementsInlineEditFormatter =
       inlineEditController.isEditing(additionalData),
     renderValue: (value, additionalData) => {
       const { rowData } = additionalData;
-      if (rowData.available < 0) {
+      if (rowData.available < 0 || !rowData.upstream_pool_id) {
         return (
-          <td>{__('Unlimited')}</td>
+          <td>{rowData.available < 0 ? __('Unlimited') : rowData.available}</td>
         );
       }
       return (

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTable.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTable.js
@@ -151,7 +151,8 @@ class SubscriptionsTable extends Component {
     };
 
     const inlineEditController = {
-      isEditing: ({ rowData }) => (this.state.editing && rowData.available >= 0),
+      isEditing: ({ rowData }) =>
+        (this.state.editing && rowData.available >= 0 && rowData.upstream_pool_id),
       hasChanged: ({ rowData }) => {
         const editedValue = this.state.updatedQuantity[rowData.id];
         return this.hasQuantityChanged(rowData, editedValue);

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/EntitlementsInlineEditFormatter.test.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/EntitlementsInlineEditFormatter.test.js
@@ -92,7 +92,9 @@ describe('EntitlementsInlineEditFormatter', () => {
     it('renders the value', async () => {
       const controller = mockController({ editing: false });
       const value = 200;
-      const formatter = editFormatter(controller)(value, data({}));
+      const formatter = editFormatter(controller)(value, data({
+        upstream_pool_id: ' ',
+      }));
 
       expect(toJson(shallow(formatter))).toMatchSnapshot();
     });
@@ -102,6 +104,7 @@ describe('EntitlementsInlineEditFormatter', () => {
       const value = 200;
       const formatter = editFormatter(controller)(value, data({
         available: -1,
+        upstream_pool_id: ' ',
       }));
 
       expect(toJson(shallow(formatter))).toMatchSnapshot();


### PR DESCRIPTION
Handle non-unlimited guest subscriptions in the subscriptions page. Do
not allow editing said rows, and prevent the UI from creating a text box
when the user hovers.

API Change: adds `upstream_pool_id` to subscriptions

Reproduce:
1. Create some virt-who guest subscriptions (have a virt-who hypervisor, attach a physical sub to it)
1. Ensure the guest subscription has a quantity > 0 (updating the pool using the Rails console is fine for reproducing)
1. Navigate to the subscriptions page