### PR TITLE
[3.8] fixes #25518 - clear credentials from invalid repos

### DIFF
--- a/lib/katello/tasks/upgrades/3.8/annul_invalid_repo_credentials.rake
+++ b/lib/katello/tasks/upgrades/3.8/annul_invalid_repo_credentials.rake
@@ -1,0 +1,24 @@
+# Before 3.8, you could successfully edit only the username, or only the
+# password, but since we added a validation now those old repos are now
+# invalid, breaking upgrades.  This finds those repos and clears their
+# credentials.
+
+namespace :katello do
+  namespace :upgrades do
+    namespace '3.8' do
+      desc "Clear invalid credentials for repositories"
+      task :annul_invalid_repo_credentials => %w(environment) do
+        User.current = User.anonymous_admin
+
+        # Where one, but not both, is set
+        repos = Katello::Repository.where('(upstream_username IS NULL AND upstream_password is NOT NULL) OR (upstream_username IS NOT NULL AND upstream_password is NULL)')
+
+        repos.each do |repo|
+          puts "Clearing invalid credentials for #{repo.label} (#{repo.id})"
+          repo.update_attributes(upstream_username: nil, upstream_password: nil)
+          ForemanTasks.sync_task(::Actions::Pulp::Repository::Refresh, repo)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Before 3.8, you could successfully edit only the username, or only the password, but since we added a validation now those old repos are now invalid, breaking upgrades.  This finds those repos and clears their credentials.

If the user has such repos, it has to be run before clear_checksum, this happens alphabetically right? Or is that not safe to rely on?
