### PR TITLE
Fixes #25544 - Resolve upgrade issue with db:migrate

### DIFF
--- a/db/migrate/20180814202747_add_recurring_logic_to_sync_plan.rb
+++ b/db/migrate/20180814202747_add_recurring_logic_to_sync_plan.rb
@@ -3,11 +3,5 @@ class AddRecurringLogicToSyncPlan < ActiveRecord::Migration[5.1]
     add_column :katello_sync_plans, :foreman_tasks_recurring_logic_id, :integer
     add_column :katello_sync_plans, :cron_expression, :string
     add_foreign_key :katello_sync_plans, :foreman_tasks_recurring_logics, :name => "katello_sync_plan_foreman_tasks_recurring_logic_fk", :column => "foreman_tasks_recurring_logic_id"
-    Katello::SyncPlan.find_each do |sync_plan|
-      User.as_anonymous_admin do
-        sync_plan.associate_recurring_logic
-        sync_plan.save!
-      end
-    end
   end
 end

--- a/lib/katello/tasks/upgrades/3.9/migrate_sync_plans.rake
+++ b/lib/katello/tasks/upgrades/3.9/migrate_sync_plans.rake
@@ -7,6 +7,8 @@ namespace :katello do
         puts "Starting recurring logic for migrated sync plans and deleting Pulp schedules"
 
         Katello::SyncPlan.find_each do |sync_plan|
+          sync_plan.associate_recurring_logic
+          sync_plan.save!
           if sync_plan.foreman_tasks_recurring_logic.state.nil?
             sync_plan.start_recurring_logic
             sync_plan.foreman_tasks_recurring_logic.enabled = false unless sync_plan.enabled


### PR DESCRIPTION
There is a conflict during 3.8 to 3.9 upgrade between db/migrate/20180814202747_add_recurring_logic_to_sync_plan.rb and db/migrate/20180920214134_create_repository_root.rb. We need to migrate the root repositories before sync plans are migrated.

The upgrade issue occurs for redhat products with sync plans.