### PR TITLE
Fixes #25509 - delay content removal upon repo delete

### DIFF
--- a/app/lib/actions/katello/repository/destroy.rb
+++ b/app/lib/actions/katello/repository/destroy.rb
@@ -26,7 +26,7 @@ module Actions
           sequence do
             delete_record(repository) if planned_destroy
             if repository.redhat?
-              handle_redhat_content(repository)
+              handle_redhat_content(repository) unless skip_environment_update
             else
               handle_custom_content(repository) unless skip_environment_update
             end


### PR DESCRIPTION
when deleting an org, we rely on the org destroy to
cleanup the content, so no need to plan an update
on the repository