### PR TITLE
Fixes #25475: Use default proxy for nil capsule_id

### DIFF
--- a/app/lib/actions/pulp/repository/refresh.rb
+++ b/app/lib/actions/pulp/repository/refresh.rb
@@ -8,6 +8,7 @@ module Actions
         end
 
         def plan(repository, options = {})
+          options[:capsule_id] ||= SmartProxy.default_capsule!.id
           plan_self(:capsule_id => options[:capsule_id], :pulp_id => repository.pulp_id)
         end
 

--- a/test/actions/pulp/repository/refresh_test.rb
+++ b/test/actions/pulp/repository/refresh_test.rb
@@ -26,10 +26,20 @@ module ::Actions::Pulp::Repository
         create_and_plan_action action_class, repo, :capsule_id => SmartProxy.pulp_master.id
       end
 
+      let(:planned_action_without_capsule_id) do
+        create_and_plan_action action_class, repo
+      end
+
       it 'runs' do
         ::Katello::Repository.expects(:find_by).returns repo
         repo.backend_service(:default_smart_proxy).expects(:refresh).once.returns({})
         run_action planned_action
+      end
+
+      it 'runs without a capsule ID (uses default proxy)' do
+        ::Katello::Repository.expects(:find_by).returns repo
+        repo.backend_service(:default_smart_proxy).expects(:refresh).once.returns({})
+        run_action planned_action_without_capsule_id
       end
     end
   end


### PR DESCRIPTION
Caused by https://github.com/Katello/katello/pull/7762/files#diff-39454af49e2756358c14bc834489beaeL10