### PR TITLE
Fixes #25519 - Enable save button post error

### DIFF
--- a/app/models/katello/sync_plan.rb
+++ b/app/models/katello/sync_plan.rb
@@ -46,6 +46,7 @@ module Katello
     end
 
     def save_with_logic!
+      self.cron_expression = '' if (self.cron_expression && !(self.interval.eql? CUSTOM_CRON))
       associate_recurring_logic
       self.save!
       start_recurring_logic

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/new/new-sync-plan-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/new/new-sync-plan-modal.controller.js
@@ -11,36 +11,40 @@
  *   A controller for creating a new sync plan in a modal.
  */
 angular.module('Bastion.products').controller('NewSyncPlanModalController',
-    ['$scope', '$uibModalInstance', 'SyncPlan', 'SyncPlanHelper',
-        function ($scope, $uibModalInstance, SyncPlan, SyncPlanHelper) {
+    ['$scope', '$uibModalInstance', 'SyncPlan', 'SyncPlanHelper', 'Notification', 'translate',
+        function ($scope, $uibModalInstance, SyncPlan, SyncPlanHelper, Notification, translate) {
             function success(syncPlan) {
+                Notification.setSuccessMessage(translate("Sync Plan saved"));
+                $scope.isWorking = false;
                 $uibModalInstance.close(syncPlan);
             }
 
             function error(response) {
                 var form = SyncPlanHelper.getForm();
-
+                $scope.isWorking = false;
                 angular.forEach(response.data.errors, function (errors, field) {
                     if (form[field]) {
                         form[field].$setValidity('server', false);
                         form[field].$error.messages = errors;
                     } else {
-                        Notification.setErrorMessage("Error saving the Sync Plan: " + " " + errors);
+                        Notification.setErrorMessage(translate("Error saving the Sync Plan: " + " " + errors));
                     }
                 });
             }
 
             $scope.ok = function (syncPlan) {
+                $scope.isWorking = true;
                 SyncPlanHelper.createSyncPlan(syncPlan, success, error);
             };
 
             $scope.cancel = function () {
+                $scope.isWorking = true;
                 $uibModalInstance.dismiss('cancel');
             };
 
             $scope.isFormDisabled = function () {
                 var form = SyncPlanHelper.getForm();
-                return form && !form.$valid;
+                return form && $scope.isWorking;
             };
 
             $scope.intervals = SyncPlanHelper.getIntervals();

--- a/engines/bastion_katello/test/products/new/new-sync-plan-modal.controller.test.js
+++ b/engines/bastion_katello/test/products/new/new-sync-plan-modal.controller.test.js
@@ -1,5 +1,5 @@
 describe('Controller: NewSyncPlanModalController', function() {
-    var $scope, $uibModalInstance, SyncPlan, SyncPlanHelper;
+    var $scope, $uibModalInstance, SyncPlan, SyncPlanHelper, Notification;
 
     beforeEach(module(
         'Bastion.sync-plans',
@@ -8,7 +8,6 @@ describe('Controller: NewSyncPlanModalController', function() {
 
     beforeEach(inject(function($injector) {
         var $controller = $injector.get('$controller');
-
         SyncPlan = $injector.get('MockResource').$new();
         $scope = $injector.get('$rootScope').$new();
 
@@ -40,11 +39,17 @@ describe('Controller: NewSyncPlanModalController', function() {
             setForm: function () {}
         };
 
+        Notification = {
+            setSuccessMessage: function () {},
+            setErrorMessage: function () {}
+        };
+
         $controller('NewSyncPlanModalController', {
             $scope: $scope,
             $uibModalInstance: $uibModalInstance,
             SyncPlan: SyncPlan,
-            SyncPlanHelper: SyncPlanHelper
+            SyncPlanHelper: SyncPlanHelper,
+            Notification: Notification
         });
     }));
 
@@ -74,8 +79,10 @@ describe('Controller: NewSyncPlanModalController', function() {
         });
 
         it('and succeed', function() {
+            spyOn(Notification, 'setSuccessMessage');
             spyOn($uibModalInstance, 'close');
             $scope.ok(syncPlan);
+            expect(Notification.setSuccessMessage).toHaveBeenCalled();
             expect($uibModalInstance.close).toHaveBeenCalledWith(syncPlan);
         });
 

--- a/test/models/sync_plan_test.rb
+++ b/test/models/sync_plan_test.rb
@@ -111,10 +111,9 @@ module Katello
 
     def test_invalid_cron_status
       @plan.cron_expression = "20 * * * *"
-      assert_raises(Exception) { @plan.save_with_logic! }
-      assert_equal @plan.errors.full_messages.first.to_s, "Custom cron expression only needs to be set for interval value of custom cron"
-      @plan.interval = 'custom cron'
+      refute @plan.valid?, "Custom cron expression only needs to be set for interval value of custom cron"
       assert @plan.save_with_logic!
+      assert_equal @plan.cron_expression, ''
     end
 
     def test_nil_cron_status


### PR DESCRIPTION
**Steps to reproduce:**
1. Create New Product -> Click on 'Create Sync Plan' link -> try to create duplicate sync plan -> Save button gets disabled 
2. Open the sync plan again on new product page still, it is disabled.

_This is tied to PR: https://github.com/Katello/katello/pull/7723 which fixed similar issue on new sync plan page. This PR is for sync plan modal on new product page._