### PR TITLE
Fixes #25236 - Move regenerate applicability to service class

### DIFF
--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -50,7 +50,7 @@ module Actions
               plan_action(Pulp::Repository::Download, :pulp_id => repo.pulp_id, :options => {:verify_all_units => true}) if validate_contents
               plan_action(Katello::Repository::MetadataGenerate, repo, :force => true) if skip_metadata_check
               plan_action(Katello::Repository::ErrataMail, repo, nil, contents_changed)
-              plan_action(Pulp::Repository::RegenerateApplicability, :pulp_id => repo.pulp_id, :contents_changed => contents_changed) if generate_applicability
+              plan_action(Pulp::Repository::RegenerateApplicability, :repository_id => repo.id, :contents_changed => contents_changed) if generate_applicability
             end
             plan_self(:id => repo.id, :sync_result => output, :skip_metadata_check => skip_metadata_check, :validate_contents => validate_contents,
                       :contents_changed => contents_changed)

--- a/app/lib/actions/pulp/repository/regenerate_applicability.rb
+++ b/app/lib/actions/pulp/repository/regenerate_applicability.rb
@@ -5,12 +5,15 @@ module Actions
         middleware.use Actions::Middleware::ExecuteIfContentsChanged
 
         input_format do
-          param :pulp_id
+          param :repository_id
+          param :capsule_id
           param :contents_changed
         end
 
         def invoke_external_task
-          pulp_extensions.repository.regenerate_applicability_by_ids([input[:pulp_id]], true)
+          capsule_id = input[:capsule_id] || SmartProxy.default_capsule!.id
+          repo = ::Katello::Repository.find(input[:repository_id])
+          repo.backend_service(smart_proxy(capsule_id)).regenerate_applicability
         end
       end
     end

--- a/app/services/katello/pulp/repository.rb
+++ b/app/services/katello/pulp/repository.rb
@@ -49,6 +49,10 @@ module Katello
         fail NotImplementedError
       end
 
+      def regenerate_applicability
+        fail NotImplementedError
+      end
+
       def sync(overrides = {})
         sync_options = {}
         sync_options[:max_speed] = SETTINGS.dig(:katello, :pulp, :sync_KBlimit)

--- a/app/services/katello/pulp/repository/yum.rb
+++ b/app/services/katello/pulp/repository/yum.rb
@@ -55,6 +55,10 @@ module Katello
             policy
           end
         end
+
+        def regenerate_applicability
+          smart_proxy.pulp_api.extensions.repository.regenerate_applicability_by_ids([repo.pulp_id], true)
+        end
       end
     end
   end

--- a/test/fixtures/vcr_cassettes/scenarios/org_create.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/org_create.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://dev.example.com:8443/candlepin/owners/
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/
     body:
       encoding: UTF-8
       base64_string: |
@@ -15,11 +15,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp",
-        oauth_nonce="ATN1Anw4PRtC6bvFpI9eaM2k2NkJIgYA115QCyUnbo", oauth_signature="XrU58N9yd5uvzjM9Tb8tG%2F5ZKac%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1540228106", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk",
+        oauth_nonce="2iOhJsKM0mekSFji7pJ3bRUuxKRoRjC8Yiy0ZQ43o", oauth_signature="3ZPcYu9p%2B0GWb74ZeHDBHmoT79I%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1543815534", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -36,7 +36,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 966f9c7d-fd12-4bc6-8ce7-41753751e3d7
+      - 67c8cd88-77a0-47e1-a2ee-dc354118cc39
       X-Version:
       - 2.5.6-1
       Content-Type:
@@ -44,13 +44,13 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 22 Oct 2018 17:08:25 GMT
+      - Mon, 03 Dec 2018 05:38:54 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOC0xMC0yMlQxNzowODoyNiswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTgtMTAtMjJUMTc6MDg6MjYrMDAwMCIsImlkIjoiNDAyOGY5NTE2
-        Njg4N2Q2ZjAxNjY5Y2JmYzdjNDAwNDUiLCJrZXkiOiJzY2VuYXJpb190ZXN0
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNTozODo1NCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6Mzg6NTQrMDAwMCIsImlkIjoiNDAyOGY5NjY2
+        NzcxOTU3ZDAxNjc3MjkzOTk3MDAwNGUiLCJrZXkiOiJzY2VuYXJpb190ZXN0
         IiwiZGlzcGxheU5hbWUiOiJzY2VuYXJpb190ZXN0IiwicGFyZW50T3duZXIi
         Om51bGwsImNvbnRlbnRQcmVmaXgiOiIvc2NlbmFyaW9fdGVzdC8kZW52Iiwi
         ZGVmYXVsdFNlcnZpY2VMZXZlbCI6bnVsbCwidXBzdHJlYW1Db25zdW1lciI6
@@ -59,10 +59,10 @@ http_interactions:
         Y2Vzc01vZGVMaXN0IjoiZW50aXRsZW1lbnQiLCJsYXN0UmVmcmVzaGVkIjpu
         dWxsLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0=
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:26 GMT
+  recorded_at: Mon, 03 Dec 2018 05:38:54 GMT
 - request:
     method: post
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/environments
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/environments
     body:
       encoding: UTF-8
       base64_string: |
@@ -74,11 +74,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp",
-        oauth_nonce="YoGs9I8FUGB1wnJWR1kFOsbW1xSCSqdyDWjcbiI6r1Y", oauth_signature="Q1i3Fps5UJWXOQbVN%2BWdu4BBxug%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1540228106", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk",
+        oauth_nonce="efy44fXB5sXzOWQRKH0rxUNES0VD5mcvvHW2AplmTac", oauth_signature="EGYkSlxKhyAFrB6CYh4Q5YINHkI%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1543815534", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -95,7 +95,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - e7190230-676d-417c-a1cc-5e9c9a3446b7
+      - d5adc3bc-23bb-4e61-97f8-849f2f67c548
       X-Version:
       - 2.5.6-1
       Content-Type:
@@ -103,22 +103,22 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 22 Oct 2018 17:08:25 GMT
+      - Mon, 03 Dec 2018 05:38:54 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOC0xMC0yMlQxNzowODoyNiswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTgtMTAtMjJUMTc6MDg6MjYrMDAwMCIsImlkIjoiZDgwYTU3ODNj
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNTozODo1NSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6Mzg6NTUrMDAwMCIsImlkIjoiZDgwYTU3ODNj
         NTAyZjBmOTY5ZTIzMDg5NDM3YmI3Y2UiLCJuYW1lIjoiTGlicmFyeSIsImRl
-        c2NyaXB0aW9uIjpudWxsLCJvd25lciI6eyJpZCI6IjQwMjhmOTUxNjY4ODdk
-        NmYwMTY2OWNiZmM3YzQwMDQ1Iiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRp
+        c2NyaXB0aW9uIjpudWxsLCJvd25lciI6eyJpZCI6IjQwMjhmOTY2Njc3MTk1
+        N2QwMTY3NzI5Mzk5NzAwMDRlIiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRp
         c3BsYXlOYW1lIjoic2NlbmFyaW9fdGVzdCIsImhyZWYiOiIvb3duZXJzL3Nj
         ZW5hcmlvX3Rlc3QifSwiZW52aXJvbm1lbnRDb250ZW50IjpbXX0=
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:26 GMT
+  recorded_at: Mon, 03 Dec 2018 05:38:55 GMT
 - request:
     method: get
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/uebercert
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/uebercert
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -128,11 +128,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="MXcVhHyiXmxKm781UDpi8YfgtiU4A8MZorwo2z8",
-        oauth_signature="jwbKzlAIseyBfEUk0jSI6VoszUE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1540228106", oauth_version="1.0"
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="EkxC7dHRpce1UIxnJ28o0Xb9L0NWGDgleDB6DCW99Q",
+        oauth_signature="9J5fxtm0%2BAZ0reLuI0vxNZfX8%2BU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543815535", oauth_version="1.0"
       Cp-User:
       - foreman_admin
   response:
@@ -143,7 +143,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 7bf75aec-28ce-4e95-a8d7-493cbcf23ac4
+      - a72542b8-a265-4001-99d1-f1b84faf365f
       X-Version:
       - 2.5.6-1
       - 2.5.6-1
@@ -152,19 +152,19 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 22 Oct 2018 17:08:25 GMT
+      - Mon, 03 Dec 2018 05:38:54 GMT
     body:
       encoding: UTF-8
       base64_string: |
         eyJkaXNwbGF5TWVzc2FnZSI6InViZXIgY2VydGlmaWNhdGUgZm9yIG93bmVy
         IHNjZW5hcmlvX3Rlc3Qgd2FzIG5vdCBmb3VuZC4gUGxlYXNlIGdlbmVyYXRl
-        IG9uZS4iLCJyZXF1ZXN0VXVpZCI6IjdiZjc1YWVjLTI4Y2UtNGU5NS1hOGQ3
-        LTQ5M2NiY2YyM2FjNCJ9
+        IG9uZS4iLCJyZXF1ZXN0VXVpZCI6ImE3MjU0MmI4LWEyNjUtNDAwMS05OWQx
+        LWYxYjg0ZmFmMzY1ZiJ9
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:26 GMT
+  recorded_at: Mon, 03 Dec 2018 05:38:55 GMT
 - request:
     method: post
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/uebercert
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/uebercert
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -176,11 +176,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp",
-        oauth_nonce="NniJcYrC7FIjUvWkHH7b76M04dGAgYdHM55FJxhVcI", oauth_signature="ORRPyOn%2BODTPyAs3S7KhF6evb%2Bo%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1540228106", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk",
+        oauth_nonce="WDShH3sTQHr5xJEyFt70odIS0xPSnhcr9IUXPVyfw", oauth_signature="FqC34hrHMG1f7U%2FufZNuk%2F8ba0s%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1543815535", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -197,7 +197,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 3c9c61de-bc1c-4d73-8153-9f203a252ff6
+      - 9b86df84-dd2f-4336-8bf6-03eb106c36e9
       X-Version:
       - 2.5.6-1
       Content-Type:
@@ -205,110 +205,110 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 22 Oct 2018 17:08:25 GMT
+      - Mon, 03 Dec 2018 05:38:54 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOC0xMC0yMlQxNzowODoyNiswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTgtMTAtMjJUMTc6MDg6MjYrMDAwMCIsImlkIjoiNDAyOGY5NTE2
-        Njg4N2Q2ZjAxNjY5Y2JmYzhmYTAwNDgiLCJrZXkiOiItLS0tLUJFR0lOIFJT
-        QSBQUklWQVRFIEtFWS0tLS0tXG5NSUlFcEFJQkFBS0NBUUVBdTZTSk9GcEJP
-        MDd6M2FyditQd0RnK0VsWUVMRzF5MlFESDhSMER1c0RCM1VFTmVVXG5VaDF4
-        YlhoRFdySHN4Z3d3ck1nS3p3SU1CbzFwTGplRmxMR1RZall1RnBmbVErclY4
-        bXV6SDBISU1qNVRtNnhhXG5udkFNTUEzaHVYN0prU3VsSS9HaWZuT3JmVXhv
-        SzVJMmQ3U2Qrdnh2TTlmZUM4ejlFSjFqUzliTlRDTTVkNXpaXG51b3NBcUlQ
-        SU5UZThSK21ZR2N1eGg3TEJjb1Q0MlV1STZtSDR6SUN4UyswbjlIK2tBenF1
-        cUU1WGMrWDdzZEVaXG5peU5maWFvc1dFWnJiOTZHN291VjlwNWxFMk00RHpO
-        eU5oa0ovRGdvSnFBSFRZTDVWdWJ6SCtBS0NOM2U1TUdnXG4ydGk3OVQrN3Y1
-        aVBMVkdVa0dkNFlVbWhUcENKVGF5Slo0VncvUUlEQVFBQkFvSUJBRnBuZUhF
-        OUVzYVhVR2tSXG5EVk1oWURRdXlrb3BnaEZ6OHo0Q0Ryd0xzK1dXalhDYjNP
-        ci9Jb0lDZWpqOUZqMkk2LzZpMW9wTHl5MXcvaWIxXG5PeGVid28yRDJ3cXBu
-        cGhFVVZYZHk4d1libksra3B1akczb04zMkZibnRBM0pMZ2JsaEhPUG1LOEtm
-        aFJVck1EXG5XOWlxblo2cDlvMjh5RTlaTU9mTFhHYlNrOURGSnV2SXROZjU5
-        VTdINUM0S1A2cFFzQzgrTGJLTGZRY3YrTmNqXG4xdXdoU3hBQ3h6cklnS0VE
-        QTNoN25Ic0pISW9keTViQ28wMEFjRmRCWGtTOE9YSXlFQUxDdlZwUFhKVXNX
-        djVoXG5lSThUVThtM3BNYVFraENURXhhdkg0UzMyKzNjM0pRRUY3eVJvbWFX
-        TmpLeW9BOGx4bnN1b2toVWNhM0xzMzQ4XG5FeTBFMFVFQ2dZRUErTWh5UzM5
-        NE5LUmRCb2dpMWJpZzZiR2lCeDV1dldJaHBYMGlHdmdIOTVVRnYzMUx1MGQ3
-        XG5MdUV0QnZjN01zWFFIUzhhdndIZ0RYUytqTjV3SDRZNGliZjdQZlI2TnJX
-        TWtaSEpiUFBIMlA0TEJXbWx5R1MzXG5oR05uZzI0UDhtZFpBeFVRQ0VSTGN5
-        Q216VU9QZGUvbGo4MjFyMGpKTjlOWU5jaDhIMWlTYUpFQ2dZRUF3UllLXG5I
-        SmFGaEsvY3doRFo3WURmcXFNcTRkNjJSK2RTbFVJaGMzWE10ZTBrYU1wNU54
-        YUluZTlZNVFWanpVc3BNVEpDXG5DbGFDMFRSYk1sUlo3bTEvM1hrVzRiZUhW
-        c05HTDdUWHM2U0kxZUx5ZlNVdXgwVndxV0t2VDMzK1haNWlESDJsXG5qTTkw
-        NmIzbUpwOXhkbTV6VDNjTWc4cWpQaGhlUEVTWlJwUVQxNjBDZ1lBYjhsaDBo
-        ck00SnFhVWowSnFnN3ovXG53NGFTQ2ljaWV4MlFlNGdUUTMyUm9GbnU4dUpJ
-        L1hTbkJZQ0xZY1p5bzZvSFBUMWg2NUlCc1BXZTJYWDY5SmJ4XG5VWXVWb0Jz
-        Q2ZrNTJJOHhld3R2V1VtTm1qa0dqU3owYVVCaFd1VXh0VEpMQk4rSi9LenpX
-        aC9wMDRId0RJWm5HXG5GN09ySnlBRGQyaFhVbGd2SlVIOUlRS0JnUUNUTTZV
-        ejFFRW9QaFp6MFBzRGlRdDdnSGVSeVFONFg4OWl3UTdWXG5na28xcS92azgr
-        OWpZd2QyT0dHeC8rRHRRczY5bGM0cEtYa0Qyd0ZucGswRmEyOWV2aEVHdGE4
-        MUl4d2dCS09wXG5iZGR3RUZ2RHNwUXVFUzlwd3pWWnlma2hFRDA1dnBSMmZE
-        WnFlSDY4bFRPZ0VXWlJmN1lIeDNXYVFtT2RXTUx0XG52cmc5NVFLQmdRRG8w
-        TEFEc1QwRHBTSy96cnhyK0pZMXRSQ042WUlLVUpOaEdaQ0hlQUJLK29jdEww
-        UCsvYXhQXG5HN0FiQ0FidkF6cThlWjhCTVAzQVRkYXI1cjRFMVNqU3pMaTQw
-        dUs1WE55NXlXWDBBaDFEZlhza3V2MGFpWE9EXG5pdzVLMFh4MmNvL1Y5b1Qr
-        YzJ2MDRZbTUwdzVTeGFVaEtiRXV2Tit6T09GNGgwY1EydVZ5R2c9PVxuLS0t
-        LS1FTkQgUlNBIFBSSVZBVEUgS0VZLS0tLS1cbiIsImNlcnQiOiItLS0tLUJF
-        R0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUdWakNDQlQ2Z0F3SUJBZ0lJYUdZ
-        SW4xVElCcEl3RFFZSktvWklodmNOQVFFTEJRQXdlakVMTUFrR0ExVUVcbkJo
-        TUNWVk14RnpBVkJnTlZCQWdURGs1dmNuUm9JRU5oY205c2FXNWhNUkF3RGdZ
-        RFZRUUhFd2RTWVd4bGFXZG9cbk1SQXdEZ1lEVlFRS0V3ZExZWFJsYkd4dk1S
-        UXdFZ1lEVlFRTEV3dFRiMjFsVDNKblZXNXBkREVZTUJZR0ExVUVcbkF4TVBa
-        R1YyTG1WNFlXMXdiR1V1WTI5dE1CNFhEVEU0TVRBeU1qRTNNRGd5TmxvWERU
-        UTVNVEl3TVRFek1EQXdcbk1Gb3dHREVXTUJRR0ExVUVDZ3dOYzJObGJtRnlh
-        VzlmZEdWemREQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURcbmdnRVBBREND
-        QVFvQ2dnRUJBTHVraVRoYVFUdE84OTJxNy9qOEE0UGhKV0JDeHRjdGtBeC9F
-        ZEE3ckF3ZDFCRFhcbmxGSWRjVzE0UTFxeDdNWU1NS3pJQ3M4Q0RBYU5hUzQz
-        aFpTeGsySTJMaGFYNWtQcTFmSnJzeDlCeURJK1U1dXNcbldwN3dEREFONGJs
-        K3laRXJwU1B4b241enEzMU1hQ3VTTm5lMG5mcjhielBYM2d2TS9SQ2RZMHZX
-        elV3ak9YZWNcbjJicUxBS2lEeURVM3ZFZnBtQm5Mc1lleXdYS0UrTmxMaU9w
-        aCtNeUFzVXZ0Si9SL3BBTTZycWhPVjNQbCs3SFJcbkdZc2pYNG1xTEZoR2Ey
-        L2VodTZMbGZhZVpSTmpPQTh6Y2pZWkNmdzRLQ2FnQjAyQytWYm04eC9nQ2dq
-        ZDN1VEJcbm9Ocll1L1UvdTcrWWp5MVJsSkJuZUdGSm9VNlFpVTJzaVdlRmNQ
-        MENBd0VBQWFPQ0EwQXdnZ004TUE0R0ExVWRcbkR3RUIvd1FFQXdJRXNEQVRC
-        Z05WSFNVRUREQUtCZ2dyQmdFRkJRY0RBakFKQmdOVkhSTUVBakFBTUJFR0NX
-        Q0dcblNBR0crRUlCQVFRRUF3SUZvREFkQmdOVkhRNEVGZ1FVeVptcC9qRmM4
-        MGp1Q0xIQ2w0ZFhqMXZaTXRJd0h3WURcblZSMGpCQmd3Rm9BVXZXdTBhT2pT
-        dUxRT2ZQSk9XRnNyV1ZtanFnWXdNUVlRS3dZQkJBR1NDQWtCck9ubC81Qllc
-        bkFRUWREQnR6WTJWdVlYSnBiMTkwWlhOMFgzVmxZbVZ5WDNCeWIyUjFZM1F3
-        RmdZUUt3WUJCQUdTQ0FrQnJPbmxcbi81QllBd1FDREFBd0ZnWVFLd1lCQkFH
-        U0NBa0JyT25sLzVCWUFnUUNEQUF3RmdZUUt3WUJCQUdTQ0FrQnJPbmxcbi81
-        QllCUVFDREFBd0dRWVFLd1lCQkFHU0NBa0NyT25sLzVCWkFRUUZEQU41ZFcw
-        d0pBWVJLd1lCQkFHU0NBa0NcbnJPbmwvNUJaQVFFRUR3d05kV1ZpWlhKZlky
-        OXVkR1Z1ZERBeUJoRXJCZ0VFQVpJSUNRS3M2ZVgva0ZrQkFnUWRcbkRCc3hO
-        VFF3TWpJNE1UQTJNekk0WDNWbFltVnlYMk52Ym5SbGJuUXdIUVlSS3dZQkJB
-        R1NDQWtDck9ubC81QlpcbkFRVUVDQXdHUTNWemRHOXRNQ1VHRVNzR0FRUUJr
-        Z2dKQXF6cDVmK1FXUUVHQkJBTURpOXpZMlZ1WVhKcGIxOTBcblpYTjBNQmNH
-        RVNzR0FRUUJrZ2dKQXF6cDVmK1FXUUVIQkFJTUFEQVlCaEVyQmdFRUFaSUlD
-        UUtzNmVYL2tGa0JcbkNBUUREQUV4TUNzR0Npc0dBUVFCa2dnSkJBRUVIUXdi
-        YzJObGJtRnlhVzlmZEdWemRGOTFaV0psY2w5d2NtOWtcbmRXTjBNQkFHQ2lz
-        R0FRUUJrZ2dKQkFJRUFnd0FNQjBHQ2lzR0FRUUJrZ2dKQkFNRUR3d05NVFUw
-        TURJeU9ERXdcbk5qTXlPREFSQmdvckJnRUVBWklJQ1FRRkJBTU1BVEV3SkFZ
-        S0t3WUJCQUdTQ0FrRUJnUVdEQlF5TURFNExURXdcbkxUSXlWREUzT2pBNE9q
-        STJXakFrQmdvckJnRUVBWklJQ1FRSEJCWU1GREl3TkRrdE1USXRNREZVTVRN
-        Nk1EQTZcbk1EQmFNQkVHQ2lzR0FRUUJrZ2dKQkF3RUF3d0JNREFRQmdvckJn
-        RUVBWklJQ1FRS0JBSU1BREFRQmdvckJnRUVcbkFaSUlDUVFOQkFJTUFEQVJC
-        Z29yQmdFRUFaSUlDUVFPQkFNTUFUQXdFUVlLS3dZQkJBR1NDQWtFQ3dRRERB
-        RXhcbk1EUUdDaXNHQVFRQmtnZ0pCUUVFSmd3a01XWXpaR1ExT1RRdFlURTVO
-        UzAwT0RneUxUZzJOVE10WmpSa01ETTFcblptWmhaVFZpTUEwR0NTcUdTSWIz
-        RFFFQkN3VUFBNElCQVFDZEJpSFFpUWdnSzQwZ3ZPc3dsQkx3Y3VXNGJ1bUFc
-        blBIQW01UjUraHpVWGM0VEkzM1dpUmRIVGpaNDhrMW9YZkh0MEtRRzY2UXZS
-        bkF5OE9zV0ZUMk0xUjE3eHRnWXhcbjE1V2ZnTUJGRXN1R05HRVI5VzJ6NVlG
-        bEtkYmlHZERxRTN5dkYrQ05Sbm5ieTdOcC91NnJpdTlQZTNEVUhSQmpcbnBV
-        N2Q5cWg3dkl0NjhDcHNLWmdzb09PNUs1NWJnYXRISXhxd3Q4Nm94amJLZklZ
-        RlQ1L0FpU09VOERNUE1yTElcbjltano4SHk3cm5GWUVTdlJidStUeEFmOVJ2
-        Qi9WZGwxZUNVSUtRZHBpZG1CYytIbmVKc2VGUzBmU2VHaFBsc2VcbjhWbVFL
-        TElXWGkzbnhFWS9DdE8rejBHNnR5NTVaRlF6WVBVa2JGZXVQZHYzQlc2akd4
-        TmVXdUNOXG4tLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tXG4iLCJzZXJpYWwi
-        OnsiY3JlYXRlZCI6IjIwMTgtMTAtMjJUMTc6MDg6MjYrMDAwMCIsInVwZGF0
-        ZWQiOiIyMDE4LTEwLTIyVDE3OjA4OjI2KzAwMDAiLCJpZCI6NzUyMjcwOTcw
-        Nzk4NDIwOTU1NCwic2VyaWFsIjo3NTIyNzA5NzA3OTg0MjA5NTU0LCJleHBp
-        cmF0aW9uIjoiMjA0OS0xMi0wMVQxMzowMDowMCswMDAwIiwiY29sbGVjdGVk
-        IjpmYWxzZSwicmV2b2tlZCI6ZmFsc2V9LCJvd25lciI6eyJpZCI6IjQwMjhm
-        OTUxNjY4ODdkNmYwMTY2OWNiZmM3YzQwMDQ1Iiwia2V5Ijoic2NlbmFyaW9f
-        dGVzdCIsImRpc3BsYXlOYW1lIjoic2NlbmFyaW9fdGVzdCIsImhyZWYiOiIv
-        b3duZXJzL3NjZW5hcmlvX3Rlc3QifX0=
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNTozODo1NSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6Mzg6NTUrMDAwMCIsImlkIjoiNDAyOGY5NjY2
+        NzcxOTU3ZDAxNjc3MjkzOWExYzAwNTEiLCJrZXkiOiItLS0tLUJFR0lOIFJT
+        QSBQUklWQVRFIEtFWS0tLS0tXG5NSUlFb3dJQkFBS0NBUUVBaWovaDVJdGpu
+        RC91U0FGTEJ2RFlpdzhOd3o2dHBvMTRvcXJFVlIzeFJPcUloaGRsXG5yL3F2
+        Z3hxNCtCUnA4SWNPZXh3NVdqM0ZHTUp2MmZnNGxNZWhleGxESFhodFNlYkgz
+        eTQvOVUxbkw0UFJjV1BUXG5NQlhmZUQzbCtPdmdmVGdBTTM3dklWL2FNWnh2
+        SjdVNFFxTno4OCtqOTVINjZsOStjeFA5SmpsR1NoQURLdzhuXG5ybEFyZnBZ
+        WDlnOVc5T05ETGZaRG8xUjNFRDFhTTh6V3BxSHdaWXFxNEVBdzhNNC9HVytN
+        QWNBa3k1VG9FY1ZLXG55YkYyNHFYTVYwbEVQVE4xbHptRmpjQjhxSTQ2V3Bi
+        Zi9xMjBOOStVWlViTC8wdVV3aVphaDVlSjdDZXY1aEs3XG5kbmRVNWY2Q0hH
+        czhEQUIzN3BZTzJGd0JLelJBWDY4bTJQVzFId0lEQVFBQkFvSUJBQ0V5YjlM
+        S2FkUG1RaGlHXG5QdmJldEpESHY1MUhtcmtvdFhRU0gyejA4SytFeGQyMUZw
+        VG9WR2JkN3RhYlNFa2FsUzZZdTJqZzlrZ1l3SFVOXG50c0I3STFxRTJXbmxO
+        aEVOMnFiTDIwM1RGVmtDaFROK0xnTVk3WDFaRjdUckp3L0tkN25sM0JRZWlT
+        MXFqQUp6XG44SnVIMWxzUVhDWWhwcWZLNEhsUHJuVVVRYjJjdWx1MnF5VWpI
+        dzVqZ3BYVlRBRVBHWTZVcXdjaUtub0RPMENEXG4vNE9WUDFuWklSTmF4S1Jq
+        U0htMU1QeE85MVcrb3N5YTdFcEdRcEYzOVhESnU1KzllWG8yMGt6bEpWVEZP
+        N2g1XG5YWWU0aDNWbmRiRVcweVRGVXQ3SHY5L1pCWHMvZXRnQ0x0R0tvd0lm
+        QXhzak1aUDVLMmpkdkFhWmpUMW9JTEJZXG5RSVFuenRrQ2dZRUF2ZFltZmdx
+        NDJhcXZiQmJnMzI1MlhFUnlIRFpqZXc5ODVsZWg1Yis2dWw3WDh4VnJIa3FW
+        XG5TdlgyNFYvb05rNlA3RW1jSmUyb2ZsMXpQcHdXMFY1ZDhKeFhrZFU3N2cy
+        Z2cveFNpMTdqMEc0UmpKNjVMV1ErXG5oNWxsRVp6TDZvSzAzMUhHR3pGK3Yz
+        K0NwdUEyNzdxejM3cDdrbm1rTWFJM2pGRmVnK3BlZFdzQ2dZRUF1bTc0XG5B
+        VTZqYjRvN3F6K0FyMWxZeE9zanFZVG1hcnR3N3VrbEloR2dEdnVjdWNUaGlL
+        SmFJQWMwUEEzNVFNWUhLN2ZNXG4zRm8rckFrUmxNTkxuN3B0RUI2L1U1OG1V
+        UHhVRzQ1aWJOaE05QXBmRmM0d3d1LzFqUVRzay9jWVloaUFxQ1daXG5hVFZ4
+        ekoybGJxR3hFdHZCVG85NW5vclhrVGNqendEWXR5bDVPQjBDZ1lFQXZTSDA2
+        N0tuQkVYbnpGcm00L1JiXG4vQVU5WXhwVTlyQXhraFJRK21PUkdFbVNBVitm
+        ZjJoellXRzQvRVhmUnV2eXZFbUNScytIQlk3NVdMR09rajNnXG5mZTVsMktl
+        SHM5N2p3MXZLcVl4NmtKaDQ1NDdqazNQQ1VMcmxWU3pRaE82QVlkWkk5NkxT
+        VXR3cFFUVTF4cFpPXG55Mkl4NTNkRnZTV1BEaityV09aU0FjMENnWUJ5Zjlp
+        OUpNam5waVJEWm5yb05wMTRRMW5oc1FlNm9XZ1lzd1BsXG5TcUhjMGRkTm1J
+        ZFRYVEt3M1B2TnJsOVkwc1p3cVMrZVhhYUVEZ1hJTWJGdVpoYTVnY2pMMk1D
+        MW1HTW5rV2tOXG5wRUtPMXhmUzBwSE1CNGZ0bGdxZVRYR2lQWjQycHZEelZx
+        bVBtM3FRMmFsaEJhcFJUM2pJVUVsWW5GN1hzWk5uXG4yb2JpV1FLQmdHOUdI
+        RXhkRytUSURqaTY1MSs4bFBQSHNGdjVEM1FWdXRnMkhjVytlcEVvRnpHK3Jq
+        RytjRmZOXG5FeVB5RGh2bCsxRHpFaHd6bzV0SU42eFd4VFR2M1p0K0NJS1dB
+        aExZbWc1WnFlbHBqbXVoV1BuSndtaHNDNWFmXG5xcUJGdDNvQjlVSksrb3FH
+        OXhyZ2ZYZy9qNnVKQllzZ1Bvak0xWDl5M3VwUFFzc3Y4M1VMXG4tLS0tLUVO
+        RCBSU0EgUFJJVkFURSBLRVktLS0tLVxuIiwiY2VydCI6Ii0tLS0tQkVHSU4g
+        Q0VSVElGSUNBVEUtLS0tLVxuTUlJR2FEQ0NCVkNnQXdJQkFnSUlhK2p2dzVL
+        R2JJNHdEUVlKS29aSWh2Y05BUUVMQlFBd2dZc3hDekFKQmdOVlxuQkFZVEFs
+        VlRNUmN3RlFZRFZRUUlEQTVPYjNKMGFDQkRZWEp2YkdsdVlURVFNQTRHQTFV
+        RUJ3d0hVbUZzWldsblxuYURFUU1BNEdBMVVFQ2d3SFMyRjBaV3hzYnpFVU1C
+        SUdBMVVFQ3d3TFUyOXRaVTl5WjFWdWFYUXhLVEFuQmdOVlxuQkFNTUlHTmxi
+        blJ2Y3pjdFpHVjJaV3d5TG5OaGJXbHlMbVY0WVcxd2JHVXVZMjl0TUI0WERU
+        RTRNVEl3TXpBMVxuTXpnMU5Wb1hEVFE1TVRJd01URXpNREF3TUZvd0dERVdN
+        QlFHQTFVRUNnd05jMk5sYm1GeWFXOWZkR1Z6ZERDQ1xuQVNJd0RRWUpLb1pJ
+        aHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFJby80ZVNMWTV3LzdrZ0JT
+        d2J3MklzUFxuRGNNK3JhYU5lS0txeEZVZDhVVHFpSVlYWmEvNnI0TWF1UGdV
+        YWZDSERuc2NPVm85eFJqQ2I5bjRPSlRIb1hzWlxuUXgxNGJVbm14OTh1UC9W
+        Tlp5K0QwWEZqMHpBVjMzZzk1ZmpyNEgwNEFETis3eUZmMmpHY2J5ZTFPRUtq
+        Yy9QUFxuby9lUit1cGZmbk1UL1NZNVJrb1FBeXNQSjY1UUszNldGL1lQVnZU
+        alF5MzJRNk5VZHhBOVdqUE0xcWFoOEdXS1xucXVCQU1QRE9QeGx2akFIQUpN
+        dVU2QkhGU3NteGR1S2x6RmRKUkQwemRaYzVoWTNBZktpT09scVczLzZ0dERm
+        ZlxubEdWR3kvOUxsTUltV29lWGlld25yK1lTdTNaM1ZPWCtnaHhyUEF3QWQr
+        NldEdGhjQVNzMFFGK3ZKdGoxdFI4Q1xuQXdFQUFhT0NBMEF3Z2dNOE1BNEdB
+        MVVkRHdFQi93UUVBd0lFc0RBVEJnTlZIU1VFRERBS0JnZ3JCZ0VGQlFjRFxu
+        QWpBSkJnTlZIUk1FQWpBQU1CRUdDV0NHU0FHRytFSUJBUVFFQXdJRm9EQWRC
+        Z05WSFE0RUZnUVVNa3hTZ1pPSlxuMWtjWEhHSWFXTG9HTmdObEVDb3dId1lE
+        VlIwakJCZ3dGb0FVME8vRjFtSjdsblQrOHFPditpaG9ObHhLNmFNd1xuTVFZ
+        UUt3WUJCQUdTQ0FrQnJQZVV6ck56QVFRZERCdHpZMlZ1WVhKcGIxOTBaWE4w
+        WDNWbFltVnlYM0J5YjJSMVxuWTNRd0ZnWVFLd1lCQkFHU0NBa0JyUGVVenJO
+        ekF3UUNEQUF3RmdZUUt3WUJCQUdTQ0FrQnJQZVV6ck56QWdRQ1xuREFBd0Zn
+        WVFLd1lCQkFHU0NBa0JyUGVVenJOekJRUUNEQUF3R1FZUUt3WUJCQUdTQ0Fr
+        Q3JQZVV6ck4wQVFRRlxuREFONWRXMHdKQVlSS3dZQkJBR1NDQWtDclBlVXpy
+        TjBBUUVFRHd3TmRXVmlaWEpmWTI5dWRHVnVkREF5QmhFclxuQmdFRUFaSUlD
+        UUtzOTVUT3MzUUJBZ1FkREJzeE5UUXpPREUxTlRNMU1Ea3hYM1ZsWW1WeVgy
+        TnZiblJsYm5Rd1xuSFFZUkt3WUJCQUdTQ0FrQ3JQZVV6ck4wQVFVRUNBd0dR
+        M1Z6ZEc5dE1DVUdFU3NHQVFRQmtnZ0pBcXozbE02elxuZEFFR0JCQU1EaTl6
+        WTJWdVlYSnBiMTkwWlhOME1CY0dFU3NHQVFRQmtnZ0pBcXozbE02emRBRUhC
+        QUlNQURBWVxuQmhFckJnRUVBWklJQ1FLczk1VE9zM1FCQ0FRRERBRXhNQ3NH
+        Q2lzR0FRUUJrZ2dKQkFFRUhRd2JjMk5sYm1GeVxuYVc5ZmRHVnpkRjkxWldK
+        bGNsOXdjbTlrZFdOME1CQUdDaXNHQVFRQmtnZ0pCQUlFQWd3QU1CMEdDaXNH
+        QVFRQlxua2dnSkJBTUVEd3dOTVRVME16Z3hOVFV6TlRBNU1UQVJCZ29yQmdF
+        RUFaSUlDUVFGQkFNTUFURXdKQVlLS3dZQlxuQkFHU0NBa0VCZ1FXREJReU1E
+        RTRMVEV5TFRBelZEQTFPak00T2pVMVdqQWtCZ29yQmdFRUFaSUlDUVFIQkJZ
+        TVxuRkRJd05Ea3RNVEl0TURGVU1UTTZNREE2TURCYU1CRUdDaXNHQVFRQmtn
+        Z0pCQXdFQXd3Qk1EQVFCZ29yQmdFRVxuQVpJSUNRUUtCQUlNQURBUUJnb3JC
+        Z0VFQVpJSUNRUU5CQUlNQURBUkJnb3JCZ0VFQVpJSUNRUU9CQU1NQVRBd1xu
+        RVFZS0t3WUJCQUdTQ0FrRUN3UUREQUV4TURRR0Npc0dBUVFCa2dnSkJRRUVK
+        Z3drT1RJMVpUUTJOVGN0TXpRMFxuTmkwME0yVmxMV0kzTnpndFpXWmlZV0Uz
+        WXpjM09EUmlNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUF2Z0F1Y1xuMzg2
+        UkhZMnVTTytBVFp3WHRJRVRmOG1xbTk2NTlhNng0eEMyS0xhd2tvRUFFSnM2
+        eFZmQkE0Vk8zclptbTdTNFxuTzlvYkp4RzlPTHFjZThteEVoaExMZVhWNTR4
+        OHVTa2x3V2dCNUc2cWdXRFZFeGdVVFhvbCtjVW9SeDI2bzBYM1xuZ3BOLzh1
+        SldOT25tN0E0Vk1uaGhCcHNlb1ZhbzBZR2RjMlpLd09HcjhKaW1NNEdxZXdN
+        WmdRUllwSFNCakRNL1xuU2tZQzRaZzlIYkc2Q1JSRVVsc3FROUZCL3VmcG5M
+        Q0RNNXJnZDFSeHFVaGxIaHhBWVJCN1EvUTV6S21UZEVUclxuNkEzRUlzZzhj
+        a2JrMzkrMENnWVN1aEo2clVXNCtXak1NVVlkWnoxTEI3eE1CNmNHemk0cUJh
+        UnZ5L29MdElYbFxudytMckRiaDlSdWhBUUNOdVxuLS0tLS1FTkQgQ0VSVElG
+        SUNBVEUtLS0tLVxuIiwic2VyaWFsIjp7ImNyZWF0ZWQiOiIyMDE4LTEyLTAz
+        VDA1OjM4OjU1KzAwMDAiLCJ1cGRhdGVkIjoiMjAxOC0xMi0wM1QwNTozODo1
+        NSswMDAwIiwiaWQiOjc3NzU3MjgzNzk5MTExMDU2NzgsInNlcmlhbCI6Nzc3
+        NTcyODM3OTkxMTEwNTY3OCwiZXhwaXJhdGlvbiI6IjIwNDktMTItMDFUMTM6
+        MDA6MDArMDAwMCIsImNvbGxlY3RlZCI6ZmFsc2UsInJldm9rZWQiOmZhbHNl
+        fSwib3duZXIiOnsiaWQiOiI0MDI4Zjk2NjY3NzE5NTdkMDE2NzcyOTM5OTcw
+        MDA0ZSIsImtleSI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5TmFtZSI6InNj
+        ZW5hcmlvX3Rlc3QiLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In19
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:26 GMT
+  recorded_at: Mon, 03 Dec 2018 05:38:55 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/organization_destroy.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/organization_destroy.yml
@@ -1,45 +1,6 @@
 ---
 http_interactions:
 - request:
-    method: delete
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 22 Oct 2018 17:08:50 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzdlYmJjODQ5LWJlN2ItNDIzYS1iYjI0LWZhMGE5OTQwNGFiMC8iLCAi
-        dGFza19pZCI6ICI3ZWJiYzg0OS1iZTdiLTQyM2EtYmIyNC1mYTBhOTk0MDRh
-        YjAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:50 GMT
-- request:
     method: get
     uri: https://dev.example.com/pulp/api/v2/tasks/7ebbc849-be7b-423a-bb24-fa0a99404ab0/
     body:
@@ -203,44 +164,200 @@ http_interactions:
   recorded_at: Mon, 22 Oct 2018 17:08:50 GMT
 - request:
     method: delete
-    uri: https://dev.example.com:8443/candlepin/environments/d80a5783c502f0f969e23089437bb7ce
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
-      - "*/*"
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
-      Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="ewMlNMr3pDTNFyG9UGG8hA1W9fNCqlpm7TRzhMjRE",
-        oauth_signature="6eI0Or1CbQwI0i74QI4KUAGESuc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1540228130", oauth_version="1.0"
-      Cp-User:
-      - foreman_admin
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
   response:
     status:
-      code: 204
-      message: No Content
+      code: 202
+      message: Accepted
     headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 4e35faca-9454-4db9-8239-7baede3b7940
-      X-Version:
-      - 2.5.6-1
       Date:
-      - Mon, 22 Oct 2018 17:08:50 GMT
+      - Mon, 03 Dec 2018 05:39:19 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
     body:
       encoding: UTF-8
-      base64_string: ''
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzkzOGU0NWRiLTI3NzQtNGVkMy1hNjRhLTYyNDAzZDZkYmQzYy8iLCAi
+        dGFza19pZCI6ICI5MzhlNDVkYi0yNzc0LTRlZDMtYTY0YS02MjQwM2Q2ZGJk
+        M2MifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:50 GMT
+  recorded_at: Mon, 03 Dec 2018 05:39:19 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/938e45db-2774-4ed3-a64a-62403d6dbd3c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:19 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"290fa181f719f0727f01eef9f8cc8bed-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '546'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85MzhlNDVkYi0yNzc0LTRlZDMtYTY0YS02MjQwM2Q2ZGJk
+        M2MvIiwgInRhc2tfaWQiOiAiOTM4ZTQ1ZGItMjc3NC00ZWQzLWE2NGEtNjI0
+        MDNkNmRiZDNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUi
+        OiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBu
+        dWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwg
+        InByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiIiwgInN0YXRlIjog
+        IndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0IjogbnVs
+        bCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YzE4NzQ5
+        OGVkYjgyNTViYjQ4MWQifSwgImlkIjogIjVjMDRjMTg3NDk4ZWRiODI1NWJi
+        NDgxZCJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:19 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/938e45db-2774-4ed3-a64a-62403d6dbd3c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:19 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"4ed6bae812a9216bfaf96119914844b3-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '684'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85MzhlNDVkYi0yNzc0LTRlZDMtYTY0YS02MjQwM2Q2ZGJk
+        M2MvIiwgInRhc2tfaWQiOiAiOTM4ZTQ1ZGItMjc3NC00ZWQzLWE2NGEtNjI0
+        MDNkNmRiZDNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUi
+        OiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAi
+        MjAxOC0xMi0wM1QwNTozOToxOVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
+        YXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVl
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZl
+        bDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmci
+        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
+        Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YzE4
+        NzQ5OGVkYjgyNTViYjQ4MWQifSwgImlkIjogIjVjMDRjMTg3NDk4ZWRiODI1
+        NWJiNDgxZCJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:19 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/938e45db-2774-4ed3-a64a-62403d6dbd3c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:19 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"07c4dae4bf9e0f437976e53372d036f6-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '703'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85MzhlNDVkYi0yNzc0LTRlZDMtYTY0YS02MjQwM2Q2ZGJk
+        M2MvIiwgInRhc2tfaWQiOiAiOTM4ZTQ1ZGItMjc3NC00ZWQzLWE2NGEtNjI0
+        MDNkNmRiZDNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUi
+        OiAiMjAxOC0xMi0wM1QwNTozOToxOVoiLCAiX25zIjogInRhc2tfc3RhdHVz
+        IiwgInN0YXJ0X3RpbWUiOiAiMjAxOC0xMi0wM1QwNTozOToxOVoiLCAidHJh
+        Y2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNz
+        X3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwg
+        InN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVk
+        X3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1w
+        bGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQi
+        OiB7IiRvaWQiOiAiNWMwNGMxODc0OThlZGI4MjU1YmI0ODFkIn0sICJpZCI6
+        ICI1YzA0YzE4NzQ5OGVkYjgyNTViYjQ4MWQifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:19 GMT
 - request:
     method: delete
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/environments/d80a5783c502f0f969e23089437bb7ce
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -250,11 +367,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="K7zJPQTUwt5lUl753EqH59u0w5z4jAN40LdKKsge0",
-        oauth_signature="4XvaR8B3r6TEHT6mLnCTxrO3BOQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1540228130", oauth_version="1.0"
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="sjFHDejsMhCw3SXvjmDCW2WtYdPoYTfOoGMofp8",
+        oauth_signature="0YlT2iVKnKUi%2FEHBStokK2YCDos%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543815559", oauth_version="1.0"
       Cp-User:
       - foreman_admin
   response:
@@ -265,14 +382,51 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 0063b37c-6f5b-447c-a50d-75e75f0e0d8e
+      - 8a153745-3e3b-4ead-8949-7a97fe25ab75
       X-Version:
       - 2.5.6-1
       Date:
-      - Mon, 22 Oct 2018 17:08:50 GMT
+      - Mon, 03 Dec 2018 05:39:19 GMT
     body:
       encoding: UTF-8
       base64_string: ''
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:50 GMT
+  recorded_at: Mon, 03 Dec 2018 05:39:19 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="LfSAVVLAJVBOxSt5gIx1fKooKgyYUBeuK8MMdv6HXg",
+        oauth_signature="cKt3cOr%2FAuAyazwf9u8H%2BA%2F%2BqYA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543815559", oauth_version="1.0"
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - a07610b5-654d-4fb0-aa25-c3a07d685d73
+      X-Version:
+      - 2.5.6-1
+      Date:
+      - Mon, 03 Dec 2018 05:39:19 GMT
+    body:
+      encoding: UTF-8
+      base64_string: ''
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:19 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/product_create.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/product_create.yml
@@ -1,264 +1,6 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/products/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJuYW1lIjoiU2NlbmFyaW8gUHJvZHVjdCIsImlkIjoiN2M4MjUwMTNjYWIw
-        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJtdWx0aXBsaWVyIjoxLCJhdHRyaWJ1
-        dGVzIjpbeyJuYW1lIjoiYXJjaCIsInZhbHVlIjoiQUxMIn1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp",
-        oauth_nonce="LTeVPXdys6wY5Z0oXB5JezBE91qAhBOXoDddHWQ8", oauth_signature="qz86D0z034ViRD0FWpuhhuZRqS8%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1540228106", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-      Content-Length:
-      - '127'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - cb859a18-9e80-48b6-a37d-3a4f6af87596
-      X-Version:
-      - 2.5.6-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Mon, 22 Oct 2018 17:08:26 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOC0xMC0yMlQxNzowODoyNiswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTgtMTAtMjJUMTc6MDg6MjYrMDAwMCIsInV1aWQiOiI0MDI4Zjk1
-        MTY2ODg3ZDZmMDE2NjljYmZjOWY2MDA0OSIsImlkIjoiN2M4MjUwMTNjYWIw
-        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
-        dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
-        IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
-        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOTUxNjY4ODdkNmYwMTY2OWNiZmM5ZjYw
-        MDQ5IiwicHJvZHVjdENvbnRlbnQiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:26 GMT
-- request:
-    method: post
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/pools
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzdGFydERhdGUiOiIyMDE3LTAxLTAxVDIwOjE1OjAxLjAwMFoiLCJlbmRE
-        YXRlIjoiMjA0Ni0xMi0yNVQyMDoxNTowMS4wMDBaIiwicXVhbnRpdHkiOi0x
-        LCJhY2NvdW50TnVtYmVyIjoiIiwicHJvZHVjdElkIjoiN2M4MjUwMTNjYWIw
-        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJwcm92aWRlZFByb2R1Y3RzIjpbXSwi
-        Y29udHJhY3ROdW1iZXIiOiIifQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp",
-        oauth_nonce="7XeLyZG5r97sBCx8lJ74LXwO1NDFqLgjxrLRlm1lGfs", oauth_signature="ksP2ExCXvna7CsW1zr%2Fgs5kTPOE%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1540228106", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-      Content-Length:
-      - '199'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 81ea9aba-1ab3-4dc6-b9d6-f5fce9056e9a
-      X-Version:
-      - 2.5.6-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Mon, 22 Oct 2018 17:08:26 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOC0xMC0yMlQxNzowODoyNiswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTgtMTAtMjJUMTc6MDg6MjYrMDAwMCIsImlkIjoiNDAyOGY5NTE2
-        Njg4N2Q2ZjAxNjY5Y2JmY2ExZjAwNGEiLCJ0eXBlIjoiTk9STUFMIiwib3du
-        ZXIiOnsiaWQiOiI0MDI4Zjk1MTY2ODg3ZDZmMDE2NjljYmZjN2M0MDA0NSIs
-        ImtleSI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5TmFtZSI6InNjZW5hcmlv
-        X3Rlc3QiLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0sImFjdGl2
-        ZVN1YnNjcmlwdGlvbiI6dHJ1ZSwic291cmNlRW50aXRsZW1lbnQiOm51bGws
-        InF1YW50aXR5IjotMSwic3RhcnREYXRlIjoiMjAxNy0wMS0wMVQyMDoxNTow
-        MSswMDAwIiwiZW5kRGF0ZSI6IjIwNDYtMTItMjVUMjA6MTU6MDErMDAwMCIs
-        ImF0dHJpYnV0ZXMiOltdLCJyZXN0cmljdGVkVG9Vc2VybmFtZSI6bnVsbCwi
-        Y29udHJhY3ROdW1iZXIiOm51bGwsImFjY291bnROdW1iZXIiOm51bGwsIm9y
-        ZGVyTnVtYmVyIjpudWxsLCJjb25zdW1lZCI6MCwiZXhwb3J0ZWQiOjAsImJy
-        YW5kaW5nIjpbXSwiY2FsY3VsYXRlZEF0dHJpYnV0ZXMiOm51bGwsInVwc3Ry
-        ZWFtUG9vbElkIjpudWxsLCJ1cHN0cmVhbUVudGl0bGVtZW50SWQiOm51bGws
-        InVwc3RyZWFtQ29uc3VtZXJJZCI6bnVsbCwicHJvZHVjdE5hbWUiOiJTY2Vu
-        YXJpbyBQcm9kdWN0IiwicHJvZHVjdElkIjoiN2M4MjUwMTNjYWIwMTM0OWFl
-        OGNiOGRiMTg3ZGUzOTEiLCJwcm9kdWN0QXR0cmlidXRlcyI6W3sibmFtZSI6
-        ImFyY2giLCJ2YWx1ZSI6IkFMTCJ9XSwic3RhY2tJZCI6bnVsbCwic3RhY2tl
-        ZCI6ZmFsc2UsInNvdXJjZVN0YWNrSWQiOm51bGwsImRldmVsb3BtZW50UG9v
-        bCI6ZmFsc2UsImRlcml2ZWRQcm9kdWN0QXR0cmlidXRlcyI6W10sImRlcml2
-        ZWRQcm9kdWN0SWQiOm51bGwsImRlcml2ZWRQcm9kdWN0TmFtZSI6bnVsbCwi
-        cHJvdmlkZWRQcm9kdWN0cyI6W10sImRlcml2ZWRQcm92aWRlZFByb2R1Y3Rz
-        IjpbXSwic3Vic2NyaXB0aW9uU3ViS2V5IjpudWxsLCJzdWJzY3JpcHRpb25J
-        ZCI6bnVsbCwiaHJlZiI6Ii9wb29scy80MDI4Zjk1MTY2ODg3ZDZmMDE2Njlj
-        YmZjYTFmMDA0YSJ9
-    http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:26 GMT
-- request:
-    method: get
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
-      Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="CqFDSd1x32H1mIOoUPx7XiSZ8ujtDcx8UT7HTsIB6k",
-        oauth_signature="rZFFRazka3ZpRXFbRCXZdp20SDM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1540228106", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - cce2efc0-9269-4f13-aaa4-ef4e55e7510f
-      X-Version:
-      - 2.5.6-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Mon, 22 Oct 2018 17:08:26 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOC0xMC0yMlQxNzowODoyNiswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTgtMTAtMjJUMTc6MDg6MjYrMDAwMCIsInV1aWQiOiI0MDI4Zjk1
-        MTY2ODg3ZDZmMDE2NjljYmZjOWY2MDA0OSIsImlkIjoiN2M4MjUwMTNjYWIw
-        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
-        dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
-        IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
-        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOTUxNjY4ODdkNmYwMTY2OWNiZmM5ZjYw
-        MDQ5IiwicHJvZHVjdENvbnRlbnQiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:26 GMT
-- request:
-    method: get
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/pools?add_future=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
-      Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="MPVdC8zjsTAkl3V1KQC4hwaZ1KjGxwqBV8GE32WHg9s",
-        oauth_signature="oocQ%2FXOyl7BviZiiwCbDkfPCOgQ%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1540228106", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - e478a31b-16d6-41fb-bb8b-27c8ee721714
-      X-Version:
-      - 2.5.6-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Mon, 22 Oct 2018 17:08:26 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        W3siY3JlYXRlZCI6IjIwMTgtMTAtMjJUMTc6MDg6MjYrMDAwMCIsInVwZGF0
-        ZWQiOiIyMDE4LTEwLTIyVDE3OjA4OjI2KzAwMDAiLCJpZCI6IjQwMjhmOTUx
-        NjY4ODdkNmYwMTY2OWNiZmNhMWYwMDRhIiwidHlwZSI6Ik5PUk1BTCIsIm93
-        bmVyIjp7ImlkIjoiNDAyOGY5NTE2Njg4N2Q2ZjAxNjY5Y2JmYzdjNDAwNDUi
-        LCJrZXkiOiJzY2VuYXJpb190ZXN0IiwiZGlzcGxheU5hbWUiOiJzY2VuYXJp
-        b190ZXN0IiwiaHJlZiI6Ii9vd25lcnMvc2NlbmFyaW9fdGVzdCJ9LCJhY3Rp
-        dmVTdWJzY3JpcHRpb24iOnRydWUsInNvdXJjZUVudGl0bGVtZW50IjpudWxs
-        LCJxdWFudGl0eSI6LTEsInN0YXJ0RGF0ZSI6IjIwMTctMDEtMDFUMjA6MTU6
-        MDErMDAwMCIsImVuZERhdGUiOiIyMDQ2LTEyLTI1VDIwOjE1OjAxKzAwMDAi
-        LCJhdHRyaWJ1dGVzIjpbXSwicmVzdHJpY3RlZFRvVXNlcm5hbWUiOm51bGws
-        ImNvbnRyYWN0TnVtYmVyIjpudWxsLCJhY2NvdW50TnVtYmVyIjpudWxsLCJv
-        cmRlck51bWJlciI6bnVsbCwiY29uc3VtZWQiOjAsImV4cG9ydGVkIjowLCJi
-        cmFuZGluZyI6W10sImNhbGN1bGF0ZWRBdHRyaWJ1dGVzIjp7ImNvbXBsaWFu
-        Y2VfdHlwZSI6IlN0YW5kYXJkIn0sInVwc3RyZWFtUG9vbElkIjpudWxsLCJ1
-        cHN0cmVhbUVudGl0bGVtZW50SWQiOm51bGwsInVwc3RyZWFtQ29uc3VtZXJJ
-        ZCI6bnVsbCwicHJvZHVjdE5hbWUiOiJTY2VuYXJpbyBQcm9kdWN0IiwicHJv
-        ZHVjdElkIjoiN2M4MjUwMTNjYWIwMTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJw
-        cm9kdWN0QXR0cmlidXRlcyI6W3sibmFtZSI6ImFyY2giLCJ2YWx1ZSI6IkFM
-        TCJ9XSwic3RhY2tJZCI6bnVsbCwic3RhY2tlZCI6ZmFsc2UsInNvdXJjZVN0
-        YWNrSWQiOm51bGwsImRldmVsb3BtZW50UG9vbCI6ZmFsc2UsImRlcml2ZWRQ
-        cm9kdWN0QXR0cmlidXRlcyI6W10sImRlcml2ZWRQcm9kdWN0SWQiOm51bGws
-        ImRlcml2ZWRQcm9kdWN0TmFtZSI6bnVsbCwicHJvdmlkZWRQcm9kdWN0cyI6
-        W10sImRlcml2ZWRQcm92aWRlZFByb2R1Y3RzIjpbXSwic3Vic2NyaXB0aW9u
-        U3ViS2V5IjpudWxsLCJzdWJzY3JpcHRpb25JZCI6bnVsbCwiaHJlZiI6Ii9w
-        b29scy80MDI4Zjk1MTY2ODg3ZDZmMDE2NjljYmZjYTFmMDA0YSJ9XQ==
-    http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:26 GMT
-- request:
     method: get
     uri: https://dev.example.com:8443/candlepin/pools/4028f95166887d6f01669cbfca1f004a
     body:
@@ -330,53 +72,6 @@ http_interactions:
   recorded_at: Mon, 22 Oct 2018 17:08:26 GMT
 - request:
     method: get
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/activation_keys/?include=pools.pool.id
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
-      Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="4BZrolEb0S3NpKRkO8prJ0wJkQbwFTLG5uxJV2aM",
-        oauth_signature="bSU1TBDVaeZrDuoDPowCIl0DmYs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1540228106", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 889e7dee-8fdf-4fc9-8862-731488ff72eb
-      X-Version:
-      - 2.5.6-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Mon, 22 Oct 2018 17:08:26 GMT
-    body:
-      encoding: UTF-8
-      base64_string: 'W10=
-
-'
-    http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:27 GMT
-- request:
-    method: get
     uri: https://dev.example.com:8443/candlepin/pools/4028f95166887d6f01669cbfca1f004a/entitlements/consumer_uuids
     body:
       encoding: US-ASCII
@@ -422,4 +117,1128 @@ http_interactions:
 '
     http_version: 
   recorded_at: Mon, 22 Oct 2018 17:08:27 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/pools/4028f9666771957d01677271844c0005
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="B7JGI1xpi84fhywAlefGsBvjUJm8FsRmQSR0RcqMVOM",
+        oauth_signature="uORSXSNaAHyJZG%2BPjYzAetH95PI%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543813301", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - d6ec7602-60f4-48c1-90d2-7854ab65741e
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:01:40 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNTowMTo0MSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6MDE6NDErMDAwMCIsImlkIjoiNDAyOGY5NjY2
+        NzcxOTU3ZDAxNjc3MjcxODQ0YzAwMDUiLCJ0eXBlIjoiTk9STUFMIiwib3du
+        ZXIiOnsiaWQiOiI0MDI4Zjk2NjY3NzE5NTdkMDE2NzcyNzE4MDI4MDAwMCIs
+        ImtleSI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5TmFtZSI6InNjZW5hcmlv
+        X3Rlc3QiLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0sImFjdGl2
+        ZVN1YnNjcmlwdGlvbiI6dHJ1ZSwic291cmNlRW50aXRsZW1lbnQiOm51bGws
+        InF1YW50aXR5IjotMSwic3RhcnREYXRlIjoiMjAxNy0wMS0wMVQyMDoxNTow
+        MSswMDAwIiwiZW5kRGF0ZSI6IjIwNDYtMTItMjVUMjA6MTU6MDErMDAwMCIs
+        ImF0dHJpYnV0ZXMiOltdLCJyZXN0cmljdGVkVG9Vc2VybmFtZSI6bnVsbCwi
+        Y29udHJhY3ROdW1iZXIiOm51bGwsImFjY291bnROdW1iZXIiOm51bGwsIm9y
+        ZGVyTnVtYmVyIjpudWxsLCJjb25zdW1lZCI6MCwiZXhwb3J0ZWQiOjAsImJy
+        YW5kaW5nIjpbXSwiY2FsY3VsYXRlZEF0dHJpYnV0ZXMiOnsiY29tcGxpYW5j
+        ZV90eXBlIjoiU3RhbmRhcmQifSwidXBzdHJlYW1Qb29sSWQiOm51bGwsInVw
+        c3RyZWFtRW50aXRsZW1lbnRJZCI6bnVsbCwidXBzdHJlYW1Db25zdW1lcklk
+        IjpudWxsLCJwcm9kdWN0TmFtZSI6IlNjZW5hcmlvIFByb2R1Y3QiLCJwcm9k
+        dWN0SWQiOiI3YzgyNTAxM2NhYjAxMzQ5YWU4Y2I4ZGIxODdkZTM5MSIsInBy
+        b2R1Y3RBdHRyaWJ1dGVzIjpbeyJuYW1lIjoiYXJjaCIsInZhbHVlIjoiQUxM
+        In1dLCJzdGFja0lkIjpudWxsLCJzdGFja2VkIjpmYWxzZSwic291cmNlU3Rh
+        Y2tJZCI6bnVsbCwiZGV2ZWxvcG1lbnRQb29sIjpmYWxzZSwiZGVyaXZlZFBy
+        b2R1Y3RBdHRyaWJ1dGVzIjpbXSwiZGVyaXZlZFByb2R1Y3RJZCI6bnVsbCwi
+        ZGVyaXZlZFByb2R1Y3ROYW1lIjpudWxsLCJwcm92aWRlZFByb2R1Y3RzIjpb
+        XSwiZGVyaXZlZFByb3ZpZGVkUHJvZHVjdHMiOltdLCJzdWJzY3JpcHRpb25T
+        dWJLZXkiOm51bGwsInN1YnNjcmlwdGlvbklkIjpudWxsLCJocmVmIjoiL3Bv
+        b2xzLzQwMjhmOTY2Njc3MTk1N2QwMTY3NzI3MTg0NGMwMDA1In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:01:41 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/pools/4028f9666771957d01677271844c0005/entitlements/consumer_uuids
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="OiJERcC6WsKYCdeO6AapXxd1BVvaZO5reEzpVGRR7s",
+        oauth_signature="qud4jh63JmwAq%2BGm0I7T8QUWIsM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543813301", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 882c133f-24f4-40ca-bf95-1e28c89d3661
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:01:40 GMT
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:01:41 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/pools/4028f9666771957d016772729c470012
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="nJvxsoshOCDi4DOXEP1ImHcwiiS5cctKtQjLfuHcxs",
+        oauth_signature="eXiYnagP%2FrWKGoxR1KdbCKtcAU4%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543813373", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - f6326376-9f0f-4b0f-9c26-72ebfbd13bd4
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:02:52 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNTowMjo1MiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6MDI6NTIrMDAwMCIsImlkIjoiNDAyOGY5NjY2
+        NzcxOTU3ZDAxNjc3MjcyOWM0NzAwMTIiLCJ0eXBlIjoiTk9STUFMIiwib3du
+        ZXIiOnsiaWQiOiI0MDI4Zjk2NjY3NzE5NTdkMDE2NzcyNzI5YTJjMDAwZCIs
+        ImtleSI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5TmFtZSI6InNjZW5hcmlv
+        X3Rlc3QiLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0sImFjdGl2
+        ZVN1YnNjcmlwdGlvbiI6dHJ1ZSwic291cmNlRW50aXRsZW1lbnQiOm51bGws
+        InF1YW50aXR5IjotMSwic3RhcnREYXRlIjoiMjAxNy0wMS0wMVQyMDoxNTow
+        MSswMDAwIiwiZW5kRGF0ZSI6IjIwNDYtMTItMjVUMjA6MTU6MDErMDAwMCIs
+        ImF0dHJpYnV0ZXMiOltdLCJyZXN0cmljdGVkVG9Vc2VybmFtZSI6bnVsbCwi
+        Y29udHJhY3ROdW1iZXIiOm51bGwsImFjY291bnROdW1iZXIiOm51bGwsIm9y
+        ZGVyTnVtYmVyIjpudWxsLCJjb25zdW1lZCI6MCwiZXhwb3J0ZWQiOjAsImJy
+        YW5kaW5nIjpbXSwiY2FsY3VsYXRlZEF0dHJpYnV0ZXMiOnsiY29tcGxpYW5j
+        ZV90eXBlIjoiU3RhbmRhcmQifSwidXBzdHJlYW1Qb29sSWQiOm51bGwsInVw
+        c3RyZWFtRW50aXRsZW1lbnRJZCI6bnVsbCwidXBzdHJlYW1Db25zdW1lcklk
+        IjpudWxsLCJwcm9kdWN0TmFtZSI6IlNjZW5hcmlvIFByb2R1Y3QiLCJwcm9k
+        dWN0SWQiOiI3YzgyNTAxM2NhYjAxMzQ5YWU4Y2I4ZGIxODdkZTM5MSIsInBy
+        b2R1Y3RBdHRyaWJ1dGVzIjpbeyJuYW1lIjoiYXJjaCIsInZhbHVlIjoiQUxM
+        In1dLCJzdGFja0lkIjpudWxsLCJzdGFja2VkIjpmYWxzZSwic291cmNlU3Rh
+        Y2tJZCI6bnVsbCwiZGV2ZWxvcG1lbnRQb29sIjpmYWxzZSwiZGVyaXZlZFBy
+        b2R1Y3RBdHRyaWJ1dGVzIjpbXSwiZGVyaXZlZFByb2R1Y3RJZCI6bnVsbCwi
+        ZGVyaXZlZFByb2R1Y3ROYW1lIjpudWxsLCJwcm92aWRlZFByb2R1Y3RzIjpb
+        XSwiZGVyaXZlZFByb3ZpZGVkUHJvZHVjdHMiOltdLCJzdWJzY3JpcHRpb25T
+        dWJLZXkiOm51bGwsInN1YnNjcmlwdGlvbklkIjpudWxsLCJocmVmIjoiL3Bv
+        b2xzLzQwMjhmOTY2Njc3MTk1N2QwMTY3NzI3MjljNDcwMDEyIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:02:53 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/pools/4028f9666771957d016772729c470012/entitlements/consumer_uuids
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="E12pNBwwUyqBMqlYUskDs3BgT5FxIat9Q1169vAhaI",
+        oauth_signature="01SqwJfDLtPRZdjb%2BKvVEnNYg%2Bo%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543813373", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - caa2b348-2605-4288-a256-fef40d16fee1
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:02:52 GMT
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:02:53 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/pools/4028f9666771957d0167727aa69f001f
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="u1xJggmQtKwbVXuNKEIV7Fnon8xmsoDoOfYwMueYSfs",
+        oauth_signature="WXA2pT3AElHnkbDYUzsBZiyoHyE%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543813900", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - f09cd3e9-9b53-4ab0-a1bc-31e783f20677
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:11:39 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNToxMTozOSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6MTE6MzkrMDAwMCIsImlkIjoiNDAyOGY5NjY2
+        NzcxOTU3ZDAxNjc3MjdhYTY5ZjAwMWYiLCJ0eXBlIjoiTk9STUFMIiwib3du
+        ZXIiOnsiaWQiOiI0MDI4Zjk2NjY3NzE5NTdkMDE2NzcyN2FhNGEzMDAxYSIs
+        ImtleSI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5TmFtZSI6InNjZW5hcmlv
+        X3Rlc3QiLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0sImFjdGl2
+        ZVN1YnNjcmlwdGlvbiI6dHJ1ZSwic291cmNlRW50aXRsZW1lbnQiOm51bGws
+        InF1YW50aXR5IjotMSwic3RhcnREYXRlIjoiMjAxNy0wMS0wMVQyMDoxNTow
+        MSswMDAwIiwiZW5kRGF0ZSI6IjIwNDYtMTItMjVUMjA6MTU6MDErMDAwMCIs
+        ImF0dHJpYnV0ZXMiOltdLCJyZXN0cmljdGVkVG9Vc2VybmFtZSI6bnVsbCwi
+        Y29udHJhY3ROdW1iZXIiOm51bGwsImFjY291bnROdW1iZXIiOm51bGwsIm9y
+        ZGVyTnVtYmVyIjpudWxsLCJjb25zdW1lZCI6MCwiZXhwb3J0ZWQiOjAsImJy
+        YW5kaW5nIjpbXSwiY2FsY3VsYXRlZEF0dHJpYnV0ZXMiOnsiY29tcGxpYW5j
+        ZV90eXBlIjoiU3RhbmRhcmQifSwidXBzdHJlYW1Qb29sSWQiOm51bGwsInVw
+        c3RyZWFtRW50aXRsZW1lbnRJZCI6bnVsbCwidXBzdHJlYW1Db25zdW1lcklk
+        IjpudWxsLCJwcm9kdWN0TmFtZSI6IlNjZW5hcmlvIFByb2R1Y3QiLCJwcm9k
+        dWN0SWQiOiI3YzgyNTAxM2NhYjAxMzQ5YWU4Y2I4ZGIxODdkZTM5MSIsInBy
+        b2R1Y3RBdHRyaWJ1dGVzIjpbeyJuYW1lIjoiYXJjaCIsInZhbHVlIjoiQUxM
+        In1dLCJzdGFja0lkIjpudWxsLCJzdGFja2VkIjpmYWxzZSwic291cmNlU3Rh
+        Y2tJZCI6bnVsbCwiZGV2ZWxvcG1lbnRQb29sIjpmYWxzZSwiZGVyaXZlZFBy
+        b2R1Y3RBdHRyaWJ1dGVzIjpbXSwiZGVyaXZlZFByb2R1Y3RJZCI6bnVsbCwi
+        ZGVyaXZlZFByb2R1Y3ROYW1lIjpudWxsLCJwcm92aWRlZFByb2R1Y3RzIjpb
+        XSwiZGVyaXZlZFByb3ZpZGVkUHJvZHVjdHMiOltdLCJzdWJzY3JpcHRpb25T
+        dWJLZXkiOm51bGwsInN1YnNjcmlwdGlvbklkIjpudWxsLCJocmVmIjoiL3Bv
+        b2xzLzQwMjhmOTY2Njc3MTk1N2QwMTY3NzI3YWE2OWYwMDFmIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:11:40 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/pools/4028f9666771957d0167727aa69f001f/entitlements/consumer_uuids
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="GoS6pHIR3ZAI8sqIVRGBYU8WH3VYF50smjTnbG3wDs",
+        oauth_signature="a6aF9XADH5lH%2BNIN5FkA3gXZ6m8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543813900", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - a35e1172-15f0-462a-a80c-ef7fd7860121
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:11:39 GMT
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:11:40 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/pools/4028f9666771957d016772856adf002c
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="QInbgLO7xZjSJqr3moIO1ciI7PAKq0MJTmDWvFPitaY",
+        oauth_signature="8UyyRQAIQUZ2tjgXXqjNrxgXQME%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543814605", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 489fa963-0049-4572-9970-c87364df9820
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:23:25 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNToyMzoyNSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6MjM6MjUrMDAwMCIsImlkIjoiNDAyOGY5NjY2
+        NzcxOTU3ZDAxNjc3Mjg1NmFkZjAwMmMiLCJ0eXBlIjoiTk9STUFMIiwib3du
+        ZXIiOnsiaWQiOiI0MDI4Zjk2NjY3NzE5NTdkMDE2NzcyODU2OGFiMDAyNyIs
+        ImtleSI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5TmFtZSI6InNjZW5hcmlv
+        X3Rlc3QiLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0sImFjdGl2
+        ZVN1YnNjcmlwdGlvbiI6dHJ1ZSwic291cmNlRW50aXRsZW1lbnQiOm51bGws
+        InF1YW50aXR5IjotMSwic3RhcnREYXRlIjoiMjAxNy0wMS0wMVQyMDoxNTow
+        MSswMDAwIiwiZW5kRGF0ZSI6IjIwNDYtMTItMjVUMjA6MTU6MDErMDAwMCIs
+        ImF0dHJpYnV0ZXMiOltdLCJyZXN0cmljdGVkVG9Vc2VybmFtZSI6bnVsbCwi
+        Y29udHJhY3ROdW1iZXIiOm51bGwsImFjY291bnROdW1iZXIiOm51bGwsIm9y
+        ZGVyTnVtYmVyIjpudWxsLCJjb25zdW1lZCI6MCwiZXhwb3J0ZWQiOjAsImJy
+        YW5kaW5nIjpbXSwiY2FsY3VsYXRlZEF0dHJpYnV0ZXMiOnsiY29tcGxpYW5j
+        ZV90eXBlIjoiU3RhbmRhcmQifSwidXBzdHJlYW1Qb29sSWQiOm51bGwsInVw
+        c3RyZWFtRW50aXRsZW1lbnRJZCI6bnVsbCwidXBzdHJlYW1Db25zdW1lcklk
+        IjpudWxsLCJwcm9kdWN0TmFtZSI6IlNjZW5hcmlvIFByb2R1Y3QiLCJwcm9k
+        dWN0SWQiOiI3YzgyNTAxM2NhYjAxMzQ5YWU4Y2I4ZGIxODdkZTM5MSIsInBy
+        b2R1Y3RBdHRyaWJ1dGVzIjpbeyJuYW1lIjoiYXJjaCIsInZhbHVlIjoiQUxM
+        In1dLCJzdGFja0lkIjpudWxsLCJzdGFja2VkIjpmYWxzZSwic291cmNlU3Rh
+        Y2tJZCI6bnVsbCwiZGV2ZWxvcG1lbnRQb29sIjpmYWxzZSwiZGVyaXZlZFBy
+        b2R1Y3RBdHRyaWJ1dGVzIjpbXSwiZGVyaXZlZFByb2R1Y3RJZCI6bnVsbCwi
+        ZGVyaXZlZFByb2R1Y3ROYW1lIjpudWxsLCJwcm92aWRlZFByb2R1Y3RzIjpb
+        XSwiZGVyaXZlZFByb3ZpZGVkUHJvZHVjdHMiOltdLCJzdWJzY3JpcHRpb25T
+        dWJLZXkiOm51bGwsInN1YnNjcmlwdGlvbklkIjpudWxsLCJocmVmIjoiL3Bv
+        b2xzLzQwMjhmOTY2Njc3MTk1N2QwMTY3NzI4NTZhZGYwMDJjIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:25 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/pools/4028f9666771957d016772856adf002c/entitlements/consumer_uuids
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="JOPqDaIJTsm4g731RM4ngpEVlBH1TxuxZiyIQhM4FA",
+        oauth_signature="bEEaBBIcLd%2B5I1miIS3%2BW0oqDBM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543814605", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - df2ff1ab-7318-4003-9f68-3f2af366f217
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:23:25 GMT
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:25 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/pools/4028f9666771957d016772876f5c0039
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="BIXHaSpSMe3IkH4FnMw5PqCYxcCPg3Km7IdZn2bBAU",
+        oauth_signature="5%2BApm7olhkHc127Zr5e7ntNWfg4%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543814737", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - a49edea6-f864-4c5e-9897-38a72469b822
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:25:37 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNToyNTozNyswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6MjU6MzcrMDAwMCIsImlkIjoiNDAyOGY5NjY2
+        NzcxOTU3ZDAxNjc3Mjg3NmY1YzAwMzkiLCJ0eXBlIjoiTk9STUFMIiwib3du
+        ZXIiOnsiaWQiOiI0MDI4Zjk2NjY3NzE5NTdkMDE2NzcyODc2ZDM3MDAzNCIs
+        ImtleSI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5TmFtZSI6InNjZW5hcmlv
+        X3Rlc3QiLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0sImFjdGl2
+        ZVN1YnNjcmlwdGlvbiI6dHJ1ZSwic291cmNlRW50aXRsZW1lbnQiOm51bGws
+        InF1YW50aXR5IjotMSwic3RhcnREYXRlIjoiMjAxNy0wMS0wMVQyMDoxNTow
+        MSswMDAwIiwiZW5kRGF0ZSI6IjIwNDYtMTItMjVUMjA6MTU6MDErMDAwMCIs
+        ImF0dHJpYnV0ZXMiOltdLCJyZXN0cmljdGVkVG9Vc2VybmFtZSI6bnVsbCwi
+        Y29udHJhY3ROdW1iZXIiOm51bGwsImFjY291bnROdW1iZXIiOm51bGwsIm9y
+        ZGVyTnVtYmVyIjpudWxsLCJjb25zdW1lZCI6MCwiZXhwb3J0ZWQiOjAsImJy
+        YW5kaW5nIjpbXSwiY2FsY3VsYXRlZEF0dHJpYnV0ZXMiOnsiY29tcGxpYW5j
+        ZV90eXBlIjoiU3RhbmRhcmQifSwidXBzdHJlYW1Qb29sSWQiOm51bGwsInVw
+        c3RyZWFtRW50aXRsZW1lbnRJZCI6bnVsbCwidXBzdHJlYW1Db25zdW1lcklk
+        IjpudWxsLCJwcm9kdWN0TmFtZSI6IlNjZW5hcmlvIFByb2R1Y3QiLCJwcm9k
+        dWN0SWQiOiI3YzgyNTAxM2NhYjAxMzQ5YWU4Y2I4ZGIxODdkZTM5MSIsInBy
+        b2R1Y3RBdHRyaWJ1dGVzIjpbeyJuYW1lIjoiYXJjaCIsInZhbHVlIjoiQUxM
+        In1dLCJzdGFja0lkIjpudWxsLCJzdGFja2VkIjpmYWxzZSwic291cmNlU3Rh
+        Y2tJZCI6bnVsbCwiZGV2ZWxvcG1lbnRQb29sIjpmYWxzZSwiZGVyaXZlZFBy
+        b2R1Y3RBdHRyaWJ1dGVzIjpbXSwiZGVyaXZlZFByb2R1Y3RJZCI6bnVsbCwi
+        ZGVyaXZlZFByb2R1Y3ROYW1lIjpudWxsLCJwcm92aWRlZFByb2R1Y3RzIjpb
+        XSwiZGVyaXZlZFByb3ZpZGVkUHJvZHVjdHMiOltdLCJzdWJzY3JpcHRpb25T
+        dWJLZXkiOm51bGwsInN1YnNjcmlwdGlvbklkIjpudWxsLCJocmVmIjoiL3Bv
+        b2xzLzQwMjhmOTY2Njc3MTk1N2QwMTY3NzI4NzZmNWMwMDM5In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:25:37 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/pools/4028f9666771957d016772876f5c0039/entitlements/consumer_uuids
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="P2Zy14p2MUZxqqXx8vHmWV33WehTAsSRjVJ5ofxs",
+        oauth_signature="ATcW6phbygi645uPQAGY9BKrHfQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543814737", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 47950e30-7a8f-4007-8c62-5b6d52a32a51
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:25:37 GMT
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:25:37 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/pools/4028f9666771957d01677289978e0046
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="cjFH43qkJAQtQIVZADrGAkMIB1wINH3cmSWDTrNSC0",
+        oauth_signature="MIWW%2FqUfAwv9gCEKLIbnlj3Iw%2Bw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543814879", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 38601b3d-7676-4e16-b6fa-0c73f3d03d2d
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:27:59 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNToyNzo1OSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6Mjc6NTkrMDAwMCIsImlkIjoiNDAyOGY5NjY2
+        NzcxOTU3ZDAxNjc3Mjg5OTc4ZTAwNDYiLCJ0eXBlIjoiTk9STUFMIiwib3du
+        ZXIiOnsiaWQiOiI0MDI4Zjk2NjY3NzE5NTdkMDE2NzcyODk5NWM1MDA0MSIs
+        ImtleSI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5TmFtZSI6InNjZW5hcmlv
+        X3Rlc3QiLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0sImFjdGl2
+        ZVN1YnNjcmlwdGlvbiI6dHJ1ZSwic291cmNlRW50aXRsZW1lbnQiOm51bGws
+        InF1YW50aXR5IjotMSwic3RhcnREYXRlIjoiMjAxNy0wMS0wMVQyMDoxNTow
+        MSswMDAwIiwiZW5kRGF0ZSI6IjIwNDYtMTItMjVUMjA6MTU6MDErMDAwMCIs
+        ImF0dHJpYnV0ZXMiOltdLCJyZXN0cmljdGVkVG9Vc2VybmFtZSI6bnVsbCwi
+        Y29udHJhY3ROdW1iZXIiOm51bGwsImFjY291bnROdW1iZXIiOm51bGwsIm9y
+        ZGVyTnVtYmVyIjpudWxsLCJjb25zdW1lZCI6MCwiZXhwb3J0ZWQiOjAsImJy
+        YW5kaW5nIjpbXSwiY2FsY3VsYXRlZEF0dHJpYnV0ZXMiOnsiY29tcGxpYW5j
+        ZV90eXBlIjoiU3RhbmRhcmQifSwidXBzdHJlYW1Qb29sSWQiOm51bGwsInVw
+        c3RyZWFtRW50aXRsZW1lbnRJZCI6bnVsbCwidXBzdHJlYW1Db25zdW1lcklk
+        IjpudWxsLCJwcm9kdWN0TmFtZSI6IlNjZW5hcmlvIFByb2R1Y3QiLCJwcm9k
+        dWN0SWQiOiI3YzgyNTAxM2NhYjAxMzQ5YWU4Y2I4ZGIxODdkZTM5MSIsInBy
+        b2R1Y3RBdHRyaWJ1dGVzIjpbeyJuYW1lIjoiYXJjaCIsInZhbHVlIjoiQUxM
+        In1dLCJzdGFja0lkIjpudWxsLCJzdGFja2VkIjpmYWxzZSwic291cmNlU3Rh
+        Y2tJZCI6bnVsbCwiZGV2ZWxvcG1lbnRQb29sIjpmYWxzZSwiZGVyaXZlZFBy
+        b2R1Y3RBdHRyaWJ1dGVzIjpbXSwiZGVyaXZlZFByb2R1Y3RJZCI6bnVsbCwi
+        ZGVyaXZlZFByb2R1Y3ROYW1lIjpudWxsLCJwcm92aWRlZFByb2R1Y3RzIjpb
+        XSwiZGVyaXZlZFByb3ZpZGVkUHJvZHVjdHMiOltdLCJzdWJzY3JpcHRpb25T
+        dWJLZXkiOm51bGwsInN1YnNjcmlwdGlvbklkIjpudWxsLCJocmVmIjoiL3Bv
+        b2xzLzQwMjhmOTY2Njc3MTk1N2QwMTY3NzI4OTk3OGUwMDQ2In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:27:59 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/pools/4028f9666771957d01677289978e0046/entitlements/consumer_uuids
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="oyBSBydDlXvlJ5BL6XTI8D0RZTm01tOfCVyV4FjK4",
+        oauth_signature="E%2BoQfRfyc6kTiXWou1%2BVA0oMCoQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543814879", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - a2301421-baa3-4d84-ab14-b1d915a98310
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:27:59 GMT
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:27:59 GMT
+- request:
+    method: post
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/products/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiU2NlbmFyaW8gUHJvZHVjdCIsImlkIjoiN2M4MjUwMTNjYWIw
+        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJtdWx0aXBsaWVyIjoxLCJhdHRyaWJ1
+        dGVzIjpbeyJuYW1lIjoiYXJjaCIsInZhbHVlIjoiQUxMIn1dfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk",
+        oauth_nonce="L7hAbF5k9saUUZ2QBRjaE3GkRpWc78l3bDBGW9sH08", oauth_signature="Njs8pE0ys93gNT%2BVAL21IlMDTqI%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1543815535", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '127'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - cd9b5a1d-7d34-4483-9190-6f98b39a6683
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:38:55 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNTozODo1NSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6Mzg6NTUrMDAwMCIsInV1aWQiOiI0MDI4Zjk2
+        NjY3NzE5NTdkMDE2NzcyOTM5YjMyMDA1MiIsImlkIjoiN2M4MjUwMTNjYWIw
+        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
+        dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
+        IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
+        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOTY2Njc3MTk1N2QwMTY3NzI5MzliMzIw
+        MDUyIiwicHJvZHVjdENvbnRlbnQiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:38:55 GMT
+- request:
+    method: post
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/pools
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzdGFydERhdGUiOiIyMDE3LTAxLTAxVDIwOjE1OjAxLjAwMFoiLCJlbmRE
+        YXRlIjoiMjA0Ni0xMi0yNVQyMDoxNTowMS4wMDBaIiwicXVhbnRpdHkiOi0x
+        LCJhY2NvdW50TnVtYmVyIjoiIiwicHJvZHVjdElkIjoiN2M4MjUwMTNjYWIw
+        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJwcm92aWRlZFByb2R1Y3RzIjpbXSwi
+        Y29udHJhY3ROdW1iZXIiOiIifQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk",
+        oauth_nonce="f92Ivmrmnm3uJlB6V2g331ataMMpSQwj4xsItKR8lE", oauth_signature="lDRWmAr3woBFNJ3Pngm9E1HdtYs%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1543815535", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '199'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - b06a7ec2-cd0c-4505-a0f0-3f6461ed9e1c
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:38:55 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNTozODo1NSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6Mzg6NTUrMDAwMCIsImlkIjoiNDAyOGY5NjY2
+        NzcxOTU3ZDAxNjc3MjkzOWI1NTAwNTMiLCJ0eXBlIjoiTk9STUFMIiwib3du
+        ZXIiOnsiaWQiOiI0MDI4Zjk2NjY3NzE5NTdkMDE2NzcyOTM5OTcwMDA0ZSIs
+        ImtleSI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5TmFtZSI6InNjZW5hcmlv
+        X3Rlc3QiLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0sImFjdGl2
+        ZVN1YnNjcmlwdGlvbiI6dHJ1ZSwic291cmNlRW50aXRsZW1lbnQiOm51bGws
+        InF1YW50aXR5IjotMSwic3RhcnREYXRlIjoiMjAxNy0wMS0wMVQyMDoxNTow
+        MSswMDAwIiwiZW5kRGF0ZSI6IjIwNDYtMTItMjVUMjA6MTU6MDErMDAwMCIs
+        ImF0dHJpYnV0ZXMiOltdLCJyZXN0cmljdGVkVG9Vc2VybmFtZSI6bnVsbCwi
+        Y29udHJhY3ROdW1iZXIiOm51bGwsImFjY291bnROdW1iZXIiOm51bGwsIm9y
+        ZGVyTnVtYmVyIjpudWxsLCJjb25zdW1lZCI6MCwiZXhwb3J0ZWQiOjAsImJy
+        YW5kaW5nIjpbXSwiY2FsY3VsYXRlZEF0dHJpYnV0ZXMiOm51bGwsInVwc3Ry
+        ZWFtUG9vbElkIjpudWxsLCJ1cHN0cmVhbUVudGl0bGVtZW50SWQiOm51bGws
+        InVwc3RyZWFtQ29uc3VtZXJJZCI6bnVsbCwicHJvZHVjdE5hbWUiOiJTY2Vu
+        YXJpbyBQcm9kdWN0IiwicHJvZHVjdElkIjoiN2M4MjUwMTNjYWIwMTM0OWFl
+        OGNiOGRiMTg3ZGUzOTEiLCJwcm9kdWN0QXR0cmlidXRlcyI6W3sibmFtZSI6
+        ImFyY2giLCJ2YWx1ZSI6IkFMTCJ9XSwic3RhY2tJZCI6bnVsbCwic3RhY2tl
+        ZCI6ZmFsc2UsInNvdXJjZVN0YWNrSWQiOm51bGwsImRldmVsb3BtZW50UG9v
+        bCI6ZmFsc2UsImRlcml2ZWRQcm9kdWN0QXR0cmlidXRlcyI6W10sImRlcml2
+        ZWRQcm9kdWN0SWQiOm51bGwsImRlcml2ZWRQcm9kdWN0TmFtZSI6bnVsbCwi
+        cHJvdmlkZWRQcm9kdWN0cyI6W10sImRlcml2ZWRQcm92aWRlZFByb2R1Y3Rz
+        IjpbXSwic3Vic2NyaXB0aW9uU3ViS2V5IjpudWxsLCJzdWJzY3JpcHRpb25J
+        ZCI6bnVsbCwiaHJlZiI6Ii9wb29scy80MDI4Zjk2NjY3NzE5NTdkMDE2Nzcy
+        OTM5YjU1MDA1MyJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:38:55 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="kDiu4379QvDB4UWUTLOHj10QOsVOkBqAadnxVPWL4eo",
+        oauth_signature="jI9a1EPmevWmyJpdIT45%2FyzKIW8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543815535", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 3ff61bea-977c-4d97-b358-15bf516c2074
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:38:55 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNTozODo1NSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6Mzg6NTUrMDAwMCIsInV1aWQiOiI0MDI4Zjk2
+        NjY3NzE5NTdkMDE2NzcyOTM5YjMyMDA1MiIsImlkIjoiN2M4MjUwMTNjYWIw
+        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
+        dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
+        IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
+        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOTY2Njc3MTk1N2QwMTY3NzI5MzliMzIw
+        MDUyIiwicHJvZHVjdENvbnRlbnQiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:38:55 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/pools?add_future=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="RYm7Ddq6m2xAxT6ZU9mw56QGL3JA5hFPNkXwV1LPh4",
+        oauth_signature="JHmbjqMyKzU4VybFEXVj9iTsCgQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543815535", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - b4693c9d-ee3e-4d9a-b55b-80e85e865fb0
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:38:55 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        W3siY3JlYXRlZCI6IjIwMTgtMTItMDNUMDU6Mzg6NTUrMDAwMCIsInVwZGF0
+        ZWQiOiIyMDE4LTEyLTAzVDA1OjM4OjU1KzAwMDAiLCJpZCI6IjQwMjhmOTY2
+        Njc3MTk1N2QwMTY3NzI5MzliNTUwMDUzIiwidHlwZSI6Ik5PUk1BTCIsIm93
+        bmVyIjp7ImlkIjoiNDAyOGY5NjY2NzcxOTU3ZDAxNjc3MjkzOTk3MDAwNGUi
+        LCJrZXkiOiJzY2VuYXJpb190ZXN0IiwiZGlzcGxheU5hbWUiOiJzY2VuYXJp
+        b190ZXN0IiwiaHJlZiI6Ii9vd25lcnMvc2NlbmFyaW9fdGVzdCJ9LCJhY3Rp
+        dmVTdWJzY3JpcHRpb24iOnRydWUsInNvdXJjZUVudGl0bGVtZW50IjpudWxs
+        LCJxdWFudGl0eSI6LTEsInN0YXJ0RGF0ZSI6IjIwMTctMDEtMDFUMjA6MTU6
+        MDErMDAwMCIsImVuZERhdGUiOiIyMDQ2LTEyLTI1VDIwOjE1OjAxKzAwMDAi
+        LCJhdHRyaWJ1dGVzIjpbXSwicmVzdHJpY3RlZFRvVXNlcm5hbWUiOm51bGws
+        ImNvbnRyYWN0TnVtYmVyIjpudWxsLCJhY2NvdW50TnVtYmVyIjpudWxsLCJv
+        cmRlck51bWJlciI6bnVsbCwiY29uc3VtZWQiOjAsImV4cG9ydGVkIjowLCJi
+        cmFuZGluZyI6W10sImNhbGN1bGF0ZWRBdHRyaWJ1dGVzIjp7ImNvbXBsaWFu
+        Y2VfdHlwZSI6IlN0YW5kYXJkIn0sInVwc3RyZWFtUG9vbElkIjpudWxsLCJ1
+        cHN0cmVhbUVudGl0bGVtZW50SWQiOm51bGwsInVwc3RyZWFtQ29uc3VtZXJJ
+        ZCI6bnVsbCwicHJvZHVjdE5hbWUiOiJTY2VuYXJpbyBQcm9kdWN0IiwicHJv
+        ZHVjdElkIjoiN2M4MjUwMTNjYWIwMTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJw
+        cm9kdWN0QXR0cmlidXRlcyI6W3sibmFtZSI6ImFyY2giLCJ2YWx1ZSI6IkFM
+        TCJ9XSwic3RhY2tJZCI6bnVsbCwic3RhY2tlZCI6ZmFsc2UsInNvdXJjZVN0
+        YWNrSWQiOm51bGwsImRldmVsb3BtZW50UG9vbCI6ZmFsc2UsImRlcml2ZWRQ
+        cm9kdWN0QXR0cmlidXRlcyI6W10sImRlcml2ZWRQcm9kdWN0SWQiOm51bGws
+        ImRlcml2ZWRQcm9kdWN0TmFtZSI6bnVsbCwicHJvdmlkZWRQcm9kdWN0cyI6
+        W10sImRlcml2ZWRQcm92aWRlZFByb2R1Y3RzIjpbXSwic3Vic2NyaXB0aW9u
+        U3ViS2V5IjpudWxsLCJzdWJzY3JpcHRpb25JZCI6bnVsbCwiaHJlZiI6Ii9w
+        b29scy80MDI4Zjk2NjY3NzE5NTdkMDE2NzcyOTM5YjU1MDA1MyJ9XQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:38:55 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/pools/4028f9666771957d016772939b550053
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="uPlXtteWPumo5JPEuGfWPlscemffENayl2ghYCQJCtI",
+        oauth_signature="TZ%2Fy4jS1JLehn2xs%2FfwE%2FS3i8E4%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543815535", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 3d78df51-acd7-4b81-968a-17a23b2a5fbc
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:38:55 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNTozODo1NSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6Mzg6NTUrMDAwMCIsImlkIjoiNDAyOGY5NjY2
+        NzcxOTU3ZDAxNjc3MjkzOWI1NTAwNTMiLCJ0eXBlIjoiTk9STUFMIiwib3du
+        ZXIiOnsiaWQiOiI0MDI4Zjk2NjY3NzE5NTdkMDE2NzcyOTM5OTcwMDA0ZSIs
+        ImtleSI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5TmFtZSI6InNjZW5hcmlv
+        X3Rlc3QiLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0sImFjdGl2
+        ZVN1YnNjcmlwdGlvbiI6dHJ1ZSwic291cmNlRW50aXRsZW1lbnQiOm51bGws
+        InF1YW50aXR5IjotMSwic3RhcnREYXRlIjoiMjAxNy0wMS0wMVQyMDoxNTow
+        MSswMDAwIiwiZW5kRGF0ZSI6IjIwNDYtMTItMjVUMjA6MTU6MDErMDAwMCIs
+        ImF0dHJpYnV0ZXMiOltdLCJyZXN0cmljdGVkVG9Vc2VybmFtZSI6bnVsbCwi
+        Y29udHJhY3ROdW1iZXIiOm51bGwsImFjY291bnROdW1iZXIiOm51bGwsIm9y
+        ZGVyTnVtYmVyIjpudWxsLCJjb25zdW1lZCI6MCwiZXhwb3J0ZWQiOjAsImJy
+        YW5kaW5nIjpbXSwiY2FsY3VsYXRlZEF0dHJpYnV0ZXMiOnsiY29tcGxpYW5j
+        ZV90eXBlIjoiU3RhbmRhcmQifSwidXBzdHJlYW1Qb29sSWQiOm51bGwsInVw
+        c3RyZWFtRW50aXRsZW1lbnRJZCI6bnVsbCwidXBzdHJlYW1Db25zdW1lcklk
+        IjpudWxsLCJwcm9kdWN0TmFtZSI6IlNjZW5hcmlvIFByb2R1Y3QiLCJwcm9k
+        dWN0SWQiOiI3YzgyNTAxM2NhYjAxMzQ5YWU4Y2I4ZGIxODdkZTM5MSIsInBy
+        b2R1Y3RBdHRyaWJ1dGVzIjpbeyJuYW1lIjoiYXJjaCIsInZhbHVlIjoiQUxM
+        In1dLCJzdGFja0lkIjpudWxsLCJzdGFja2VkIjpmYWxzZSwic291cmNlU3Rh
+        Y2tJZCI6bnVsbCwiZGV2ZWxvcG1lbnRQb29sIjpmYWxzZSwiZGVyaXZlZFBy
+        b2R1Y3RBdHRyaWJ1dGVzIjpbXSwiZGVyaXZlZFByb2R1Y3RJZCI6bnVsbCwi
+        ZGVyaXZlZFByb2R1Y3ROYW1lIjpudWxsLCJwcm92aWRlZFByb2R1Y3RzIjpb
+        XSwiZGVyaXZlZFByb3ZpZGVkUHJvZHVjdHMiOltdLCJzdWJzY3JpcHRpb25T
+        dWJLZXkiOm51bGwsInN1YnNjcmlwdGlvbklkIjpudWxsLCJocmVmIjoiL3Bv
+        b2xzLzQwMjhmOTY2Njc3MTk1N2QwMTY3NzI5MzliNTUwMDUzIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:38:55 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/activation_keys/?include=pools.pool.id
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="QsWvBLsnqKNcnGxBUoZvs85UGi7v04xDUiLwbiAlFgk",
+        oauth_signature="OJbcYLaSMf7miWi02ydAbSdg5MQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543815535", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 455f59af-2ec3-40aa-a606-9ecfe52f668c
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:38:55 GMT
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:38:55 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/pools/4028f9666771957d016772939b550053/entitlements/consumer_uuids
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="5ZUVtFX1ANuumKBuYLyw55giCZvCZIuruen6ALlD6M",
+        oauth_signature="aRqynwtzjLfz6d%2FLfOKqgh34o50%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543815535", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 0f7c759c-a6c7-4dfe-8cd5-a1bbab5c8081
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:38:55 GMT
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:38:55 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/repo_create.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/repo_create.yml
@@ -2,139 +2,6 @@
 http_interactions:
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5X25hbWUiOiJTY2VuYXJp
-        byB5dW0gcHJvZHVjdCIsImltcG9ydGVyX3R5cGVfaWQiOiJ5dW1faW1wb3J0
-        ZXIiLCJpbXBvcnRlcl9jb25maWciOnsiZG93bmxvYWRfcG9saWN5IjoiaW1t
-        ZWRpYXRlIiwicmVtb3ZlX21pc3NpbmciOnRydWUsImZlZWQiOiJmaWxlOi8v
-        L3Zhci93d3cvdGVzdF9yZXBvcy96b28iLCJ0eXBlX3NraXBfbGlzdCI6bnVs
-        bCwicHJveHlfaG9zdCI6bnVsbCwiYmFzaWNfYXV0aF91c2VybmFtZSI6bnVs
-        bCwiYmFzaWNfYXV0aF9wYXNzd29yZCI6bnVsbCwic3NsX3ZhbGlkYXRpb24i
-        OnRydWUsInNzbF9jbGllbnRfY2VydCI6bnVsbCwic3NsX2NsaWVudF9rZXki
-        Om51bGwsInNzbF9jYV9jZXJ0IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlw
-        ZSI6InJwbS1yZXBvIn0sImRpc3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3Jf
-        dHlwZV9pZCI6Inl1bV9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZp
-        ZyI6eyJyZWxhdGl2ZV91cmwiOiJzY2VuYXJpb190ZXN0IiwiaHR0cCI6ZmFs
-        c2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRydWUsImNoZWNrc3VtX3R5
-        cGUiOm51bGx9LCJhdXRvX3B1Ymxpc2giOnRydWUsImRpc3RyaWJ1dG9yX2lk
-        Ijoic2NlbmFyaW9fdGVzdCJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1
-        bV9jbG9uZV9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJk
-        ZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6InNjZW5hcmlvX3Rlc3QifSwi
-        YXV0b19wdWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJzY2VuYXJp
-        b190ZXN0X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBlX2lkIjoiZXhwb3J0
-        X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7Imh0dHAiOmZh
-        bHNlLCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6InNjZW5hcmlvX3Rl
-        c3QifSwiYXV0b19wdWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJl
-        eHBvcnRfZGlzdHJpYnV0b3IifV19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1011'
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Mon, 22 Oct 2018 17:08:27 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '332'
-      Location:
-      - "/pulp/api/v2/repositories/scenario_test/"
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiU2NlbmFyaW8g
-        eXVtIHByb2R1Y3QiLCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0
-        X2FkZGVkIjogbnVsbCwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
-        ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
-        aXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lkIjogeyIkb2lk
-        IjogIjViY2UwNDBiYjQ3Y2ViNGIyMDNlZTliMiJ9LCAiaWQiOiAic2NlbmFy
-        aW9fdGVzdCIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVz
-        L3NjZW5hcmlvX3Rlc3QvIn0=
-    http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:27 GMT
-- request:
-    method: post
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test/content/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJuYW1lIjoiU2NlbmFyaW8geXVtIHByb2R1Y3QiLCJjb250ZW50VXJsIjoi
-        L2N1c3RvbS9TY2VuYXJpb19Qcm9kdWN0L1NjZW5hcmlvX3l1bV9wcm9kdWN0
-        IiwidHlwZSI6Inl1bSIsImFyY2hlcyI6bnVsbCwibGFiZWwiOiJzY2VuYXJp
-        b190ZXN0X1NjZW5hcmlvX1Byb2R1Y3RfU2NlbmFyaW9feXVtX3Byb2R1Y3Qi
-        LCJtZXRhZGF0YUV4cGlyZSI6MSwidmVuZG9yIjoiQ3VzdG9tIn0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp",
-        oauth_nonce="2Y7DoomDrSWgaQESZfQYO2QPclzrWiLfuWHDe7pIs", oauth_signature="dsqRedc%2F7u5wpRnMKAU%2BmSsFfYM%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1540228107", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-      Content-Length:
-      - '218'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 0e81a489-df31-41fa-86f0-cb813aa7ba8f
-      X-Version:
-      - 2.5.6-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Mon, 22 Oct 2018 17:08:26 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOC0xMC0yMlQxNzowODoyNyswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTgtMTAtMjJUMTc6MDg6MjcrMDAwMCIsInV1aWQiOiI0MDI4Zjk1
-        MTY2ODg3ZDZmMDE2NjljYmZjY2FiMDA0YyIsImlkIjoiMTU0MDIyODEwNzQ0
-        NyIsInR5cGUiOiJ5dW0iLCJsYWJlbCI6InNjZW5hcmlvX3Rlc3RfU2NlbmFy
-        aW9fUHJvZHVjdF9TY2VuYXJpb195dW1fcHJvZHVjdCIsIm5hbWUiOiJTY2Vu
-        YXJpbyB5dW0gcHJvZHVjdCIsInZlbmRvciI6IkN1c3RvbSIsImNvbnRlbnRV
-        cmwiOiIvY3VzdG9tL1NjZW5hcmlvX1Byb2R1Y3QvU2NlbmFyaW9feXVtX3By
-        b2R1Y3QiLCJyZXF1aXJlZFRhZ3MiOm51bGwsImdwZ1VybCI6bnVsbCwibW9k
-        aWZpZWRQcm9kdWN0SWRzIjpbXSwiYXJjaGVzIjpudWxsLCJyZXF1aXJlZFBy
-        b2R1Y3RJZHMiOltdLCJtZXRhZGF0YUV4cGlyZSI6MSwicmVsZWFzZVZlciI6
-        bnVsbH0=
-    http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:27 GMT
-- request:
-    method: post
     uri: https://dev.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/content/1540228107447?enabled=true
     body:
       encoding: UTF-8
@@ -198,58 +65,6 @@ http_interactions:
     http_version: 
   recorded_at: Mon, 22 Oct 2018 17:08:27 GMT
 - request:
-    method: get
-    uri: https://dev.example.com:8443/candlepin/environments/d80a5783c502f0f969e23089437bb7ce
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
-      Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="3L2XdlrFKRmeVNcZDt1CoVVRz5xzJ1cDjeSC1cnpfg",
-        oauth_signature="0VWS4TmF1KHxqFutj4HuxROPcjI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1540228107", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - c0be9510-f9c6-4bc5-b4b6-be5065546584
-      X-Version:
-      - 2.5.6-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Mon, 22 Oct 2018 17:08:26 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOC0xMC0yMlQxNzowODoyNiswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTgtMTAtMjJUMTc6MDg6MjYrMDAwMCIsImlkIjoiZDgwYTU3ODNj
-        NTAyZjBmOTY5ZTIzMDg5NDM3YmI3Y2UiLCJuYW1lIjoiTGlicmFyeSIsImRl
-        c2NyaXB0aW9uIjpudWxsLCJvd25lciI6eyJpZCI6IjQwMjhmOTUxNjY4ODdk
-        NmYwMTY2OWNiZmM3YzQwMDQ1Iiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRp
-        c3BsYXlOYW1lIjoic2NlbmFyaW9fdGVzdCIsImhyZWYiOiIvb3duZXJzL3Nj
-        ZW5hcmlvX3Rlc3QifSwiZW52aXJvbm1lbnRDb250ZW50IjpbXX0=
-    http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:27 GMT
-- request:
     method: post
     uri: https://dev.example.com:8443/candlepin/environments/d80a5783c502f0f969e23089437bb7ce/content
     body:
@@ -307,139 +122,6 @@ http_interactions:
         OiIvam9icy9yZWdlbl9lbnRpdGxlbWVudF9jZXJ0X29mX2VudmZjNWM3YmFj
         LTU1NmMtNDRhNC1hYTFmLTBlYWE2YzdkNGQ3MCIsImdyb3VwIjoiYXN5bmMg
         Z3JvdXAifQ==
-    http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:27 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 22 Oct 2018 17:08:27 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"30851fcb161c8e8a80d47b2b03d421fd-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2292'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiU2NlbmFyaW8g
-        eXVtIHByb2R1Y3QiLCAiZGVzY3JpcHRpb24iOiBudWxsLCAiZGlzdHJpYnV0
-        b3JzIjogW3sicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgImxhc3RfdXBk
-        YXRlZCI6ICIyMDE4LTEwLTIyVDE3OjA4OjI3WiIsICJfaHJlZiI6ICIvcHVs
-        cC9hcGkvdjIvcmVwb3NpdG9yaWVzL3NjZW5hcmlvX3Rlc3QvZGlzdHJpYnV0
-        b3JzL3NjZW5hcmlvX3Rlc3RfY2xvbmUvIiwgImxhc3Rfb3ZlcnJpZGVfY29u
-        ZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3Jf
-        dHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJs
-        aXNoIjogZmFsc2UsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19k
-        aXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjViY2UwNDBiYjQ3Y2Vi
-        NGIyMDNlZTliNSJ9LCAiY29uZmlnIjogeyJkZXN0aW5hdGlvbl9kaXN0cmli
-        dXRvcl9pZCI6ICJzY2VuYXJpb190ZXN0In0sICJpZCI6ICJzY2VuYXJpb190
-        ZXN0X2Nsb25lIn0sIHsicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgImxh
-        c3RfdXBkYXRlZCI6ICIyMDE4LTEwLTIyVDE3OjA4OjI3WiIsICJfaHJlZiI6
-        ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL3NjZW5hcmlvX3Rlc3QvZGlz
-        dHJpYnV0b3JzL3NjZW5hcmlvX3Rlc3QvIiwgImxhc3Rfb3ZlcnJpZGVfY29u
-        ZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3Jf
-        dHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjog
-        dHJ1ZSwgInNjcmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1
-        dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAiNWJjZTA0MGJiNDdjZWI0YjIwM2Vl
-        OWI0In0sICJjb25maWciOiB7InByb3RlY3RlZCI6IHRydWUsICJodHRwIjog
-        ZmFsc2UsICJodHRwcyI6IHRydWUsICJyZWxhdGl2ZV91cmwiOiAic2NlbmFy
-        aW9fdGVzdCJ9LCAiaWQiOiAic2NlbmFyaW9fdGVzdCJ9LCB7InJlcG9faWQi
-        OiAic2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOC0xMC0y
-        MlQxNzowODoyN1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRv
-        cmllcy9zY2VuYXJpb190ZXN0L2Rpc3RyaWJ1dG9ycy9leHBvcnRfZGlzdHJp
-        YnV0b3IvIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1
-        Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJleHBvcnRf
-        ZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNo
-        cGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjog
-        eyIkb2lkIjogIjViY2UwNDBiYjQ3Y2ViNGIyMDNlZTliNiJ9LCAiY29uZmln
-        IjogeyJodHRwIjogZmFsc2UsICJyZWxhdGl2ZV91cmwiOiAic2NlbmFyaW9f
-        dGVzdCIsICJodHRwcyI6IGZhbHNlfSwgImlkIjogImV4cG9ydF9kaXN0cmli
-        dXRvciJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3RlcyI6IHsi
-        X3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3JlbW92ZWQi
-        OiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25zIjogInJl
-        cG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAic2NlbmFyaW9fdGVz
-        dCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOC0xMC0yMlQxNzowODoyN1oiLCAi
-        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJpb190
-        ZXN0L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2lt
-        cG9ydGVycyIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIs
-        ICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjogbnVs
-        bCwgInNjcmF0Y2hwYWQiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjViY2Uw
-        NDBiYjQ3Y2ViNGIyMDNlZTliMyJ9LCAiY29uZmlnIjogeyJmZWVkIjogImZp
-        bGU6Ly8vdmFyL3d3dy90ZXN0X3JlcG9zL3pvbyIsICJzc2xfdmFsaWRhdGlv
-        biI6IHRydWUsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9w
-        b2xpY3kiOiAiaW1tZWRpYXRlIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0s
-        ICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQiOiAi
-        NWJjZTA0MGJiNDdjZWI0YjIwM2VlOWIyIn0sICJ0b3RhbF9yZXBvc2l0b3J5
-        X3VuaXRzIjogMCwgImlkIjogInNjZW5hcmlvX3Rlc3QiLCAiX2hyZWYiOiAi
-        L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJpb190ZXN0LyJ9
-    http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:27 GMT
-- request:
-    method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/actions/publish/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6InNjZW5hcmlvX3Rlc3QiLCJvdmVycmlkZV9jb25maWciOnsiZm9y
-        Y2VfZnVsbCI6ZmFsc2V9fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '61'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 22 Oct 2018 17:08:27 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2U1Zjc5MzlkLWY3MzUtNDRiNC04YTk4LTc2YmRkMGU0NzNkZi8iLCAi
-        dGFza19pZCI6ICJlNWY3OTM5ZC1mNzM1LTQ0YjQtOGE5OC03NmJkZDBlNDcz
-        ZGYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
   recorded_at: Mon, 22 Oct 2018 17:08:27 GMT
 - request:
@@ -1262,4 +944,6574 @@ http_interactions:
         YzBkMGVhNGUifQ==
     http_version: 
   recorded_at: Mon, 22 Oct 2018 17:08:28 GMT
+- request:
+    method: post
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/content/1543813302333?enabled=true
+    body:
+      encoding: UTF-8
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk",
+        oauth_nonce="0JVPL5YvvI6mAZw2aWkBCveokUl29Jd7ZsdEX7slA", oauth_signature="S2DBG1%2FlXM%2F0s8zNS7NZJOGBlXQ%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1543813302", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 10ab86be-2baa-4fcd-b2b2-67195cb1b90a
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:01:42 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNTowMTo0MSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6MDE6NDIrMDAwMCIsInV1aWQiOiI0MDI4Zjk2
+        NjY3NzE5NTdkMDE2NzcyNzE4OGNiMDAwOCIsImlkIjoiN2M4MjUwMTNjYWIw
+        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
+        dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
+        IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
+        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOTY2Njc3MTk1N2QwMTY3NzI3MTg4Y2Iw
+        MDA4IiwicHJvZHVjdENvbnRlbnQiOlt7ImNvbnRlbnQiOnsiY3JlYXRlZCI6
+        IjIwMTgtMTItMDNUMDU6MDE6NDIrMDAwMCIsInVwZGF0ZWQiOiIyMDE4LTEy
+        LTAzVDA1OjAxOjQyKzAwMDAiLCJ1dWlkIjoiNDAyOGY5NjY2NzcxOTU3ZDAx
+        Njc3MjcxODg0MzAwMDciLCJpZCI6IjE1NDM4MTMzMDIzMzMiLCJ0eXBlIjoi
+        eXVtIiwibGFiZWwiOiJzY2VuYXJpb190ZXN0X1NjZW5hcmlvX1Byb2R1Y3Rf
+        U2NlbmFyaW9feXVtX3Byb2R1Y3QiLCJuYW1lIjoiU2NlbmFyaW8geXVtIHBy
+        b2R1Y3QiLCJ2ZW5kb3IiOiJDdXN0b20iLCJjb250ZW50VXJsIjoiL2N1c3Rv
+        bS9TY2VuYXJpb19Qcm9kdWN0L1NjZW5hcmlvX3l1bV9wcm9kdWN0IiwicmVx
+        dWlyZWRUYWdzIjpudWxsLCJncGdVcmwiOm51bGwsIm1vZGlmaWVkUHJvZHVj
+        dElkcyI6W10sImFyY2hlcyI6bnVsbCwicmVxdWlyZWRQcm9kdWN0SWRzIjpb
+        XSwibWV0YWRhdGFFeHBpcmUiOjEsInJlbGVhc2VWZXIiOm51bGx9LCJlbmFi
+        bGVkIjp0cnVlfV19
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:01:42 GMT
+- request:
+    method: post
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/environments/d80a5783c502f0f969e23089437bb7ce/content
+    body:
+      encoding: UTF-8
+      base64_string: 'W3siY29udGVudElkIjoiMTU0MzgxMzMwMjMzMyJ9XQ==
+
+'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk",
+        oauth_nonce="8Ahi5vfwKr1WOl9RIpzZkL9mAFGgFJzJmFYc2fmjs", oauth_signature="DtX3hHxS6viCJIwAqDXYGZKpq2U%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1543813302", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '31'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 49f2368f-0ba3-4149-a2c7-b72b2726b946
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:01:42 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNTowMTo0MiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6MDE6NDIrMDAwMCIsImlkIjoicmVnZW5fZW50
+        aXRsZW1lbnRfY2VydF9vZl9lbnY1MTRlNDIwNi0zYWNiLTRmYjItYjZmYS04
+        MWJmMjU0NjlkMTMiLCJzdGF0ZSI6IkNSRUFURUQiLCJzdGFydFRpbWUiOm51
+        bGwsImZpbmlzaFRpbWUiOm51bGwsInJlc3VsdCI6bnVsbCwicHJpbmNpcGFs
+        TmFtZSI6ImZvcmVtYW5fYWRtaW4iLCJ0YXJnZXRUeXBlIjpudWxsLCJ0YXJn
+        ZXRJZCI6bnVsbCwib3duZXJJZCI6bnVsbCwiY29ycmVsYXRpb25JZCI6bnVs
+        bCwicmVzdWx0RGF0YSI6bnVsbCwiZG9uZSI6ZmFsc2UsInN0YXR1c1BhdGgi
+        OiIvam9icy9yZWdlbl9lbnRpdGxlbWVudF9jZXJ0X29mX2VudjUxNGU0MjA2
+        LTNhY2ItNGZiMi1iNmZhLTgxYmYyNTQ2OWQxMyIsImdyb3VwIjoiYXN5bmMg
+        Z3JvdXAifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:01:42 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/b571a696-51e0-4017-b891-de1f55114c9c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:01:42 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"27f65792de8ab5824714e303de3a73ab-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '691'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9iNTcxYTY5Ni01MWUwLTQwMTctYjg5MS1kZTFm
+        NTUxMTRjOWMvIiwgInRhc2tfaWQiOiAiYjU3MWE2OTYtNTFlMC00MDE3LWI4
+        OTEtZGUxZjU1MTE0YzljIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MDE6NDNaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
+        NWMwNGI4YjY0OThlZGI4MjU1YmIwNTc2In0sICJpZCI6ICI1YzA0YjhiNjQ5
+        OGVkYjgyNTViYjA1NzYifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:01:43 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/b571a696-51e0-4017-b891-de1f55114c9c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:01:43 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"81457a55b79ebad9c040893d18b4e1fb-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4308'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9iNTcxYTY5Ni01MWUwLTQwMTctYjg5MS1kZTFm
+        NTUxMTRjOWMvIiwgInRhc2tfaWQiOiAiYjU3MWE2OTYtNTFlMC00MDE3LWI4
+        OTEtZGUxZjU1MTE0YzljIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MDE6NDNaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImFjNjRmMDIxLTJiZmQtNDNlMy1iODEzLTlhOWY1YzZkMzAzYyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzZjQx
+        OGYxYy1jZmQ3LTQzZWUtYjA5Yi0wYTM3Yjk2MWI3ODMiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIxNmRlOWFlMi1hZWY0LTRjZDMtYWE2Zi00ODlhYTg5
+        MzI1Y2EiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJz
+        dGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODJlNDEx
+        MDMtYmYzMi00NmIwLTk3ZTYtN2Q0NDg0MGUyNzkyIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjhkYjcwZDUxLTBjY2ItNGRiYi1iY2NlLWQwNWE1
+        MzU4MDg2NiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0
+        ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQzMzJh
+        MDEzLTgzNzItNGRjNi05NGJiLTQ5ZDdjMGMwNzk0ZSIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        UHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI0ZWJhMzllOS02ZTVlLTQ2NTktOGQ4NC00
+        YTgzZjNjNDY2ZDMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEu
+        IiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJjNzZkMTdhMC1lYjJmLTRhMGItODBjMS0zNTUyNGYzZDIzMjQiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAi
+        Y2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjZmY0
+        NTFlOS0zMjQxLTRiODItOGNkOS0zMzg2ZjIzZTQ3NTciLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5l
+        cmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDI0MTkyZDktNWVk
+        Mi00YjBiLThiOGQtMmIwYzQ3NDhhZjJhIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmlu
+        ZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVw
+        b2RhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOWY1ODY4M2EtZjM2OS00OGM2
+        LWI5OTctY2ViMTEyNGM3N2JiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhU
+        TUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3Rv
+        dGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImVlM2Y2YmQyLTU2MGItNGZhMC05OTYyLWFjZjg2NDE5NmYx
+        YSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3Rl
+        cF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjog
+        MSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjYxNzIxYzIxLTE1NDUtNDRmOC04ZWFkLTk2OGJiYjk2M2ExZSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6
+        ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAx
+        LCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiNTQ4MDVhYWQtYWExNS00ZTYyLTliYzQtNjUzZDliODUxOTE5IiwgIm51
+        bV9wcm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20u
+        ZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1YzA0YjhiNjQ5OGVkYjgyNTViYjA1NzYifSwg
+        ImlkIjogIjVjMDRiOGI2NDk4ZWRiODI1NWJiMDU3NiJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:01:43 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/b571a696-51e0-4017-b891-de1f55114c9c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:01:43 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"b37b57dacb09623ccef4eb5ff611d5ac-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4292'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9iNTcxYTY5Ni01MWUwLTQwMTctYjg5MS1kZTFm
+        NTUxMTRjOWMvIiwgInRhc2tfaWQiOiAiYjU3MWE2OTYtNTFlMC00MDE3LWI4
+        OTEtZGUxZjU1MTE0YzljIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MDE6NDNaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImFjNjRmMDIxLTJiZmQtNDNlMy1iODEzLTlhOWY1YzZkMzAzYyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzZjQx
+        OGYxYy1jZmQ3LTQzZWUtYjA5Yi0wYTM3Yjk2MWI3ODMiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIxNmRlOWFlMi1hZWY0LTRjZDMtYWE2Zi00ODlhYTg5MzI1
+        Y2EiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4MmU0MTEwMy1iZjMy
+        LTQ2YjAtOTdlNi03ZDQ0ODQwZTI3OTIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiOGRiNzBkNTEtMGNjYi00ZGJiLWJjY2UtZDA1YTUzNTgwODY2Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDMzMmEwMTMtODM3Mi00ZGM2
+        LTk0YmItNDlkN2MwYzA3OTRlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
+        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjRlYmEzOWU5LTZlNWUtNDY1OS04ZDg0LTRhODNmM2M0NjZkMyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
+        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIklOX1BS
+        T0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM3NmQxN2EwLWViMmYt
+        NGEwYi04MGMxLTM1NTI0ZjNkMjMyNCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyBy
+        ZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFk
+        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNmZjQ1MWU5LTMyNDEtNGI4Mi04
+        Y2Q5LTMzODZmMjNlNDc1NyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxp
+        dGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI0MjQxOTJkOS01ZWQyLTRiMGItOGI4ZC0yYjBj
+        NDc0OGFmMmEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIs
+        ICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI5ZjU4NjgzYS1mMzY5LTQ4YzYtYjk5Ny1jZWIxMTI0Yzc3
+        YmIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVw
+        X3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWUzZjZi
+        ZDItNTYwYi00ZmEwLTk5NjItYWNmODY0MTk2ZjFhIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
+        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjE3MjFjMjEtMTU0
+        NS00NGY4LThlYWQtOTY4YmJiOTYzYTFlIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5n
+        IExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVw
+        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
+        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1NDgwNWFhZC1hYTE1
+        LTRlNjItOWJjNC02NTNkOWI4NTE5MTkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50
+        b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAi
+        cnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJy
+        ZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjog
+        IjVjMDRiOGI2NDk4ZWRiODI1NWJiMDU3NiJ9LCAiaWQiOiAiNWMwNGI4YjY0
+        OThlZGI4MjU1YmIwNTc2In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:01:43 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/b571a696-51e0-4017-b891-de1f55114c9c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:01:43 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"3071d16ae7cfb67f2bdab0f6f1081149-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4275'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9iNTcxYTY5Ni01MWUwLTQwMTctYjg5MS1kZTFm
+        NTUxMTRjOWMvIiwgInRhc2tfaWQiOiAiYjU3MWE2OTYtNTFlMC00MDE3LWI4
+        OTEtZGUxZjU1MTE0YzljIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MDE6NDNaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImFjNjRmMDIxLTJiZmQtNDNlMy1iODEzLTlhOWY1YzZkMzAzYyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzZjQx
+        OGYxYy1jZmQ3LTQzZWUtYjA5Yi0wYTM3Yjk2MWI3ODMiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIxNmRlOWFlMi1hZWY0LTRjZDMtYWE2Zi00ODlhYTg5MzI1
+        Y2EiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4MmU0MTEwMy1iZjMy
+        LTQ2YjAtOTdlNi03ZDQ0ODQwZTI3OTIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiOGRiNzBkNTEtMGNjYi00ZGJiLWJjY2UtZDA1YTUzNTgwODY2Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDMzMmEwMTMtODM3Mi00ZGM2
+        LTk0YmItNDlkN2MwYzA3OTRlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
+        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjRlYmEzOWU5LTZlNWUtNDY1OS04ZDg0LTRhODNmM2M0NjZkMyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
+        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM3NmQxN2EwLWViMmYtNGEw
+        Yi04MGMxLTM1NTI0ZjNkMjMyNCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
+        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImNmZjQ1MWU5LTMyNDEtNGI4Mi04Y2Q5LTMz
+        ODZmMjNlNDc1NyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjQyNDE5MmQ5LTVlZDItNGIwYi04YjhkLTJiMGM0NzQ4YWYyYSIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjlm
+        NTg2ODNhLWYzNjktNDhjNi1iOTk3LWNlYjExMjRjNzdiYiIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBv
+        dmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImVlM2Y2YmQyLTU2MGItNGZhMC05OTYy
+        LWFjZjg2NDE5NmYxYSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0
+        byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjYxNzIxYzIxLTE1NDUtNDRmOC04ZWFkLTk2OGJi
+        Yjk2M2ExZSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiNTQ4MDVhYWQtYWExNS00ZTYyLTliYzQtNjUzZDli
+        ODUxOTE5IiwgIm51bV9wcm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2Vy
+        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
+        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YjhiNjQ5OGVkYjgy
+        NTViYjA1NzYifSwgImlkIjogIjVjMDRiOGI2NDk4ZWRiODI1NWJiMDU3NiJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:01:43 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/b571a696-51e0-4017-b891-de1f55114c9c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:01:43 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"c513fc8c9a873331f1f5703eee9f7f6a-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '8549'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9iNTcxYTY5Ni01MWUwLTQwMTctYjg5MS1kZTFm
+        NTUxMTRjOWMvIiwgInRhc2tfaWQiOiAiYjU3MWE2OTYtNTFlMC00MDE3LWI4
+        OTEtZGUxZjU1MTE0YzljIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTgtMTItMDNUMDU6MDE6NDNaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MDE6NDNa
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
+        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
+        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImFjNjRmMDIxLTJiZmQtNDNlMy1iODEz
+        LTlhOWY1YzZkMzAzYyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
+        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIzZjQxOGYxYy1jZmQ3LTQzZWUtYjA5Yi0wYTM3Yjk2
+        MWI3ODMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
+        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNmRlOWFlMi1hZWY0LTRj
+        ZDMtYWE2Zi00ODlhYTg5MzI1Y2EiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
+        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICI4MmU0MTEwMy1iZjMyLTQ2YjAtOTdlNi03ZDQ0ODQwZTI3OTIiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
+        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOGRiNzBkNTEtMGNjYi00ZGJiLWJj
+        Y2UtZDA1YTUzNTgwODY2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVs
+        ZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        ZDMzMmEwMTMtODM3Mi00ZGM2LTk0YmItNDlkN2MwYzA3OTRlIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNv
+        bXBzIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjRlYmEzOWU5LTZlNWUtNDY1OS04ZDg0
+        LTRhODNmM2M0NjZkMyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0
+        YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        ImM3NmQxN2EwLWViMmYtNGEwYi04MGMxLTM1NTI0ZjNkMjMyNCIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRp
+        b24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJj
+        bG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNmZjQ1MWU5
+        LTMyNDEtNGI4Mi04Y2Q5LTMzODZmMjNlNDc1NyIsICJudW1fcHJvY2Vzc2Vk
+        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
+        ZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRl
+        IHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQyNDE5MmQ5LTVlZDItNGIwYi04
+        YjhkLTJiMGM0NzQ4YWYyYSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJl
+        cG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjlmNTg2ODNhLWYzNjktNDhjNi1iOTk3LWNlYjEx
+        MjRjNzdiYiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwg
+        InN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVlM2Y2
+        YmQyLTU2MGItNGZhMC05OTYyLWFjZjg2NDE5NmYxYSIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        UHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxp
+        c2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjYxNzIxYzIxLTE1NDUt
+        NDRmOC04ZWFkLTk2OGJiYjk2M2ExZSIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBM
+        aXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9f
+        bWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTQ4MDVhYWQtYWExNS00ZTYy
+        LTliYzQtNjUzZDliODUxOTE5IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
+        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlz
+        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwg
+        InJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJzdGFydGVkIjogIjIwMTgt
+        MTItMDNUMDU6MDE6NDNaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0
+        cyIsICJjb21wbGV0ZWQiOiAiMjAxOC0xMi0wM1QwNTowMTo0M1oiLCAidHJh
+        Y2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Rp
+        c3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7ImdlbmVyYXRlIHNxbGl0ZSI6ICJT
+        S0lQUEVEIiwgInJwbXMiOiAiRklOSVNIRUQiLCAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIjogIkZJTklTSEVEIiwgInJlbW92ZV9vbGRfcmVwb2RhdGEi
+        OiAiRklOSVNIRUQiLCAibW9kdWxlcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9y
+        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQi
+        LCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklT
+        SEVEIiwgInJlcG92aWV3IjogIlNLSVBQRUQiLCAicHVibGlzaF9kaXJlY3Rv
+        cnkiOiAiRklOSVNIRUQiLCAiZXJyYXRhIjogIkZJTklTSEVEIiwgIm1ldGFk
+        YXRhIjogIkZJTklTSEVEIn0sICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImRp
+        c3RyaWJ1dG9yX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAiaWQiOiAiNWMwNGI4
+        YjcwNWY1ZWUwNWMzZmQ4NDJmIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2Vz
+        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRh
+        ZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImFjNjRmMDIxLTJiZmQtNDNlMy1iODEzLTlh
+        OWY1YzZkMzAzYyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRp
+        b24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIzZjQxOGYxYy1jZmQ3LTQzZWUtYjA5Yi0wYTM3Yjk2MWI3
+        ODMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUi
+        OiAicnBtcyIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNmRlOWFlMi1hZWY0LTRjZDMt
+        YWE2Zi00ODlhYTg5MzI1Y2EiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVs
+        dGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICI4MmU0MTEwMy1iZjMyLTQ2YjAtOTdlNi03ZDQ0ODQwZTI3OTIiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiOGRiNzBkNTEtMGNjYi00ZGJiLWJjY2Ut
+        ZDA1YTUzNTgwODY2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMi
+        LCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDMz
+        MmEwMTMtODM3Mi00ZGM2LTk0YmItNDlkN2MwYzA3OTRlIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBz
+        IiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjRlYmEzOWU5LTZlNWUtNDY1OS04ZDg0LTRh
+        ODNmM2M0NjZkMyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4i
+        LCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM3
+        NmQxN2EwLWViMmYtNGEwYi04MGMxLTM1NTI0ZjNkMjMyNCIsICJudW1fcHJv
+        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
+        OiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9z
+        ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNmZjQ1MWU5LTMy
+        NDEtNGI4Mi04Y2Q5LTMzODZmMjNlNDc1NyIsICJudW1fcHJvY2Vzc2VkIjog
+        MX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
+        dGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNx
+        bGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjQyNDE5MmQ5LTVlZDItNGIwYi04Yjhk
+        LTJiMGM0NzQ4YWYyYSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9k
+        YXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjlmNTg2ODNhLWYzNjktNDhjNi1iOTk3LWNlYjExMjRj
+        NzdiYiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0
+        ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVlM2Y2YmQy
+        LTU2MGItNGZhMC05OTYyLWFjZjg2NDE5NmYxYSIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjYxNzIxYzIxLTE1NDUtNDRm
+        OC04ZWFkLTk2OGJiYjk2M2ExZSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTQ4MDVhYWQtYWExNS00ZTYyLTli
+        YzQtNjUzZDliODUxOTE5IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiOGI2NDk4ZWRiODI1
+        NWJiMDU3NiJ9LCAiaWQiOiAiNWMwNGI4YjY0OThlZGI4MjU1YmIwNTc2In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:01:43 GMT
+- request:
+    method: post
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/content/1543813373723?enabled=true
+    body:
+      encoding: UTF-8
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk",
+        oauth_nonce="oqoPEiDYLaGH18AYhFfy42IqHv8343lUHie7Pud18", oauth_signature="tOi8Tb%2BbtlB4ZLZrwZaZRM4K5qM%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1543813373", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - f5b4117c-83e4-4839-b58b-03c55fd68c7c
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:02:52 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNTowMjo1MiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6MDI6NTMrMDAwMCIsInV1aWQiOiI0MDI4Zjk2
+        NjY3NzE5NTdkMDE2NzcyNzI5ZjQzMDAxNSIsImlkIjoiN2M4MjUwMTNjYWIw
+        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
+        dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
+        IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
+        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOTY2Njc3MTk1N2QwMTY3NzI3MjlmNDMw
+        MDE1IiwicHJvZHVjdENvbnRlbnQiOlt7ImNvbnRlbnQiOnsiY3JlYXRlZCI6
+        IjIwMTgtMTItMDNUMDU6MDI6NTMrMDAwMCIsInVwZGF0ZWQiOiIyMDE4LTEy
+        LTAzVDA1OjAyOjUzKzAwMDAiLCJ1dWlkIjoiNDAyOGY5NjY2NzcxOTU3ZDAx
+        Njc3MjcyOWYxNjAwMTQiLCJpZCI6IjE1NDM4MTMzNzM3MjMiLCJ0eXBlIjoi
+        eXVtIiwibGFiZWwiOiJzY2VuYXJpb190ZXN0X1NjZW5hcmlvX1Byb2R1Y3Rf
+        U2NlbmFyaW9feXVtX3Byb2R1Y3QiLCJuYW1lIjoiU2NlbmFyaW8geXVtIHBy
+        b2R1Y3QiLCJ2ZW5kb3IiOiJDdXN0b20iLCJjb250ZW50VXJsIjoiL2N1c3Rv
+        bS9TY2VuYXJpb19Qcm9kdWN0L1NjZW5hcmlvX3l1bV9wcm9kdWN0IiwicmVx
+        dWlyZWRUYWdzIjpudWxsLCJncGdVcmwiOm51bGwsIm1vZGlmaWVkUHJvZHVj
+        dElkcyI6W10sImFyY2hlcyI6bnVsbCwicmVxdWlyZWRQcm9kdWN0SWRzIjpb
+        XSwibWV0YWRhdGFFeHBpcmUiOjEsInJlbGVhc2VWZXIiOm51bGx9LCJlbmFi
+        bGVkIjp0cnVlfV19
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:02:53 GMT
+- request:
+    method: post
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/environments/d80a5783c502f0f969e23089437bb7ce/content
+    body:
+      encoding: UTF-8
+      base64_string: 'W3siY29udGVudElkIjoiMTU0MzgxMzM3MzcyMyJ9XQ==
+
+'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk",
+        oauth_nonce="VicBzDIof6kpFvLxerrnrqNvdvDJf0GYnAwxpNckI", oauth_signature="Fx0nHPA%2BGlDpYU96lkx2iqKkUvw%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1543813373", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '31'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 7833b891-8da0-468c-9b20-703bc4d5ee60
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:02:52 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNTowMjo1MyswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6MDI6NTMrMDAwMCIsImlkIjoicmVnZW5fZW50
+        aXRsZW1lbnRfY2VydF9vZl9lbnZjNGUzZmZhOS05YjYxLTQ3NDctYjkzMS1h
+        ZjdlMmY3NWE0MDMiLCJzdGF0ZSI6IkNSRUFURUQiLCJzdGFydFRpbWUiOm51
+        bGwsImZpbmlzaFRpbWUiOm51bGwsInJlc3VsdCI6bnVsbCwicHJpbmNpcGFs
+        TmFtZSI6ImZvcmVtYW5fYWRtaW4iLCJ0YXJnZXRUeXBlIjpudWxsLCJ0YXJn
+        ZXRJZCI6bnVsbCwib3duZXJJZCI6bnVsbCwiY29ycmVsYXRpb25JZCI6bnVs
+        bCwicmVzdWx0RGF0YSI6bnVsbCwiZG9uZSI6ZmFsc2UsInN0YXR1c1BhdGgi
+        OiIvam9icy9yZWdlbl9lbnRpdGxlbWVudF9jZXJ0X29mX2VudmM0ZTNmZmE5
+        LTliNjEtNDc0Ny1iOTMxLWFmN2UyZjc1YTQwMyIsImdyb3VwIjoiYXN5bmMg
+        Z3JvdXAifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:02:53 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/836d6569-81b5-4f77-8971-f2979f47d332/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:02:54 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"08eed1287e6211f96623eff2c921438f-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '553'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy84MzZkNjU2OS04MWI1LTRmNzctODk3MS1mMjk3
+        OWY0N2QzMzIvIiwgInRhc2tfaWQiOiAiODM2ZDY1NjktODFiNS00Zjc3LTg5
+        NzEtZjI5NzlmNDdkMzMyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIiIsICJz
+        dGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWMw
+        NGI4ZmU0OThlZGI4MjU1YmIwYWM3In0sICJpZCI6ICI1YzA0YjhmZTQ5OGVk
+        YjgyNTViYjBhYzcifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:02:54 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/836d6569-81b5-4f77-8971-f2979f47d332/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:02:54 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"16fa68e91a69c39fdf3f582c44a1f7b2-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4311'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy84MzZkNjU2OS04MWI1LTRmNzctODk3MS1mMjk3
+        OWY0N2QzMzIvIiwgInRhc2tfaWQiOiAiODM2ZDY1NjktODFiNS00Zjc3LTg5
+        NzEtZjI5NzlmNDdkMzMyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MDI6NTRaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImNjNTNkYjMyLTUxN2QtNGYxMS1iMjBiLWIwOWExNjQ1NzdmNSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIw
+        ZjY3YTkxMS1hMDNmLTRlZDItOTYyOS1jZjc3ZTczZDIxYmEiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJiN2JhM2Y5MC05YTllLTQwYWItODFhNi04M2U2
+        MDQ1ZDNhZTYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
+        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGIw
+        Mjc5MTgtMzg0Zi00Y2EyLWEwNmMtNzk3YzZkOTI1NTg1IiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjQ4NGYzOGQyLTMzOGItNDEyZS04ZjQ0LTdi
+        NmY4OTYwMmM3YSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwg
+        InN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImMz
+        NDliY2Y3LTZmMWQtNDI2Zi1iMzBmLWI1ZThlMmVkMDc5YSIsICJudW1fcHJv
+        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
+        cyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMzBlZDliYy0zOGRiLTQ2ZTEtODNk
+        Zi01ZDBiZTU3ZWZkNDciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRh
+        dGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICIwYTQ0OGIzMy04MTZiLTRlNDAtODI2Ni00ZjZkNDQ2NzQyMmMiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUi
+        OiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJj
+        MTJlYTM5Ny1kMDVhLTQxNjQtYjJmNi0xMWNkNzVkMDZmMTMiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJn
+        ZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzBjMTM4MTkt
+        YzRkZS00OThhLTk0MWEtYmUwNGRjOGUwZGFjIiwgIm51bV9wcm9jZXNzZWQi
+        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJSZW1v
+        dmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRf
+        cmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
+        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDMwNjI0ZjYtZWUwYy00
+        NDQ5LTk5YTctMzFlZTlmMGI0NTEzIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
+        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5n
+        IEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImU4NjlhMzdlLWE0ZjgtNDc5NS04NTk2LTNiNjIxMDJl
+        ZTg5MyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAi
+        c3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjQwYWU0YWYyLTNjYjYtNGZkMi1iYTI2LWRlMWU2ZDZmYjkwNiIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
+        Y3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlw
+        ZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiNjgxOWYwYjQtN2FiMi00YWM5LWFjNmUtZWJlODc1NjYyYmZhIiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YjhmZTQ5OGVkYjgyNTViYjBhYzci
+        fSwgImlkIjogIjVjMDRiOGZlNDk4ZWRiODI1NWJiMGFjNyJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:02:54 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/836d6569-81b5-4f77-8971-f2979f47d332/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:02:54 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"e8c9a406479a0ce0cc06c1908304bca6-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4295'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy84MzZkNjU2OS04MWI1LTRmNzctODk3MS1mMjk3
+        OWY0N2QzMzIvIiwgInRhc2tfaWQiOiAiODM2ZDY1NjktODFiNS00Zjc3LTg5
+        NzEtZjI5NzlmNDdkMzMyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MDI6NTRaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImNjNTNkYjMyLTUxN2QtNGYxMS1iMjBiLWIwOWExNjQ1NzdmNSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwZjY3
+        YTkxMS1hMDNmLTRlZDItOTYyOS1jZjc3ZTczZDIxYmEiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJiN2JhM2Y5MC05YTllLTQwYWItODFhNi04M2U2MDQ1ZDNh
+        ZTYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYjAyNzkxOC0zODRm
+        LTRjYTItYTA2Yy03OTdjNmQ5MjU1ODUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiNDg0ZjM4ZDItMzM4Yi00MTJlLThmNDQtN2I2Zjg5NjAyYzdhIiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzM0OWJjZjctNmYxZC00MjZm
+        LWIzMGYtYjVlOGUyZWQwNzlhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
+        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogImIzMGVkOWJjLTM4ZGItNDZlMS04M2RmLTVkMGJlNTdlZmQ0NyIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
+        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBl
+        IjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
+        VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBhNDQ4YjMzLTgx
+        NmItNGU0MC04MjY2LTRmNmQ0NDY3NDIyYyIsICJudW1fcHJvY2Vzc2VkIjog
+        MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2lu
+        ZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21l
+        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFS
+        VEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImMxMmVhMzk3LWQwNWEtNDE2
+        NC1iMmY2LTExY2Q3NWQwNmYxMyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBz
+        cWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJjMGMxMzgxOS1jNGRlLTQ5OGEtOTQxYS1i
+        ZTA0ZGM4ZTBkYWMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0
+        YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVt
+        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJkMzA2MjRmNi1lZTBjLTQ0NDktOTlhNy0zMWVlOWYw
+        YjQ1MTMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJz
+        dGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTg2
+        OWEzN2UtYTRmOC00Nzk1LTg1OTYtM2I2MjEwMmVlODkzIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVi
+        bGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDBhZTRhZjIt
+        M2NiNi00ZmQyLWJhMjYtZGUxZTZkNmZiOTA2IiwgIm51bV9wcm9jZXNzZWQi
+        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0
+        aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVf
+        cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2ODE5ZjBiNC03
+        YWIyLTRhYzktYWM2ZS1lYmU4NzU2NjJiZmEiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDB9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBj
+        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUi
+        OiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIs
+        ICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
+        IjogIjVjMDRiOGZlNDk4ZWRiODI1NWJiMGFjNyJ9LCAiaWQiOiAiNWMwNGI4
+        ZmU0OThlZGI4MjU1YmIwYWM3In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:02:54 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/836d6569-81b5-4f77-8971-f2979f47d332/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:02:54 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"1bb9b5b2aeebb031fd7af3f76d1d1231-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4275'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy84MzZkNjU2OS04MWI1LTRmNzctODk3MS1mMjk3
+        OWY0N2QzMzIvIiwgInRhc2tfaWQiOiAiODM2ZDY1NjktODFiNS00Zjc3LTg5
+        NzEtZjI5NzlmNDdkMzMyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MDI6NTRaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImNjNTNkYjMyLTUxN2QtNGYxMS1iMjBiLWIwOWExNjQ1NzdmNSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwZjY3
+        YTkxMS1hMDNmLTRlZDItOTYyOS1jZjc3ZTczZDIxYmEiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJiN2JhM2Y5MC05YTllLTQwYWItODFhNi04M2U2MDQ1ZDNh
+        ZTYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYjAyNzkxOC0zODRm
+        LTRjYTItYTA2Yy03OTdjNmQ5MjU1ODUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiNDg0ZjM4ZDItMzM4Yi00MTJlLThmNDQtN2I2Zjg5NjAyYzdhIiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzM0OWJjZjctNmYxZC00MjZm
+        LWIzMGYtYjVlOGUyZWQwNzlhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
+        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImIzMGVkOWJjLTM4ZGItNDZlMS04M2RmLTVkMGJlNTdlZmQ0NyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
+        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBhNDQ4YjMzLTgxNmItNGU0
+        MC04MjY2LTRmNmQ0NDY3NDIyYyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
+        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImMxMmVhMzk3LWQwNWEtNDE2NC1iMmY2LTEx
+        Y2Q3NWQwNmYxMyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogImMwYzEzODE5LWM0ZGUtNDk4YS05NDFhLWJlMDRkYzhlMGRhYyIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQz
+        MDYyNGY2LWVlMGMtNDQ0OS05OWE3LTMxZWU5ZjBiNDUxMyIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBv
+        dmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImU4NjlhMzdlLWE0ZjgtNDc5NS04NTk2
+        LTNiNjIxMDJlZTg5MyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0
+        byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjQwYWU0YWYyLTNjYjYtNGZkMi1iYTI2LWRlMWU2
+        ZDZmYjkwNiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiNjgxOWYwYjQtN2FiMi00YWM5LWFjNmUtZWJlODc1
+        NjYyYmZhIiwgIm51bV9wcm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2Vy
+        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
+        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YjhmZTQ5OGVkYjgy
+        NTViYjBhYzcifSwgImlkIjogIjVjMDRiOGZlNDk4ZWRiODI1NWJiMGFjNyJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:02:54 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/836d6569-81b5-4f77-8971-f2979f47d332/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:02:54 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"d8481eea97cba7d41d9b4b72f09de0ee-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4269'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy84MzZkNjU2OS04MWI1LTRmNzctODk3MS1mMjk3
+        OWY0N2QzMzIvIiwgInRhc2tfaWQiOiAiODM2ZDY1NjktODFiNS00Zjc3LTg5
+        NzEtZjI5NzlmNDdkMzMyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MDI6NTRaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImNjNTNkYjMyLTUxN2QtNGYxMS1iMjBiLWIwOWExNjQ1NzdmNSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwZjY3
+        YTkxMS1hMDNmLTRlZDItOTYyOS1jZjc3ZTczZDIxYmEiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJiN2JhM2Y5MC05YTllLTQwYWItODFhNi04M2U2MDQ1ZDNh
+        ZTYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYjAyNzkxOC0zODRm
+        LTRjYTItYTA2Yy03OTdjNmQ5MjU1ODUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiNDg0ZjM4ZDItMzM4Yi00MTJlLThmNDQtN2I2Zjg5NjAyYzdhIiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzM0OWJjZjctNmYxZC00MjZm
+        LWIzMGYtYjVlOGUyZWQwNzlhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
+        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImIzMGVkOWJjLTM4ZGItNDZlMS04M2RmLTVkMGJlNTdlZmQ0NyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
+        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBhNDQ4YjMzLTgxNmItNGU0
+        MC04MjY2LTRmNmQ0NDY3NDIyYyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
+        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImMxMmVhMzk3LWQwNWEtNDE2NC1iMmY2LTEx
+        Y2Q3NWQwNmYxMyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogImMwYzEzODE5LWM0ZGUtNDk4YS05NDFhLWJlMDRkYzhlMGRhYyIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQz
+        MDYyNGY2LWVlMGMtNDQ0OS05OWE3LTMxZWU5ZjBiNDUxMyIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBv
+        dmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImU4NjlhMzdlLWE0ZjgtNDc5NS04NTk2
+        LTNiNjIxMDJlZTg5MyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0
+        byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjQwYWU0YWYyLTNjYjYtNGZkMi1iYTI2LWRlMWU2ZDZm
+        YjkwNiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0
+        ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiNjgxOWYwYjQtN2FiMi00YWM5LWFjNmUtZWJlODc1NjYyYmZh
+        IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAicXVldWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBs
+        ZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIu
+        c2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YjhmZTQ5OGVkYjgyNTViYjBh
+        YzcifSwgImlkIjogIjVjMDRiOGZlNDk4ZWRiODI1NWJiMGFjNyJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:02:54 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/836d6569-81b5-4f77-8971-f2979f47d332/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:02:54 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"6aacdb7fcd1482486a650d84d8c1e9d2-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '8549'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy84MzZkNjU2OS04MWI1LTRmNzctODk3MS1mMjk3
+        OWY0N2QzMzIvIiwgInRhc2tfaWQiOiAiODM2ZDY1NjktODFiNS00Zjc3LTg5
+        NzEtZjI5NzlmNDdkMzMyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTgtMTItMDNUMDU6MDI6NTRaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MDI6NTRa
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
+        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
+        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImNjNTNkYjMyLTUxN2QtNGYxMS1iMjBi
+        LWIwOWExNjQ1NzdmNSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
+        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIwZjY3YTkxMS1hMDNmLTRlZDItOTYyOS1jZjc3ZTcz
+        ZDIxYmEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
+        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiN2JhM2Y5MC05YTllLTQw
+        YWItODFhNi04M2U2MDQ1ZDNhZTYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
+        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICIwYjAyNzkxOC0zODRmLTRjYTItYTA2Yy03OTdjNmQ5MjU1ODUiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
+        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDg0ZjM4ZDItMzM4Yi00MTJlLThm
+        NDQtN2I2Zjg5NjAyYzdhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVs
+        ZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        YzM0OWJjZjctNmYxZC00MjZmLWIzMGYtYjVlOGUyZWQwNzlhIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNv
+        bXBzIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImIzMGVkOWJjLTM4ZGItNDZlMS04M2Rm
+        LTVkMGJlNTdlZmQ0NyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0
+        YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjBhNDQ4YjMzLTgxNmItNGU0MC04MjY2LTRmNmQ0NDY3NDIyYyIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRp
+        b24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJj
+        bG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImMxMmVhMzk3
+        LWQwNWEtNDE2NC1iMmY2LTExY2Q3NWQwNmYxMyIsICJudW1fcHJvY2Vzc2Vk
+        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
+        ZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRl
+        IHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImMwYzEzODE5LWM0ZGUtNDk4YS05
+        NDFhLWJlMDRkYzhlMGRhYyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJl
+        cG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImQzMDYyNGY2LWVlMGMtNDQ0OS05OWE3LTMxZWU5
+        ZjBiNDUxMyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwg
+        InN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImU4Njlh
+        MzdlLWE0ZjgtNDc5NS04NTk2LTNiNjIxMDJlZTg5MyIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        UHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxp
+        c2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQwYWU0YWYyLTNjYjYt
+        NGZkMi1iYTI2LWRlMWU2ZDZmYjkwNiIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBM
+        aXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9f
+        bWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjgxOWYwYjQtN2FiMi00YWM5
+        LWFjNmUtZWJlODc1NjYyYmZhIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
+        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlz
+        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwg
+        InJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJzdGFydGVkIjogIjIwMTgt
+        MTItMDNUMDU6MDI6NTRaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0
+        cyIsICJjb21wbGV0ZWQiOiAiMjAxOC0xMi0wM1QwNTowMjo1NFoiLCAidHJh
+        Y2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Rp
+        c3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7ImdlbmVyYXRlIHNxbGl0ZSI6ICJT
+        S0lQUEVEIiwgInJwbXMiOiAiRklOSVNIRUQiLCAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIjogIkZJTklTSEVEIiwgInJlbW92ZV9vbGRfcmVwb2RhdGEi
+        OiAiRklOSVNIRUQiLCAibW9kdWxlcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9y
+        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQi
+        LCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklT
+        SEVEIiwgInJlcG92aWV3IjogIlNLSVBQRUQiLCAicHVibGlzaF9kaXJlY3Rv
+        cnkiOiAiRklOSVNIRUQiLCAiZXJyYXRhIjogIkZJTklTSEVEIiwgIm1ldGFk
+        YXRhIjogIkZJTklTSEVEIn0sICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImRp
+        c3RyaWJ1dG9yX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAiaWQiOiAiNWMwNGI4
+        ZmUwNWY1ZWUwNWMzZmQ4NDQ2IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2Vz
+        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRh
+        ZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImNjNTNkYjMyLTUxN2QtNGYxMS1iMjBiLWIw
+        OWExNjQ1NzdmNSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRp
+        b24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIwZjY3YTkxMS1hMDNmLTRlZDItOTYyOS1jZjc3ZTczZDIx
+        YmEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUi
+        OiAicnBtcyIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiN2JhM2Y5MC05YTllLTQwYWIt
+        ODFhNi04M2U2MDQ1ZDNhZTYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVs
+        dGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICIwYjAyNzkxOC0zODRmLTRjYTItYTA2Yy03OTdjNmQ5MjU1ODUiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNDg0ZjM4ZDItMzM4Yi00MTJlLThmNDQt
+        N2I2Zjg5NjAyYzdhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMi
+        LCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzM0
+        OWJjZjctNmYxZC00MjZmLWIzMGYtYjVlOGUyZWQwNzlhIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBz
+        IiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImIzMGVkOWJjLTM4ZGItNDZlMS04M2RmLTVk
+        MGJlNTdlZmQ0NyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4i
+        LCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBh
+        NDQ4YjMzLTgxNmItNGU0MC04MjY2LTRmNmQ0NDY3NDIyYyIsICJudW1fcHJv
+        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
+        OiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9z
+        ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImMxMmVhMzk3LWQw
+        NWEtNDE2NC1iMmY2LTExY2Q3NWQwNmYxMyIsICJudW1fcHJvY2Vzc2VkIjog
+        MX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
+        dGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNx
+        bGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImMwYzEzODE5LWM0ZGUtNDk4YS05NDFh
+        LWJlMDRkYzhlMGRhYyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9k
+        YXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImQzMDYyNGY2LWVlMGMtNDQ0OS05OWE3LTMxZWU5ZjBi
+        NDUxMyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0
+        ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImU4NjlhMzdl
+        LWE0ZjgtNDc5NS04NTk2LTNiNjIxMDJlZTg5MyIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQwYWU0YWYyLTNjYjYtNGZk
+        Mi1iYTI2LWRlMWU2ZDZmYjkwNiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjgxOWYwYjQtN2FiMi00YWM5LWFj
+        NmUtZWJlODc1NjYyYmZhIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiOGZlNDk4ZWRiODI1
+        NWJiMGFjNyJ9LCAiaWQiOiAiNWMwNGI4ZmU0OThlZGI4MjU1YmIwYWM3In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:02:54 GMT
+- request:
+    method: post
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/content/1543813900667?enabled=true
+    body:
+      encoding: UTF-8
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk",
+        oauth_nonce="WEw4MjJwLkyJQ8Niz71AjShnkOVShUjLk1bIvUig", oauth_signature="Ru2as7LmbMq3798HNa%2BTGsLKtII%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1543813900", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 1919d6bd-0d48-4d11-92d8-678358cbdc60
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:11:39 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNToxMTozOSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6MTE6NDArMDAwMCIsInV1aWQiOiI0MDI4Zjk2
+        NjY3NzE5NTdkMDE2NzcyN2FhOWJmMDAyMiIsImlkIjoiN2M4MjUwMTNjYWIw
+        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
+        dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
+        IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
+        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOTY2Njc3MTk1N2QwMTY3NzI3YWE5YmYw
+        MDIyIiwicHJvZHVjdENvbnRlbnQiOlt7ImNvbnRlbnQiOnsiY3JlYXRlZCI6
+        IjIwMTgtMTItMDNUMDU6MTE6NDArMDAwMCIsInVwZGF0ZWQiOiIyMDE4LTEy
+        LTAzVDA1OjExOjQwKzAwMDAiLCJ1dWlkIjoiNDAyOGY5NjY2NzcxOTU3ZDAx
+        Njc3MjdhYTk3NDAwMjEiLCJpZCI6IjE1NDM4MTM5MDA2NjciLCJ0eXBlIjoi
+        eXVtIiwibGFiZWwiOiJzY2VuYXJpb190ZXN0X1NjZW5hcmlvX1Byb2R1Y3Rf
+        U2NlbmFyaW9feXVtX3Byb2R1Y3QiLCJuYW1lIjoiU2NlbmFyaW8geXVtIHBy
+        b2R1Y3QiLCJ2ZW5kb3IiOiJDdXN0b20iLCJjb250ZW50VXJsIjoiL2N1c3Rv
+        bS9TY2VuYXJpb19Qcm9kdWN0L1NjZW5hcmlvX3l1bV9wcm9kdWN0IiwicmVx
+        dWlyZWRUYWdzIjpudWxsLCJncGdVcmwiOm51bGwsIm1vZGlmaWVkUHJvZHVj
+        dElkcyI6W10sImFyY2hlcyI6bnVsbCwicmVxdWlyZWRQcm9kdWN0SWRzIjpb
+        XSwibWV0YWRhdGFFeHBpcmUiOjEsInJlbGVhc2VWZXIiOm51bGx9LCJlbmFi
+        bGVkIjp0cnVlfV19
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:11:40 GMT
+- request:
+    method: post
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/environments/d80a5783c502f0f969e23089437bb7ce/content
+    body:
+      encoding: UTF-8
+      base64_string: 'W3siY29udGVudElkIjoiMTU0MzgxMzkwMDY2NyJ9XQ==
+
+'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk",
+        oauth_nonce="AOwrXA9gJickUo4phF0ZoKt3Ki0tt0aS2NAVdpBfj8", oauth_signature="7n%2F3lJGnOW573P2zIOOUmS2ZQkE%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1543813900", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '31'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - a56de2b1-9c5e-48e5-9277-ed2951371437
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:11:39 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNToxMTo0MCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6MTE6NDArMDAwMCIsImlkIjoicmVnZW5fZW50
+        aXRsZW1lbnRfY2VydF9vZl9lbnY5ZjFhZjZkYy0wYzQxLTQyMmYtYjZlYi03
+        MzhkZjJmNTFlMWIiLCJzdGF0ZSI6IkNSRUFURUQiLCJzdGFydFRpbWUiOm51
+        bGwsImZpbmlzaFRpbWUiOm51bGwsInJlc3VsdCI6bnVsbCwicHJpbmNpcGFs
+        TmFtZSI6ImZvcmVtYW5fYWRtaW4iLCJ0YXJnZXRUeXBlIjpudWxsLCJ0YXJn
+        ZXRJZCI6bnVsbCwib3duZXJJZCI6bnVsbCwiY29ycmVsYXRpb25JZCI6bnVs
+        bCwicmVzdWx0RGF0YSI6bnVsbCwiZG9uZSI6ZmFsc2UsInN0YXR1c1BhdGgi
+        OiIvam9icy9yZWdlbl9lbnRpdGxlbWVudF9jZXJ0X29mX2VudjlmMWFmNmRj
+        LTBjNDEtNDIyZi1iNmViLTczOGRmMmY1MWUxYiIsImdyb3VwIjoiYXN5bmMg
+        Z3JvdXAifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:11:40 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/c88e0fe7-7b01-4a4e-ab1a-4d6702a0a6c8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:11:41 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"b09035b323178caa61711314feb3aa33-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '553'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9jODhlMGZlNy03YjAxLTRhNGUtYWIxYS00ZDY3
+        MDJhMGE2YzgvIiwgInRhc2tfaWQiOiAiYzg4ZTBmZTctN2IwMS00YTRlLWFi
+        MWEtNGQ2NzAyYTBhNmM4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIiIsICJz
+        dGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWMw
+        NGJiMGM0OThlZGI4MjU1YmIxN2ZlIn0sICJpZCI6ICI1YzA0YmIwYzQ5OGVk
+        YjgyNTViYjE3ZmUifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:11:41 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/c88e0fe7-7b01-4a4e-ab1a-4d6702a0a6c8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:11:41 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"cc9aa1af58af899ca85dafba74978565-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4314'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9jODhlMGZlNy03YjAxLTRhNGUtYWIxYS00ZDY3
+        MDJhMGE2YzgvIiwgInRhc2tfaWQiOiAiYzg4ZTBmZTctN2IwMS00YTRlLWFi
+        MWEtNGQ2NzAyYTBhNmM4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MTE6NDFaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogImMzZjA1OGIzLTdkNjMtNDU5MS1hNWQ1LTI5MzU0MTk1YzFlOSIs
+        ICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
+        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAi
+        c3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICI4NTViOGM2Ni03YWQ5LTQzMjAtYWE1Yi1jMWE4ODU4Njk3YjciLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIzNmRiOTczNS03NDMzLTQ4NTUtOGVjMC0x
+        OWUyYjEyZjBiNzEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBN
+        cyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        MGEzNTNjZGMtNTMxYy00N2M2LWIzNmUtZGQ0ZmQwYTgxMGZhIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImQzMWEyNWFmLTdlYzctNGUxNS1hZTA0
+        LTVlYjRmMTdmMGQ3YyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVz
+        IiwgInN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        ImQzM2FkNGJiLWFiMWYtNGVhOC1iZDQyLWUyZjNhOGZiY2M3NyIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJj
+        b21wcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNzgxY2UxZi1jYjgyLTRmZjkt
+        OWU3YS1kZGUyMWI3YzM5MTIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0
+        YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICIzYjNjYjA0OC02OTlmLTQzNjItYmY0OS0wZDhkYmMxNDFmNDQi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJlZDUxZjEyMy0xNmFjLTRlMTUtOGE0Zi0zNTUwOGM2NmUzMjAiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMWFjZDFl
+        NDktNjQ1YS00N2EwLTgxNTctMWNmYzNiMzAyZjdjIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJS
+        ZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9v
+        bGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzUxZTc4M2UtYWM2
+        OS00ODJjLWJiYWQtZDBlZWFiZmM5OGM0IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
+        aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImVhYzk3MTQwLWUyOGQtNGEwZi04YWYyLWNhNmU5
+        MGQwNTJhMiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIi
+        LCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3Rv
+        dGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImM5ZTVjNTRhLTQxNDEtNDEzNS04YjZmLWNjODc4MjMyODg2
+        OCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
+        ZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBf
+        dHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiM2Q2NDNkZjEtOTExOS00NDI3LTkxNzYtYzQ4MjY0MzZmZjIy
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBs
+        ZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIu
+        c2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YmIwYzQ5OGVkYjgyNTViYjE3
+        ZmUifSwgImlkIjogIjVjMDRiYjBjNDk4ZWRiODI1NWJiMTdmZSJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:11:41 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/c88e0fe7-7b01-4a4e-ab1a-4d6702a0a6c8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:11:41 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"6a219a8b56a757a25c67f130ca352531-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4298'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9jODhlMGZlNy03YjAxLTRhNGUtYWIxYS00ZDY3
+        MDJhMGE2YzgvIiwgInRhc2tfaWQiOiAiYzg4ZTBmZTctN2IwMS00YTRlLWFi
+        MWEtNGQ2NzAyYTBhNmM4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MTE6NDFaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImMzZjA1OGIzLTdkNjMtNDU5MS1hNWQ1LTI5MzU0MTk1YzFlOSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4NTVi
+        OGM2Ni03YWQ5LTQzMjAtYWE1Yi1jMWE4ODU4Njk3YjciLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIzNmRiOTczNS03NDMzLTQ4NTUtOGVjMC0xOWUyYjEyZjBi
+        NzEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYTM1M2NkYy01MzFj
+        LTQ3YzYtYjM2ZS1kZDRmZDBhODEwZmEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiZDMxYTI1YWYtN2VjNy00ZTE1LWFlMDQtNWViNGYxN2YwZDdjIiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiSU5fUFJP
+        R1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDMzYWQ0YmItYWIxZi00
+        ZWE4LWJkNDItZTJmM2E4ZmJjYzc3IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
+        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
+        IENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3Rv
+        dGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjA3ODFjZTFmLWNiODItNGZmOS05ZTdhLWRkZTIxYjdjMzkx
+        MiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90
+        eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNiM2NiMDQ4
+        LTY5OWYtNDM2Mi1iZjQ5LTBkOGRiYzE0MWY0NCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xv
+        c2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVkNTFmMTIzLTE2YWMt
+        NGUxNS04YTRmLTM1NTA4YzY2ZTMyMCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
+        ZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0
+        ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxYWNkMWU0OS02NDVhLTQ3YTAtODE1
+        Ny0xY2ZjM2IzMDJmN2MiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBv
+        ZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICIzNTFlNzgzZS1hYzY5LTQ4MmMtYmJhZC1kMGVl
+        YWJmYzk4YzQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIs
+        ICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        ZWFjOTcxNDAtZTI4ZC00YTBmLThhZjItY2E2ZTkwZDA1MmEyIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAi
+        cHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzllNWM1
+        NGEtNDE0MS00MTM1LThiNmYtY2M4NzgyMzI4ODY4IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJX
+        cml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxp
+        emVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzZDY0M2Rm
+        MS05MTE5LTQ0MjctOTE3Ni1jNDgyNjQzNmZmMjIiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3Rh
+        dGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNv
+        bSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjVjMDRiYjBjNDk4ZWRiODI1NWJiMTdmZSJ9LCAiaWQiOiAiNWMw
+        NGJiMGM0OThlZGI4MjU1YmIxN2ZlIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:11:41 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/c88e0fe7-7b01-4a4e-ab1a-4d6702a0a6c8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:11:41 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"e43fd0e27778fc450edf45dc2e0446a6-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4282'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9jODhlMGZlNy03YjAxLTRhNGUtYWIxYS00ZDY3
+        MDJhMGE2YzgvIiwgInRhc2tfaWQiOiAiYzg4ZTBmZTctN2IwMS00YTRlLWFi
+        MWEtNGQ2NzAyYTBhNmM4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MTE6NDFaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImMzZjA1OGIzLTdkNjMtNDU5MS1hNWQ1LTI5MzU0MTk1YzFlOSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4NTVi
+        OGM2Ni03YWQ5LTQzMjAtYWE1Yi1jMWE4ODU4Njk3YjciLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIzNmRiOTczNS03NDMzLTQ4NTUtOGVjMC0xOWUyYjEyZjBi
+        NzEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYTM1M2NkYy01MzFj
+        LTQ3YzYtYjM2ZS1kZDRmZDBhODEwZmEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiZDMxYTI1YWYtN2VjNy00ZTE1LWFlMDQtNWViNGYxN2YwZDdjIiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDMzYWQ0YmItYWIxZi00ZWE4
+        LWJkNDItZTJmM2E4ZmJjYzc3IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
+        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjA3ODFjZTFmLWNiODItNGZmOS05ZTdhLWRkZTIxYjdjMzkxMiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
+        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNiM2NiMDQ4LTY5OWYtNDM2
+        Mi1iZjQ5LTBkOGRiYzE0MWY0NCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
+        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImVkNTFmMTIzLTE2YWMtNGUxNS04YTRmLTM1
+        NTA4YzY2ZTMyMCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjFhY2QxZTQ5LTY0NWEtNDdhMC04MTU3LTFjZmMzYjMwMmY3YyIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjM1MWU3ODNlLWFjNjktNDgyYy1iYmFkLWQwZWVhYmZjOThjNCIsICJudW1f
+        cHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJy
+        ZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RB
+        UlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlYWM5NzE0MC1lMjhkLTRh
+        MGYtOGFmMi1jYTZlOTBkMDUyYTIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
+        ZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9y
+        eSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjOWU1YzU0YS00MTQxLTQxMzUtOGI2
+        Zi1jYzg3ODIzMjg4NjgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3Mg
+        RmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjNkNjQzZGYxLTkxMTktNDQyNy05MTc2
+        LWM0ODI2NDM2ZmYyMiIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVl
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwy
+        LnNhbWlyLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNl
+        bnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWMwNGJiMGM0
+        OThlZGI4MjU1YmIxN2ZlIn0sICJpZCI6ICI1YzA0YmIwYzQ5OGVkYjgyNTVi
+        YjE3ZmUifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:11:41 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/c88e0fe7-7b01-4a4e-ab1a-4d6702a0a6c8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:11:41 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"020bdffe5abd9da387d594a9e04e049c-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4269'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9jODhlMGZlNy03YjAxLTRhNGUtYWIxYS00ZDY3
+        MDJhMGE2YzgvIiwgInRhc2tfaWQiOiAiYzg4ZTBmZTctN2IwMS00YTRlLWFi
+        MWEtNGQ2NzAyYTBhNmM4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MTE6NDFaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImMzZjA1OGIzLTdkNjMtNDU5MS1hNWQ1LTI5MzU0MTk1YzFlOSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4NTVi
+        OGM2Ni03YWQ5LTQzMjAtYWE1Yi1jMWE4ODU4Njk3YjciLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIzNmRiOTczNS03NDMzLTQ4NTUtOGVjMC0xOWUyYjEyZjBi
+        NzEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYTM1M2NkYy01MzFj
+        LTQ3YzYtYjM2ZS1kZDRmZDBhODEwZmEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiZDMxYTI1YWYtN2VjNy00ZTE1LWFlMDQtNWViNGYxN2YwZDdjIiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDMzYWQ0YmItYWIxZi00ZWE4
+        LWJkNDItZTJmM2E4ZmJjYzc3IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
+        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjA3ODFjZTFmLWNiODItNGZmOS05ZTdhLWRkZTIxYjdjMzkxMiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
+        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNiM2NiMDQ4LTY5OWYtNDM2
+        Mi1iZjQ5LTBkOGRiYzE0MWY0NCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
+        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImVkNTFmMTIzLTE2YWMtNGUxNS04YTRmLTM1
+        NTA4YzY2ZTMyMCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjFhY2QxZTQ5LTY0NWEtNDdhMC04MTU3LTFjZmMzYjMwMmY3YyIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM1
+        MWU3ODNlLWFjNjktNDgyYy1iYmFkLWQwZWVhYmZjOThjNCIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBv
+        dmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImVhYzk3MTQwLWUyOGQtNGEwZi04YWYy
+        LWNhNmU5MGQwNTJhMiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0
+        byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImM5ZTVjNTRhLTQxNDEtNDEzNS04YjZmLWNjODc4MjMy
+        ODg2OCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0
+        ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiM2Q2NDNkZjEtOTExOS00NDI3LTkxNzYtYzQ4MjY0MzZmZjIy
+        IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAicXVldWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBs
+        ZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIu
+        c2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YmIwYzQ5OGVkYjgyNTViYjE3
+        ZmUifSwgImlkIjogIjVjMDRiYjBjNDk4ZWRiODI1NWJiMTdmZSJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:11:41 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/c88e0fe7-7b01-4a4e-ab1a-4d6702a0a6c8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:11:41 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"fc4a958a9b97d2782a6948c1dd9f3f26-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '8549'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9jODhlMGZlNy03YjAxLTRhNGUtYWIxYS00ZDY3
+        MDJhMGE2YzgvIiwgInRhc2tfaWQiOiAiYzg4ZTBmZTctN2IwMS00YTRlLWFi
+        MWEtNGQ2NzAyYTBhNmM4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTgtMTItMDNUMDU6MTE6NDFaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MTE6NDFa
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
+        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
+        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImMzZjA1OGIzLTdkNjMtNDU5MS1hNWQ1
+        LTI5MzU0MTk1YzFlOSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
+        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICI4NTViOGM2Ni03YWQ5LTQzMjAtYWE1Yi1jMWE4ODU4
+        Njk3YjciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
+        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzNmRiOTczNS03NDMzLTQ4
+        NTUtOGVjMC0xOWUyYjEyZjBiNzEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
+        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICIwYTM1M2NkYy01MzFjLTQ3YzYtYjM2ZS1kZDRmZDBhODEwZmEiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
+        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDMxYTI1YWYtN2VjNy00ZTE1LWFl
+        MDQtNWViNGYxN2YwZDdjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVs
+        ZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        ZDMzYWQ0YmItYWIxZi00ZWE4LWJkNDItZTJmM2E4ZmJjYzc3IiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNv
+        bXBzIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjA3ODFjZTFmLWNiODItNGZmOS05ZTdh
+        LWRkZTIxYjdjMzkxMiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0
+        YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjNiM2NiMDQ4LTY5OWYtNDM2Mi1iZjQ5LTBkOGRiYzE0MWY0NCIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRp
+        b24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJj
+        bG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVkNTFmMTIz
+        LTE2YWMtNGUxNS04YTRmLTM1NTA4YzY2ZTMyMCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
+        ZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRl
+        IHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjFhY2QxZTQ5LTY0NWEtNDdhMC04
+        MTU3LTFjZmMzYjMwMmY3YyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJl
+        cG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjM1MWU3ODNlLWFjNjktNDgyYy1iYmFkLWQwZWVh
+        YmZjOThjNCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwg
+        InN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVhYzk3
+        MTQwLWUyOGQtNGEwZi04YWYyLWNhNmU5MGQwNTJhMiIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        UHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxp
+        c2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM5ZTVjNTRhLTQxNDEt
+        NDEzNS04YjZmLWNjODc4MjMyODg2OCIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBM
+        aXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9f
+        bWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2Q2NDNkZjEtOTExOS00NDI3
+        LTkxNzYtYzQ4MjY0MzZmZjIyIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
+        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlz
+        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwg
+        InJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJzdGFydGVkIjogIjIwMTgt
+        MTItMDNUMDU6MTE6NDFaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0
+        cyIsICJjb21wbGV0ZWQiOiAiMjAxOC0xMi0wM1QwNToxMTo0MVoiLCAidHJh
+        Y2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Rp
+        c3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7ImdlbmVyYXRlIHNxbGl0ZSI6ICJT
+        S0lQUEVEIiwgInJwbXMiOiAiRklOSVNIRUQiLCAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIjogIkZJTklTSEVEIiwgInJlbW92ZV9vbGRfcmVwb2RhdGEi
+        OiAiRklOSVNIRUQiLCAibW9kdWxlcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9y
+        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQi
+        LCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklT
+        SEVEIiwgInJlcG92aWV3IjogIlNLSVBQRUQiLCAicHVibGlzaF9kaXJlY3Rv
+        cnkiOiAiRklOSVNIRUQiLCAiZXJyYXRhIjogIkZJTklTSEVEIiwgIm1ldGFk
+        YXRhIjogIkZJTklTSEVEIn0sICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImRp
+        c3RyaWJ1dG9yX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAiaWQiOiAiNWMwNGJi
+        MGQwNWY1ZWUwNWMzZmQ4NDVkIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2Vz
+        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRh
+        ZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImMzZjA1OGIzLTdkNjMtNDU5MS1hNWQ1LTI5
+        MzU0MTk1YzFlOSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRp
+        b24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI4NTViOGM2Ni03YWQ5LTQzMjAtYWE1Yi1jMWE4ODU4Njk3
+        YjciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUi
+        OiAicnBtcyIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzNmRiOTczNS03NDMzLTQ4NTUt
+        OGVjMC0xOWUyYjEyZjBiNzEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVs
+        dGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICIwYTM1M2NkYy01MzFjLTQ3YzYtYjM2ZS1kZDRmZDBhODEwZmEiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZDMxYTI1YWYtN2VjNy00ZTE1LWFlMDQt
+        NWViNGYxN2YwZDdjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMi
+        LCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDMz
+        YWQ0YmItYWIxZi00ZWE4LWJkNDItZTJmM2E4ZmJjYzc3IiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBz
+        IiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjA3ODFjZTFmLWNiODItNGZmOS05ZTdhLWRk
+        ZTIxYjdjMzkxMiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4i
+        LCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNi
+        M2NiMDQ4LTY5OWYtNDM2Mi1iZjQ5LTBkOGRiYzE0MWY0NCIsICJudW1fcHJv
+        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
+        OiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9z
+        ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVkNTFmMTIzLTE2
+        YWMtNGUxNS04YTRmLTM1NTA4YzY2ZTMyMCIsICJudW1fcHJvY2Vzc2VkIjog
+        MX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
+        dGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNx
+        bGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjFhY2QxZTQ5LTY0NWEtNDdhMC04MTU3
+        LTFjZmMzYjMwMmY3YyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9k
+        YXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjM1MWU3ODNlLWFjNjktNDgyYy1iYmFkLWQwZWVhYmZj
+        OThjNCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0
+        ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVhYzk3MTQw
+        LWUyOGQtNGEwZi04YWYyLWNhNmU5MGQwNTJhMiIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM5ZTVjNTRhLTQxNDEtNDEz
+        NS04YjZmLWNjODc4MjMyODg2OCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2Q2NDNkZjEtOTExOS00NDI3LTkx
+        NzYtYzQ4MjY0MzZmZjIyIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiYjBjNDk4ZWRiODI1
+        NWJiMTdmZSJ9LCAiaWQiOiAiNWMwNGJiMGM0OThlZGI4MjU1YmIxN2ZlIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:11:41 GMT
+- request:
+    method: post
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/content/1543814606224?enabled=true
+    body:
+      encoding: UTF-8
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk",
+        oauth_nonce="9mtkTJFEZkEgwSx6GhhplTmP7DHyBkYDo7FO7l7swa4", oauth_signature="H18GKf4N2lJlSD%2BY60HjOBOj%2BBk%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1543814606", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 8c21f732-8ca6-4d23-97f3-6d1944ec5784
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:23:25 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNToyMzoyNSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6MjM6MjYrMDAwMCIsInV1aWQiOiI0MDI4Zjk2
+        NjY3NzE5NTdkMDE2NzcyODU2ZGNjMDAyZiIsImlkIjoiN2M4MjUwMTNjYWIw
+        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
+        dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
+        IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
+        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOTY2Njc3MTk1N2QwMTY3NzI4NTZkY2Mw
+        MDJmIiwicHJvZHVjdENvbnRlbnQiOlt7ImNvbnRlbnQiOnsiY3JlYXRlZCI6
+        IjIwMTgtMTItMDNUMDU6MjM6MjYrMDAwMCIsInVwZGF0ZWQiOiIyMDE4LTEy
+        LTAzVDA1OjIzOjI2KzAwMDAiLCJ1dWlkIjoiNDAyOGY5NjY2NzcxOTU3ZDAx
+        Njc3Mjg1NmQ4NTAwMmUiLCJpZCI6IjE1NDM4MTQ2MDYyMjQiLCJ0eXBlIjoi
+        eXVtIiwibGFiZWwiOiJzY2VuYXJpb190ZXN0X1NjZW5hcmlvX1Byb2R1Y3Rf
+        U2NlbmFyaW9feXVtX3Byb2R1Y3QiLCJuYW1lIjoiU2NlbmFyaW8geXVtIHBy
+        b2R1Y3QiLCJ2ZW5kb3IiOiJDdXN0b20iLCJjb250ZW50VXJsIjoiL2N1c3Rv
+        bS9TY2VuYXJpb19Qcm9kdWN0L1NjZW5hcmlvX3l1bV9wcm9kdWN0IiwicmVx
+        dWlyZWRUYWdzIjpudWxsLCJncGdVcmwiOm51bGwsIm1vZGlmaWVkUHJvZHVj
+        dElkcyI6W10sImFyY2hlcyI6bnVsbCwicmVxdWlyZWRQcm9kdWN0SWRzIjpb
+        XSwibWV0YWRhdGFFeHBpcmUiOjEsInJlbGVhc2VWZXIiOm51bGx9LCJlbmFi
+        bGVkIjp0cnVlfV19
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:26 GMT
+- request:
+    method: post
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/environments/d80a5783c502f0f969e23089437bb7ce/content
+    body:
+      encoding: UTF-8
+      base64_string: 'W3siY29udGVudElkIjoiMTU0MzgxNDYwNjIyNCJ9XQ==
+
+'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk",
+        oauth_nonce="eyAK24asHrZjGhBCqCUqL7ksdtFbrjYem4kb7FlYus", oauth_signature="GoriaTllvUVPAamI1vSBYxtkaC8%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1543814606", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '31'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 62238f9f-bb0a-42bd-b0c1-110e09ea27ad
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:23:25 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNToyMzoyNiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6MjM6MjYrMDAwMCIsImlkIjoicmVnZW5fZW50
+        aXRsZW1lbnRfY2VydF9vZl9lbnZhODYwMjY0MS05ZDg4LTRlNDgtYWNkNC05
+        M2MwMTY5MGFmMmQiLCJzdGF0ZSI6IkNSRUFURUQiLCJzdGFydFRpbWUiOm51
+        bGwsImZpbmlzaFRpbWUiOm51bGwsInJlc3VsdCI6bnVsbCwicHJpbmNpcGFs
+        TmFtZSI6ImZvcmVtYW5fYWRtaW4iLCJ0YXJnZXRUeXBlIjpudWxsLCJ0YXJn
+        ZXRJZCI6bnVsbCwib3duZXJJZCI6bnVsbCwiY29ycmVsYXRpb25JZCI6bnVs
+        bCwicmVzdWx0RGF0YSI6bnVsbCwiZG9uZSI6ZmFsc2UsInN0YXR1c1BhdGgi
+        OiIvam9icy9yZWdlbl9lbnRpdGxlbWVudF9jZXJ0X29mX2VudmE4NjAyNjQx
+        LTlkODgtNGU0OC1hY2Q0LTkzYzAxNjkwYWYyZCIsImdyb3VwIjoiYXN5bmMg
+        Z3JvdXAifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:26 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/670204b8-370e-47e5-a6bd-86f7c74ec77d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"245edf2edcf91ca019ff1543a5313a4d-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '553'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy82NzAyMDRiOC0zNzBlLTQ3ZTUtYTZiZC04NmY3
+        Yzc0ZWM3N2QvIiwgInRhc2tfaWQiOiAiNjcwMjA0YjgtMzcwZS00N2U1LWE2
+        YmQtODZmN2M3NGVjNzdkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIiIsICJz
+        dGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWMw
+        NGJkY2U0OThlZGI4MjU1YmIyODViIn0sICJpZCI6ICI1YzA0YmRjZTQ5OGVk
+        YjgyNTViYjI4NWIifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:26 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/670204b8-370e-47e5-a6bd-86f7c74ec77d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"00452642777eb3da0d6287e924b52560-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4314'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy82NzAyMDRiOC0zNzBlLTQ3ZTUtYTZiZC04NmY3
+        Yzc0ZWM3N2QvIiwgInRhc2tfaWQiOiAiNjcwMjA0YjgtMzcwZS00N2U1LWE2
+        YmQtODZmN2M3NGVjNzdkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MjM6MjZaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogImE4MzViOTMyLTcwZDItNGQyZS05MTBhLWRhYWMzNmNhNTQ1MCIs
+        ICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
+        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAi
+        c3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICIxOThkMGU2Ni0wNzYzLTQ1NTMtYmQxYi1hODljNDE2YmI2Y2MiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI5OTEyYzZjYy03NmVhLTQwYzQtYTJjZC0x
+        MjJkNmI1MTNlMTUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBN
+        cyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        NTU0NTc5ZGYtMDJjYS00YjIyLThlMDctMDI1Y2JlZDZkZWI2IiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImI2N2ZhNDFlLTUwYjMtNGRkNi04ODE3
+        LWM3MTdhODkzYjViNyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVz
+        IiwgInN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        ImU4N2FhNTZhLTUxYmQtNGM5MS1hNDhhLTBiMWNkN2I3MmVhMSIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJj
+        b21wcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkMDA0YjZjYy1iMjUzLTQ0Njct
+        OThlZi1mMmJmOWJhMDZjZmMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0
+        YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI4ZmZlMDRiOC1jNDU2LTQxN2YtODE0Yy0yMjBlMTczMGNhMTYi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJiYWFiYTliNC1lMDkyLTQwNDItOGRiMC0zNmE0NWY4ZTliZTEiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTY1NjIw
+        YjctZDI5OS00OTA5LTg3MDQtYmVmMGIwYmE4OTRhIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJS
+        ZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9v
+        bGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTU2YTQzYzItZDIx
+        MS00YjYxLWEyZDYtZTIzMjUyZjgxNzdiIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
+        aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImE1NDA2NTFjLTZlNGQtNDVlNy1hMjhhLWQ1ZDhi
+        ZjljZTNiMCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIi
+        LCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3Rv
+        dGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImMwMjBlMjI4LTliM2UtNDVkOC05OTZlLTk5Y2M5MTFkMjg5
+        ZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
+        ZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBf
+        dHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiMDhjNGY5NjAtN2ZkYy00NjA1LWFkNWMtYTI5MDcxNGRjMjli
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBs
+        ZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIu
+        c2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YmRjZTQ5OGVkYjgyNTViYjI4
+        NWIifSwgImlkIjogIjVjMDRiZGNlNDk4ZWRiODI1NWJiMjg1YiJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:26 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/670204b8-370e-47e5-a6bd-86f7c74ec77d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"e718ad675b4e4db333e7d5de514acdc0-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4298'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy82NzAyMDRiOC0zNzBlLTQ3ZTUtYTZiZC04NmY3
+        Yzc0ZWM3N2QvIiwgInRhc2tfaWQiOiAiNjcwMjA0YjgtMzcwZS00N2U1LWE2
+        YmQtODZmN2M3NGVjNzdkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MjM6MjZaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImE4MzViOTMyLTcwZDItNGQyZS05MTBhLWRhYWMzNmNhNTQ1MCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxOThk
+        MGU2Ni0wNzYzLTQ1NTMtYmQxYi1hODljNDE2YmI2Y2MiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI5OTEyYzZjYy03NmVhLTQwYzQtYTJjZC0xMjJkNmI1MTNl
+        MTUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1NTQ1NzlkZi0wMmNh
+        LTRiMjItOGUwNy0wMjVjYmVkNmRlYjYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiYjY3ZmE0MWUtNTBiMy00ZGQ2LTg4MTctYzcxN2E4OTNiNWI3Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiSU5fUFJP
+        R1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTg3YWE1NmEtNTFiZC00
+        YzkxLWE0OGEtMGIxY2Q3YjcyZWExIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
+        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
+        IENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3Rv
+        dGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImQwMDRiNmNjLWIyNTMtNDQ2Ny05OGVmLWYyYmY5YmEwNmNm
+        YyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90
+        eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjhmZmUwNGI4
+        LWM0NTYtNDE3Zi04MTRjLTIyMGUxNzMwY2ExNiIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xv
+        c2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJhYWJhOWI0LWUwOTIt
+        NDA0Mi04ZGIwLTM2YTQ1ZjhlOWJlMSIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
+        ZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0
+        ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNjU2MjBiNy1kMjk5LTQ5MDktODcw
+        NC1iZWYwYjBiYTg5NGEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBv
+        ZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICIxNTZhNDNjMi1kMjExLTRiNjEtYTJkNi1lMjMy
+        NTJmODE3N2IiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIs
+        ICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        YTU0MDY1MWMtNmU0ZC00NWU3LWEyOGEtZDVkOGJmOWNlM2IwIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAi
+        cHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzAyMGUy
+        MjgtOWIzZS00NWQ4LTk5NmUtOTljYzkxMWQyODlmIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJX
+        cml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxp
+        emVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwOGM0Zjk2
+        MC03ZmRjLTQ2MDUtYWQ1Yy1hMjkwNzE0ZGMyOWIiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3Rh
+        dGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNv
+        bSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjVjMDRiZGNlNDk4ZWRiODI1NWJiMjg1YiJ9LCAiaWQiOiAiNWMw
+        NGJkY2U0OThlZGI4MjU1YmIyODViIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:26 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/670204b8-370e-47e5-a6bd-86f7c74ec77d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"28f12db517dfa01616f59d41c91a4ef9-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4275'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy82NzAyMDRiOC0zNzBlLTQ3ZTUtYTZiZC04NmY3
+        Yzc0ZWM3N2QvIiwgInRhc2tfaWQiOiAiNjcwMjA0YjgtMzcwZS00N2U1LWE2
+        YmQtODZmN2M3NGVjNzdkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MjM6MjZaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImE4MzViOTMyLTcwZDItNGQyZS05MTBhLWRhYWMzNmNhNTQ1MCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxOThk
+        MGU2Ni0wNzYzLTQ1NTMtYmQxYi1hODljNDE2YmI2Y2MiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI5OTEyYzZjYy03NmVhLTQwYzQtYTJjZC0xMjJkNmI1MTNl
+        MTUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1NTQ1NzlkZi0wMmNh
+        LTRiMjItOGUwNy0wMjVjYmVkNmRlYjYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiYjY3ZmE0MWUtNTBiMy00ZGQ2LTg4MTctYzcxN2E4OTNiNWI3Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTg3YWE1NmEtNTFiZC00Yzkx
+        LWE0OGEtMGIxY2Q3YjcyZWExIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
+        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImQwMDRiNmNjLWIyNTMtNDQ2Ny05OGVmLWYyYmY5YmEwNmNmYyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
+        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjhmZmUwNGI4LWM0NTYtNDE3
+        Zi04MTRjLTIyMGUxNzMwY2ExNiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
+        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImJhYWJhOWI0LWUwOTItNDA0Mi04ZGIwLTM2
+        YTQ1ZjhlOWJlMSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjE2NTYyMGI3LWQyOTktNDkwOS04NzA0LWJlZjBiMGJhODk0YSIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE1
+        NmE0M2MyLWQyMTEtNGI2MS1hMmQ2LWUyMzI1MmY4MTc3YiIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBv
+        dmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImE1NDA2NTFjLTZlNGQtNDVlNy1hMjhh
+        LWQ1ZDhiZjljZTNiMCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0
+        byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImMwMjBlMjI4LTliM2UtNDVkOC05OTZlLTk5Y2M5
+        MTFkMjg5ZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiMDhjNGY5NjAtN2ZkYy00NjA1LWFkNWMtYTI5MDcx
+        NGRjMjliIiwgIm51bV9wcm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2Vy
+        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
+        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YmRjZTQ5OGVkYjgy
+        NTViYjI4NWIifSwgImlkIjogIjVjMDRiZGNlNDk4ZWRiODI1NWJiMjg1YiJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:26 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/670204b8-370e-47e5-a6bd-86f7c74ec77d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"a2ad81a906dc9c6d83b55c1370822536-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4269'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy82NzAyMDRiOC0zNzBlLTQ3ZTUtYTZiZC04NmY3
+        Yzc0ZWM3N2QvIiwgInRhc2tfaWQiOiAiNjcwMjA0YjgtMzcwZS00N2U1LWE2
+        YmQtODZmN2M3NGVjNzdkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MjM6MjZaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImE4MzViOTMyLTcwZDItNGQyZS05MTBhLWRhYWMzNmNhNTQ1MCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxOThk
+        MGU2Ni0wNzYzLTQ1NTMtYmQxYi1hODljNDE2YmI2Y2MiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI5OTEyYzZjYy03NmVhLTQwYzQtYTJjZC0xMjJkNmI1MTNl
+        MTUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1NTQ1NzlkZi0wMmNh
+        LTRiMjItOGUwNy0wMjVjYmVkNmRlYjYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiYjY3ZmE0MWUtNTBiMy00ZGQ2LTg4MTctYzcxN2E4OTNiNWI3Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTg3YWE1NmEtNTFiZC00Yzkx
+        LWE0OGEtMGIxY2Q3YjcyZWExIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
+        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImQwMDRiNmNjLWIyNTMtNDQ2Ny05OGVmLWYyYmY5YmEwNmNmYyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
+        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjhmZmUwNGI4LWM0NTYtNDE3
+        Zi04MTRjLTIyMGUxNzMwY2ExNiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
+        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImJhYWJhOWI0LWUwOTItNDA0Mi04ZGIwLTM2
+        YTQ1ZjhlOWJlMSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjE2NTYyMGI3LWQyOTktNDkwOS04NzA0LWJlZjBiMGJhODk0YSIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE1
+        NmE0M2MyLWQyMTEtNGI2MS1hMmQ2LWUyMzI1MmY4MTc3YiIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBv
+        dmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImE1NDA2NTFjLTZlNGQtNDVlNy1hMjhh
+        LWQ1ZDhiZjljZTNiMCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0
+        byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImMwMjBlMjI4LTliM2UtNDVkOC05OTZlLTk5Y2M5MTFk
+        Mjg5ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0
+        ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiMDhjNGY5NjAtN2ZkYy00NjA1LWFkNWMtYTI5MDcxNGRjMjli
+        IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAicXVldWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBs
+        ZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIu
+        c2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YmRjZTQ5OGVkYjgyNTViYjI4
+        NWIifSwgImlkIjogIjVjMDRiZGNlNDk4ZWRiODI1NWJiMjg1YiJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:26 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/670204b8-370e-47e5-a6bd-86f7c74ec77d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:26 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"b77214f0ce4b8c2db9ad01fb5a23332e-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '8549'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy82NzAyMDRiOC0zNzBlLTQ3ZTUtYTZiZC04NmY3
+        Yzc0ZWM3N2QvIiwgInRhc2tfaWQiOiAiNjcwMjA0YjgtMzcwZS00N2U1LWE2
+        YmQtODZmN2M3NGVjNzdkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTgtMTItMDNUMDU6MjM6MjZaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MjM6MjZa
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
+        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
+        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImE4MzViOTMyLTcwZDItNGQyZS05MTBh
+        LWRhYWMzNmNhNTQ1MCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
+        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIxOThkMGU2Ni0wNzYzLTQ1NTMtYmQxYi1hODljNDE2
+        YmI2Y2MiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
+        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5OTEyYzZjYy03NmVhLTQw
+        YzQtYTJjZC0xMjJkNmI1MTNlMTUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
+        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICI1NTQ1NzlkZi0wMmNhLTRiMjItOGUwNy0wMjVjYmVkNmRlYjYiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
+        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjY3ZmE0MWUtNTBiMy00ZGQ2LTg4
+        MTctYzcxN2E4OTNiNWI3IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVs
+        ZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        ZTg3YWE1NmEtNTFiZC00YzkxLWE0OGEtMGIxY2Q3YjcyZWExIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNv
+        bXBzIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImQwMDRiNmNjLWIyNTMtNDQ2Ny05OGVm
+        LWYyYmY5YmEwNmNmYyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0
+        YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjhmZmUwNGI4LWM0NTYtNDE3Zi04MTRjLTIyMGUxNzMwY2ExNiIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRp
+        b24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJj
+        bG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJhYWJhOWI0
+        LWUwOTItNDA0Mi04ZGIwLTM2YTQ1ZjhlOWJlMSIsICJudW1fcHJvY2Vzc2Vk
+        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
+        ZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRl
+        IHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE2NTYyMGI3LWQyOTktNDkwOS04
+        NzA0LWJlZjBiMGJhODk0YSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJl
+        cG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjE1NmE0M2MyLWQyMTEtNGI2MS1hMmQ2LWUyMzI1
+        MmY4MTc3YiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwg
+        InN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE1NDA2
+        NTFjLTZlNGQtNDVlNy1hMjhhLWQ1ZDhiZjljZTNiMCIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        UHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxp
+        c2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImMwMjBlMjI4LTliM2Ut
+        NDVkOC05OTZlLTk5Y2M5MTFkMjg5ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBM
+        aXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9f
+        bWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDhjNGY5NjAtN2ZkYy00NjA1
+        LWFkNWMtYTI5MDcxNGRjMjliIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
+        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlz
+        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwg
+        InJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJzdGFydGVkIjogIjIwMTgt
+        MTItMDNUMDU6MjM6MjZaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0
+        cyIsICJjb21wbGV0ZWQiOiAiMjAxOC0xMi0wM1QwNToyMzoyNloiLCAidHJh
+        Y2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Rp
+        c3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7ImdlbmVyYXRlIHNxbGl0ZSI6ICJT
+        S0lQUEVEIiwgInJwbXMiOiAiRklOSVNIRUQiLCAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIjogIkZJTklTSEVEIiwgInJlbW92ZV9vbGRfcmVwb2RhdGEi
+        OiAiRklOSVNIRUQiLCAibW9kdWxlcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9y
+        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQi
+        LCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklT
+        SEVEIiwgInJlcG92aWV3IjogIlNLSVBQRUQiLCAicHVibGlzaF9kaXJlY3Rv
+        cnkiOiAiRklOSVNIRUQiLCAiZXJyYXRhIjogIkZJTklTSEVEIiwgIm1ldGFk
+        YXRhIjogIkZJTklTSEVEIn0sICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImRp
+        c3RyaWJ1dG9yX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAiaWQiOiAiNWMwNGJk
+        Y2UwNWY1ZWUwNWMzZmQ4NDc0IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2Vz
+        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRh
+        ZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImE4MzViOTMyLTcwZDItNGQyZS05MTBhLWRh
+        YWMzNmNhNTQ1MCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRp
+        b24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIxOThkMGU2Ni0wNzYzLTQ1NTMtYmQxYi1hODljNDE2YmI2
+        Y2MiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUi
+        OiAicnBtcyIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5OTEyYzZjYy03NmVhLTQwYzQt
+        YTJjZC0xMjJkNmI1MTNlMTUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVs
+        dGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICI1NTQ1NzlkZi0wMmNhLTRiMjItOGUwNy0wMjVjYmVkNmRlYjYiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiYjY3ZmE0MWUtNTBiMy00ZGQ2LTg4MTct
+        YzcxN2E4OTNiNWI3IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMi
+        LCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTg3
+        YWE1NmEtNTFiZC00YzkxLWE0OGEtMGIxY2Q3YjcyZWExIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBz
+        IiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImQwMDRiNmNjLWIyNTMtNDQ2Ny05OGVmLWYy
+        YmY5YmEwNmNmYyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4i
+        LCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjhm
+        ZmUwNGI4LWM0NTYtNDE3Zi04MTRjLTIyMGUxNzMwY2ExNiIsICJudW1fcHJv
+        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
+        OiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9z
+        ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJhYWJhOWI0LWUw
+        OTItNDA0Mi04ZGIwLTM2YTQ1ZjhlOWJlMSIsICJudW1fcHJvY2Vzc2VkIjog
+        MX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
+        dGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNx
+        bGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjE2NTYyMGI3LWQyOTktNDkwOS04NzA0
+        LWJlZjBiMGJhODk0YSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9k
+        YXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjE1NmE0M2MyLWQyMTEtNGI2MS1hMmQ2LWUyMzI1MmY4
+        MTc3YiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0
+        ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE1NDA2NTFj
+        LTZlNGQtNDVlNy1hMjhhLWQ1ZDhiZjljZTNiMCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImMwMjBlMjI4LTliM2UtNDVk
+        OC05OTZlLTk5Y2M5MTFkMjg5ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDhjNGY5NjAtN2ZkYy00NjA1LWFk
+        NWMtYTI5MDcxNGRjMjliIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZGNlNDk4ZWRiODI1
+        NWJiMjg1YiJ9LCAiaWQiOiAiNWMwNGJkY2U0OThlZGI4MjU1YmIyODViIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:26 GMT
+- request:
+    method: post
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/content/1543814738508?enabled=true
+    body:
+      encoding: UTF-8
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk",
+        oauth_nonce="TpB2joBuaWfkWZHs20JW4XOvHaZmCaiYUSPUeofMtA", oauth_signature="fIwyDV1pGpRSxrF5HKSYJhuxcrI%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1543814738", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - ef6b767b-0cc6-416b-80ff-106cc70f79ab
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:25:37 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNToyNTozNyswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6MjU6MzgrMDAwMCIsInV1aWQiOiI0MDI4Zjk2
+        NjY3NzE5NTdkMDE2NzcyODc3MjhiMDAzYyIsImlkIjoiN2M4MjUwMTNjYWIw
+        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
+        dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
+        IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
+        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOTY2Njc3MTk1N2QwMTY3NzI4NzcyOGIw
+        MDNjIiwicHJvZHVjdENvbnRlbnQiOlt7ImNvbnRlbnQiOnsiY3JlYXRlZCI6
+        IjIwMTgtMTItMDNUMDU6MjU6MzgrMDAwMCIsInVwZGF0ZWQiOiIyMDE4LTEy
+        LTAzVDA1OjI1OjM4KzAwMDAiLCJ1dWlkIjoiNDAyOGY5NjY2NzcxOTU3ZDAx
+        Njc3Mjg3NzI0MTAwM2IiLCJpZCI6IjE1NDM4MTQ3Mzg1MDgiLCJ0eXBlIjoi
+        eXVtIiwibGFiZWwiOiJzY2VuYXJpb190ZXN0X1NjZW5hcmlvX1Byb2R1Y3Rf
+        U2NlbmFyaW9feXVtX3Byb2R1Y3QiLCJuYW1lIjoiU2NlbmFyaW8geXVtIHBy
+        b2R1Y3QiLCJ2ZW5kb3IiOiJDdXN0b20iLCJjb250ZW50VXJsIjoiL2N1c3Rv
+        bS9TY2VuYXJpb19Qcm9kdWN0L1NjZW5hcmlvX3l1bV9wcm9kdWN0IiwicmVx
+        dWlyZWRUYWdzIjpudWxsLCJncGdVcmwiOm51bGwsIm1vZGlmaWVkUHJvZHVj
+        dElkcyI6W10sImFyY2hlcyI6bnVsbCwicmVxdWlyZWRQcm9kdWN0SWRzIjpb
+        XSwibWV0YWRhdGFFeHBpcmUiOjEsInJlbGVhc2VWZXIiOm51bGx9LCJlbmFi
+        bGVkIjp0cnVlfV19
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:25:38 GMT
+- request:
+    method: post
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/environments/d80a5783c502f0f969e23089437bb7ce/content
+    body:
+      encoding: UTF-8
+      base64_string: 'W3siY29udGVudElkIjoiMTU0MzgxNDczODUwOCJ9XQ==
+
+'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk",
+        oauth_nonce="rZi2Jqu9JUXYQBEo9cL3fdf9573AIX0FkTdGbU2iS4", oauth_signature="68deqEpd6k0H73otFYkVniCbGV8%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1543814738", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '31'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - c83b7c88-e534-40b2-8604-f601c74f12f2
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:25:37 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNToyNTozOCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6MjU6MzgrMDAwMCIsImlkIjoicmVnZW5fZW50
+        aXRsZW1lbnRfY2VydF9vZl9lbnYyODAwYmMyYS0zMTdmLTQ4NGItODZlNS1m
+        MTMxODBiZjZhNDAiLCJzdGF0ZSI6IkNSRUFURUQiLCJzdGFydFRpbWUiOm51
+        bGwsImZpbmlzaFRpbWUiOm51bGwsInJlc3VsdCI6bnVsbCwicHJpbmNpcGFs
+        TmFtZSI6ImZvcmVtYW5fYWRtaW4iLCJ0YXJnZXRUeXBlIjpudWxsLCJ0YXJn
+        ZXRJZCI6bnVsbCwib3duZXJJZCI6bnVsbCwiY29ycmVsYXRpb25JZCI6bnVs
+        bCwicmVzdWx0RGF0YSI6bnVsbCwiZG9uZSI6ZmFsc2UsInN0YXR1c1BhdGgi
+        OiIvam9icy9yZWdlbl9lbnRpdGxlbWVudF9jZXJ0X29mX2VudjI4MDBiYzJh
+        LTMxN2YtNDg0Yi04NmU1LWYxMzE4MGJmNmE0MCIsImdyb3VwIjoiYXN5bmMg
+        Z3JvdXAifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:25:38 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/dae6d237-c356-406c-8e8e-2c7ddf1e64e5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:25:38 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"63a864d9ddf14e28b9346a6e5556d1dd-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '553'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9kYWU2ZDIzNy1jMzU2LTQwNmMtOGU4ZS0yYzdk
+        ZGYxZTY0ZTUvIiwgInRhc2tfaWQiOiAiZGFlNmQyMzctYzM1Ni00MDZjLThl
+        OGUtMmM3ZGRmMWU2NGU1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIiIsICJz
+        dGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWMw
+        NGJlNTI0OThlZGI4MjU1YmIyZTkzIn0sICJpZCI6ICI1YzA0YmU1MjQ5OGVk
+        YjgyNTViYjJlOTMifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:25:38 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/dae6d237-c356-406c-8e8e-2c7ddf1e64e5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:25:38 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"3d899e6058f0e9618bc6d0051bfe301d-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4314'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9kYWU2ZDIzNy1jMzU2LTQwNmMtOGU4ZS0yYzdk
+        ZGYxZTY0ZTUvIiwgInRhc2tfaWQiOiAiZGFlNmQyMzctYzM1Ni00MDZjLThl
+        OGUtMmM3ZGRmMWU2NGU1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MjU6MzhaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjExZjkxMWRjLWUxYjktNDEzMi1hZjZhLTEyNDIxZTc4YTA0ZSIs
+        ICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
+        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAi
+        c3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICI0YTIwNzI4NC01ZDUyLTQ5NzktYmZiMC05ZWNhMGY1MjcyNmUiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJiNWI5OWQwMS04YmYwLTQ4MjYtOTM4NC1j
+        NzdhZDZlNmRkZjEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBN
+        cyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        Njk5NDhlOTgtYzRlOC00YWQxLTgwMjMtY2U2OTY1MWI5ODExIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjY2NDhjNGY1LTVlYTItNGE5MC04ZDdl
+        LWMwNzY4MzU1Y2RjMiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVz
+        IiwgInN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjRmYTYxZmZmLWEzNDYtNDRkZi1hMDBkLTZiMWQ4NmYxMDliYSIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJj
+        b21wcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4YzJlZjg2Yi1jZDZlLTQ2ZDkt
+        ODJkZi00MDdlYmU5ODkzNWYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0
+        YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI1OTU2NGVlZi0zZDIxLTRlMjctOWI5NC1jOTRkYzgzZThmZTki
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJhNzYzNTkxNC0wMmQ1LTQzMDctYWNiZS02MDIwMzNiYzUyMTUiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDM1N2Ni
+        Y2QtN2M1Yi00NmQ1LTljMWUtZmJkYzkzZWI0YTdmIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJS
+        ZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9v
+        bGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOWY1NTg1MmUtMjA0
+        OS00YzljLTkxZmItOWYwNmU2MjU0NGVkIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
+        aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjhjZjRiYzkzLTQ1NDctNDUxMy04ZDViLTkwMjBk
+        MTYyMTQxZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIi
+        LCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3Rv
+        dGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImNiYzE4ZDVjLWU2NGQtNDc1OC04MDA1LTdhYTMyYTI5MmMy
+        ZSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
+        ZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBf
+        dHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiODE2MWUwNDAtMDYyZi00MDczLTg1ZDEtMGZjZDNiYWE4YzEy
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBs
+        ZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIu
+        c2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YmU1MjQ5OGVkYjgyNTViYjJl
+        OTMifSwgImlkIjogIjVjMDRiZTUyNDk4ZWRiODI1NWJiMmU5MyJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:25:38 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/dae6d237-c356-406c-8e8e-2c7ddf1e64e5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:25:38 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"7f314efabe6b9e41c527819688306024-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4298'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9kYWU2ZDIzNy1jMzU2LTQwNmMtOGU4ZS0yYzdk
+        ZGYxZTY0ZTUvIiwgInRhc2tfaWQiOiAiZGFlNmQyMzctYzM1Ni00MDZjLThl
+        OGUtMmM3ZGRmMWU2NGU1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MjU6MzhaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjExZjkxMWRjLWUxYjktNDEzMi1hZjZhLTEyNDIxZTc4YTA0ZSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0YTIw
+        NzI4NC01ZDUyLTQ5NzktYmZiMC05ZWNhMGY1MjcyNmUiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJiNWI5OWQwMS04YmYwLTQ4MjYtOTM4NC1jNzdhZDZlNmRk
+        ZjEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2OTk0OGU5OC1jNGU4
+        LTRhZDEtODAyMy1jZTY5NjUxYjk4MTEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiNjY0OGM0ZjUtNWVhMi00YTkwLThkN2UtYzA3NjgzNTVjZGMyIiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiSU5fUFJP
+        R1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGZhNjFmZmYtYTM0Ni00
+        NGRmLWEwMGQtNmIxZDg2ZjEwOWJhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
+        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
+        IENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3Rv
+        dGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjhjMmVmODZiLWNkNmUtNDZkOS04MmRmLTQwN2ViZTk4OTM1
+        ZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90
+        eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjU5NTY0ZWVm
+        LTNkMjEtNGUyNy05Yjk0LWM5NGRjODNlOGZlOSIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xv
+        c2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE3NjM1OTE0LTAyZDUt
+        NDMwNy1hY2JlLTYwMjAzM2JjNTIxNSIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
+        ZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0
+        ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkMzU3Y2JjZC03YzViLTQ2ZDUtOWMx
+        ZS1mYmRjOTNlYjRhN2YiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBv
+        ZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI5ZjU1ODUyZS0yMDQ5LTRjOWMtOTFmYi05ZjA2
+        ZTYyNTQ0ZWQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIs
+        ICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        OGNmNGJjOTMtNDU0Ny00NTEzLThkNWItOTAyMGQxNjIxNDFkIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAi
+        cHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2JjMThk
+        NWMtZTY0ZC00NzU4LTgwMDUtN2FhMzJhMjkyYzJlIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJX
+        cml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxp
+        emVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4MTYxZTA0
+        MC0wNjJmLTQwNzMtODVkMS0wZmNkM2JhYThjMTIiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3Rh
+        dGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNv
+        bSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjVjMDRiZTUyNDk4ZWRiODI1NWJiMmU5MyJ9LCAiaWQiOiAiNWMw
+        NGJlNTI0OThlZGI4MjU1YmIyZTkzIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:25:38 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/dae6d237-c356-406c-8e8e-2c7ddf1e64e5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:25:38 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"dc9835e650a79f030d951122a278dc29-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4275'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9kYWU2ZDIzNy1jMzU2LTQwNmMtOGU4ZS0yYzdk
+        ZGYxZTY0ZTUvIiwgInRhc2tfaWQiOiAiZGFlNmQyMzctYzM1Ni00MDZjLThl
+        OGUtMmM3ZGRmMWU2NGU1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MjU6MzhaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjExZjkxMWRjLWUxYjktNDEzMi1hZjZhLTEyNDIxZTc4YTA0ZSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0YTIw
+        NzI4NC01ZDUyLTQ5NzktYmZiMC05ZWNhMGY1MjcyNmUiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJiNWI5OWQwMS04YmYwLTQ4MjYtOTM4NC1jNzdhZDZlNmRk
+        ZjEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2OTk0OGU5OC1jNGU4
+        LTRhZDEtODAyMy1jZTY5NjUxYjk4MTEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiNjY0OGM0ZjUtNWVhMi00YTkwLThkN2UtYzA3NjgzNTVjZGMyIiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGZhNjFmZmYtYTM0Ni00NGRm
+        LWEwMGQtNmIxZDg2ZjEwOWJhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
+        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjhjMmVmODZiLWNkNmUtNDZkOS04MmRmLTQwN2ViZTk4OTM1ZiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
+        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjU5NTY0ZWVmLTNkMjEtNGUy
+        Ny05Yjk0LWM5NGRjODNlOGZlOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
+        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImE3NjM1OTE0LTAyZDUtNDMwNy1hY2JlLTYw
+        MjAzM2JjNTIxNSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogImQzNTdjYmNkLTdjNWItNDZkNS05YzFlLWZiZGM5M2ViNGE3ZiIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjlm
+        NTU4NTJlLTIwNDktNGM5Yy05MWZiLTlmMDZlNjI1NDRlZCIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBv
+        dmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjhjZjRiYzkzLTQ1NDctNDUxMy04ZDVi
+        LTkwMjBkMTYyMTQxZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0
+        byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImNiYzE4ZDVjLWU2NGQtNDc1OC04MDA1LTdhYTMy
+        YTI5MmMyZSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwg
+        InN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiODE2MWUwNDAtMDYyZi00MDczLTg1ZDEtMGZjZDNi
+        YWE4YzEyIiwgIm51bV9wcm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2Vy
+        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
+        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YmU1MjQ5OGVkYjgy
+        NTViYjJlOTMifSwgImlkIjogIjVjMDRiZTUyNDk4ZWRiODI1NWJiMmU5MyJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:25:38 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/dae6d237-c356-406c-8e8e-2c7ddf1e64e5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:25:38 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"8fdbd627ac3f2612d8748e4126ccbbe4-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4269'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9kYWU2ZDIzNy1jMzU2LTQwNmMtOGU4ZS0yYzdk
+        ZGYxZTY0ZTUvIiwgInRhc2tfaWQiOiAiZGFlNmQyMzctYzM1Ni00MDZjLThl
+        OGUtMmM3ZGRmMWU2NGU1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MjU6MzhaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjExZjkxMWRjLWUxYjktNDEzMi1hZjZhLTEyNDIxZTc4YTA0ZSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0YTIw
+        NzI4NC01ZDUyLTQ5NzktYmZiMC05ZWNhMGY1MjcyNmUiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJiNWI5OWQwMS04YmYwLTQ4MjYtOTM4NC1jNzdhZDZlNmRk
+        ZjEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2OTk0OGU5OC1jNGU4
+        LTRhZDEtODAyMy1jZTY5NjUxYjk4MTEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiNjY0OGM0ZjUtNWVhMi00YTkwLThkN2UtYzA3NjgzNTVjZGMyIiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGZhNjFmZmYtYTM0Ni00NGRm
+        LWEwMGQtNmIxZDg2ZjEwOWJhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
+        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjhjMmVmODZiLWNkNmUtNDZkOS04MmRmLTQwN2ViZTk4OTM1ZiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
+        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjU5NTY0ZWVmLTNkMjEtNGUy
+        Ny05Yjk0LWM5NGRjODNlOGZlOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
+        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImE3NjM1OTE0LTAyZDUtNDMwNy1hY2JlLTYw
+        MjAzM2JjNTIxNSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogImQzNTdjYmNkLTdjNWItNDZkNS05YzFlLWZiZGM5M2ViNGE3ZiIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjlm
+        NTU4NTJlLTIwNDktNGM5Yy05MWZiLTlmMDZlNjI1NDRlZCIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBv
+        dmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjhjZjRiYzkzLTQ1NDctNDUxMy04ZDVi
+        LTkwMjBkMTYyMTQxZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0
+        byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImNiYzE4ZDVjLWU2NGQtNDc1OC04MDA1LTdhYTMyYTI5
+        MmMyZSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0
+        ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiODE2MWUwNDAtMDYyZi00MDczLTg1ZDEtMGZjZDNiYWE4YzEy
+        IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAicXVldWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBs
+        ZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIu
+        c2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YmU1MjQ5OGVkYjgyNTViYjJl
+        OTMifSwgImlkIjogIjVjMDRiZTUyNDk4ZWRiODI1NWJiMmU5MyJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:25:38 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/dae6d237-c356-406c-8e8e-2c7ddf1e64e5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:25:39 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"65f9713f324581f6ffc30be8df263af0-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '8549'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9kYWU2ZDIzNy1jMzU2LTQwNmMtOGU4ZS0yYzdk
+        ZGYxZTY0ZTUvIiwgInRhc2tfaWQiOiAiZGFlNmQyMzctYzM1Ni00MDZjLThl
+        OGUtMmM3ZGRmMWU2NGU1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTgtMTItMDNUMDU6MjU6MzhaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MjU6Mzha
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
+        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
+        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjExZjkxMWRjLWUxYjktNDEzMi1hZjZh
+        LTEyNDIxZTc4YTA0ZSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
+        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICI0YTIwNzI4NC01ZDUyLTQ5NzktYmZiMC05ZWNhMGY1
+        MjcyNmUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
+        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNWI5OWQwMS04YmYwLTQ4
+        MjYtOTM4NC1jNzdhZDZlNmRkZjEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
+        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICI2OTk0OGU5OC1jNGU4LTRhZDEtODAyMy1jZTY5NjUxYjk4MTEiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
+        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjY0OGM0ZjUtNWVhMi00YTkwLThk
+        N2UtYzA3NjgzNTVjZGMyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVs
+        ZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        NGZhNjFmZmYtYTM0Ni00NGRmLWEwMGQtNmIxZDg2ZjEwOWJhIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNv
+        bXBzIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjhjMmVmODZiLWNkNmUtNDZkOS04MmRm
+        LTQwN2ViZTk4OTM1ZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0
+        YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjU5NTY0ZWVmLTNkMjEtNGUyNy05Yjk0LWM5NGRjODNlOGZlOSIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRp
+        b24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJj
+        bG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE3NjM1OTE0
+        LTAyZDUtNDMwNy1hY2JlLTYwMjAzM2JjNTIxNSIsICJudW1fcHJvY2Vzc2Vk
+        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
+        ZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRl
+        IHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQzNTdjYmNkLTdjNWItNDZkNS05
+        YzFlLWZiZGM5M2ViNGE3ZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJl
+        cG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjlmNTU4NTJlLTIwNDktNGM5Yy05MWZiLTlmMDZl
+        NjI1NDRlZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwg
+        InN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjhjZjRi
+        YzkzLTQ1NDctNDUxMy04ZDViLTkwMjBkMTYyMTQxZCIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        UHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxp
+        c2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNiYzE4ZDVjLWU2NGQt
+        NDc1OC04MDA1LTdhYTMyYTI5MmMyZSIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBM
+        aXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9f
+        bWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODE2MWUwNDAtMDYyZi00MDcz
+        LTg1ZDEtMGZjZDNiYWE4YzEyIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
+        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlz
+        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwg
+        InJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJzdGFydGVkIjogIjIwMTgt
+        MTItMDNUMDU6MjU6MzhaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0
+        cyIsICJjb21wbGV0ZWQiOiAiMjAxOC0xMi0wM1QwNToyNTozOFoiLCAidHJh
+        Y2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Rp
+        c3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7ImdlbmVyYXRlIHNxbGl0ZSI6ICJT
+        S0lQUEVEIiwgInJwbXMiOiAiRklOSVNIRUQiLCAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIjogIkZJTklTSEVEIiwgInJlbW92ZV9vbGRfcmVwb2RhdGEi
+        OiAiRklOSVNIRUQiLCAibW9kdWxlcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9y
+        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQi
+        LCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklT
+        SEVEIiwgInJlcG92aWV3IjogIlNLSVBQRUQiLCAicHVibGlzaF9kaXJlY3Rv
+        cnkiOiAiRklOSVNIRUQiLCAiZXJyYXRhIjogIkZJTklTSEVEIiwgIm1ldGFk
+        YXRhIjogIkZJTklTSEVEIn0sICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImRp
+        c3RyaWJ1dG9yX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAiaWQiOiAiNWMwNGJl
+        NTIwNWY1ZWUwNWMzZmQ4NDhiIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2Vz
+        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRh
+        ZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjExZjkxMWRjLWUxYjktNDEzMi1hZjZhLTEy
+        NDIxZTc4YTA0ZSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRp
+        b24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI0YTIwNzI4NC01ZDUyLTQ5NzktYmZiMC05ZWNhMGY1Mjcy
+        NmUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUi
+        OiAicnBtcyIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNWI5OWQwMS04YmYwLTQ4MjYt
+        OTM4NC1jNzdhZDZlNmRkZjEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVs
+        dGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICI2OTk0OGU5OC1jNGU4LTRhZDEtODAyMy1jZTY5NjUxYjk4MTEiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNjY0OGM0ZjUtNWVhMi00YTkwLThkN2Ut
+        YzA3NjgzNTVjZGMyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMi
+        LCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGZh
+        NjFmZmYtYTM0Ni00NGRmLWEwMGQtNmIxZDg2ZjEwOWJhIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBz
+        IiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjhjMmVmODZiLWNkNmUtNDZkOS04MmRmLTQw
+        N2ViZTk4OTM1ZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4i
+        LCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjU5
+        NTY0ZWVmLTNkMjEtNGUyNy05Yjk0LWM5NGRjODNlOGZlOSIsICJudW1fcHJv
+        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
+        OiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9z
+        ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE3NjM1OTE0LTAy
+        ZDUtNDMwNy1hY2JlLTYwMjAzM2JjNTIxNSIsICJudW1fcHJvY2Vzc2VkIjog
+        MX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
+        dGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNx
+        bGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImQzNTdjYmNkLTdjNWItNDZkNS05YzFl
+        LWZiZGM5M2ViNGE3ZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9k
+        YXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjlmNTU4NTJlLTIwNDktNGM5Yy05MWZiLTlmMDZlNjI1
+        NDRlZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0
+        ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjhjZjRiYzkz
+        LTQ1NDctNDUxMy04ZDViLTkwMjBkMTYyMTQxZCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNiYzE4ZDVjLWU2NGQtNDc1
+        OC04MDA1LTdhYTMyYTI5MmMyZSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODE2MWUwNDAtMDYyZi00MDczLTg1
+        ZDEtMGZjZDNiYWE4YzEyIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZTUyNDk4ZWRiODI1
+        NWJiMmU5MyJ9LCAiaWQiOiAiNWMwNGJlNTI0OThlZGI4MjU1YmIyZTkzIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:25:39 GMT
+- request:
+    method: post
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/content/1543814879761?enabled=true
+    body:
+      encoding: UTF-8
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk",
+        oauth_nonce="aze6zxqfWATWUIQsMkr4n5b66ywYUsyNwBceWlX0vJE", oauth_signature="ldiP5uOQqAf8RFOJKOzukX3fWiU%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1543814879", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - d1b72a6c-a11b-4e39-93b8-74ea8f5a8b3f
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:27:59 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNToyNzo1OSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6Mjc6NTkrMDAwMCIsInV1aWQiOiI0MDI4Zjk2
+        NjY3NzE5NTdkMDE2NzcyODk5YTJiMDA0OSIsImlkIjoiN2M4MjUwMTNjYWIw
+        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
+        dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
+        IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
+        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOTY2Njc3MTk1N2QwMTY3NzI4OTlhMmIw
+        MDQ5IiwicHJvZHVjdENvbnRlbnQiOlt7ImNvbnRlbnQiOnsiY3JlYXRlZCI6
+        IjIwMTgtMTItMDNUMDU6Mjc6NTkrMDAwMCIsInVwZGF0ZWQiOiIyMDE4LTEy
+        LTAzVDA1OjI3OjU5KzAwMDAiLCJ1dWlkIjoiNDAyOGY5NjY2NzcxOTU3ZDAx
+        Njc3Mjg5OWEwMTAwNDgiLCJpZCI6IjE1NDM4MTQ4Nzk3NjEiLCJ0eXBlIjoi
+        eXVtIiwibGFiZWwiOiJzY2VuYXJpb190ZXN0X1NjZW5hcmlvX1Byb2R1Y3Rf
+        U2NlbmFyaW9feXVtX3Byb2R1Y3QiLCJuYW1lIjoiU2NlbmFyaW8geXVtIHBy
+        b2R1Y3QiLCJ2ZW5kb3IiOiJDdXN0b20iLCJjb250ZW50VXJsIjoiL2N1c3Rv
+        bS9TY2VuYXJpb19Qcm9kdWN0L1NjZW5hcmlvX3l1bV9wcm9kdWN0IiwicmVx
+        dWlyZWRUYWdzIjpudWxsLCJncGdVcmwiOm51bGwsIm1vZGlmaWVkUHJvZHVj
+        dElkcyI6W10sImFyY2hlcyI6bnVsbCwicmVxdWlyZWRQcm9kdWN0SWRzIjpb
+        XSwibWV0YWRhdGFFeHBpcmUiOjEsInJlbGVhc2VWZXIiOm51bGx9LCJlbmFi
+        bGVkIjp0cnVlfV19
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:27:59 GMT
+- request:
+    method: post
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/environments/d80a5783c502f0f969e23089437bb7ce/content
+    body:
+      encoding: UTF-8
+      base64_string: 'W3siY29udGVudElkIjoiMTU0MzgxNDg3OTc2MSJ9XQ==
+
+'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk",
+        oauth_nonce="MGk7HXkazCiLNaAjOvSy539UBgSJrpxOVQ5jXbASA", oauth_signature="Uj1dqfzyJeA6Zadmburmc5%2B01p8%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1543814879", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '31'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - fdde2755-ad12-4af2-8d7c-68cb8e3680ce
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:27:59 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNToyNzo1OSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6Mjc6NTkrMDAwMCIsImlkIjoicmVnZW5fZW50
+        aXRsZW1lbnRfY2VydF9vZl9lbnY5ZDgwNWIwOS03OWM2LTRmOWUtODQ1Zi0x
+        OWFhOWI2OTI5ZDUiLCJzdGF0ZSI6IkNSRUFURUQiLCJzdGFydFRpbWUiOm51
+        bGwsImZpbmlzaFRpbWUiOm51bGwsInJlc3VsdCI6bnVsbCwicHJpbmNpcGFs
+        TmFtZSI6ImZvcmVtYW5fYWRtaW4iLCJ0YXJnZXRUeXBlIjpudWxsLCJ0YXJn
+        ZXRJZCI6bnVsbCwib3duZXJJZCI6bnVsbCwiY29ycmVsYXRpb25JZCI6bnVs
+        bCwicmVzdWx0RGF0YSI6bnVsbCwiZG9uZSI6ZmFsc2UsInN0YXR1c1BhdGgi
+        OiIvam9icy9yZWdlbl9lbnRpdGxlbWVudF9jZXJ0X29mX2VudjlkODA1YjA5
+        LTc5YzYtNGY5ZS04NDVmLTE5YWE5YjY5MjlkNSIsImdyb3VwIjoiYXN5bmMg
+        Z3JvdXAifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:27:59 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/d42599c2-24fa-4e7b-87f7-a97c0b78931b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"8bb601d152a6a54652100428cc2f6ac1-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '553'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9kNDI1OTljMi0yNGZhLTRlN2ItODdmNy1hOTdj
+        MGI3ODkzMWIvIiwgInRhc2tfaWQiOiAiZDQyNTk5YzItMjRmYS00ZTdiLTg3
+        ZjctYTk3YzBiNzg5MzFiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIiIsICJz
+        dGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWMw
+        NGJlZTA0OThlZGI4MjU1YmIzNGQ2In0sICJpZCI6ICI1YzA0YmVlMDQ5OGVk
+        YjgyNTViYjM0ZDYifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:00 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/d42599c2-24fa-4e7b-87f7-a97c0b78931b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"3ae81dff54eca36b4413fd3d27a0c037-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4308'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9kNDI1OTljMi0yNGZhLTRlN2ItODdmNy1hOTdj
+        MGI3ODkzMWIvIiwgInRhc2tfaWQiOiAiZDQyNTk5YzItMjRmYS00ZTdiLTg3
+        ZjctYTk3YzBiNzg5MzFiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6Mjg6MDBaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjg2NDk2ZWE2LTZiNDEtNDljNS1hMTdmLTE0ZWExMGY5NTE2MCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3ZmM5
+        ZTU2OC04ODQwLTQ1MjAtYjc3MS04ZjIxYjMyZjUzN2MiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICI3N2Y3OGI0MS01ODg4LTQ2NjAtOTc4ZC01MDc4NWJm
+        ODM5YzQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJz
+        dGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTUzYTRk
+        ZjYtMzg0Yi00NTA4LTgyMDItZGI4YTdiYjUyNTI4IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImRhMGM2NzE3LTA1ZmMtNDNkYS05OWFlLWQyZThk
+        MzZjNDAzOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0
+        ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNjM2Jm
+        NzQwLTQ0ZjEtNGRlMy04NDk3LTMzMzc4YmM5ZTI2ZCIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        UHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJhOTFmY2YwOS0xOGZhLTRkOTMtYmJkNC1l
+        ZTU0Njk3ZDc5NWMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEu
+        IiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICI1MWY1M2UxNS1iOWJkLTRiNDUtOWZhZi0zZDY0MWE1YmFiMDQiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAi
+        Y2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5ZGYz
+        NTRjYi0yMzY2LTQ4NTctYWRlZS1hMzAzNTU0ODI3ZmMiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5l
+        cmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTg5YmExNjAtOGJm
+        MC00ZDZhLWFiNDMtMzNkMzRlOWYzY2YzIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmlu
+        ZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVw
+        b2RhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODM3ZmFjYTUtZjQ5ZS00NjRl
+        LThjMGItZTkwYjliZmEzZjI2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhU
+        TUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3Rv
+        dGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImZkMmFmZWUyLTA0YWQtNDI5MC05MzFiLTIxOTRlNDVkMDkw
+        YSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3Rl
+        cF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjog
+        MSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImUwZjU4ZTYyLWFjN2ItNDc3ZC05MjJjLWE3Mjg2Y2MxN2M1MSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6
+        ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAx
+        LCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiMGJiZGRjNzctZjQ5Ni00ZTE5LWIwYzEtNmZmZGRmMWYyNjFjIiwgIm51
+        bV9wcm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20u
+        ZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIu
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
+        Il9pZCI6IHsiJG9pZCI6ICI1YzA0YmVlMDQ5OGVkYjgyNTViYjM0ZDYifSwg
+        ImlkIjogIjVjMDRiZWUwNDk4ZWRiODI1NWJiMzRkNiJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:00 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/d42599c2-24fa-4e7b-87f7-a97c0b78931b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"9aed058f8e9f47df2571646d41d35ae3-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4292'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9kNDI1OTljMi0yNGZhLTRlN2ItODdmNy1hOTdj
+        MGI3ODkzMWIvIiwgInRhc2tfaWQiOiAiZDQyNTk5YzItMjRmYS00ZTdiLTg3
+        ZjctYTk3YzBiNzg5MzFiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6Mjg6MDBaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjg2NDk2ZWE2LTZiNDEtNDljNS1hMTdmLTE0ZWExMGY5NTE2MCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3ZmM5
+        ZTU2OC04ODQwLTQ1MjAtYjc3MS04ZjIxYjMyZjUzN2MiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI3N2Y3OGI0MS01ODg4LTQ2NjAtOTc4ZC01MDc4NWJmODM5
+        YzQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1NTNhNGRmNi0zODRi
+        LTQ1MDgtODIwMi1kYjhhN2JiNTI1MjgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiZGEwYzY3MTctMDVmYy00M2RhLTk5YWUtZDJlOGQzNmM0MDM5Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2MzYmY3NDAtNDRmMS00ZGUz
+        LTg0OTctMzMzNzhiYzllMjZkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
+        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImE5MWZjZjA5LTE4ZmEtNGQ5My1iYmQ0LWVlNTQ2OTdkNzk1YyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
+        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIklOX1BS
+        T0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjUxZjUzZTE1LWI5YmQt
+        NGI0NS05ZmFmLTNkNjQxYTViYWIwNCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyBy
+        ZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFk
+        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjlkZjM1NGNiLTIzNjYtNDg1Ny1h
+        ZGVlLWEzMDM1NTQ4MjdmYyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxp
+        dGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJlODliYTE2MC04YmYwLTRkNmEtYWI0My0zM2Qz
+        NGU5ZjNjZjMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIs
+        ICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI4MzdmYWNhNS1mNDllLTQ2NGUtOGMwYi1lOTBiOWJmYTNm
+        MjYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVw
+        X3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmQyYWZl
+        ZTItMDRhZC00MjkwLTkzMWItMjE5NGU0NWQwOTBhIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
+        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTBmNThlNjItYWM3
+        Yi00NzdkLTkyMmMtYTcyODZjYzE3YzUxIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5n
+        IExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVw
+        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
+        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYmJkZGM3Ny1mNDk2
+        LTRlMTktYjBjMS02ZmZkZGYxZjI2MWMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50
+        b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAi
+        cnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJy
+        ZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjog
+        IjVjMDRiZWUwNDk4ZWRiODI1NWJiMzRkNiJ9LCAiaWQiOiAiNWMwNGJlZTA0
+        OThlZGI4MjU1YmIzNGQ2In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:00 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/d42599c2-24fa-4e7b-87f7-a97c0b78931b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"01b4b68852efc7f3fe1728b506d16fed-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4272'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9kNDI1OTljMi0yNGZhLTRlN2ItODdmNy1hOTdj
+        MGI3ODkzMWIvIiwgInRhc2tfaWQiOiAiZDQyNTk5YzItMjRmYS00ZTdiLTg3
+        ZjctYTk3YzBiNzg5MzFiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6Mjg6MDBaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjg2NDk2ZWE2LTZiNDEtNDljNS1hMTdmLTE0ZWExMGY5NTE2MCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3ZmM5
+        ZTU2OC04ODQwLTQ1MjAtYjc3MS04ZjIxYjMyZjUzN2MiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI3N2Y3OGI0MS01ODg4LTQ2NjAtOTc4ZC01MDc4NWJmODM5
+        YzQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1NTNhNGRmNi0zODRi
+        LTQ1MDgtODIwMi1kYjhhN2JiNTI1MjgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiZGEwYzY3MTctMDVmYy00M2RhLTk5YWUtZDJlOGQzNmM0MDM5Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2MzYmY3NDAtNDRmMS00ZGUz
+        LTg0OTctMzMzNzhiYzllMjZkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
+        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImE5MWZjZjA5LTE4ZmEtNGQ5My1iYmQ0LWVlNTQ2OTdkNzk1YyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
+        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjUxZjUzZTE1LWI5YmQtNGI0
+        NS05ZmFmLTNkNjQxYTViYWIwNCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
+        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjlkZjM1NGNiLTIzNjYtNDg1Ny1hZGVlLWEz
+        MDM1NTQ4MjdmYyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogImU4OWJhMTYwLThiZjAtNGQ2YS1hYjQzLTMzZDM0ZTlmM2NmMyIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjgz
+        N2ZhY2E1LWY0OWUtNDY0ZS04YzBiLWU5MGI5YmZhM2YyNiIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBv
+        dmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImZkMmFmZWUyLTA0YWQtNDI5MC05MzFi
+        LTIxOTRlNDVkMDkwYSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0
+        byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImUwZjU4ZTYyLWFjN2ItNDc3ZC05MjJjLWE3Mjg2Y2Mx
+        N2M1MSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0
+        ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiMGJiZGRjNzctZjQ5Ni00ZTE5LWIwYzEtNmZmZGRmMWYy
+        NjFjIiwgIm51bV9wcm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhh
+        bXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZl
+        bDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9y
+        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YmVlMDQ5OGVkYjgyNTVi
+        YjM0ZDYifSwgImlkIjogIjVjMDRiZWUwNDk4ZWRiODI1NWJiMzRkNiJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:00 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/d42599c2-24fa-4e7b-87f7-a97c0b78931b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"686d0faf68cb5a5ccc1b5e86b07557e1-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '8549'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9kNDI1OTljMi0yNGZhLTRlN2ItODdmNy1hOTdj
+        MGI3ODkzMWIvIiwgInRhc2tfaWQiOiAiZDQyNTk5YzItMjRmYS00ZTdiLTg3
+        ZjctYTk3YzBiNzg5MzFiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTgtMTItMDNUMDU6Mjg6MDBaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6Mjg6MDBa
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
+        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
+        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjg2NDk2ZWE2LTZiNDEtNDljNS1hMTdm
+        LTE0ZWExMGY5NTE2MCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
+        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICI3ZmM5ZTU2OC04ODQwLTQ1MjAtYjc3MS04ZjIxYjMy
+        ZjUzN2MiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
+        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3N2Y3OGI0MS01ODg4LTQ2
+        NjAtOTc4ZC01MDc4NWJmODM5YzQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
+        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICI1NTNhNGRmNi0zODRiLTQ1MDgtODIwMi1kYjhhN2JiNTI1MjgiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
+        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZGEwYzY3MTctMDVmYy00M2RhLTk5
+        YWUtZDJlOGQzNmM0MDM5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVs
+        ZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        M2MzYmY3NDAtNDRmMS00ZGUzLTg0OTctMzMzNzhiYzllMjZkIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNv
+        bXBzIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImE5MWZjZjA5LTE4ZmEtNGQ5My1iYmQ0
+        LWVlNTQ2OTdkNzk1YyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0
+        YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjUxZjUzZTE1LWI5YmQtNGI0NS05ZmFmLTNkNjQxYTViYWIwNCIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRp
+        b24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJj
+        bG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjlkZjM1NGNi
+        LTIzNjYtNDg1Ny1hZGVlLWEzMDM1NTQ4MjdmYyIsICJudW1fcHJvY2Vzc2Vk
+        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
+        ZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRl
+        IHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImU4OWJhMTYwLThiZjAtNGQ2YS1h
+        YjQzLTMzZDM0ZTlmM2NmMyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJl
+        cG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjgzN2ZhY2E1LWY0OWUtNDY0ZS04YzBiLWU5MGI5
+        YmZhM2YyNiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwg
+        InN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZkMmFm
+        ZWUyLTA0YWQtNDI5MC05MzFiLTIxOTRlNDVkMDkwYSIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        UHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxp
+        c2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUwZjU4ZTYyLWFjN2It
+        NDc3ZC05MjJjLWE3Mjg2Y2MxN2M1MSIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBM
+        aXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9f
+        bWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGJiZGRjNzctZjQ5Ni00ZTE5
+        LWIwYzEtNmZmZGRmMWYyNjFjIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
+        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlz
+        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwg
+        InJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJzdGFydGVkIjogIjIwMTgt
+        MTItMDNUMDU6Mjg6MDBaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0
+        cyIsICJjb21wbGV0ZWQiOiAiMjAxOC0xMi0wM1QwNToyODowMFoiLCAidHJh
+        Y2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Rp
+        c3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7ImdlbmVyYXRlIHNxbGl0ZSI6ICJT
+        S0lQUEVEIiwgInJwbXMiOiAiRklOSVNIRUQiLCAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIjogIkZJTklTSEVEIiwgInJlbW92ZV9vbGRfcmVwb2RhdGEi
+        OiAiRklOSVNIRUQiLCAibW9kdWxlcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9y
+        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQi
+        LCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklT
+        SEVEIiwgInJlcG92aWV3IjogIlNLSVBQRUQiLCAicHVibGlzaF9kaXJlY3Rv
+        cnkiOiAiRklOSVNIRUQiLCAiZXJyYXRhIjogIkZJTklTSEVEIiwgIm1ldGFk
+        YXRhIjogIkZJTklTSEVEIn0sICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImRp
+        c3RyaWJ1dG9yX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAiaWQiOiAiNWMwNGJl
+        ZTAwNWY1ZWUwNWMzZmQ4NGEyIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2Vz
+        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRh
+        ZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjg2NDk2ZWE2LTZiNDEtNDljNS1hMTdmLTE0
+        ZWExMGY5NTE2MCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRp
+        b24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI3ZmM5ZTU2OC04ODQwLTQ1MjAtYjc3MS04ZjIxYjMyZjUz
+        N2MiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUi
+        OiAicnBtcyIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3N2Y3OGI0MS01ODg4LTQ2NjAt
+        OTc4ZC01MDc4NWJmODM5YzQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVs
+        dGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICI1NTNhNGRmNi0zODRiLTQ1MDgtODIwMi1kYjhhN2JiNTI1MjgiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZGEwYzY3MTctMDVmYy00M2RhLTk5YWUt
+        ZDJlOGQzNmM0MDM5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMi
+        LCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2Mz
+        YmY3NDAtNDRmMS00ZGUzLTg0OTctMzMzNzhiYzllMjZkIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBz
+        IiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImE5MWZjZjA5LTE4ZmEtNGQ5My1iYmQ0LWVl
+        NTQ2OTdkNzk1YyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4i
+        LCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjUx
+        ZjUzZTE1LWI5YmQtNGI0NS05ZmFmLTNkNjQxYTViYWIwNCIsICJudW1fcHJv
+        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
+        OiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9z
+        ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjlkZjM1NGNiLTIz
+        NjYtNDg1Ny1hZGVlLWEzMDM1NTQ4MjdmYyIsICJudW1fcHJvY2Vzc2VkIjog
+        MX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
+        dGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNx
+        bGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImU4OWJhMTYwLThiZjAtNGQ2YS1hYjQz
+        LTMzZDM0ZTlmM2NmMyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9k
+        YXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjgzN2ZhY2E1LWY0OWUtNDY0ZS04YzBiLWU5MGI5YmZh
+        M2YyNiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0
+        ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZkMmFmZWUy
+        LTA0YWQtNDI5MC05MzFiLTIxOTRlNDVkMDkwYSIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUwZjU4ZTYyLWFjN2ItNDc3
+        ZC05MjJjLWE3Mjg2Y2MxN2M1MSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGJiZGRjNzctZjQ5Ni00ZTE5LWIw
+        YzEtNmZmZGRmMWYyNjFjIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZWUwNDk4ZWRiODI1
+        NWJiMzRkNiJ9LCAiaWQiOiAiNWMwNGJlZTA0OThlZGI4MjU1YmIzNGQ2In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:00 GMT
+- request:
+    method: post
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5X25hbWUiOiJTY2VuYXJp
+        byB5dW0gcHJvZHVjdCIsImltcG9ydGVyX3R5cGVfaWQiOiJ5dW1faW1wb3J0
+        ZXIiLCJpbXBvcnRlcl9jb25maWciOnsiZG93bmxvYWRfcG9saWN5IjoiaW1t
+        ZWRpYXRlIiwicmVtb3ZlX21pc3NpbmciOnRydWUsImZlZWQiOiJmaWxlOi8v
+        L3Zhci93d3cvdGVzdF9yZXBvcy96b28iLCJ0eXBlX3NraXBfbGlzdCI6bnVs
+        bCwicHJveHlfaG9zdCI6bnVsbCwiYmFzaWNfYXV0aF91c2VybmFtZSI6bnVs
+        bCwiYmFzaWNfYXV0aF9wYXNzd29yZCI6bnVsbCwic3NsX3ZhbGlkYXRpb24i
+        OnRydWUsInNzbF9jbGllbnRfY2VydCI6bnVsbCwic3NsX2NsaWVudF9rZXki
+        Om51bGwsInNzbF9jYV9jZXJ0IjpudWxsfSwibm90ZXMiOnsiX3JlcG8tdHlw
+        ZSI6InJwbS1yZXBvIn0sImRpc3RyaWJ1dG9ycyI6W3siZGlzdHJpYnV0b3Jf
+        dHlwZV9pZCI6Inl1bV9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZp
+        ZyI6eyJyZWxhdGl2ZV91cmwiOiJzY2VuYXJpb190ZXN0IiwiaHR0cCI6ZmFs
+        c2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRydWUsImNoZWNrc3VtX3R5
+        cGUiOm51bGx9LCJhdXRvX3B1Ymxpc2giOnRydWUsImRpc3RyaWJ1dG9yX2lk
+        Ijoic2NlbmFyaW9fdGVzdCJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1
+        bV9jbG9uZV9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJk
+        ZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6InNjZW5hcmlvX3Rlc3QifSwi
+        YXV0b19wdWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJzY2VuYXJp
+        b190ZXN0X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBlX2lkIjoiZXhwb3J0
+        X2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7Imh0dHAiOmZh
+        bHNlLCJodHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6InNjZW5hcmlvX3Rl
+        c3QifSwiYXV0b19wdWJsaXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJl
+        eHBvcnRfZGlzdHJpYnV0b3IifV19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1011'
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:38:55 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '332'
+      Location:
+      - "/pulp/api/v2/repositories/scenario_test/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiU2NlbmFyaW8g
+        eXVtIHByb2R1Y3QiLCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0
+        X2FkZGVkIjogbnVsbCwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
+        ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
+        aXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lkIjogeyIkb2lk
+        IjogIjVjMDRjMTZmMDVmNWVlMzE2ZDljYWVhMSJ9LCAiaWQiOiAic2NlbmFy
+        aW9fdGVzdCIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVz
+        L3NjZW5hcmlvX3Rlc3QvIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:38:55 GMT
+- request:
+    method: post
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/content/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiU2NlbmFyaW8geXVtIHByb2R1Y3QiLCJjb250ZW50VXJsIjoi
+        L2N1c3RvbS9TY2VuYXJpb19Qcm9kdWN0L1NjZW5hcmlvX3l1bV9wcm9kdWN0
+        IiwidHlwZSI6Inl1bSIsImFyY2hlcyI6bnVsbCwibGFiZWwiOiJzY2VuYXJp
+        b190ZXN0X1NjZW5hcmlvX1Byb2R1Y3RfU2NlbmFyaW9feXVtX3Byb2R1Y3Qi
+        LCJtZXRhZGF0YUV4cGlyZSI6MSwidmVuZG9yIjoiQ3VzdG9tIn0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk",
+        oauth_nonce="BQyQw4645CvMk91iGeoUqr96aef6iWBjvWhaklY4", oauth_signature="jTUDKRTnUnFrY0vLPj27MAq1cdo%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1543815536", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '218'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - bb37f0ce-0b9f-4486-a97d-3cf382e7b882
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:38:55 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNTozODo1NiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6Mzg6NTYrMDAwMCIsInV1aWQiOiI0MDI4Zjk2
+        NjY3NzE5NTdkMDE2NzcyOTM5ZTEyMDA1NSIsImlkIjoiMTU0MzgxNTUzNjE2
+        NiIsInR5cGUiOiJ5dW0iLCJsYWJlbCI6InNjZW5hcmlvX3Rlc3RfU2NlbmFy
+        aW9fUHJvZHVjdF9TY2VuYXJpb195dW1fcHJvZHVjdCIsIm5hbWUiOiJTY2Vu
+        YXJpbyB5dW0gcHJvZHVjdCIsInZlbmRvciI6IkN1c3RvbSIsImNvbnRlbnRV
+        cmwiOiIvY3VzdG9tL1NjZW5hcmlvX1Byb2R1Y3QvU2NlbmFyaW9feXVtX3By
+        b2R1Y3QiLCJyZXF1aXJlZFRhZ3MiOm51bGwsImdwZ1VybCI6bnVsbCwibW9k
+        aWZpZWRQcm9kdWN0SWRzIjpbXSwiYXJjaGVzIjpudWxsLCJyZXF1aXJlZFBy
+        b2R1Y3RJZHMiOltdLCJtZXRhZGF0YUV4cGlyZSI6MSwicmVsZWFzZVZlciI6
+        bnVsbH0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:38:56 GMT
+- request:
+    method: post
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/content/1543815536166?enabled=true
+    body:
+      encoding: UTF-8
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk",
+        oauth_nonce="0LU6aYdlIrozWe1NaBbFCo4xnk6fGqspcn0Tx3YZaUE", oauth_signature="kpjPAF9Bv%2B76QztOqo9JfhwOEJA%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1543815536", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 6f843242-ec8d-45e3-adff-306ae67703d3
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:38:55 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNTozODo1NSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6Mzg6NTYrMDAwMCIsInV1aWQiOiI0MDI4Zjk2
+        NjY3NzE5NTdkMDE2NzcyOTM5ZTNhMDA1NiIsImlkIjoiN2M4MjUwMTNjYWIw
+        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
+        dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
+        IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
+        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOTY2Njc3MTk1N2QwMTY3NzI5MzllM2Ew
+        MDU2IiwicHJvZHVjdENvbnRlbnQiOlt7ImNvbnRlbnQiOnsiY3JlYXRlZCI6
+        IjIwMTgtMTItMDNUMDU6Mzg6NTYrMDAwMCIsInVwZGF0ZWQiOiIyMDE4LTEy
+        LTAzVDA1OjM4OjU2KzAwMDAiLCJ1dWlkIjoiNDAyOGY5NjY2NzcxOTU3ZDAx
+        Njc3MjkzOWUxMjAwNTUiLCJpZCI6IjE1NDM4MTU1MzYxNjYiLCJ0eXBlIjoi
+        eXVtIiwibGFiZWwiOiJzY2VuYXJpb190ZXN0X1NjZW5hcmlvX1Byb2R1Y3Rf
+        U2NlbmFyaW9feXVtX3Byb2R1Y3QiLCJuYW1lIjoiU2NlbmFyaW8geXVtIHBy
+        b2R1Y3QiLCJ2ZW5kb3IiOiJDdXN0b20iLCJjb250ZW50VXJsIjoiL2N1c3Rv
+        bS9TY2VuYXJpb19Qcm9kdWN0L1NjZW5hcmlvX3l1bV9wcm9kdWN0IiwicmVx
+        dWlyZWRUYWdzIjpudWxsLCJncGdVcmwiOm51bGwsIm1vZGlmaWVkUHJvZHVj
+        dElkcyI6W10sImFyY2hlcyI6bnVsbCwicmVxdWlyZWRQcm9kdWN0SWRzIjpb
+        XSwibWV0YWRhdGFFeHBpcmUiOjEsInJlbGVhc2VWZXIiOm51bGx9LCJlbmFi
+        bGVkIjp0cnVlfV19
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:38:56 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/environments/d80a5783c502f0f969e23089437bb7ce
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="WCxT0r9kaSaJjS2cJ4FV9hzaWLxDe4a5XlgncCyQvFo",
+        oauth_signature="BtB3i1kw%2BeqP6Q4M6esG%2Fdp8RI8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543815536", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 5ca8fb55-60f6-438a-9992-e604f5f1c21d
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:38:55 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNTozODo1NSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6Mzg6NTUrMDAwMCIsImlkIjoiZDgwYTU3ODNj
+        NTAyZjBmOTY5ZTIzMDg5NDM3YmI3Y2UiLCJuYW1lIjoiTGlicmFyeSIsImRl
+        c2NyaXB0aW9uIjpudWxsLCJvd25lciI6eyJpZCI6IjQwMjhmOTY2Njc3MTk1
+        N2QwMTY3NzI5Mzk5NzAwMDRlIiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRp
+        c3BsYXlOYW1lIjoic2NlbmFyaW9fdGVzdCIsImhyZWYiOiIvb3duZXJzL3Nj
+        ZW5hcmlvX3Rlc3QifSwiZW52aXJvbm1lbnRDb250ZW50IjpbXX0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:38:56 GMT
+- request:
+    method: post
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/environments/d80a5783c502f0f969e23089437bb7ce/content
+    body:
+      encoding: UTF-8
+      base64_string: 'W3siY29udGVudElkIjoiMTU0MzgxNTUzNjE2NiJ9XQ==
+
+'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk",
+        oauth_nonce="99r5gUqYhAKvkdZyTX3W49Gi6v6h5P7LAo8Z4lyRIs", oauth_signature="vBp8TC3ReVbIlbOW8vyjb%2F6Ehoo%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1543815536", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '31'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - f043ea67-dd44-4c01-aab7-a76b3c804143
+      X-Version:
+      - 2.5.6-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 03 Dec 2018 05:38:55 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNTozODo1NiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6Mzg6NTYrMDAwMCIsImlkIjoicmVnZW5fZW50
+        aXRsZW1lbnRfY2VydF9vZl9lbnYxY2NjMjc3My02NzVjLTQ3ZTItOGRmNi0x
+        YTFjMWU4ZWI3YWEiLCJzdGF0ZSI6IkNSRUFURUQiLCJzdGFydFRpbWUiOm51
+        bGwsImZpbmlzaFRpbWUiOm51bGwsInJlc3VsdCI6bnVsbCwicHJpbmNpcGFs
+        TmFtZSI6ImZvcmVtYW5fYWRtaW4iLCJ0YXJnZXRUeXBlIjpudWxsLCJ0YXJn
+        ZXRJZCI6bnVsbCwib3duZXJJZCI6bnVsbCwiY29ycmVsYXRpb25JZCI6bnVs
+        bCwicmVzdWx0RGF0YSI6bnVsbCwiZG9uZSI6ZmFsc2UsInN0YXR1c1BhdGgi
+        OiIvam9icy9yZWdlbl9lbnRpdGxlbWVudF9jZXJ0X29mX2VudjFjY2MyNzcz
+        LTY3NWMtNDdlMi04ZGY2LTFhMWMxZThlYjdhYSIsImdyb3VwIjoiYXN5bmMg
+        Z3JvdXAifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:38:56 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:38:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"3aadedfb261fe72574ae14d893d1a4be-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2292'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiU2NlbmFyaW8g
+        eXVtIHByb2R1Y3QiLCAiZGVzY3JpcHRpb24iOiBudWxsLCAiZGlzdHJpYnV0
+        b3JzIjogW3sicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgImxhc3RfdXBk
+        YXRlZCI6ICIyMDE4LTEyLTAzVDA1OjM4OjU1WiIsICJfaHJlZiI6ICIvcHVs
+        cC9hcGkvdjIvcmVwb3NpdG9yaWVzL3NjZW5hcmlvX3Rlc3QvZGlzdHJpYnV0
+        b3JzL3NjZW5hcmlvX3Rlc3RfY2xvbmUvIiwgImxhc3Rfb3ZlcnJpZGVfY29u
+        ZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3Jf
+        dHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJs
+        aXNoIjogZmFsc2UsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19k
+        aXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVjMDRjMTZmMDVmNWVl
+        MzE2ZDljYWVhNCJ9LCAiY29uZmlnIjogeyJkZXN0aW5hdGlvbl9kaXN0cmli
+        dXRvcl9pZCI6ICJzY2VuYXJpb190ZXN0In0sICJpZCI6ICJzY2VuYXJpb190
+        ZXN0X2Nsb25lIn0sIHsicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgImxh
+        c3RfdXBkYXRlZCI6ICIyMDE4LTEyLTAzVDA1OjM4OjU1WiIsICJfaHJlZiI6
+        ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL3NjZW5hcmlvX3Rlc3QvZGlz
+        dHJpYnV0b3JzL3NjZW5hcmlvX3Rlc3QvIiwgImxhc3Rfb3ZlcnJpZGVfY29u
+        ZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3Jf
+        dHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjog
+        dHJ1ZSwgInNjcmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1
+        dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAiNWMwNGMxNmYwNWY1ZWUzMTZkOWNh
+        ZWEzIn0sICJjb25maWciOiB7InByb3RlY3RlZCI6IHRydWUsICJodHRwIjog
+        ZmFsc2UsICJodHRwcyI6IHRydWUsICJyZWxhdGl2ZV91cmwiOiAic2NlbmFy
+        aW9fdGVzdCJ9LCAiaWQiOiAic2NlbmFyaW9fdGVzdCJ9LCB7InJlcG9faWQi
+        OiAic2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNTozODo1NVoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRv
+        cmllcy9zY2VuYXJpb190ZXN0L2Rpc3RyaWJ1dG9ycy9leHBvcnRfZGlzdHJp
+        YnV0b3IvIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1
+        Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJleHBvcnRf
+        ZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNo
+        cGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjog
+        eyIkb2lkIjogIjVjMDRjMTZmMDVmNWVlMzE2ZDljYWVhNSJ9LCAiY29uZmln
+        IjogeyJodHRwIjogZmFsc2UsICJyZWxhdGl2ZV91cmwiOiAic2NlbmFyaW9f
+        dGVzdCIsICJodHRwcyI6IGZhbHNlfSwgImlkIjogImV4cG9ydF9kaXN0cmli
+        dXRvciJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3RlcyI6IHsi
+        X3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3JlbW92ZWQi
+        OiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25zIjogInJl
+        cG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAic2NlbmFyaW9fdGVz
+        dCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOC0xMi0wM1QwNTozODo1NVoiLCAi
+        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJpb190
+        ZXN0L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2lt
+        cG9ydGVycyIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjogbnVs
+        bCwgInNjcmF0Y2hwYWQiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRj
+        MTZmMDVmNWVlMzE2ZDljYWVhMiJ9LCAiY29uZmlnIjogeyJmZWVkIjogImZp
+        bGU6Ly8vdmFyL3d3dy90ZXN0X3JlcG9zL3pvbyIsICJzc2xfdmFsaWRhdGlv
+        biI6IHRydWUsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9w
+        b2xpY3kiOiAiaW1tZWRpYXRlIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0s
+        ICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQiOiAi
+        NWMwNGMxNmYwNWY1ZWUzMTZkOWNhZWExIn0sICJ0b3RhbF9yZXBvc2l0b3J5
+        X3VuaXRzIjogMCwgImlkIjogInNjZW5hcmlvX3Rlc3QiLCAiX2hyZWYiOiAi
+        L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJpb190ZXN0LyJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:38:56 GMT
+- request:
+    method: post
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/actions/publish/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6InNjZW5hcmlvX3Rlc3QiLCJvdmVycmlkZV9jb25maWciOnsiZm9y
+        Y2VfZnVsbCI6ZmFsc2V9fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '61'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:38:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2M3MmMyMzc1LWZlMzEtNGRiYS05ZmVlLWMyYzQ4MGI1YWQ1YS8iLCAi
+        dGFza19pZCI6ICJjNzJjMjM3NS1mZTMxLTRkYmEtOWZlZS1jMmM0ODBiNWFk
+        NWEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:38:56 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/c72c2375-fe31-4dba-9fee-c2c480b5ad5a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:38:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"7e98738f4e40695f9e12dfefd2ccf132-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '553'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9jNzJjMjM3NS1mZTMxLTRkYmEtOWZlZS1jMmM0
+        ODBiNWFkNWEvIiwgInRhc2tfaWQiOiAiYzcyYzIzNzUtZmUzMS00ZGJhLTlm
+        ZWUtYzJjNDgwYjVhZDVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIiIsICJz
+        dGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWMw
+        NGMxNzA0OThlZGI4MjU1YmI0NDRlIn0sICJpZCI6ICI1YzA0YzE3MDQ5OGVk
+        YjgyNTViYjQ0NGUifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:38:56 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/c72c2375-fe31-4dba-9fee-c2c480b5ad5a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:38:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"5308547cc4fba36459afb4575be22272-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4314'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9jNzJjMjM3NS1mZTMxLTRkYmEtOWZlZS1jMmM0
+        ODBiNWFkNWEvIiwgInRhc2tfaWQiOiAiYzcyYzIzNzUtZmUzMS00ZGJhLTlm
+        ZWUtYzJjNDgwYjVhZDVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6Mzg6NTZaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogImFhNGQ0M2MzLTM4YzgtNDg5Ni05NTUwLWUwNWRmNjRmMDg1NCIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
+        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAi
+        c3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICIwOGI4MTQwYS1kOWU3LTQyYTUtYmViYS00NzNiYzQxN2U3YTkiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJhYTI1ZWVlMC1lNDc0LTRlMTktOTBmZC1m
+        ZTY1YTJiYzY0MjkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBN
+        cyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        ZGNkNWVkZDUtMGJjYi00ZWUwLTk1ZTctNjI2YjM5MjdkZjUzIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImIxYTFkMGE0LWViMzctNGQ4OC04YTli
+        LWMzZjQ0ZWE5M2ZlOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVz
+        IiwgInN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        ImVhOGU5NmFjLTgzYjAtNDQ2Zi04YTVjLTI0MzMxOWJkZmEzYiIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJj
+        b21wcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlOGFjMjM3MS04ZDMxLTQ1MzMt
+        YmFkZi1kMDJiZTAzZGUxY2IiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0
+        YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICIxMmI2ZDY4YS1iOGYzLTRhZDEtOWIxMi1lMTg4OGI2NTRiMDQi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICIyZWRlYjlkMi1mMjhkLTQ5OGQtOTVmYy01M2M5MDZhMzU4ZmMiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZGJhZTNk
+        MTktMTRkOC00ZDA3LTllMzctODMzNjRjM2Q2MDkwIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJS
+        ZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9v
+        bGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDZlNmQwYTgtOWZh
+        Yi00YjkyLThjYzItNzM0NTlmM2M0ZThmIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
+        aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjE4YmNkMGM2LTNmNjItNGU4Ni1hZGFlLTI4YjZj
+        NTUzZTE5YiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIi
+        LCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3Rv
+        dGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImI5NThkNjA2LWE3YWUtNDM0OC1hNTAxLTQ1MDYxNjJiNGZj
+        NSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
+        ZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBf
+        dHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiMzgzYmJiM2QtODM1Ni00NGM1LTk0YzctM2I2YzkyMTFhYzNk
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBs
+        ZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIu
+        c2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YzE3MDQ5OGVkYjgyNTViYjQ0
+        NGUifSwgImlkIjogIjVjMDRjMTcwNDk4ZWRiODI1NWJiNDQ0ZSJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:38:56 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/c72c2375-fe31-4dba-9fee-c2c480b5ad5a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:38:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"e15a8ca076f744d5a6a25c4ce5a4fe3f-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4301'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9jNzJjMjM3NS1mZTMxLTRkYmEtOWZlZS1jMmM0
+        ODBiNWFkNWEvIiwgInRhc2tfaWQiOiAiYzcyYzIzNzUtZmUzMS00ZGJhLTlm
+        ZWUtYzJjNDgwYjVhZDVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6Mzg6NTZaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImFhNGQ0M2MzLTM4YzgtNDg5Ni05NTUwLWUwNWRmNjRmMDg1NCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwOGI4
+        MTQwYS1kOWU3LTQyYTUtYmViYS00NzNiYzQxN2U3YTkiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJhYTI1ZWVlMC1lNDc0LTRlMTktOTBmZC1mZTY1YTJiYzY0
+        MjkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkY2Q1ZWRkNS0wYmNi
+        LTRlZTAtOTVlNy02MjZiMzkyN2RmNTMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiYjFhMWQwYTQtZWIzNy00ZDg4LThhOWItYzNmNDRlYTkzZmU5
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBl
+        IjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWE4ZTk2YWMtODNi
+        MC00NDZmLThhNWMtMjQzMzE5YmRmYTNiIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImU4YWMyMzcxLThkMzEtNDUzMy1iYWRmLWQwMmJlMDNk
+        ZTFjYiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3Rl
+        cF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjEyYjZk
+        NjhhLWI4ZjMtNGFkMS05YjEyLWUxODg4YjY1NGIwNCIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        Q2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9y
+        ZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
+        VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJlZGViOWQyLWYy
+        OGQtNDk4ZC05NWZjLTUzYzkwNmEzNThmYyIsICJudW1fcHJvY2Vzc2VkIjog
+        MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
+        dGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNx
+        bGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkYmFlM2QxOS0xNGQ4LTRkMDct
+        OWUzNy04MzM2NGMzZDYwOTAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCBy
+        ZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIwNmU2ZDBhOC05ZmFiLTRiOTItOGNjMi03
+        MzQ1OWYzYzRlOGYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxl
+        cyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAx
+        LCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiMThiY2QwYzYtM2Y2Mi00ZTg2LWFkYWUtMjhiNmM1NTNlMTliIiwgIm51
+        bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUi
+        OiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjk1
+        OGQ2MDYtYTdhZS00MzQ4LWE1MDEtNDUwNjE2MmI0ZmM1IiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRp
+        YWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzODNi
+        YmIzZC04MzU2LTQ0YzUtOTRjNy0zYjZjOTIxMWFjM2QiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIiLCAi
+        c3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
+        ZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxl
+        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
+        eyIkb2lkIjogIjVjMDRjMTcwNDk4ZWRiODI1NWJiNDQ0ZSJ9LCAiaWQiOiAi
+        NWMwNGMxNzA0OThlZGI4MjU1YmI0NDRlIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:38:56 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/c72c2375-fe31-4dba-9fee-c2c480b5ad5a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:38:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"b175489ae7e4f3548853012cd74a3bcf-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4282'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9jNzJjMjM3NS1mZTMxLTRkYmEtOWZlZS1jMmM0
+        ODBiNWFkNWEvIiwgInRhc2tfaWQiOiAiYzcyYzIzNzUtZmUzMS00ZGJhLTlm
+        ZWUtYzJjNDgwYjVhZDVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6Mzg6NTZaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImFhNGQ0M2MzLTM4YzgtNDg5Ni05NTUwLWUwNWRmNjRmMDg1NCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwOGI4
+        MTQwYS1kOWU3LTQyYTUtYmViYS00NzNiYzQxN2U3YTkiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJhYTI1ZWVlMC1lNDc0LTRlMTktOTBmZC1mZTY1YTJiYzY0
+        MjkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkY2Q1ZWRkNS0wYmNi
+        LTRlZTAtOTVlNy02MjZiMzkyN2RmNTMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiYjFhMWQwYTQtZWIzNy00ZDg4LThhOWItYzNmNDRlYTkzZmU5Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWE4ZTk2YWMtODNiMC00NDZm
+        LThhNWMtMjQzMzE5YmRmYTNiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
+        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImU4YWMyMzcxLThkMzEtNDUzMy1iYWRmLWQwMmJlMDNkZTFjYiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
+        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjEyYjZkNjhhLWI4ZjMtNGFk
+        MS05YjEyLWUxODg4YjY1NGIwNCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
+        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjJlZGViOWQyLWYyOGQtNDk4ZC05NWZjLTUz
+        YzkwNmEzNThmYyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogImRiYWUzZDE5LTE0ZDgtNGQwNy05ZTM3LTgzMzY0YzNkNjA5MCIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
+        Y3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjA2ZTZkMGE4LTlmYWItNGI5Mi04Y2MyLTczNDU5ZjNjNGU4ZiIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJy
+        ZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RB
+        UlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxOGJjZDBjNi0zZjYyLTRl
+        ODYtYWRhZS0yOGI2YzU1M2UxOWIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
+        ZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9y
+        eSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiOTU4ZDYwNi1hN2FlLTQzNDgtYTUw
+        MS00NTA2MTYyYjRmYzUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3Mg
+        RmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjM4M2JiYjNkLTgzNTYtNDRjNS05NGM3
+        LTNiNmM5MjExYWMzZCIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVl
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwy
+        LnNhbWlyLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNl
+        bnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWMwNGMxNzA0
+        OThlZGI4MjU1YmI0NDRlIn0sICJpZCI6ICI1YzA0YzE3MDQ5OGVkYjgyNTVi
+        YjQ0NGUifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:38:56 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/c72c2375-fe31-4dba-9fee-c2c480b5ad5a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:38:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"fde7d79674ce37575374f988b07bcc68-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4269'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9jNzJjMjM3NS1mZTMxLTRkYmEtOWZlZS1jMmM0
+        ODBiNWFkNWEvIiwgInRhc2tfaWQiOiAiYzcyYzIzNzUtZmUzMS00ZGJhLTlm
+        ZWUtYzJjNDgwYjVhZDVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6Mzg6NTZaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImFhNGQ0M2MzLTM4YzgtNDg5Ni05NTUwLWUwNWRmNjRmMDg1NCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwOGI4
+        MTQwYS1kOWU3LTQyYTUtYmViYS00NzNiYzQxN2U3YTkiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJhYTI1ZWVlMC1lNDc0LTRlMTktOTBmZC1mZTY1YTJiYzY0
+        MjkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkY2Q1ZWRkNS0wYmNi
+        LTRlZTAtOTVlNy02MjZiMzkyN2RmNTMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiYjFhMWQwYTQtZWIzNy00ZDg4LThhOWItYzNmNDRlYTkzZmU5Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWE4ZTk2YWMtODNiMC00NDZm
+        LThhNWMtMjQzMzE5YmRmYTNiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
+        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImU4YWMyMzcxLThkMzEtNDUzMy1iYWRmLWQwMmJlMDNkZTFjYiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
+        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjEyYjZkNjhhLWI4ZjMtNGFk
+        MS05YjEyLWUxODg4YjY1NGIwNCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
+        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjJlZGViOWQyLWYyOGQtNDk4ZC05NWZjLTUz
+        YzkwNmEzNThmYyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogImRiYWUzZDE5LTE0ZDgtNGQwNy05ZTM3LTgzMzY0YzNkNjA5MCIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA2
+        ZTZkMGE4LTlmYWItNGI5Mi04Y2MyLTczNDU5ZjNjNGU4ZiIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBv
+        dmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjE4YmNkMGM2LTNmNjItNGU4Ni1hZGFl
+        LTI4YjZjNTUzZTE5YiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0
+        byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImI5NThkNjA2LWE3YWUtNDM0OC1hNTAxLTQ1MDYxNjJi
+        NGZjNSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0
+        ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiMzgzYmJiM2QtODM1Ni00NGM1LTk0YzctM2I2YzkyMTFhYzNk
+        IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAicXVldWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBs
+        ZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIu
+        c2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YzE3MDQ5OGVkYjgyNTViYjQ0
+        NGUifSwgImlkIjogIjVjMDRjMTcwNDk4ZWRiODI1NWJiNDQ0ZSJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:38:56 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/c72c2375-fe31-4dba-9fee-c2c480b5ad5a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:38:56 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"7d31ff90d7a8f5f84df1d699a1ce941c-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '8549'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9jNzJjMjM3NS1mZTMxLTRkYmEtOWZlZS1jMmM0
+        ODBiNWFkNWEvIiwgInRhc2tfaWQiOiAiYzcyYzIzNzUtZmUzMS00ZGJhLTlm
+        ZWUtYzJjNDgwYjVhZDVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTgtMTItMDNUMDU6Mzg6NTZaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6Mzg6NTZa
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
+        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
+        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImFhNGQ0M2MzLTM4YzgtNDg5Ni05NTUw
+        LWUwNWRmNjRmMDg1NCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
+        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
+        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIwOGI4MTQwYS1kOWU3LTQyYTUtYmViYS00NzNiYzQx
+        N2U3YTkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
+        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhYTI1ZWVlMC1lNDc0LTRl
+        MTktOTBmZC1mZTY1YTJiYzY0MjkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
+        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJkY2Q1ZWRkNS0wYmNiLTRlZTAtOTVlNy02MjZiMzkyN2RmNTMiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
+        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjFhMWQwYTQtZWIzNy00ZDg4LThh
+        OWItYzNmNDRlYTkzZmU5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVs
+        ZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        ZWE4ZTk2YWMtODNiMC00NDZmLThhNWMtMjQzMzE5YmRmYTNiIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNv
+        bXBzIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImU4YWMyMzcxLThkMzEtNDUzMy1iYWRm
+        LWQwMmJlMDNkZTFjYiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0
+        YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjEyYjZkNjhhLWI4ZjMtNGFkMS05YjEyLWUxODg4YjY1NGIwNCIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRp
+        b24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJj
+        bG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJlZGViOWQy
+        LWYyOGQtNDk4ZC05NWZjLTUzYzkwNmEzNThmYyIsICJudW1fcHJvY2Vzc2Vk
+        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
+        ZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRl
+        IHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImRiYWUzZDE5LTE0ZDgtNGQwNy05
+        ZTM3LTgzMzY0YzNkNjA5MCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJl
+        cG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjA2ZTZkMGE4LTlmYWItNGI5Mi04Y2MyLTczNDU5
+        ZjNjNGU4ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwg
+        InN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE4YmNk
+        MGM2LTNmNjItNGU4Ni1hZGFlLTI4YjZjNTUzZTE5YiIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        UHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxp
+        c2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI5NThkNjA2LWE3YWUt
+        NDM0OC1hNTAxLTQ1MDYxNjJiNGZjNSIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBM
+        aXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9f
+        bWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzgzYmJiM2QtODM1Ni00NGM1
+        LTk0YzctM2I2YzkyMTFhYzNkIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
+        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlz
+        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwg
+        InJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJzdGFydGVkIjogIjIwMTgt
+        MTItMDNUMDU6Mzg6NTZaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0
+        cyIsICJjb21wbGV0ZWQiOiAiMjAxOC0xMi0wM1QwNTozODo1NloiLCAidHJh
+        Y2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Rp
+        c3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7ImdlbmVyYXRlIHNxbGl0ZSI6ICJT
+        S0lQUEVEIiwgInJwbXMiOiAiRklOSVNIRUQiLCAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIjogIkZJTklTSEVEIiwgInJlbW92ZV9vbGRfcmVwb2RhdGEi
+        OiAiRklOSVNIRUQiLCAibW9kdWxlcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9y
+        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQi
+        LCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklT
+        SEVEIiwgInJlcG92aWV3IjogIlNLSVBQRUQiLCAicHVibGlzaF9kaXJlY3Rv
+        cnkiOiAiRklOSVNIRUQiLCAiZXJyYXRhIjogIkZJTklTSEVEIiwgIm1ldGFk
+        YXRhIjogIkZJTklTSEVEIn0sICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImRp
+        c3RyaWJ1dG9yX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAiaWQiOiAiNWMwNGMx
+        NzAwNWY1ZWUwNWMzZmQ4NGI5IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2Vz
+        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRh
+        ZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImFhNGQ0M2MzLTM4YzgtNDg5Ni05NTUwLWUw
+        NWRmNjRmMDg1NCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRp
+        b24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIwOGI4MTQwYS1kOWU3LTQyYTUtYmViYS00NzNiYzQxN2U3
+        YTkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUi
+        OiAicnBtcyIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhYTI1ZWVlMC1lNDc0LTRlMTkt
+        OTBmZC1mZTY1YTJiYzY0MjkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVs
+        dGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJkY2Q1ZWRkNS0wYmNiLTRlZTAtOTVlNy02MjZiMzkyN2RmNTMiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiYjFhMWQwYTQtZWIzNy00ZDg4LThhOWIt
+        YzNmNDRlYTkzZmU5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMi
+        LCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWE4
+        ZTk2YWMtODNiMC00NDZmLThhNWMtMjQzMzE5YmRmYTNiIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBz
+        IiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImU4YWMyMzcxLThkMzEtNDUzMy1iYWRmLWQw
+        MmJlMDNkZTFjYiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4i
+        LCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjEy
+        YjZkNjhhLWI4ZjMtNGFkMS05YjEyLWUxODg4YjY1NGIwNCIsICJudW1fcHJv
+        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
+        OiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9z
+        ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJlZGViOWQyLWYy
+        OGQtNDk4ZC05NWZjLTUzYzkwNmEzNThmYyIsICJudW1fcHJvY2Vzc2VkIjog
+        MX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
+        dGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNx
+        bGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImRiYWUzZDE5LTE0ZDgtNGQwNy05ZTM3
+        LTgzMzY0YzNkNjA5MCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9k
+        YXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjA2ZTZkMGE4LTlmYWItNGI5Mi04Y2MyLTczNDU5ZjNj
+        NGU4ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0
+        ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE4YmNkMGM2
+        LTNmNjItNGU4Ni1hZGFlLTI4YjZjNTUzZTE5YiIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
+        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI5NThkNjA2LWE3YWUtNDM0
+        OC1hNTAxLTQ1MDYxNjJiNGZjNSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
+        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzgzYmJiM2QtODM1Ni00NGM1LTk0
+        YzctM2I2YzkyMTFhYzNkIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRjMTcwNDk4ZWRiODI1
+        NWJiNDQ0ZSJ9LCAiaWQiOiAiNWMwNGMxNzA0OThlZGI4MjU1YmI0NDRlIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:38:56 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/repo_sync.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/repo_sync.yml
@@ -1,51 +1,8 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/actions/sync/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
-        Ijp0cnVlfX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '53'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 22 Oct 2018 17:08:48 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Content-Length:
-      - '172'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2VmODY5YWNlLTM1OTUtNDJmZC04YTYyLWYyYzIzZDQ3NDA1MC8iLCAi
-        dGFza19pZCI6ICJlZjg2OWFjZS0zNTk1LTQyZmQtOGE2Mi1mMmMyM2Q0NzQw
-        NTAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:48 GMT
-- request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/ef869ace-3595-42fd-8a62-f2c23d474050/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/ca0b6695-55d7-4240-994e-217f682829ba/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -55,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -64,17 +21,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:48 GMT
+      - Mon, 03 Dec 2018 05:12:01 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Etag:
-      - '"ccbf5dd81f686c6d2ed56e5cca3356f5-gzip"'
+      - '"5b0c51aca341256fa777103c2ddddba0-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '630'
-      Connection:
-      - close
+      - '544'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -82,23 +37,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjg2OWFjZS0zNTk1LTQyZmQtOGE2Mi1mMmMyM2Q0NzQw
-        NTAvIiwgInRhc2tfaWQiOiAiZWY4NjlhY2UtMzU5NS00MmZkLThhNjItZjJj
-        MjNkNDc0MDUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9jYTBiNjY5NS01NWQ3LTQyNDAtOTk0ZS0yMTdmNjgyODI5
+        YmEvIiwgInRhc2tfaWQiOiAiY2EwYjY2OTUtNTVkNy00MjQwLTk5NGUtMjE3
+        ZjY4MjgyOWJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogbnVs
         bCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
-        cm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGRldi5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAi
-        d2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
-        b3JrZXItMUBkZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
-        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YmNlMDQyMDJmYTE4M2Yx
-        YzBkMGVhNGYifSwgImlkIjogIjViY2UwNDIwMmZhMTgzZjFjMGQwZWE0ZiJ9
+        cm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIiIsICJzdGF0ZSI6ICJ3
+        YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51bGws
+        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWMwNGJiMjE0OThl
+        ZGI4MjU1YmIxOGYyIn0sICJpZCI6ICI1YzA0YmIyMTQ5OGVkYjgyNTViYjE4
+        ZjIifQ==
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:48 GMT
+  recorded_at: Mon, 03 Dec 2018 05:12:01 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/ef869ace-3595-42fd-8a62-f2c23d474050/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/ca0b6695-55d7-4240-994e-217f682829ba/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -108,7 +62,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -117,17 +71,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:48 GMT
+      - Mon, 03 Dec 2018 05:12:01 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Etag:
-      - '"4af0845a32f87682ef768a87b300acbb-gzip"'
+      - '"2033d9c73fc0ad9ac7950ee167d423a5-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1157'
-      Connection:
-      - close
+      - '1191'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -135,12 +87,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjg2OWFjZS0zNTk1LTQyZmQtOGE2Mi1mMmMyM2Q0NzQw
-        NTAvIiwgInRhc2tfaWQiOiAiZWY4NjlhY2UtMzU5NS00MmZkLThhNjItZjJj
-        MjNkNDc0MDUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9jYTBiNjY5NS01NWQ3LTQyNDAtOTk0ZS0yMTdmNjgyODI5
+        YmEvIiwgInRhc2tfaWQiOiAiY2EwYjY2OTUtNTVkNy00MjQwLTk5NGUtMjE3
+        ZjY4MjgyOWJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTgtMTAtMjJUMTc6MDg6NDhaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTgtMTItMDNUMDU6MTI6MDFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
@@ -153,17 +105,18 @@ http_interactions:
         dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
         YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
         VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiSU5fUFJPR1JF
-        U1MifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
-        ZGV2LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndv
-        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGRldi5l
-        eGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjViY2UwNDIwMmZhMTgzZjFjMGQwZWE0ZiJ9LCAi
-        aWQiOiAiNWJjZTA0MjAyZmExODNmMWMwZDBlYTRmIn0=
+        U1MifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
+        Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRl
+        IjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1YzA0YmIyMTQ5OGVkYjgyNTViYjE4ZjIifSwgImlkIjogIjVjMDRi
+        YjIxNDk4ZWRiODI1NWJiMThmMiJ9
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:48 GMT
+  recorded_at: Mon, 03 Dec 2018 05:12:01 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/ef869ace-3595-42fd-8a62-f2c23d474050/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/ca0b6695-55d7-4240-994e-217f682829ba/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -173,7 +126,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -182,17 +135,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:48 GMT
+      - Mon, 03 Dec 2018 05:12:01 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Etag:
-      - '"54a106cd69014c291da0775939be7021-gzip"'
+      - '"5963060e7d731e87f5ca02f39a799400-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1154'
-      Connection:
-      - close
+      - '1188'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -200,12 +151,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjg2OWFjZS0zNTk1LTQyZmQtOGE2Mi1mMmMyM2Q0NzQw
-        NTAvIiwgInRhc2tfaWQiOiAiZWY4NjlhY2UtMzU5NS00MmZkLThhNjItZjJj
-        MjNkNDc0MDUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9jYTBiNjY5NS01NWQ3LTQyNDAtOTk0ZS0yMTdmNjgyODI5
+        YmEvIiwgInRhc2tfaWQiOiAiY2EwYjY2OTUtNTVkNy00MjQwLTk5NGUtMjE3
+        ZjY4MjgyOWJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTgtMTAtMjJUMTc6MDg6NDhaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTgtMTItMDNUMDU6MTI6MDFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
@@ -218,17 +169,18 @@ http_interactions:
         dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
         YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
         VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2
-        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGRldi5leGFt
-        cGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjViY2UwNDIwMmZhMTgzZjFjMGQwZWE0ZiJ9LCAiaWQi
-        OiAiNWJjZTA0MjAyZmExODNmMWMwZDBlYTRmIn0=
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
+        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzA0YmIyMTQ5OGVkYjgyNTViYjE4ZjIifSwgImlkIjogIjVjMDRiYjIx
+        NDk4ZWRiODI1NWJiMThmMiJ9
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:48 GMT
+  recorded_at: Mon, 03 Dec 2018 05:12:01 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/ef869ace-3595-42fd-8a62-f2c23d474050/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/ca0b6695-55d7-4240-994e-217f682829ba/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -238,7 +190,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -247,17 +199,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:48 GMT
+      - Mon, 03 Dec 2018 05:12:01 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Etag:
-      - '"54a106cd69014c291da0775939be7021-gzip"'
+      - '"5963060e7d731e87f5ca02f39a799400-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1154'
-      Connection:
-      - close
+      - '1188'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -265,12 +215,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjg2OWFjZS0zNTk1LTQyZmQtOGE2Mi1mMmMyM2Q0NzQw
-        NTAvIiwgInRhc2tfaWQiOiAiZWY4NjlhY2UtMzU5NS00MmZkLThhNjItZjJj
-        MjNkNDc0MDUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9jYTBiNjY5NS01NWQ3LTQyNDAtOTk0ZS0yMTdmNjgyODI5
+        YmEvIiwgInRhc2tfaWQiOiAiY2EwYjY2OTUtNTVkNy00MjQwLTk5NGUtMjE3
+        ZjY4MjgyOWJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTgtMTAtMjJUMTc6MDg6NDhaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTgtMTItMDNUMDU6MTI6MDFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
@@ -283,17 +233,18 @@ http_interactions:
         dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
         YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
         VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2
-        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGRldi5leGFt
-        cGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjViY2UwNDIwMmZhMTgzZjFjMGQwZWE0ZiJ9LCAiaWQi
-        OiAiNWJjZTA0MjAyZmExODNmMWMwZDBlYTRmIn0=
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
+        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzA0YmIyMTQ5OGVkYjgyNTViYjE4ZjIifSwgImlkIjogIjVjMDRiYjIx
+        NDk4ZWRiODI1NWJiMThmMiJ9
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:48 GMT
+  recorded_at: Mon, 03 Dec 2018 05:12:01 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/ef869ace-3595-42fd-8a62-f2c23d474050/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/ca0b6695-55d7-4240-994e-217f682829ba/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -303,7 +254,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -312,17 +263,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:48 GMT
+      - Mon, 03 Dec 2018 05:12:01 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Etag:
-      - '"54a106cd69014c291da0775939be7021-gzip"'
+      - '"5963060e7d731e87f5ca02f39a799400-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1154'
-      Connection:
-      - close
+      - '1188'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -330,12 +279,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjg2OWFjZS0zNTk1LTQyZmQtOGE2Mi1mMmMyM2Q0NzQw
-        NTAvIiwgInRhc2tfaWQiOiAiZWY4NjlhY2UtMzU5NS00MmZkLThhNjItZjJj
-        MjNkNDc0MDUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9jYTBiNjY5NS01NWQ3LTQyNDAtOTk0ZS0yMTdmNjgyODI5
+        YmEvIiwgInRhc2tfaWQiOiAiY2EwYjY2OTUtNTVkNy00MjQwLTk5NGUtMjE3
+        ZjY4MjgyOWJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTgtMTAtMjJUMTc6MDg6NDhaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTgtMTItMDNUMDU6MTI6MDFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
@@ -348,17 +297,18 @@ http_interactions:
         dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
         YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
         VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2
-        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGRldi5leGFt
-        cGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjViY2UwNDIwMmZhMTgzZjFjMGQwZWE0ZiJ9LCAiaWQi
-        OiAiNWJjZTA0MjAyZmExODNmMWMwZDBlYTRmIn0=
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
+        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzA0YmIyMTQ5OGVkYjgyNTViYjE4ZjIifSwgImlkIjogIjVjMDRiYjIx
+        NDk4ZWRiODI1NWJiMThmMiJ9
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:48 GMT
+  recorded_at: Mon, 03 Dec 2018 05:12:01 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/ef869ace-3595-42fd-8a62-f2c23d474050/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/ca0b6695-55d7-4240-994e-217f682829ba/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -368,7 +318,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -377,17 +327,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:48 GMT
+      - Mon, 03 Dec 2018 05:12:01 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Etag:
-      - '"aa574477f9c04ef5071e680620249cf0-gzip"'
+      - '"1f020756a2eae1acd80b90a9d64b8aaf-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1151'
-      Connection:
-      - close
+      - '1185'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -395,12 +343,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjg2OWFjZS0zNTk1LTQyZmQtOGE2Mi1mMmMyM2Q0NzQw
-        NTAvIiwgInRhc2tfaWQiOiAiZWY4NjlhY2UtMzU5NS00MmZkLThhNjItZjJj
-        MjNkNDc0MDUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9jYTBiNjY5NS01NWQ3LTQyNDAtOTk0ZS0yMTdmNjgyODI5
+        YmEvIiwgInRhc2tfaWQiOiAiY2EwYjY2OTUtNTVkNy00MjQwLTk5NGUtMjE3
+        ZjY4MjgyOWJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTgtMTAtMjJUMTc6MDg6NDhaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTgtMTItMDNUMDU6MTI6MDFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
@@ -413,17 +361,18 @@ http_interactions:
         bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRl
         IjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5PVF9T
         VEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
-        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4
-        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9u
-        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGRldi5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjViY2UwNDIwMmZhMTgzZjFjMGQwZWE0ZiJ9LCAiaWQiOiAi
-        NWJjZTA0MjAyZmExODNmMWMwZDBlYTRmIn0=
+        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9z
+        Ny1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1
+        bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        YzA0YmIyMTQ5OGVkYjgyNTViYjE4ZjIifSwgImlkIjogIjVjMDRiYjIxNDk4
+        ZWRiODI1NWJiMThmMiJ9
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:48 GMT
+  recorded_at: Mon, 03 Dec 2018 05:12:01 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/ef869ace-3595-42fd-8a62-f2c23d474050/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/ca0b6695-55d7-4240-994e-217f682829ba/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -433,7 +382,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -442,17 +391,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:48 GMT
+      - Mon, 03 Dec 2018 05:12:01 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Etag:
-      - '"f0954810e8d6a76d6ee713ac5cfca9c9-gzip"'
+      - '"0cf2b133f6960e3761f06b70365ea90e-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1145'
-      Connection:
-      - close
+      - '1182'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -460,12 +407,76 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjg2OWFjZS0zNTk1LTQyZmQtOGE2Mi1mMmMyM2Q0NzQw
-        NTAvIiwgInRhc2tfaWQiOiAiZWY4NjlhY2UtMzU5NS00MmZkLThhNjItZjJj
-        MjNkNDc0MDUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9jYTBiNjY5NS01NWQ3LTQyNDAtOTk0ZS0yMTdmNjgyODI5
+        YmEvIiwgInRhc2tfaWQiOiAiY2EwYjY2OTUtNTVkNy00MjQwLTk5NGUtMjE3
+        ZjY4MjgyOWJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTgtMTAtMjJUMTc6MDg6NDhaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTgtMTItMDNUMDU6MTI6MDFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
+        IklOX1BST0dSRVNTIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5PVF9TVEFS
+        VEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
+        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5p
+        bmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0
+        YmIyMTQ5OGVkYjgyNTViYjE4ZjIifSwgImlkIjogIjVjMDRiYjIxNDk4ZWRi
+        ODI1NWJiMThmMiJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:12:01 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/ca0b6695-55d7-4240-994e-217f682829ba/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:12:01 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"ee80a701e743429ec512eec01cdf63f1-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1179'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jYTBiNjY5NS01NWQ3LTQyNDAtOTk0ZS0yMTdmNjgyODI5
+        YmEvIiwgInRhc2tfaWQiOiAiY2EwYjY2OTUtNTVkNy00MjQwLTk5NGUtMjE3
+        ZjY4MjgyOWJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6MTI6MDFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
@@ -478,17 +489,18 @@ http_interactions:
         OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
         IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIklOX1BST0dSRVNT
         In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVl
-        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGRldi5leGFtcGxlLmNvbSIs
-        ICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjViY2UwNDIwMmZhMTgzZjFjMGQwZWE0ZiJ9LCAiaWQiOiAiNWJjZTA0
-        MjAyZmExODNmMWMwZDBlYTRmIn0=
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZl
+        bDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmci
+        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
+        Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YmIy
+        MTQ5OGVkYjgyNTViYjE4ZjIifSwgImlkIjogIjVjMDRiYjIxNDk4ZWRiODI1
+        NWJiMThmMiJ9
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:48 GMT
+  recorded_at: Mon, 03 Dec 2018 05:12:01 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/ef869ace-3595-42fd-8a62-f2c23d474050/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/ca0b6695-55d7-4240-994e-217f682829ba/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -498,7 +510,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -507,17 +519,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:48 GMT
+      - Mon, 03 Dec 2018 05:12:01 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Etag:
-      - '"860403526eb434b03a64640f8770ca99-gzip"'
+      - '"ca0fc0498cadaa1ef37fbf0e569ae185-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1142'
-      Connection:
-      - close
+      - '1173'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -525,35 +535,36 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjg2OWFjZS0zNTk1LTQyZmQtOGE2Mi1mMmMyM2Q0NzQw
-        NTAvIiwgInRhc2tfaWQiOiAiZWY4NjlhY2UtMzU5NS00MmZkLThhNjItZjJj
-        MjNkNDc0MDUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9jYTBiNjY5NS01NWQ3LTQyNDAtOTk0ZS0yMTdmNjgyODI5
+        YmEvIiwgInRhc2tfaWQiOiAiY2EwYjY2OTUtNTVkNy00MjQwLTk5NGUtMjE3
+        ZjY4MjgyOWJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTgtMTAtMjJUMTc6MDg6NDhaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTgtMTItMDNUMDU6MTI6MDFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
         IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
         OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
         bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
-        OiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
-        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUi
-        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4YW1wbGUuY29t
-        LmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJl
-        c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGRldi5leGFtcGxlLmNvbSIsICJy
-        ZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjog
-        IjViY2UwNDIwMmZhMTgzZjFjMGQwZWE0ZiJ9LCAiaWQiOiAiNWJjZTA0MjAy
-        ZmExODNmMWMwZDBlYTRmIn0=
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IklOX1BST0dSRVNTIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29y
+        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9z
+        Ny1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwg
+        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YmIyMTQ5OGVk
+        YjgyNTViYjE4ZjIifSwgImlkIjogIjVjMDRiYjIxNDk4ZWRiODI1NWJiMThm
+        MiJ9
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:48 GMT
+  recorded_at: Mon, 03 Dec 2018 05:12:02 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/ef869ace-3595-42fd-8a62-f2c23d474050/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/ca0b6695-55d7-4240-994e-217f682829ba/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -563,7 +574,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -572,17 +583,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:48 GMT
+      - Mon, 03 Dec 2018 05:12:02 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Etag:
-      - '"76f91a2ca32bb006b4407169fb1ef0cb-gzip"'
+      - '"6b84745c0342fbbefd48fe0cda7d8155-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1136'
-      Connection:
-      - close
+      - '1170'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -590,12 +599,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjg2OWFjZS0zNTk1LTQyZmQtOGE2Mi1mMmMyM2Q0NzQw
-        NTAvIiwgInRhc2tfaWQiOiAiZWY4NjlhY2UtMzU5NS00MmZkLThhNjItZjJj
-        MjNkNDc0MDUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9jYTBiNjY5NS01NWQ3LTQyNDAtOTk0ZS0yMTdmNjgyODI5
+        YmEvIiwgInRhc2tfaWQiOiAiY2EwYjY2OTUtNTVkNy00MjQwLTk5NGUtMjE3
+        ZjY4MjgyOWJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTgtMTAtMjJUMTc6MDg6NDhaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTgtMTItMDNUMDU6MTI6MDFaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
@@ -608,17 +617,17 @@ http_interactions:
         Iml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklT
         SEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
         ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAicmVz
-        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVk
-        X3Jlc291cmNlX3dvcmtlci0xQGRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQi
-        OiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjViY2Uw
-        NDIwMmZhMTgzZjFjMGQwZWE0ZiJ9LCAiaWQiOiAiNWJjZTA0MjAyZmExODNm
-        MWMwZDBlYTRmIn0=
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2Vy
+        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
+        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YmIyMTQ5OGVkYjgy
+        NTViYjE4ZjIifSwgImlkIjogIjVjMDRiYjIxNDk4ZWRiODI1NWJiMThmMiJ9
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:48 GMT
+  recorded_at: Mon, 03 Dec 2018 05:12:02 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/ef869ace-3595-42fd-8a62-f2c23d474050/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/ca0b6695-55d7-4240-994e-217f682829ba/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -628,7 +637,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -637,17 +646,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:48 GMT
+      - Mon, 03 Dec 2018 05:12:02 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Etag:
-      - '"ae15f7b6f27aae5d824764c4a0992a04-gzip"'
+      - '"22661a3be10fb05c61ed205fd2182c1d-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2389'
-      Connection:
-      - close
+      - '2423'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -655,16 +662,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjg2OWFjZS0zNTk1LTQyZmQtOGE2Mi1mMmMyM2Q0NzQw
-        NTAvIiwgInRhc2tfaWQiOiAiZWY4NjlhY2UtMzU5NS00MmZkLThhNjItZjJj
-        MjNkNDc0MDUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9jYTBiNjY5NS01NWQ3LTQyNDAtOTk0ZS0yMTdmNjgyODI5
+        YmEvIiwgInRhc2tfaWQiOiAiY2EwYjY2OTUtNTVkNy00MjQwLTk5NGUtMjE3
+        ZjY4MjgyOWJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwgInRyYWNl
+        IjIwMTgtMTItMDNUMDU6MTI6MDJaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MTI6MDFaIiwgInRyYWNl
         YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzLzQyYmMyYjU0LWI2NWQtNDNhNy04NTE0LTg1MDg5
-        MDU0ZGVkMS8iLCAidGFza19pZCI6ICI0MmJjMmI1NC1iNjVkLTQzYTctODUx
-        NC04NTA4OTA1NGRlZDEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bHAvYXBpL3YyL3Rhc2tzLzRhYzc4ZDFhLTUwYWItNGI0Mi05MjhiLWEyMjE0
+        NGJkOTUwNS8iLCAidGFza19pZCI6ICI0YWM3OGQxYS01MGFiLTRiNDItOTI4
+        Yi1hMjIxNDRiZDk1MDUifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
         bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
         dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
         cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
@@ -676,42 +683,42 @@ http_interactions:
         XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
         ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4YW1wbGUuY29tLmRx
-        MiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBkZXYuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJ5
-        dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAi
-        c2NlbmFyaW9fdGVzdCIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6
-        ICIyMDE4LTEwLTIyVDE3OjA4OjQ4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jl
-        c3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwg
-        ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21l
-        c3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1
-        cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
-        b24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAs
-        ICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjViY2UwNDIwYjQ3Y2ViMDc1
-        MDFhYjFlYSIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVt
-        c19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwi
-        OiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2Rv
-        bmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
-        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWJjZTA0MjAyZmEx
-        ODNmMWMwZDBlYTRmIn0sICJpZCI6ICI1YmNlMDQyMDJmYTE4M2YxYzBkMGVh
-        NGYifQ==
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToxMjowMVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjEyOjAyWiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmIyMjA1ZjVlZTA1YzNmZDg0NzIiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiYjIxNDk4ZWRiODI1NWJiMThm
+        MiJ9LCAiaWQiOiAiNWMwNGJiMjE0OThlZGI4MjU1YmIxOGYyIn0=
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:48 GMT
+  recorded_at: Mon, 03 Dec 2018 05:12:02 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/42bc2b54-b65d-43a7-8514-85089054ded1/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/4ac78d1a-50ab-4b42-928b-a22144bd9505/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -721,7 +728,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -730,17 +737,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:48 GMT
+      - Mon, 03 Dec 2018 05:12:02 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Etag:
-      - '"a20f70059549072fce962df533de7362-gzip"'
+      - '"51b104fa859015e277d42222bec11907-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '657'
-      Connection:
-      - close
+      - '4556'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -748,257 +753,341 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80MmJjMmI1NC1iNjVkLTQzYTctODUxNC04NTA4
-        OTA1NGRlZDEvIiwgInRhc2tfaWQiOiAiNDJiYzJiNTQtYjY1ZC00M2E3LTg1
-        MTQtODUwODkwNTRkZWQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy80YWM3OGQxYS01MGFiLTRiNDItOTI4Yi1hMjIx
+        NDRiZDk1MDUvIiwgInRhc2tfaWQiOiAiNGFjNzhkMWEtNTBhYi00YjQyLTky
+        OGItYTIyMTQ0YmQ5NTA1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGRldi5l
-        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBkZXYuZXhhbXBs
-        ZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6
-        IHsiJG9pZCI6ICI1YmNlMDQyMDJmYTE4M2YxYzBkMGVhNWYifSwgImlkIjog
-        IjViY2UwNDIwMmZhMTgzZjFjMGQwZWE1ZiJ9
-    http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:48 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/ef869ace-3595-42fd-8a62-f2c23d474050/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 22 Oct 2018 17:08:48 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"ae15f7b6f27aae5d824764c4a0992a04-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2389'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjg2OWFjZS0zNTk1LTQyZmQtOGE2Mi1mMmMyM2Q0NzQw
-        NTAvIiwgInRhc2tfaWQiOiAiZWY4NjlhY2UtMzU5NS00MmZkLThhNjItZjJj
-        MjNkNDc0MDUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzLzQyYmMyYjU0LWI2NWQtNDNhNy04NTE0LTg1MDg5
-        MDU0ZGVkMS8iLCAidGFza19pZCI6ICI0MmJjMmI1NC1iNjVkLTQzYTctODUx
-        NC04NTA4OTA1NGRlZDEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
-        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4YW1wbGUuY29tLmRx
-        MiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBkZXYuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJ5
-        dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAi
-        c2NlbmFyaW9fdGVzdCIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6
-        ICIyMDE4LTEwLTIyVDE3OjA4OjQ4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jl
-        c3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwg
-        ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21l
-        c3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1
-        cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
-        b24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAs
-        ICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjViY2UwNDIwYjQ3Y2ViMDc1
-        MDFhYjFlYSIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVt
-        c19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwi
-        OiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2Rv
-        bmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
-        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWJjZTA0MjAyZmEx
-        ODNmMWMwZDBlYTRmIn0sICJpZCI6ICI1YmNlMDQyMDJmYTE4M2YxYzBkMGVh
-        NGYifQ==
-    http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:48 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/42bc2b54-b65d-43a7-8514-85089054ded1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 22 Oct 2018 17:08:48 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"739105fa5172358c322ce8158a0b2d80-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4516'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80MmJjMmI1NC1iNjVkLTQzYTctODUxNC04NTA4
-        OTA1NGRlZDEvIiwgInRhc2tfaWQiOiAiNDJiYzJiNTQtYjY1ZC00M2E3LTg1
-        MTQtODUwODkwNTRkZWQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwgInRyYWNlYmFjayI6IG51
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MTI6MDJaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
         InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
         ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI4MWI5ZTU1My0xZTc1LTQ5ODEtODUzZi1m
-        ZjkyMWM1ZDcyNWEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI0MzdlOGZkNy1mNDJmLTRjNDctODA1Mi04
+        YmNkNmY5OGUxMDAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiSU5fUFJPR1JFU1Mi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjE3ZWQxNWYtZjYwZS00Mzc1LTlj
+        ZjEtODZhMTE4NTZjNTQzIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3Ry
+        aWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjNmNWIyYTJjLTA2YTEtNGZmMC04MzVmLTRi
+        MTZkNzY4YTczZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0
+        ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjZmNDAwMWU5
+        LTM5MTgtNDc1Ni1hNGNhLTVkZDg1YzJmMzQ1NyIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICIyMmVjODY0OS1hZTA3LTQwZGEtOTVjYi04ZDJl
+        NTJiMTZhMjUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOWViNDM4
+        OWQtZTFlMS00OGI3LWIwZjYtOWUyNzkyYTM1NjM1IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAi
+        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiMTdkZDc4MDktMmVjZS00NDI5LWIwNjUtNDlh
+        YjhlMGVhZDBjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUi
+        LCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRk
+        MDViMWU0LTEwMjktNDc3Ni1hNzFhLTk0NWRmOTFlYWM5NSIsICJudW1fcHJv
+        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFk
+        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjViN2ZlYWUxLWVkMzgtNDVjYy1i
+        MDQxLTAzNGFjMGU5MDg1MiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjViN2Q2Yzg0LWEyZTgtNDcxMi1hZmZkLWEz
+        Y2Q1NGViYzY5NCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIzNWI0NzhmMS03ZDA1LTQ4ODAtOTNhOC01NGQxZjI5MzMz
+        N2YiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVw
+        X3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICI5ZjE0MjUyZi1lMzk2LTQ3MTktOTFhYy0yNzUxZTFkNGViYmIiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUi
+        OiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzVhMTQxNTMtYmI5
+        ZC00YWE3LTkwYjctNDdhMmU4NjdjYzg0IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJl
+        Y3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODJlZmFmYzYtZmI1Mi00NWJi
+        LWE4ZmItNGY3OTc1M2ZmODI3IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3Rp
+        bmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRh
+        ZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NDI5ZjczZC1lYjQ5LTQ1N2Ut
+        OWUzOS0xNzJkYmZmYzYyNTIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJx
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRl
+        dmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJyZXN1bHQi
+        OiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRi
+        YjIyNDk4ZWRiODI1NWJiMWE5OCJ9LCAiaWQiOiAiNWMwNGJiMjI0OThlZGI4
+        MjU1YmIxYTk4In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:12:02 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/ca0b6695-55d7-4240-994e-217f682829ba/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:12:02 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"22661a3be10fb05c61ed205fd2182c1d-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jYTBiNjY5NS01NWQ3LTQyNDAtOTk0ZS0yMTdmNjgyODI5
+        YmEvIiwgInRhc2tfaWQiOiAiY2EwYjY2OTUtNTVkNy00MjQwLTk5NGUtMjE3
+        ZjY4MjgyOWJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6MTI6MDJaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MTI6MDFaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzLzRhYzc4ZDFhLTUwYWItNGI0Mi05MjhiLWEyMjE0
+        NGJkOTUwNS8iLCAidGFza19pZCI6ICI0YWM3OGQxYS01MGFiLTRiNDItOTI4
+        Yi1hMjIxNDRiZDk1MDUifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToxMjowMVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjEyOjAyWiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmIyMjA1ZjVlZTA1YzNmZDg0NzIiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiYjIxNDk4ZWRiODI1NWJiMThm
+        MiJ9LCAiaWQiOiAiNWMwNGJiMjE0OThlZGI4MjU1YmIxOGYyIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:12:02 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/4ac78d1a-50ab-4b42-928b-a22144bd9505/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:12:02 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"6b05f889748c89b9260888973976a10c-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4550'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy80YWM3OGQxYS01MGFiLTRiNDItOTI4Yi1hMjIx
+        NDRiZDk1MDUvIiwgInRhc2tfaWQiOiAiNGFjNzhkMWEtNTBhYi00YjQyLTky
+        OGItYTIyMTQ0YmQ5NTA1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MTI6MDJaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI0MzdlOGZkNy1mNDJmLTRjNDctODA1Mi04
+        YmNkNmY5OGUxMDAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
         dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
         dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiODNkNWZmYWUtM2U2My00MGE5LWI1Nzct
-        ZWMyMDRlMGFiMjU4IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNjE3ZWQxNWYtZjYwZS00Mzc1LTljZjEt
+        ODZhMTE4NTZjNTQzIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
         Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
         dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
         ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjFmYTc0M2Q2LWE5YmEtNDI2My1hMmMzLTJlMDBiOWEx
-        ODY3ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        ICJzdGVwX2lkIjogIjNmNWIyYTJjLTA2YTEtNGZmMC04MzVmLTRiMTZkNzY4
+        YTczZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA0
         LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
         ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIklOX1BS
         T0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM3ZDI1MzJkLTc1MmYt
-        NDhhMi05ZWRhLWE0ODY5NTAwNDI0MyIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjZmNDAwMWU5LTM5MTgt
+        NDc1Ni1hNGNhLTVkZDg1YzJmMzQ1NyIsICJudW1fcHJvY2Vzc2VkIjogNH0s
         IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
         ZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICIzYjQwMWExYy1mOWJjLTQ5MzEtYjRiNy1mMjNiOTQwY2Qy
-        YzUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICIyMmVjODY0OS1hZTA3LTQwZGEtOTVjYi04ZDJlNTJiMTZh
+        MjUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlw
         ZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
         X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMWQwZTQ1OTYtMTVk
-        NC00ZGViLWI2YjYtYzY5YjIwYjdjM2U4IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOWViNDM4OWQtZTFl
+        MS00OGI3LWIwZjYtOWUyNzkyYTM1NjM1IiwgIm51bV9wcm9jZXNzZWQiOiAw
         fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
         aW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNf
         dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
         YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiYWQ5NDViNDktYTI5Yi00ZDVmLWIxODgtZmZlZmI2YmUz
-        ZjgyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        InN0ZXBfaWQiOiAiMTdkZDc4MDktMmVjZS00NDI5LWIwNjUtNDlhYjhlMGVh
+        ZDBjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
         ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
         cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
         Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRiZmUwNjA3
-        LTg1ZjMtNDZjZC04ZmRhLTJmYjc2ODA0OGUxZCIsICJudW1fcHJvY2Vzc2Vk
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRkMDViMWU0
+        LTEwMjktNDc3Ni1hNzFhLTk0NWRmOTFlYWM5NSIsICJudW1fcHJvY2Vzc2Vk
         IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
         bGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
         cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogImY3OWYxNWQxLTgzMWMtNGNkOS1iYTYwLWMy
-        NDEzZmI3NjRlYyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        cyI6IDAsICJzdGVwX2lkIjogIjViN2ZlYWUxLWVkMzgtNDVjYy1iMDQxLTAz
+        NGFjMGU5MDg1MiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
         c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
         IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
         X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImMzNmI3YzBiLTk4OGQtNDY5OS04ODkwLTY4YjdlM2Zm
-        MzgwZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        ICJzdGVwX2lkIjogIjViN2Q2Yzg0LWEyZTgtNDcxMi1hZmZkLWEzY2Q1NGVi
+        YzY5NCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
         LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAi
         c3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6
         IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICJkMmQ2YjlhMS0wYTcyLTQyODUtYjM3Mi1jMjNiYjEwMTc5MjkiLCAi
+        ZCI6ICIzNWI0NzhmMS03ZDA1LTQ4ODAtOTNhOC01NGQxZjI5MzMzN2YiLCAi
         bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
         aXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUi
         OiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJm
-        MTA4NzlhZS1jNzQ5LTQ1MmEtOWZjYS0xNGI0YzZjZDM2M2UiLCAibnVtX3By
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5
+        ZjE0MjUyZi1lMzk2LTQ3MTktOTFhYy0yNzUxZTFkNGViYmIiLCAibnVtX3By
         b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
         IjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVw
         b3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
         RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTYxNTE4ODktNWJiYy00ZWE4
-        LTgwMGQtMjk5NzgwOGIwZTBjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzVhMTQxNTMtYmI5ZC00YWE3
+        LTkwYjctNDdhMmU4NjdjYzg0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
         dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZp
         bGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rvcnki
         LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZjFmZjkwNDktNDA1NC00YjY4LWJiYWMt
-        ZDllMmU2Yjc1MzY0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiODJlZmFmYzYtZmI1Mi00NWJiLWE4ZmIt
+        NGY3OTc1M2ZmODI3IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZp
         bGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIzYjIzMGE4Ny02NTM5LTQyODAtOTk5Yi02
-        ZDZiYWYzYTM2M2EiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBkZXYuZXhhbXBsZS5jb20u
-        ZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVz
-        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4YW1wbGUuY29tIiwgInJl
-        c3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWJjZTA0MjAyZmExODNmMWMwZDBlYTVmIn0sICJpZCI6ICI1YmNlMDQyMDJm
-        YTE4M2YxYzBkMGVhNWYifQ==
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI0NDI5ZjczZC1lYjQ5LTQ1N2UtOWUzOS0x
+        NzJkYmZmYzYyNTIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRldmVsMi5z
+        YW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50
+        b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiYjIyNDk4
+        ZWRiODI1NWJiMWE5OCJ9LCAiaWQiOiAiNWMwNGJiMjI0OThlZGI4MjU1YmIx
+        YTk4In0=
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:48 GMT
+  recorded_at: Mon, 03 Dec 2018 05:12:02 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/ef869ace-3595-42fd-8a62-f2c23d474050/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/ca0b6695-55d7-4240-994e-217f682829ba/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1008,7 +1097,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -1017,17 +1106,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:48 GMT
+      - Mon, 03 Dec 2018 05:12:02 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Etag:
-      - '"ae15f7b6f27aae5d824764c4a0992a04-gzip"'
+      - '"22661a3be10fb05c61ed205fd2182c1d-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2389'
-      Connection:
-      - close
+      - '2423'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1035,16 +1122,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjg2OWFjZS0zNTk1LTQyZmQtOGE2Mi1mMmMyM2Q0NzQw
-        NTAvIiwgInRhc2tfaWQiOiAiZWY4NjlhY2UtMzU5NS00MmZkLThhNjItZjJj
-        MjNkNDc0MDUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9jYTBiNjY5NS01NWQ3LTQyNDAtOTk0ZS0yMTdmNjgyODI5
+        YmEvIiwgInRhc2tfaWQiOiAiY2EwYjY2OTUtNTVkNy00MjQwLTk5NGUtMjE3
+        ZjY4MjgyOWJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwgInRyYWNl
+        IjIwMTgtMTItMDNUMDU6MTI6MDJaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MTI6MDFaIiwgInRyYWNl
         YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzLzQyYmMyYjU0LWI2NWQtNDNhNy04NTE0LTg1MDg5
-        MDU0ZGVkMS8iLCAidGFza19pZCI6ICI0MmJjMmI1NC1iNjVkLTQzYTctODUx
-        NC04NTA4OTA1NGRlZDEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bHAvYXBpL3YyL3Rhc2tzLzRhYzc4ZDFhLTUwYWItNGI0Mi05MjhiLWEyMjE0
+        NGJkOTUwNS8iLCAidGFza19pZCI6ICI0YWM3OGQxYS01MGFiLTRiNDItOTI4
+        Yi1hMjIxNDRiZDk1MDUifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
         bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
         dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
         cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
@@ -1056,42 +1143,42 @@ http_interactions:
         XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
         ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4YW1wbGUuY29tLmRx
-        MiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBkZXYuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJ5
-        dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAi
-        c2NlbmFyaW9fdGVzdCIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6
-        ICIyMDE4LTEwLTIyVDE3OjA4OjQ4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jl
-        c3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwg
-        ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21l
-        c3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1
-        cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
-        b24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAs
-        ICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjViY2UwNDIwYjQ3Y2ViMDc1
-        MDFhYjFlYSIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVt
-        c19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwi
-        OiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2Rv
-        bmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
-        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWJjZTA0MjAyZmEx
-        ODNmMWMwZDBlYTRmIn0sICJpZCI6ICI1YmNlMDQyMDJmYTE4M2YxYzBkMGVh
-        NGYifQ==
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToxMjowMVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjEyOjAyWiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmIyMjA1ZjVlZTA1YzNmZDg0NzIiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiYjIxNDk4ZWRiODI1NWJiMThm
+        MiJ9LCAiaWQiOiAiNWMwNGJiMjE0OThlZGI4MjU1YmIxOGYyIn0=
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:49 GMT
+  recorded_at: Mon, 03 Dec 2018 05:12:02 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/42bc2b54-b65d-43a7-8514-85089054ded1/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/4ac78d1a-50ab-4b42-928b-a22144bd9505/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1101,7 +1188,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -1110,17 +1197,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:49 GMT
+      - Mon, 03 Dec 2018 05:12:02 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Etag:
-      - '"54b50f64c0599b4c5311bca6a86c89cb-gzip"'
+      - '"0541376dc173fcc87303aded6dbc96d9-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '4509'
-      Connection:
-      - close
+      - '4543'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1128,110 +1213,110 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80MmJjMmI1NC1iNjVkLTQzYTctODUxNC04NTA4
-        OTA1NGRlZDEvIiwgInRhc2tfaWQiOiAiNDJiYzJiNTQtYjY1ZC00M2E3LTg1
-        MTQtODUwODkwNTRkZWQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy80YWM3OGQxYS01MGFiLTRiNDItOTI4Yi1hMjIx
+        NDRiZDk1MDUvIiwgInRhc2tfaWQiOiAiNGFjNzhkMWEtNTBhYi00YjQyLTky
+        OGItYTIyMTQ0YmQ5NTA1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwgInRyYWNlYmFjayI6IG51
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MTI6MDJaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
         InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
         ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI4MWI5ZTU1My0xZTc1LTQ5ODEtODUzZi1m
-        ZjkyMWM1ZDcyNWEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI0MzdlOGZkNy1mNDJmLTRjNDctODA1Mi04
+        YmNkNmY5OGUxMDAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
         dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
         dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiODNkNWZmYWUtM2U2My00MGE5LWI1Nzct
-        ZWMyMDRlMGFiMjU4IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNjE3ZWQxNWYtZjYwZS00Mzc1LTljZjEt
+        ODZhMTE4NTZjNTQzIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
         Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
         dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
         ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjFmYTc0M2Q2LWE5YmEtNDI2My1hMmMzLTJlMDBiOWEx
-        ODY3ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        ICJzdGVwX2lkIjogIjNmNWIyYTJjLTA2YTEtNGZmMC04MzVmLTRiMTZkNzY4
+        YTczZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
         LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
         ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM3ZDI1MzJkLTc1MmYtNDhh
-        Mi05ZWRhLWE0ODY5NTAwNDI0MyIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjZmNDAwMWU5LTM5MTgtNDc1
+        Ni1hNGNhLTVkZDg1YzJmMzQ1NyIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
         bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
         ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
         bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjNiNDAxYTFjLWY5YmMtNDkzMS1iNGI3LWYyM2I5NDBjZDJjNSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        IjogIjIyZWM4NjQ5LWFlMDctNDBkYS05NWNiLThkMmU1MmIxNmEyNSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
         cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
         cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVT
         UyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxZDBlNDU5Ni0xNWQ0LTRkZWIt
-        YjZiNi1jNjliMjBiN2MzZTgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5ZWI0Mzg5ZC1lMWUxLTQ4Yjct
+        YjBmNi05ZTI3OTJhMzU2MzUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
         bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9k
         dWxlcyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6
         IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICJhZDk0NWI0OS1hMjliLTRkNWYtYjE4OC1mZmVmYjZiZTNmODIiLCAi
+        ZCI6ICIxN2RkNzgwOS0yZWNlLTQ0MjktYjA2NS00OWFiOGUwZWFkMGMiLCAi
         bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
         aXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUi
         OiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
         QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGJmZTA2MDctODVmMy00
-        NmNkLThmZGEtMmZiNzY4MDQ4ZTFkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGQwNWIxZTQtMTAyOS00
+        Nzc2LWE3MWEtOTQ1ZGY5MWVhYzk1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
         eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
         IE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNf
         dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
         YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiZjc5ZjE1ZDEtODMxYy00Y2Q5LWJhNjAtYzI0MTNmYjc2
-        NGVjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        InN0ZXBfaWQiOiAiNWI3ZmVhZTEtZWQzOC00NWNjLWIwNDEtMDM0YWMwZTkw
+        ODUyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
         ICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3Rl
         cF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
         OiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYzM2YjdjMGItOTg4ZC00Njk5LTg4OTAtNjhiN2UzZmYzODBmIiwg
+        aWQiOiAiNWI3ZDZjODQtYTJlOC00NzEyLWFmZmQtYTNjZDU0ZWJjNjk0Iiwg
         Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
         cmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5
         cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
         YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQy
-        ZDZiOWExLTBhNzItNDI4NS1iMzcyLWMyM2JiMTAxNzkyOSIsICJudW1fcHJv
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM1
+        YjQ3OGYxLTdkMDUtNDg4MC05M2E4LTU0ZDFmMjkzMzM3ZiIsICJudW1fcHJv
         Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
         OiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1v
         dmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
         Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImYxMDg3OWFl
-        LWM3NDktNDUyYS05ZmNhLTE0YjRjNmNkMzYzZSIsICJudW1fcHJvY2Vzc2Vk
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjlmMTQyNTJm
+        LWUzOTYtNDcxOS05MWFjLTI3NTFlMWQ0ZWJiYiIsICJudW1fcHJvY2Vzc2Vk
         IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
         ZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIs
         ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI1NjE1MTg4OS01YmJjLTRlYTgtODAwZC0y
-        OTk3ODA4YjBlMGMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI3NWExNDE1My1iYjlkLTRhYTctOTBiNy00
+        N2EyZTg2N2NjODQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
         ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8g
         d2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVt
         c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJmMWZmOTA0OS00MDU0LTRiNjgtYmJhYy1kOWUyZTZi
-        NzUzNjQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICI4MmVmYWZjNi1mYjUyLTQ1YmItYThmYi00Zjc5NzUz
+        ZmY4MjciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
         MCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJz
         dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
         X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjNiMjMwYTg3LTY1MzktNDI4MC05OTliLTZkNmJhZjNh
-        MzYzYSIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0xQGRldi5leGFtcGxlLmNvbS5kcTIiLCAi
-        c3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMUBkZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YmNlMDQy
-        MDJmYTE4M2YxYzBkMGVhNWYifSwgImlkIjogIjViY2UwNDIwMmZhMTgzZjFj
-        MGQwZWE1ZiJ9
+        ICJzdGVwX2lkIjogIjQ0MjlmNzNkLWViNDktNDU3ZS05ZTM5LTE3MmRiZmZj
+        NjI1MiIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2Vy
+        dmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9u
+        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2
+        ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJv
+        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWMwNGJiMjI0OThlZGI4MjU1
+        YmIxYTk4In0sICJpZCI6ICI1YzA0YmIyMjQ5OGVkYjgyNTViYjFhOTgifQ==
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:49 GMT
+  recorded_at: Mon, 03 Dec 2018 05:12:02 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/ef869ace-3595-42fd-8a62-f2c23d474050/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/ca0b6695-55d7-4240-994e-217f682829ba/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1241,7 +1326,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -1250,17 +1335,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:49 GMT
+      - Mon, 03 Dec 2018 05:12:02 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Etag:
-      - '"ae15f7b6f27aae5d824764c4a0992a04-gzip"'
+      - '"22661a3be10fb05c61ed205fd2182c1d-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2389'
-      Connection:
-      - close
+      - '2423'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1268,16 +1351,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjg2OWFjZS0zNTk1LTQyZmQtOGE2Mi1mMmMyM2Q0NzQw
-        NTAvIiwgInRhc2tfaWQiOiAiZWY4NjlhY2UtMzU5NS00MmZkLThhNjItZjJj
-        MjNkNDc0MDUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9jYTBiNjY5NS01NWQ3LTQyNDAtOTk0ZS0yMTdmNjgyODI5
+        YmEvIiwgInRhc2tfaWQiOiAiY2EwYjY2OTUtNTVkNy00MjQwLTk5NGUtMjE3
+        ZjY4MjgyOWJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwgInRyYWNl
+        IjIwMTgtMTItMDNUMDU6MTI6MDJaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MTI6MDFaIiwgInRyYWNl
         YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzLzQyYmMyYjU0LWI2NWQtNDNhNy04NTE0LTg1MDg5
-        MDU0ZGVkMS8iLCAidGFza19pZCI6ICI0MmJjMmI1NC1iNjVkLTQzYTctODUx
-        NC04NTA4OTA1NGRlZDEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bHAvYXBpL3YyL3Rhc2tzLzRhYzc4ZDFhLTUwYWItNGI0Mi05MjhiLWEyMjE0
+        NGJkOTUwNS8iLCAidGFza19pZCI6ICI0YWM3OGQxYS01MGFiLTRiNDItOTI4
+        Yi1hMjIxNDRiZDk1MDUifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
         bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
         dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
         cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
@@ -1289,42 +1372,42 @@ http_interactions:
         XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
         ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4YW1wbGUuY29tLmRx
-        MiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBkZXYuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJ5
-        dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAi
-        c2NlbmFyaW9fdGVzdCIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6
-        ICIyMDE4LTEwLTIyVDE3OjA4OjQ4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jl
-        c3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwg
-        ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21l
-        c3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1
-        cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
-        b24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAs
-        ICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjViY2UwNDIwYjQ3Y2ViMDc1
-        MDFhYjFlYSIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVt
-        c19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwi
-        OiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2Rv
-        bmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
-        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWJjZTA0MjAyZmEx
-        ODNmMWMwZDBlYTRmIn0sICJpZCI6ICI1YmNlMDQyMDJmYTE4M2YxYzBkMGVh
-        NGYifQ==
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToxMjowMVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjEyOjAyWiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmIyMjA1ZjVlZTA1YzNmZDg0NzIiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiYjIxNDk4ZWRiODI1NWJiMThm
+        MiJ9LCAiaWQiOiAiNWMwNGJiMjE0OThlZGI4MjU1YmIxOGYyIn0=
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:49 GMT
+  recorded_at: Mon, 03 Dec 2018 05:12:02 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/42bc2b54-b65d-43a7-8514-85089054ded1/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/4ac78d1a-50ab-4b42-928b-a22144bd9505/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1334,7 +1417,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -1343,17 +1426,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:49 GMT
+      - Mon, 03 Dec 2018 05:12:02 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Etag:
-      - '"6d59f952ca35007a7ca4e2772f82d8cc-gzip"'
+      - '"a127470075403b3847a1175694df08a9-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '4503'
-      Connection:
-      - close
+      - '4531'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1361,342 +1442,110 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80MmJjMmI1NC1iNjVkLTQzYTctODUxNC04NTA4
-        OTA1NGRlZDEvIiwgInRhc2tfaWQiOiAiNDJiYzJiNTQtYjY1ZC00M2E3LTg1
-        MTQtODUwODkwNTRkZWQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy80YWM3OGQxYS01MGFiLTRiNDItOTI4Yi1hMjIx
+        NDRiZDk1MDUvIiwgInRhc2tfaWQiOiAiNGFjNzhkMWEtNTBhYi00YjQyLTky
+        OGItYTIyMTQ0YmQ5NTA1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwgInRyYWNlYmFjayI6IG51
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MTI6MDJaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
         InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
         ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI4MWI5ZTU1My0xZTc1LTQ5ODEtODUzZi1m
-        ZjkyMWM1ZDcyNWEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI0MzdlOGZkNy1mNDJmLTRjNDctODA1Mi04
+        YmNkNmY5OGUxMDAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
         dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
         dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiODNkNWZmYWUtM2U2My00MGE5LWI1Nzct
-        ZWMyMDRlMGFiMjU4IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNjE3ZWQxNWYtZjYwZS00Mzc1LTljZjEt
+        ODZhMTE4NTZjNTQzIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
         Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
         dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
         ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjFmYTc0M2Q2LWE5YmEtNDI2My1hMmMzLTJlMDBiOWEx
-        ODY3ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        ICJzdGVwX2lkIjogIjNmNWIyYTJjLTA2YTEtNGZmMC04MzVmLTRiMTZkNzY4
+        YTczZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
         LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
         ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM3ZDI1MzJkLTc1MmYtNDhh
-        Mi05ZWRhLWE0ODY5NTAwNDI0MyIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjZmNDAwMWU5LTM5MTgtNDc1
+        Ni1hNGNhLTVkZDg1YzJmMzQ1NyIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
         bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
         ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
         bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjNiNDAxYTFjLWY5YmMtNDkzMS1iNGI3LWYyM2I5NDBjZDJjNSIsICJu
+        IjogIjIyZWM4NjQ5LWFlMDctNDBkYS05NWNiLThkMmU1MmIxNmEyNSIsICJu
         dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
         cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
         cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxZDBlNDU5Ni0xNWQ0LTRkZWItYjZi
-        Ni1jNjliMjBiN2MzZTgiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5ZWI0Mzg5ZC1lMWUxLTQ4YjctYjBm
+        Ni05ZTI3OTJhMzU2MzUiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
         dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
         cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
         ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJh
-        ZDk0NWI0OS1hMjliLTRkNWYtYjE4OC1mZmVmYjZiZTNmODIiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMiwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
-        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiSU5fUFJPR1JFU1Mi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGJmZTA2MDctODVmMy00NmNkLThm
-        ZGEtMmZiNzY4MDQ4ZTFkIiwgIm51bV9wcm9jZXNzZWQiOiAyfSwgeyJudW1f
-        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFk
-        YXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
-        OiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiZjc5ZjE1ZDEtODMxYy00Y2Q5LWJhNjAtYzI0MTNmYjc2NGVjIiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBl
-        IjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        YzM2YjdjMGItOTg4ZC00Njk5LTg4OTAtNjhiN2UzZmYzODBmIiwgIm51bV9w
-        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
-        biI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
-        Z2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQyZDZiOWEx
-        LTBhNzItNDI4NS1iMzcyLWMyM2JiMTAxNzkyOSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUmVt
-        b3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xk
-        X3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
-        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImYxMDg3OWFlLWM3NDkt
-        NDUyYS05ZmNhLTE0YjRjNmNkMzYzZSIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
-        ZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVt
-        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI1NjE1MTg4OS01YmJjLTRlYTgtODAwZC0yOTk3ODA4
-        YjBlMGMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwg
-        InN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJmMWZmOTA0OS00MDU0LTRiNjgtYmJhYy1kOWUyZTZiNzUzNjQi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjNiMjMwYTg3LTY1MzktNDI4MC05OTliLTZkNmJhZjNhMzYzYSIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2VydmVkX3Jl
-        c291cmNlX3dvcmtlci0xQGRldi5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUi
-        OiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMUBkZXYuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwg
-        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YmNlMDQyMDJmYTE4
-        M2YxYzBkMGVhNWYifSwgImlkIjogIjViY2UwNDIwMmZhMTgzZjFjMGQwZWE1
-        ZiJ9
-    http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:49 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/ef869ace-3595-42fd-8a62-f2c23d474050/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 22 Oct 2018 17:08:49 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"ae15f7b6f27aae5d824764c4a0992a04-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2389'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjg2OWFjZS0zNTk1LTQyZmQtOGE2Mi1mMmMyM2Q0NzQw
-        NTAvIiwgInRhc2tfaWQiOiAiZWY4NjlhY2UtMzU5NS00MmZkLThhNjItZjJj
-        MjNkNDc0MDUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzLzQyYmMyYjU0LWI2NWQtNDNhNy04NTE0LTg1MDg5
-        MDU0ZGVkMS8iLCAidGFza19pZCI6ICI0MmJjMmI1NC1iNjVkLTQzYTctODUx
-        NC04NTA4OTA1NGRlZDEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
-        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4YW1wbGUuY29tLmRx
-        MiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBkZXYuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJ5
-        dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAi
-        c2NlbmFyaW9fdGVzdCIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6
-        ICIyMDE4LTEwLTIyVDE3OjA4OjQ4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jl
-        c3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwg
-        ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21l
-        c3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1
-        cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
-        b24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAs
-        ICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjViY2UwNDIwYjQ3Y2ViMDc1
-        MDFhYjFlYSIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVt
-        c19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwi
-        OiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2Rv
-        bmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
-        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWJjZTA0MjAyZmEx
-        ODNmMWMwZDBlYTRmIn0sICJpZCI6ICI1YmNlMDQyMDJmYTE4M2YxYzBkMGVh
-        NGYifQ==
-    http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:49 GMT
-- request:
-    method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/42bc2b54-b65d-43a7-8514-85089054ded1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 22 Oct 2018 17:08:49 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"66dd01553cd4dc557067ad8f44517761-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4477'
-      Connection:
-      - close
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80MmJjMmI1NC1iNjVkLTQzYTctODUxNC04NTA4
-        OTA1NGRlZDEvIiwgInRhc2tfaWQiOiAiNDJiYzJiNTQtYjY1ZC00M2E3LTg1
-        MTQtODUwODkwNTRkZWQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
-        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI4MWI5ZTU1My0xZTc1LTQ5ODEtODUzZi1m
-        ZjkyMWM1ZDcyNWEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
-        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiODNkNWZmYWUtM2U2My00MGE5LWI1Nzct
-        ZWMyMDRlMGFiMjU4IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
-        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjFmYTc0M2Q2LWE5YmEtNDI2My1hMmMzLTJlMDBiOWEx
-        ODY3ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
-        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM3ZDI1MzJkLTc1MmYtNDhh
-        Mi05ZWRhLWE0ODY5NTAwNDI0MyIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
-        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjNiNDAxYTFjLWY5YmMtNDkzMS1iNGI3LWYyM2I5NDBjZDJjNSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
-        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxZDBlNDU5Ni0xNWQ0LTRkZWItYjZi
-        Ni1jNjliMjBiN2MzZTgiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
-        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJh
-        ZDk0NWI0OS1hMjliLTRkNWYtYjE4OC1mZmVmYjZiZTNmODIiLCAibnVtX3By
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIx
+        N2RkNzgwOS0yZWNlLTQ0MjktYjA2NS00OWFiOGUwZWFkMGMiLCAibnVtX3By
         b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9u
         IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
         cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNGJmZTA2MDctODVmMy00NmNkLThmZGEt
-        MmZiNzY4MDQ4ZTFkIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNGQwNWIxZTQtMTAyOS00Nzc2LWE3MWEt
+        OTQ1ZGY5MWVhYzk1IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRh
         LiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAw
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        Zjc5ZjE1ZDEtODMxYy00Y2Q5LWJhNjAtYzI0MTNmYjc2NGVjIiwgIm51bV9w
+        NWI3ZmVhZTEtZWQzOC00NWNjLWIwNDEtMDM0YWMwZTkwODUyIiwgIm51bV9w
         cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
         biI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNs
         b3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzM2YjdjMGIt
-        OTg4ZC00Njk5LTg4OTAtNjhiN2UzZmYzODBmIiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5l
-        cmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUg
-        c3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDJkNmI5YTEtMGE3Mi00Mjg1LWIz
-        NzItYzIzYmIxMDE3OTI5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVw
-        b2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAi
-        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiZjEwODc5YWUtYzc0OS00NTJhLTlmY2EtMTRiNGM2
-        Y2QzNjNlIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAi
-        c3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTYxNTE4
-        ODktNWJiYy00ZWE4LTgwMGQtMjk5NzgwOGIwZTBjIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
-        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklO
-        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjFmZjkwNDktNDA1NC00
-        YjY4LWJiYWMtZDllMmU2Yjc1MzY0IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwg
-        eyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
-        c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzYjIzMGE4Ny02NTM5LTQyODAt
-        OTk5Yi02ZDZiYWYzYTM2M2EiLCAibnVtX3Byb2Nlc3NlZCI6IDF9XX0sICJx
-        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBkZXYuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
-        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRv
-        aWQiOiAiNWJjZTA0MjAyZmExODNmMWMwZDBlYTVmIn0sICJpZCI6ICI1YmNl
-        MDQyMDJmYTE4M2YxYzBkMGVhNWYifQ==
+        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNWI3ZDZj
+        ODQtYTJlOC00NzEyLWFmZmQtYTNjZDU0ZWJjNjk0IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJH
+        ZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJh
+        dGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM1YjQ3OGYxLTdkMDUt
+        NDg4MC05M2E4LTU0ZDFmMjkzMzM3ZiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcg
+        b2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9k
+        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjlmMTQyNTJmLWUzOTYtNDcxOS05
+        MWFjLTI3NTFlMWQ0ZWJiYiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1M
+        IGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI3NWExNDE1My1iYjlkLTRhYTctOTBiNy00N2EyZTg2N2NjODQi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBf
+        dHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICI4MmVmYWZjNi1mYjUyLTQ1YmItYThmYi00Zjc5NzUzZmY4MjciLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAi
+        aW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjQ0MjlmNzNkLWViNDktNDU3ZS05ZTM5LTE3MmRiZmZjNjI1MiIsICJudW1f
+        cHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tLmRx
+        MiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
+        dmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNWMwNGJiMjI0OThlZGI4MjU1YmIxYTk4In0sICJp
+        ZCI6ICI1YzA0YmIyMjQ5OGVkYjgyNTViYjFhOTgifQ==
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:49 GMT
+  recorded_at: Mon, 03 Dec 2018 05:12:02 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/ef869ace-3595-42fd-8a62-f2c23d474050/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/ca0b6695-55d7-4240-994e-217f682829ba/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1706,7 +1555,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -1715,17 +1564,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:49 GMT
+      - Mon, 03 Dec 2018 05:12:02 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Etag:
-      - '"ae15f7b6f27aae5d824764c4a0992a04-gzip"'
+      - '"22661a3be10fb05c61ed205fd2182c1d-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2389'
-      Connection:
-      - close
+      - '2423'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1733,16 +1580,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lZjg2OWFjZS0zNTk1LTQyZmQtOGE2Mi1mMmMyM2Q0NzQw
-        NTAvIiwgInRhc2tfaWQiOiAiZWY4NjlhY2UtMzU5NS00MmZkLThhNjItZjJj
-        MjNkNDc0MDUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9jYTBiNjY5NS01NWQ3LTQyNDAtOTk0ZS0yMTdmNjgyODI5
+        YmEvIiwgInRhc2tfaWQiOiAiY2EwYjY2OTUtNTVkNy00MjQwLTk5NGUtMjE3
+        ZjY4MjgyOWJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwgInRyYWNl
+        IjIwMTgtMTItMDNUMDU6MTI6MDJaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MTI6MDFaIiwgInRyYWNl
         YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzLzQyYmMyYjU0LWI2NWQtNDNhNy04NTE0LTg1MDg5
-        MDU0ZGVkMS8iLCAidGFza19pZCI6ICI0MmJjMmI1NC1iNjVkLTQzYTctODUx
-        NC04NTA4OTA1NGRlZDEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bHAvYXBpL3YyL3Rhc2tzLzRhYzc4ZDFhLTUwYWItNGI0Mi05MjhiLWEyMjE0
+        NGJkOTUwNS8iLCAidGFza19pZCI6ICI0YWM3OGQxYS01MGFiLTRiNDItOTI4
+        Yi1hMjIxNDRiZDk1MDUifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
         bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
         dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
         cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
@@ -1754,42 +1601,42 @@ http_interactions:
         XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
         ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAZGV2LmV4YW1wbGUuY29tLmRx
-        MiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBkZXYuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRlcl9pZCI6ICJ5
-        dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAi
-        c2NlbmFyaW9fdGVzdCIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6
-        ICIyMDE4LTEwLTIyVDE3OjA4OjQ4WiIsICJfbnMiOiAicmVwb19zeW5jX3Jl
-        c3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwg
-        ImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9yX21l
-        c3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1
-        cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRp
-        b24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifX0sICJhZGRlZF9jb3VudCI6IDE1LCAicmVtb3ZlZF9jb3VudCI6IDAs
-        ICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjViY2UwNDIwYjQ3Y2ViMDc1
-        MDFhYjFlYSIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJpdGVt
-        c19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90YWwi
-        OiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBtX2Rv
-        bmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
-        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWJjZTA0MjAyZmEx
-        ODNmMWMwZDBlYTRmIn0sICJpZCI6ICI1YmNlMDQyMDJmYTE4M2YxYzBkMGVh
-        NGYifQ==
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToxMjowMVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjEyOjAyWiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmIyMjA1ZjVlZTA1YzNmZDg0NzIiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiYjIxNDk4ZWRiODI1NWJiMThm
+        MiJ9LCAiaWQiOiAiNWMwNGJiMjE0OThlZGI4MjU1YmIxOGYyIn0=
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:49 GMT
+  recorded_at: Mon, 03 Dec 2018 05:12:02 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/tasks/42bc2b54-b65d-43a7-8514-85089054ded1/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/4ac78d1a-50ab-4b42-928b-a22144bd9505/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1799,7 +1646,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -1808,17 +1655,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:49 GMT
+      - Mon, 03 Dec 2018 05:12:02 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Etag:
-      - '"8b9a8590f6718871e76006666504c32e-gzip"'
+      - '"13adeb605526337d7dd703c44b6479ca-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '9023'
-      Connection:
-      - close
+      - '4511'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1826,210 +1671,8196 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80MmJjMmI1NC1iNjVkLTQzYTctODUxNC04NTA4
-        OTA1NGRlZDEvIiwgInRhc2tfaWQiOiAiNDJiYzJiNTQtYjY1ZC00M2E3LTg1
-        MTQtODUwODkwNTRkZWQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy80YWM3OGQxYS01MGFiLTRiNDItOTI4Yi1hMjIx
+        NDRiZDk1MDUvIiwgInRhc2tfaWQiOiAiNGFjNzhkMWEtNTBhYi00YjQyLTky
+        OGItYTIyMTQ0YmQ5NTA1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogIjIwMTgtMTAtMjJUMTc6MDg6NDlaIiwgIl9ucyI6ICJ0YXNr
-        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTgtMTAtMjJUMTc6MDg6NDha
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MTI6MDJaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI0MzdlOGZkNy1mNDJmLTRjNDctODA1Mi04
+        YmNkNmY5OGUxMDAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNjE3ZWQxNWYtZjYwZS00Mzc1LTljZjEt
+        ODZhMTE4NTZjNTQzIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjNmNWIyYTJjLTA2YTEtNGZmMC04MzVmLTRiMTZkNzY4
+        YTczZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjZmNDAwMWU5LTM5MTgtNDc1
+        Ni1hNGNhLTVkZDg1YzJmMzQ1NyIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjIyZWM4NjQ5LWFlMDctNDBkYS05NWNiLThkMmU1MmIxNmEyNSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
+        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5ZWI0Mzg5ZC1lMWUxLTQ4YjctYjBm
+        Ni05ZTI3OTJhMzU2MzUiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
+        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIx
+        N2RkNzgwOS0yZWNlLTQ0MjktYjA2NS00OWFiOGUwZWFkMGMiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
+        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNGQwNWIxZTQtMTAyOS00Nzc2LWE3MWEt
+        OTQ1ZGY5MWVhYzk1IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRh
+        LiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        NWI3ZmVhZTEtZWQzOC00NWNjLWIwNDEtMDM0YWMwZTkwODUyIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
+        biI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNs
+        b3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNWI3ZDZjODQt
+        YTJlOC00NzEyLWFmZmQtYTNjZDU0ZWJjNjk0IiwgIm51bV9wcm9jZXNzZWQi
+        OiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5l
+        cmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUg
+        c3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzViNDc4ZjEtN2QwNS00ODgwLTkz
+        YTgtNTRkMWYyOTMzMzdmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVw
+        b2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAi
+        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiOWYxNDI1MmYtZTM5Ni00NzE5LTkxYWMtMjc1MWUx
+        ZDRlYmJiIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAi
+        c3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzVhMTQx
+        NTMtYmI5ZC00YWE3LTkwYjctNDdhMmU4NjdjYzg0IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
+        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklO
+        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODJlZmFmYzYtZmI1Mi00
+        NWJiLWE4ZmItNGY3OTc1M2ZmODI3IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwg
+        eyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
+        c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
+        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NDI5ZjczZC1lYjQ5LTQ1N2Ut
+        OWUzOS0xNzJkYmZmYzYyNTIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9XX0sICJx
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRl
+        dmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJyZXN1bHQi
+        OiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRi
+        YjIyNDk4ZWRiODI1NWJiMWE5OCJ9LCAiaWQiOiAiNWMwNGJiMjI0OThlZGI4
+        MjU1YmIxYTk4In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:12:02 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/ca0b6695-55d7-4240-994e-217f682829ba/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:12:02 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"22661a3be10fb05c61ed205fd2182c1d-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9jYTBiNjY5NS01NWQ3LTQyNDAtOTk0ZS0yMTdmNjgyODI5
+        YmEvIiwgInRhc2tfaWQiOiAiY2EwYjY2OTUtNTVkNy00MjQwLTk5NGUtMjE3
+        ZjY4MjgyOWJhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6MTI6MDJaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MTI6MDFaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzLzRhYzc4ZDFhLTUwYWItNGI0Mi05MjhiLWEyMjE0
+        NGJkOTUwNS8iLCAidGFza19pZCI6ICI0YWM3OGQxYS01MGFiLTRiNDItOTI4
+        Yi1hMjIxNDRiZDk1MDUifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToxMjowMVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjEyOjAyWiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmIyMjA1ZjVlZTA1YzNmZDg0NzIiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiYjIxNDk4ZWRiODI1NWJiMThm
+        MiJ9LCAiaWQiOiAiNWMwNGJiMjE0OThlZGI4MjU1YmIxOGYyIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:12:02 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/4ac78d1a-50ab-4b42-928b-a22144bd9505/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:12:02 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"959842f523f58fd5162d5b16b7d10ec1-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '9057'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy80YWM3OGQxYS01MGFiLTRiNDItOTI4Yi1hMjIx
+        NDRiZDk1MDUvIiwgInRhc2tfaWQiOiAiNGFjNzhkMWEtNTBhYi00YjQyLTky
+        OGItYTIyMTQ0YmQ5NTA1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTgtMTItMDNUMDU6MTI6MDJaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MTI6MDJa
         IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
         cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
         Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0
         ZXBfdHlwZSI6ICJzYXZlX3RhciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4MWI5ZTU1
-        My0xZTc1LTQ5ODEtODUzZi1mZjkyMWM1ZDcyNWEiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0MzdlOGZk
+        Ny1mNDJmLTRjNDctODA1Mi04YmNkNmY5OGUxMDAiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIklu
         aXRpYWxpemluZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0
         aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
         dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODNkNWZm
-        YWUtM2U2My00MGE5LWI1NzctZWMyMDRlMGFiMjU4IiwgIm51bV9wcm9jZXNz
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjE3ZWQx
+        NWYtZjYwZS00Mzc1LTljZjEtODZhMTE4NTZjNTQzIiwgIm51bV9wcm9jZXNz
         ZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
         dWJsaXNoaW5nIERpc3RyaWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
         ZGlzdHJpYnV0aW9uIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
         TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjFmYTc0M2Q2LWE5YmEt
-        NDI2My1hMmMzLTJlMDBiOWExODY3ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNmNWIyYTJjLTA2YTEt
+        NGZmMC04MzVmLTRiMTZkNzY4YTczZCIsICJudW1fcHJvY2Vzc2VkIjogMX0s
         IHsibnVtX3N1Y2Nlc3MiOiA4LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
         ZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjog
         OCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
         ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImM3ZDI1MzJkLTc1MmYtNDhhMi05ZWRhLWE0ODY5NTAwNDI0MyIsICJudW1f
+        IjZmNDAwMWU5LTM5MTgtNDc1Ni1hNGNhLTVkZDg1YzJmMzQ1NyIsICJudW1f
         cHJvY2Vzc2VkIjogOH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
         b24iOiAiUHVibGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJk
         cnBtcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjNiNDAxYTFjLWY5YmMtNDkzMS1iNGI3
-        LWYyM2I5NDBjZDJjNSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjIyZWM4NjQ5LWFlMDctNDBkYS05NWNi
+        LThkMmU1MmIxNmEyNSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
         Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEi
         LCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxZDBl
-        NDU5Ni0xNWQ0LTRkZWItYjZiNi1jNjliMjBiN2MzZTgiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5ZWI0
+        Mzg5ZC1lMWUxLTQ4YjctYjBmNi05ZTI3OTJhMzU2MzUiLCAibnVtX3Byb2Nl
         c3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgTW9kdWxlcyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJhZDk0NWI0OS1hMjliLTRkNWYtYjE4OC1mZmVm
-        YjZiZTNmODIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICIxN2RkNzgwOS0yZWNlLTQ0MjktYjA2NS00OWFi
+        OGUwZWFkMGMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
         IjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIs
         ICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3Rh
         dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGJmZTA2
-        MDctODVmMy00NmNkLThmZGEtMmZiNzY4MDQ4ZTFkIiwgIm51bV9wcm9jZXNz
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGQwNWIx
+        ZTQtMTAyOS00Nzc2LWE3MWEtOTQ1ZGY5MWVhYzk1IiwgIm51bV9wcm9jZXNz
         ZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
         dWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEi
         LCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
         b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiZjc5ZjE1ZDEtODMxYy00Y2Q5LWJhNjAtYzI0
-        MTNmYjc2NGVjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        IjogMCwgInN0ZXBfaWQiOiAiNWI3ZmVhZTEtZWQzOC00NWNjLWIwNDEtMDM0
+        YWMwZTkwODUyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
         cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
         dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
         cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
-        ZXBfaWQiOiAiYzM2YjdjMGItOTg4ZC00Njk5LTg4OTAtNjhiN2UzZmYzODBm
+        ZXBfaWQiOiAiNWI3ZDZjODQtYTJlOC00NzEyLWFmZmQtYTNjZDU0ZWJjNjk0
         IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
         ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
         X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDJk
-        NmI5YTEtMGE3Mi00Mjg1LWIzNzItYzIzYmIxMDE3OTI5IiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzVi
+        NDc4ZjEtN2QwNS00ODgwLTkzYTgtNTRkMWYyOTMzMzdmIiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
         ICJSZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92
         ZV9vbGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
         RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjEwODc5YWUtYzc0
-        OS00NTJhLTlmY2EtMTRiNGM2Y2QzNjNlIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOWYxNDI1MmYtZTM5
+        Ni00NzE5LTkxYWMtMjc1MWUxZDRlYmJiIiwgIm51bV9wcm9jZXNzZWQiOiAx
         fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
         aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0
         ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0
         YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiNTYxNTE4ODktNWJiYy00ZWE4LTgwMGQtMjk5NzgwOGIw
-        ZTBjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEs
+        InN0ZXBfaWQiOiAiNzVhMTQxNTMtYmI5ZC00YWE3LTkwYjctNDdhMmU4Njdj
+        Yzg0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEs
         ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJz
         dGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwi
         OiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
         LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiZjFmZjkwNDktNDA1NC00YjY4LWJiYWMtZDllMmU2Yjc1MzY0IiwgIm51
+        OiAiODJlZmFmYzYtZmI1Mi00NWJiLWE4ZmItNGY3OTc1M2ZmODI3IiwgIm51
         bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjog
         ImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
         ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIz
-        YjIzMGE4Ny02NTM5LTQyODAtOTk5Yi02ZDZiYWYzYTM2M2EiLCAibnVtX3By
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0
+        NDI5ZjczZC1lYjQ5LTQ1N2UtOWUzOS0xNzJkYmZmYzYyNTIiLCAibnVtX3By
         b2Nlc3NlZCI6IDF9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
-        b3JrZXItMUBkZXYuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGRldi5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJz
-        dWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5h
-        cmlvX3Rlc3QiLCAic3RhcnRlZCI6ICIyMDE4LTEwLTIyVDE3OjA4OjQ4WiIs
-        ICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjog
-        IjIwMTgtMTAtMjJUMTc6MDg6NDlaIiwgInRyYWNlYmFjayI6IG51bGwsICJk
-        aXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1t
-        YXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJycG1zIjog
-        IkZJTklTSEVEIiwgImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSI6ICJGSU5J
-        U0hFRCIsICJyZW1vdmVfb2xkX3JlcG9kYXRhIjogIkZJTklTSEVEIiwgIm1v
-        ZHVsZXMiOiAiRklOSVNIRUQiLCAic2F2ZV90YXIiOiAiRklOSVNIRUQiLCAi
-        Y2xvc2VfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJkcnBtcyI6ICJT
-        S0lQUEVEIiwgImNvbXBzIjogIkZJTklTSEVEIiwgImRpc3RyaWJ1dGlvbiI6
-        ICJGSU5JU0hFRCIsICJyZXBvdmlldyI6ICJTS0lQUEVEIiwgInB1Ymxpc2hf
-        ZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIs
-        ICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51
-        bGwsICJkaXN0cmlidXRvcl9pZCI6ICJzY2VuYXJpb190ZXN0IiwgImlkIjog
-        IjViY2UwNDIxYjQ3Y2ViMDc1MDFhYjFlYiIsICJkZXRhaWxzIjogW3sibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ29weWluZyBmaWxlcyIs
-        ICJzdGVwX3R5cGUiOiAic2F2ZV90YXIiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODFi
-        OWU1NTMtMWU3NS00OTgxLTg1M2YtZmY5MjFjNWQ3MjVhIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
-        ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAi
-        aW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjgz
-        ZDVmZmFlLTNlNjMtNDBhOS1iNTc3LWVjMjA0ZTBhYjI1OCIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBl
-        IjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxZmE3NDNkNi1h
-        OWJhLTQyNjMtYTJjMy0yZTAwYjlhMTg2N2YiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
-        c2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVtc190b3Rh
-        bCI6IDgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICJjN2QyNTMyZC03NTJmLTQ4YTItOWVkYS1hNDg2OTUwMDQyNDMiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUi
-        OiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBF
+        b3JrZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJl
+        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0Iiwg
+        InN0YXJ0ZWQiOiAiMjAxOC0xMi0wM1QwNToxMjowMloiLCAiX25zIjogInJl
+        cG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE4LTEyLTAz
+        VDA1OjEyOjAyWiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3Jf
+        dHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6IHsiZ2Vu
+        ZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQiLCAicnBtcyI6ICJGSU5JU0hFRCIs
+        ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicmVt
+        b3ZlX29sZF9yZXBvZGF0YSI6ICJGSU5JU0hFRCIsICJtb2R1bGVzIjogIkZJ
+        TklTSEVEIiwgInNhdmVfdGFyIjogIkZJTklTSEVEIiwgImNsb3NlX3JlcG9f
+        bWV0YWRhdGEiOiAiRklOSVNIRUQiLCAiZHJwbXMiOiAiU0tJUFBFRCIsICJj
+        b21wcyI6ICJGSU5JU0hFRCIsICJkaXN0cmlidXRpb24iOiAiRklOSVNIRUQi
+        LCAicmVwb3ZpZXciOiAiU0tJUFBFRCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6
+        ICJGSU5JU0hFRCIsICJlcnJhdGEiOiAiRklOSVNIRUQiLCAibWV0YWRhdGEi
+        OiAiRklOSVNIRUQifSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJp
+        YnV0b3JfaWQiOiAic2NlbmFyaW9fdGVzdCIsICJpZCI6ICI1YzA0YmIyMjA1
+        ZjVlZTA1YzNmZDg0NzMiLCAiZGV0YWlscyI6IFt7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIkNvcHlpbmcgZmlsZXMiLCAic3RlcF90eXBl
+        IjogInNhdmVfdGFyIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQzN2U4ZmQ3LWY0MmYt
+        NGM0Ny04MDUyLThiY2Q2Zjk4ZTEwMCIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6
+        aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVf
+        cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2MTdlZDE1Zi1mNjBl
+        LTQzNzUtOWNmMS04NmExMTg1NmM1NDMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmli
+        dXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2Y1YjJhMmMtMDZhMS00ZmYwLTgz
+        NWYtNGIxNmQ3NjhhNzNkIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1f
+        c3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMi
+        LCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNmY0MDAx
+        ZTktMzkxOC00NzU2LWE0Y2EtNWRkODVjMmYzNDU3IiwgIm51bV9wcm9jZXNz
+        ZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiMjJlYzg2NDktYWUwNy00MGRhLTk1Y2ItOGQyZTUy
+        YjE2YTI1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVw
+        X3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjllYjQzODlkLWUx
+        ZTEtNDhiNy1iMGY2LTllMjc5MmEzNTYzNSIsICJudW1fcHJvY2Vzc2VkIjog
+        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjE3ZGQ3ODA5LTJlY2UtNDQyOS1iMDY1LTQ5YWI4ZTBlYWQw
+        YyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBf
+        dHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0ZDA1YjFlNC0xMDI5
+        LTQ3NzYtYTcxYS05NDVkZjkxZWFjOTUiLCAibnVtX3Byb2Nlc3NlZCI6IDN9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI1YjdmZWFlMS1lZDM4LTQ1Y2MtYjA0MS0wMzRhYzBlOTA4
+        NTIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwg
+        ImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVw
+        X3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICI1YjdkNmM4NC1hMmU4LTQ3MTItYWZmZC1hM2NkNTRlYmM2OTQiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzNWI0NzhmMS03
+        ZDA1LTQ4ODAtOTNhOC01NGQxZjI5MzMzN2YiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92
+        aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9y
+        ZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
         RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzYjQwMWExYy1mOWJjLTQ5MzEt
-        YjRiNy1mMjNiOTQwY2QyYzUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJy
-        YXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        MWQwZTQ1OTYtMTVkNC00ZGViLWI2YjYtYzY5YjIwYjdjM2U4IiwgIm51bV9w
-        cm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
-        biI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVs
-        ZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5ZjE0MjUyZi1lMzk2LTQ3MTkt
+        OTFhYy0yNzUxZTFkNGViYmIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRN
+        TCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICI3NWExNDE1My1iYjlkLTRhYTctOTBiNy00N2EyZTg2N2NjODQiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2Ny
+        aXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlw
+        ZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4MmVm
+        YWZjNi1mYjUyLTQ1YmItYThmYi00Zjc5NzUzZmY4MjciLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
+        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ0MjlmNzNk
+        LWViNDktNDU3ZS05ZTM5LTE3MmRiZmZjNjI1MiIsICJudW1fcHJvY2Vzc2Vk
+        IjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0
+        YmIyMjQ5OGVkYjgyNTViYjFhOTgifSwgImlkIjogIjVjMDRiYjIyNDk4ZWRi
+        ODI1NWJiMWE5OCJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:12:02 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/8d945aab-ae78-4cb2-891f-03eb94a5add2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"b59fcea15cf9995c2be41892c4553b4c-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '544'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84ZDk0NWFhYi1hZTc4LTRjYjItODkxZi0wM2ViOTRhNWFk
+        ZDIvIiwgInRhc2tfaWQiOiAiOGQ5NDVhYWItYWU3OC00Y2IyLTg5MWYtMDNl
+        Yjk0YTVhZGQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogbnVs
+        bCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIiIsICJzdGF0ZSI6ICJ3
+        YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51bGws
+        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWMwNGJkZTM0OThl
+        ZGI4MjU1YmIyOTQ5In0sICJpZCI6ICI1YzA0YmRlMzQ5OGVkYjgyNTViYjI5
+        NDkifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/8d945aab-ae78-4cb2-891f-03eb94a5add2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"8a14dde195713446d5623111cfd953bb-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1191'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84ZDk0NWFhYi1hZTc4LTRjYjItODkxZi0wM2ViOTRhNWFk
+        ZDIvIiwgInRhc2tfaWQiOiAiOGQ5NDVhYWItYWU3OC00Y2IyLTg5MWYtMDNl
+        Yjk0YTVhZGQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6MjM6NDdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
+        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiSU5fUFJPR1JF
+        U1MifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
+        Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRl
+        IjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1YzA0YmRlMzQ5OGVkYjgyNTViYjI5NDkifSwgImlkIjogIjVjMDRi
+        ZGUzNDk4ZWRiODI1NWJiMjk0OSJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/8d945aab-ae78-4cb2-891f-03eb94a5add2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"23dc9bf5316b35b1cc71819c4d039b48-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1188'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84ZDk0NWFhYi1hZTc4LTRjYjItODkxZi0wM2ViOTRhNWFk
+        ZDIvIiwgInRhc2tfaWQiOiAiOGQ5NDVhYWItYWU3OC00Y2IyLTg5MWYtMDNl
+        Yjk0YTVhZGQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6MjM6NDdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
+        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
+        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzA0YmRlMzQ5OGVkYjgyNTViYjI5NDkifSwgImlkIjogIjVjMDRiZGUz
+        NDk4ZWRiODI1NWJiMjk0OSJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/8d945aab-ae78-4cb2-891f-03eb94a5add2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"23dc9bf5316b35b1cc71819c4d039b48-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1188'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84ZDk0NWFhYi1hZTc4LTRjYjItODkxZi0wM2ViOTRhNWFk
+        ZDIvIiwgInRhc2tfaWQiOiAiOGQ5NDVhYWItYWU3OC00Y2IyLTg5MWYtMDNl
+        Yjk0YTVhZGQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6MjM6NDdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
+        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
+        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzA0YmRlMzQ5OGVkYjgyNTViYjI5NDkifSwgImlkIjogIjVjMDRiZGUz
+        NDk4ZWRiODI1NWJiMjk0OSJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/8d945aab-ae78-4cb2-891f-03eb94a5add2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"23dc9bf5316b35b1cc71819c4d039b48-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1188'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84ZDk0NWFhYi1hZTc4LTRjYjItODkxZi0wM2ViOTRhNWFk
+        ZDIvIiwgInRhc2tfaWQiOiAiOGQ5NDVhYWItYWU3OC00Y2IyLTg5MWYtMDNl
+        Yjk0YTVhZGQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6MjM6NDdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
+        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
+        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzA0YmRlMzQ5OGVkYjgyNTViYjI5NDkifSwgImlkIjogIjVjMDRiZGUz
+        NDk4ZWRiODI1NWJiMjk0OSJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/8d945aab-ae78-4cb2-891f-03eb94a5add2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"c0e80477dd1b8fa34787e8ee6a22247c-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1185'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84ZDk0NWFhYi1hZTc4LTRjYjItODkxZi0wM2ViOTRhNWFk
+        ZDIvIiwgInRhc2tfaWQiOiAiOGQ5NDVhYWItYWU3OC00Y2IyLTg5MWYtMDNl
+        Yjk0YTVhZGQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6MjM6NDdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRl
+        IjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5PVF9T
+        VEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
+        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9z
+        Ny1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1
+        bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        YzA0YmRlMzQ5OGVkYjgyNTViYjI5NDkifSwgImlkIjogIjVjMDRiZGUzNDk4
+        ZWRiODI1NWJiMjk0OSJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/8d945aab-ae78-4cb2-891f-03eb94a5add2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"38f6f8cf0c73bbc21200e4d74d52afd5-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1179'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84ZDk0NWFhYi1hZTc4LTRjYjItODkxZi0wM2ViOTRhNWFk
+        ZDIvIiwgInRhc2tfaWQiOiAiOGQ5NDVhYWItYWU3OC00Y2IyLTg5MWYtMDNl
+        Yjk0YTVhZGQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6MjM6NDdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIklOX1BST0dSRVNT
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVl
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZl
+        bDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmci
+        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
+        Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YmRl
+        MzQ5OGVkYjgyNTViYjI5NDkifSwgImlkIjogIjVjMDRiZGUzNDk4ZWRiODI1
+        NWJiMjk0OSJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/8d945aab-ae78-4cb2-891f-03eb94a5add2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"14b38b7ae34c115f634bee268ffdc155-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1176'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84ZDk0NWFhYi1hZTc4LTRjYjItODkxZi0wM2ViOTRhNWFk
+        ZDIvIiwgInRhc2tfaWQiOiAiOGQ5NDVhYWItYWU3OC00Y2IyLTg5MWYtMDNl
+        Yjk0YTVhZGQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6MjM6NDdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiSU5fUFJPR1JFU1MifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIu
+        c2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAi
+        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
+        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVs
+        bCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YmRlMzQ5
+        OGVkYjgyNTViYjI5NDkifSwgImlkIjogIjVjMDRiZGUzNDk4ZWRiODI1NWJi
+        Mjk0OSJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/8d945aab-ae78-4cb2-891f-03eb94a5add2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"620f7568c4b0c05b920eeb543f04a862-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1170'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84ZDk0NWFhYi1hZTc4LTRjYjItODkxZi0wM2ViOTRhNWFk
+        ZDIvIiwgInRhc2tfaWQiOiAiOGQ5NDVhYWItYWU3OC00Y2IyLTg5MWYtMDNl
+        Yjk0YTVhZGQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6MjM6NDdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2Vy
+        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
+        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YmRlMzQ5OGVkYjgy
+        NTViYjI5NDkifSwgImlkIjogIjVjMDRiZGUzNDk4ZWRiODI1NWJiMjk0OSJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/8d945aab-ae78-4cb2-891f-03eb94a5add2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"6ab0b6e98f2e07fce0a1c87c99359de6-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84ZDk0NWFhYi1hZTc4LTRjYjItODkxZi0wM2ViOTRhNWFk
+        ZDIvIiwgInRhc2tfaWQiOiAiOGQ5NDVhYWItYWU3OC00Y2IyLTg5MWYtMDNl
+        Yjk0YTVhZGQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6MjM6NDdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MjM6NDdaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2ZiYjNlYjEwLTZiNGEtNDk2MS04OWE3LTRhNmZh
+        MGM4YTNiYS8iLCAidGFza19pZCI6ICJmYmIzZWIxMC02YjRhLTQ5NjEtODlh
+        Ny00YTZmYTBjOGEzYmEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToyMzo0N1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjIzOjQ3WiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmRlMzA1ZjVlZTA1YzNmZDg0ODkiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZGUzNDk4ZWRiODI1NWJiMjk0
+        OSJ9LCAiaWQiOiAiNWMwNGJkZTM0OThlZGI4MjU1YmIyOTQ5In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/fbb3eb10-6b4a-4961-89a7-4a6fa0c8a3ba/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"f407d9c9a1312eca360c25c5637b3556-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '673'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9mYmIzZWIxMC02YjRhLTQ5NjEtODlhNy00YTZm
+        YTBjOGEzYmEvIiwgInRhc2tfaWQiOiAiZmJiM2ViMTAtNmI0YS00OTYxLTg5
+        YTctNGE2ZmEwYzhhM2JhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2Vy
+        dmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9u
+        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2
+        ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJv
+        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWMwNGJkZTM0OThlZGI4MjU1
+        YmIyYWViIn0sICJpZCI6ICI1YzA0YmRlMzQ5OGVkYjgyNTViYjJhZWIifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/8d945aab-ae78-4cb2-891f-03eb94a5add2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"6ab0b6e98f2e07fce0a1c87c99359de6-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84ZDk0NWFhYi1hZTc4LTRjYjItODkxZi0wM2ViOTRhNWFk
+        ZDIvIiwgInRhc2tfaWQiOiAiOGQ5NDVhYWItYWU3OC00Y2IyLTg5MWYtMDNl
+        Yjk0YTVhZGQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6MjM6NDdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MjM6NDdaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2ZiYjNlYjEwLTZiNGEtNDk2MS04OWE3LTRhNmZh
+        MGM4YTNiYS8iLCAidGFza19pZCI6ICJmYmIzZWIxMC02YjRhLTQ5NjEtODlh
+        Ny00YTZmYTBjOGEzYmEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToyMzo0N1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjIzOjQ3WiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmRlMzA1ZjVlZTA1YzNmZDg0ODkiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZGUzNDk4ZWRiODI1NWJiMjk0
+        OSJ9LCAiaWQiOiAiNWMwNGJkZTM0OThlZGI4MjU1YmIyOTQ5In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/fbb3eb10-6b4a-4961-89a7-4a6fa0c8a3ba/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"ca2e989ba6e832990e2c54cd11db38b1-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4550'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9mYmIzZWIxMC02YjRhLTQ5NjEtODlhNy00YTZm
+        YTBjOGEzYmEvIiwgInRhc2tfaWQiOiAiZmJiM2ViMTAtNmI0YS00OTYxLTg5
+        YTctNGE2ZmEwYzhhM2JhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MjM6NDdaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIzMjkyOWY4Ny1jYzQwLTQ2YTgtOGE4OC1m
+        Mjc5OGFhMzM4NmIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYWQ5NDViNDktYTI5Yi00ZDVmLWIxODgt
-        ZmZlZmI2YmUzZjgyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZp
-        bGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRi
-        ZmUwNjA3LTg1ZjMtNDZjZC04ZmRhLTJmYjc2ODA0OGUxZCIsICJudW1fcHJv
-        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFk
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImY3OWYxNWQxLTgzMWMtNGNkOS1iYTYw
-        LWMyNDEzZmI3NjRlYyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFk
-        YXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMzJkNjFhNjMtOTI5NC00NDg5LTg5OWUt
+        NmJlOWQzZjYzZjVjIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
         ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImMzNmI3YzBiLTk4OGQtNDY5OS04ODkwLTY4YjdlM2Zm
-        MzgwZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        ICJzdGVwX2lkIjogIjNhZWZiZWU0LWRiMmEtNDE4ZS04NGE4LTE0NjI2YjU0
+        Y2FlMCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIklOX1BS
+        T0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImIwYzZkMDZlLTg1YzUt
+        NDExMy05OGRlLTJjYjhlMmQ0ZDkzZSIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIxNzZlZjBhNy04YTQ5LTQ5NDctOTBmNy0zMzQzYjJmNjc5
+        OTUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjVkMDBjZjktN2I5
+        OS00YjUwLWJjMTctZjZmYzEyMDUwNDQzIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiNjQyNjdlMDUtNjkzNC00ZWVmLTkwNGQtNWZjMWUzMWNh
+        ZGVhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRmZGFiNWRh
+        LWU0YjItNDQ2Zi05MTY5LTc3ZWE4YmU4MjAyZCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjA3NGI3YjM0LTc2MTAtNGVlZi05NGY0LTEz
+        MTE4MThhMDEwNCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
+        IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImY5MmU3Y2E2LTZkZDItNGUwMy1hMzJkLWMwNTcwMjA5
+        MmQ0ZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
         LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAi
         c3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImQyZDZiOWExLTBhNzItNDI4NS1iMzcyLWMyM2JiMTAxNzkyOSIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRp
-        b24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJy
-        ZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImYxMDg3OWFl
-        LWM3NDktNDUyYS05ZmNhLTE0YjRjNmNkMzYzZSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
-        ZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjU2MTUxODg5LTViYmMtNGVhOC04MDBkLTI5OTc4
-        MDhiMGUwYyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIi
-        LCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3Rv
-        dGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICI5YWE1MGRhNi1kYWYwLTQ5YjktODlkNS1iODE3NDhjYzRiNDIiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUi
+        OiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3
+        MGUzNTY4NC0wNjU4LTQ3MGItYTc3MC1hZDlkNjZlYWQxYWEiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVw
+        b3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTc0YjRhY2YtZmRjOS00NTAz
+        LTlhMDctODgyZjgxYjE1NzQ4IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZp
+        bGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rvcnki
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZDM2OTk2YjgtMzI5Zi00ODA4LWExZWMt
+        NTQyZDI1MjdmOGVmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZp
+        bGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJmZGJkNzM5NS1iZTFiLTQyZGMtYjM2MC1j
+        YjU3ZTdhNjkwNTkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRldmVsMi5z
+        YW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50
+        b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZGUzNDk4
+        ZWRiODI1NWJiMmFlYiJ9LCAiaWQiOiAiNWMwNGJkZTM0OThlZGI4MjU1YmIy
+        YWViIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/8d945aab-ae78-4cb2-891f-03eb94a5add2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"6ab0b6e98f2e07fce0a1c87c99359de6-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84ZDk0NWFhYi1hZTc4LTRjYjItODkxZi0wM2ViOTRhNWFk
+        ZDIvIiwgInRhc2tfaWQiOiAiOGQ5NDVhYWItYWU3OC00Y2IyLTg5MWYtMDNl
+        Yjk0YTVhZGQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6MjM6NDdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MjM6NDdaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2ZiYjNlYjEwLTZiNGEtNDk2MS04OWE3LTRhNmZh
+        MGM4YTNiYS8iLCAidGFza19pZCI6ICJmYmIzZWIxMC02YjRhLTQ5NjEtODlh
+        Ny00YTZmYTBjOGEzYmEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToyMzo0N1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjIzOjQ3WiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmRlMzA1ZjVlZTA1YzNmZDg0ODkiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZGUzNDk4ZWRiODI1NWJiMjk0
+        OSJ9LCAiaWQiOiAiNWMwNGJkZTM0OThlZGI4MjU1YmIyOTQ5In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/fbb3eb10-6b4a-4961-89a7-4a6fa0c8a3ba/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"6ca95205a3a7427b80dbe4a0dacd456d-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4550'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9mYmIzZWIxMC02YjRhLTQ5NjEtODlhNy00YTZm
+        YTBjOGEzYmEvIiwgInRhc2tfaWQiOiAiZmJiM2ViMTAtNmI0YS00OTYxLTg5
+        YTctNGE2ZmEwYzhhM2JhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MjM6NDdaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIzMjkyOWY4Ny1jYzQwLTQ2YTgtOGE4OC1m
+        Mjc5OGFhMzM4NmIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMzJkNjFhNjMtOTI5NC00NDg5LTg5OWUt
+        NmJlOWQzZjYzZjVjIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjNhZWZiZWU0LWRiMmEtNDE4ZS04NGE4LTE0NjI2YjU0
+        Y2FlMCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA3
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIklOX1BS
+        T0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImIwYzZkMDZlLTg1YzUt
+        NDExMy05OGRlLTJjYjhlMmQ0ZDkzZSIsICJudW1fcHJvY2Vzc2VkIjogN30s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIxNzZlZjBhNy04YTQ5LTQ5NDctOTBmNy0zMzQzYjJmNjc5
+        OTUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjVkMDBjZjktN2I5
+        OS00YjUwLWJjMTctZjZmYzEyMDUwNDQzIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiNjQyNjdlMDUtNjkzNC00ZWVmLTkwNGQtNWZjMWUzMWNh
+        ZGVhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRmZGFiNWRh
+        LWU0YjItNDQ2Zi05MTY5LTc3ZWE4YmU4MjAyZCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjA3NGI3YjM0LTc2MTAtNGVlZi05NGY0LTEz
+        MTE4MThhMDEwNCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
+        IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImY5MmU3Y2E2LTZkZDItNGUwMy1hMzJkLWMwNTcwMjA5
+        MmQ0ZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAi
+        c3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICI5YWE1MGRhNi1kYWYwLTQ5YjktODlkNS1iODE3NDhjYzRiNDIiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUi
+        OiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3
+        MGUzNTY4NC0wNjU4LTQ3MGItYTc3MC1hZDlkNjZlYWQxYWEiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVw
+        b3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTc0YjRhY2YtZmRjOS00NTAz
+        LTlhMDctODgyZjgxYjE1NzQ4IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZp
+        bGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rvcnki
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZDM2OTk2YjgtMzI5Zi00ODA4LWExZWMt
+        NTQyZDI1MjdmOGVmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZp
+        bGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJmZGJkNzM5NS1iZTFiLTQyZGMtYjM2MC1j
+        YjU3ZTdhNjkwNTkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRldmVsMi5z
+        YW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50
+        b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZGUzNDk4
+        ZWRiODI1NWJiMmFlYiJ9LCAiaWQiOiAiNWMwNGJkZTM0OThlZGI4MjU1YmIy
+        YWViIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/8d945aab-ae78-4cb2-891f-03eb94a5add2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"6ab0b6e98f2e07fce0a1c87c99359de6-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84ZDk0NWFhYi1hZTc4LTRjYjItODkxZi0wM2ViOTRhNWFk
+        ZDIvIiwgInRhc2tfaWQiOiAiOGQ5NDVhYWItYWU3OC00Y2IyLTg5MWYtMDNl
+        Yjk0YTVhZGQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6MjM6NDdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MjM6NDdaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2ZiYjNlYjEwLTZiNGEtNDk2MS04OWE3LTRhNmZh
+        MGM4YTNiYS8iLCAidGFza19pZCI6ICJmYmIzZWIxMC02YjRhLTQ5NjEtODlh
+        Ny00YTZmYTBjOGEzYmEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToyMzo0N1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjIzOjQ3WiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmRlMzA1ZjVlZTA1YzNmZDg0ODkiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZGUzNDk4ZWRiODI1NWJiMjk0
+        OSJ9LCAiaWQiOiAiNWMwNGJkZTM0OThlZGI4MjU1YmIyOTQ5In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/fbb3eb10-6b4a-4961-89a7-4a6fa0c8a3ba/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"83ef850779c286eb203e6f193283087b-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4537'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9mYmIzZWIxMC02YjRhLTQ5NjEtODlhNy00YTZm
+        YTBjOGEzYmEvIiwgInRhc2tfaWQiOiAiZmJiM2ViMTAtNmI0YS00OTYxLTg5
+        YTctNGE2ZmEwYzhhM2JhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MjM6NDdaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIzMjkyOWY4Ny1jYzQwLTQ2YTgtOGE4OC1m
+        Mjc5OGFhMzM4NmIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMzJkNjFhNjMtOTI5NC00NDg5LTg5OWUt
+        NmJlOWQzZjYzZjVjIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjNhZWZiZWU0LWRiMmEtNDE4ZS04NGE4LTE0NjI2YjU0
+        Y2FlMCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImIwYzZkMDZlLTg1YzUtNDEx
+        My05OGRlLTJjYjhlMmQ0ZDkzZSIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjE3NmVmMGE3LThhNDktNDk0Ny05MGY3LTMzNDNiMmY2Nzk5NSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
+        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmNWQwMGNmOS03Yjk5LTRiNTAtYmMx
+        Ny1mNmZjMTIwNTA0NDMiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
+        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2
+        NDI2N2UwNS02OTM0LTRlZWYtOTA0ZC01ZmMxZTMxY2FkZWEiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
+        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiSU5fUFJPR1JFU1Mi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGZkYWI1ZGEtZTRiMi00NDZmLTkx
+        NjktNzdlYThiZTgyMDJkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFk
+        YXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiMDc0YjdiMzQtNzYxMC00ZWVmLTk0ZjQtMTMxMTgxOGEwMTA0Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBl
+        IjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        ZjkyZTdjYTYtNmRkMi00ZTAzLWEzMmQtYzA1NzAyMDkyZDRkIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
+        Z2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjlhYTUwZGE2
+        LWRhZjAtNDliOS04OWQ1LWI4MTc0OGNjNGI0MiIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUmVt
+        b3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xk
+        X3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjcwZTM1Njg0LTA2NTgt
+        NDcwYi1hNzcwLWFkOWQ2NmVhZDFhYSIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
+        ZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVt
+        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJlNzRiNGFjZi1mZGM5LTQ1MDMtOWEwNy04ODJmODFi
+        MTU3NDgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwg
+        InN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJkMzY5OTZiOC0zMjlmLTQ4MDgtYTFlYy01NDJkMjUyN2Y4ZWYi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMi
         OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogImYxZmY5MDQ5LTQwNTQtNGI2OC1iYmFjLWQ5ZTJlNmI3NTM2NCIs
-        ICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
-        Y3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlw
-        ZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
+        X2lkIjogImZkYmQ3Mzk1LWJlMWItNDJkYy1iMzYwLWNiNTdlN2E2OTA1OSIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUu
+        Y29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNh
+        bWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51
+        bGwsICJfaWQiOiB7IiRvaWQiOiAiNWMwNGJkZTM0OThlZGI4MjU1YmIyYWVi
+        In0sICJpZCI6ICI1YzA0YmRlMzQ5OGVkYjgyNTViYjJhZWIifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/8d945aab-ae78-4cb2-891f-03eb94a5add2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"6ab0b6e98f2e07fce0a1c87c99359de6-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84ZDk0NWFhYi1hZTc4LTRjYjItODkxZi0wM2ViOTRhNWFk
+        ZDIvIiwgInRhc2tfaWQiOiAiOGQ5NDVhYWItYWU3OC00Y2IyLTg5MWYtMDNl
+        Yjk0YTVhZGQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6MjM6NDdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MjM6NDdaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2ZiYjNlYjEwLTZiNGEtNDk2MS04OWE3LTRhNmZh
+        MGM4YTNiYS8iLCAidGFza19pZCI6ICJmYmIzZWIxMC02YjRhLTQ5NjEtODlh
+        Ny00YTZmYTBjOGEzYmEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToyMzo0N1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjIzOjQ3WiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmRlMzA1ZjVlZTA1YzNmZDg0ODkiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZGUzNDk4ZWRiODI1NWJiMjk0
+        OSJ9LCAiaWQiOiAiNWMwNGJkZTM0OThlZGI4MjU1YmIyOTQ5In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/fbb3eb10-6b4a-4961-89a7-4a6fa0c8a3ba/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"256dccd09058745dc56e9c044094a6eb-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4517'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9mYmIzZWIxMC02YjRhLTQ5NjEtODlhNy00YTZm
+        YTBjOGEzYmEvIiwgInRhc2tfaWQiOiAiZmJiM2ViMTAtNmI0YS00OTYxLTg5
+        YTctNGE2ZmEwYzhhM2JhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MjM6NDdaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIzMjkyOWY4Ny1jYzQwLTQ2YTgtOGE4OC1m
+        Mjc5OGFhMzM4NmIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMzJkNjFhNjMtOTI5NC00NDg5LTg5OWUt
+        NmJlOWQzZjYzZjVjIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjNhZWZiZWU0LWRiMmEtNDE4ZS04NGE4LTE0NjI2YjU0
+        Y2FlMCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImIwYzZkMDZlLTg1YzUtNDEx
+        My05OGRlLTJjYjhlMmQ0ZDkzZSIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjE3NmVmMGE3LThhNDktNDk0Ny05MGY3LTMzNDNiMmY2Nzk5NSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
+        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmNWQwMGNmOS03Yjk5LTRiNTAtYmMx
+        Ny1mNmZjMTIwNTA0NDMiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
+        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2
+        NDI2N2UwNS02OTM0LTRlZWYtOTA0ZC01ZmMxZTMxY2FkZWEiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
+        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNGZkYWI1ZGEtZTRiMi00NDZmLTkxNjkt
+        NzdlYThiZTgyMDJkIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRh
+        LiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        MDc0YjdiMzQtNzYxMC00ZWVmLTk0ZjQtMTMxMTgxOGEwMTA0IiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
+        biI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNs
+        b3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjkyZTdjYTYt
+        NmRkMi00ZTAzLWEzMmQtYzA1NzAyMDkyZDRkIiwgIm51bV9wcm9jZXNzZWQi
+        OiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5l
+        cmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUg
+        c3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOWFhNTBkYTYtZGFmMC00OWI5LTg5
+        ZDUtYjgxNzQ4Y2M0YjQyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVw
+        b2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAi
+        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiNzBlMzU2ODQtMDY1OC00NzBiLWE3NzAtYWQ5ZDY2
+        ZWFkMWFhIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAi
+        c3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTc0YjRh
+        Y2YtZmRjOS00NTAzLTlhMDctODgyZjgxYjE1NzQ4IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
+        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiSU5f
+        UFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDM2OTk2YjgtMzI5
+        Zi00ODA4LWExZWMtNTQyZDI1MjdmOGVmIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5n
+        IExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVw
+        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
+        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZGJkNzM5NS1iZTFi
+        LTQyZGMtYjM2MC1jYjU3ZTdhNjkwNTkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50
+        b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAi
+        cnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJy
+        ZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjog
+        IjVjMDRiZGUzNDk4ZWRiODI1NWJiMmFlYiJ9LCAiaWQiOiAiNWMwNGJkZTM0
+        OThlZGI4MjU1YmIyYWViIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/8d945aab-ae78-4cb2-891f-03eb94a5add2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"6ab0b6e98f2e07fce0a1c87c99359de6-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84ZDk0NWFhYi1hZTc4LTRjYjItODkxZi0wM2ViOTRhNWFk
+        ZDIvIiwgInRhc2tfaWQiOiAiOGQ5NDVhYWItYWU3OC00Y2IyLTg5MWYtMDNl
+        Yjk0YTVhZGQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6MjM6NDdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MjM6NDdaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2ZiYjNlYjEwLTZiNGEtNDk2MS04OWE3LTRhNmZh
+        MGM4YTNiYS8iLCAidGFza19pZCI6ICJmYmIzZWIxMC02YjRhLTQ5NjEtODlh
+        Ny00YTZmYTBjOGEzYmEifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToyMzo0N1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjIzOjQ3WiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmRlMzA1ZjVlZTA1YzNmZDg0ODkiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZGUzNDk4ZWRiODI1NWJiMjk0
+        OSJ9LCAiaWQiOiAiNWMwNGJkZTM0OThlZGI4MjU1YmIyOTQ5In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:23:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/fbb3eb10-6b4a-4961-89a7-4a6fa0c8a3ba/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:23:47 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"2764728944795ca1f9123673a117aedc-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '9057'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9mYmIzZWIxMC02YjRhLTQ5NjEtODlhNy00YTZm
+        YTBjOGEzYmEvIiwgInRhc2tfaWQiOiAiZmJiM2ViMTAtNmI0YS00OTYxLTg5
+        YTctNGE2ZmEwYzhhM2JhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTgtMTItMDNUMDU6MjM6NDdaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MjM6NDda
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0
+        ZXBfdHlwZSI6ICJzYXZlX3RhciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzMjkyOWY4
+        Ny1jYzQwLTQ2YTgtOGE4OC1mMjc5OGFhMzM4NmIiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIklu
+        aXRpYWxpemluZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzJkNjFh
+        NjMtOTI5NC00NDg5LTg5OWUtNmJlOWQzZjYzZjVjIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIERpc3RyaWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
+        ZGlzdHJpYnV0aW9uIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNhZWZiZWU0LWRiMmEt
+        NDE4ZS04NGE4LTE0NjI2YjU0Y2FlMCIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        IHsibnVtX3N1Y2Nlc3MiOiA4LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjog
+        OCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        ImIwYzZkMDZlLTg1YzUtNDExMy05OGRlLTJjYjhlMmQ0ZDkzZSIsICJudW1f
+        cHJvY2Vzc2VkIjogOH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJk
+        cnBtcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjE3NmVmMGE3LThhNDktNDk0Ny05MGY3
+        LTMzNDNiMmY2Nzk5NSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEi
+        LCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmNWQw
+        MGNmOS03Yjk5LTRiNTAtYmMxNy1mNmZjMTIwNTA0NDMiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgTW9kdWxlcyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI2NDI2N2UwNS02OTM0LTRlZWYtOTA0ZC01ZmMx
+        ZTMxY2FkZWEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIs
+        ICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGZkYWI1
+        ZGEtZTRiMi00NDZmLTkxNjktNzdlYThiZTgyMDJkIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiMDc0YjdiMzQtNzYxMC00ZWVmLTk0ZjQtMTMx
+        MTgxOGEwMTA0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiZjkyZTdjYTYtNmRkMi00ZTAzLWEzMmQtYzA1NzAyMDkyZDRk
+        IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
+        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOWFh
+        NTBkYTYtZGFmMC00OWI5LTg5ZDUtYjgxNzQ4Y2M0YjQyIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
+        ICJSZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92
+        ZV9vbGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzBlMzU2ODQtMDY1
+        OC00NzBiLWE3NzAtYWQ5ZDY2ZWFkMWFhIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
+        aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiZTc0YjRhY2YtZmRjOS00NTAzLTlhMDctODgyZjgxYjE1
+        NzQ4IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJz
+        dGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwi
         OiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
         LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiM2IyMzBhODctNjUzOS00MjgwLTk5OWItNmQ2YmFmM2EzNjNhIiwgIm51
-        bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
-        b2lkIjogIjViY2UwNDIwMmZhMTgzZjFjMGQwZWE1ZiJ9LCAiaWQiOiAiNWJj
-        ZTA0MjAyZmExODNmMWMwZDBlYTVmIn0=
+        OiAiZDM2OTk2YjgtMzI5Zi00ODA4LWExZWMtNTQyZDI1MjdmOGVmIiwgIm51
+        bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjog
+        ImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJm
+        ZGJkNzM5NS1iZTFiLTQyZGMtYjM2MC1jYjU3ZTdhNjkwNTkiLCAibnVtX3By
+        b2Nlc3NlZCI6IDF9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJl
+        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0Iiwg
+        InN0YXJ0ZWQiOiAiMjAxOC0xMi0wM1QwNToyMzo0N1oiLCAiX25zIjogInJl
+        cG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE4LTEyLTAz
+        VDA1OjIzOjQ3WiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3Jf
+        dHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6IHsiZ2Vu
+        ZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQiLCAicnBtcyI6ICJGSU5JU0hFRCIs
+        ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicmVt
+        b3ZlX29sZF9yZXBvZGF0YSI6ICJGSU5JU0hFRCIsICJtb2R1bGVzIjogIkZJ
+        TklTSEVEIiwgInNhdmVfdGFyIjogIkZJTklTSEVEIiwgImNsb3NlX3JlcG9f
+        bWV0YWRhdGEiOiAiRklOSVNIRUQiLCAiZHJwbXMiOiAiU0tJUFBFRCIsICJj
+        b21wcyI6ICJGSU5JU0hFRCIsICJkaXN0cmlidXRpb24iOiAiRklOSVNIRUQi
+        LCAicmVwb3ZpZXciOiAiU0tJUFBFRCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6
+        ICJGSU5JU0hFRCIsICJlcnJhdGEiOiAiRklOSVNIRUQiLCAibWV0YWRhdGEi
+        OiAiRklOSVNIRUQifSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJp
+        YnV0b3JfaWQiOiAic2NlbmFyaW9fdGVzdCIsICJpZCI6ICI1YzA0YmRlMzA1
+        ZjVlZTA1YzNmZDg0OGEiLCAiZGV0YWlscyI6IFt7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIkNvcHlpbmcgZmlsZXMiLCAic3RlcF90eXBl
+        IjogInNhdmVfdGFyIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjMyOTI5Zjg3LWNjNDAt
+        NDZhOC04YTg4LWYyNzk4YWEzMzg2YiIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6
+        aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVf
+        cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzMmQ2MWE2My05Mjk0
+        LTQ0ODktODk5ZS02YmU5ZDNmNjNmNWMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmli
+        dXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2FlZmJlZTQtZGIyYS00MThlLTg0
+        YTgtMTQ2MjZiNTRjYWUwIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1f
+        c3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMi
+        LCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjBjNmQw
+        NmUtODVjNS00MTEzLTk4ZGUtMmNiOGUyZDRkOTNlIiwgIm51bV9wcm9jZXNz
+        ZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiMTc2ZWYwYTctOGE0OS00OTQ3LTkwZjctMzM0M2Iy
+        ZjY3OTk1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVw
+        X3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY1ZDAwY2Y5LTdi
+        OTktNGI1MC1iYzE3LWY2ZmMxMjA1MDQ0MyIsICJudW1fcHJvY2Vzc2VkIjog
+        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjY0MjY3ZTA1LTY5MzQtNGVlZi05MDRkLTVmYzFlMzFjYWRl
+        YSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBf
+        dHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0ZmRhYjVkYS1lNGIy
+        LTQ0NmYtOTE2OS03N2VhOGJlODIwMmQiLCAibnVtX3Byb2Nlc3NlZCI6IDN9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIwNzRiN2IzNC03NjEwLTRlZWYtOTRmNC0xMzExODE4YTAx
+        MDQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwg
+        ImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVw
+        X3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJmOTJlN2NhNi02ZGQyLTRlMDMtYTMyZC1jMDU3MDIwOTJkNGQiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5YWE1MGRhNi1k
+        YWYwLTQ5YjktODlkNS1iODE3NDhjYzRiNDIiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92
+        aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9y
+        ZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3MGUzNTY4NC0wNjU4LTQ3MGIt
+        YTc3MC1hZDlkNjZlYWQxYWEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRN
+        TCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJlNzRiNGFjZi1mZGM5LTQ1MDMtOWEwNy04ODJmODFiMTU3NDgiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2Ny
+        aXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlw
+        ZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkMzY5
+        OTZiOC0zMjlmLTQ4MDgtYTFlYy01NDJkMjUyN2Y4ZWYiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
+        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZkYmQ3Mzk1
+        LWJlMWItNDJkYy1iMzYwLWNiNTdlN2E2OTA1OSIsICJudW1fcHJvY2Vzc2Vk
+        IjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0
+        YmRlMzQ5OGVkYjgyNTViYjJhZWIifSwgImlkIjogIjVjMDRiZGUzNDk4ZWRi
+        ODI1NWJiMmFlYiJ9
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:49 GMT
+  recorded_at: Mon, 03 Dec 2018 05:23:47 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/871a9671-6263-4717-bbba-3f9ee87988cc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:25:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"0296c1a2b8100bd60e6aebc7b270c94d-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '682'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84NzFhOTY3MS02MjYzLTQ3MTctYmJiYS0zZjllZTg3OTg4
+        Y2MvIiwgInRhc2tfaWQiOiAiODcxYTk2NzEtNjI2My00NzE3LWJiYmEtM2Y5
+        ZWU4Nzk4OGNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6MjU6NTlaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVl
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwy
+        LnNhbWlyLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNl
+        bnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWMwNGJlNjc0
+        OThlZGI4MjU1YmIyZjg0In0sICJpZCI6ICI1YzA0YmU2NzQ5OGVkYjgyNTVi
+        YjJmODQifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:25:59 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/871a9671-6263-4717-bbba-3f9ee87988cc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:25:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"20feacf2de4c8edfcfd4b5ef3d6d5b9c-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1191'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84NzFhOTY3MS02MjYzLTQ3MTctYmJiYS0zZjllZTg3OTg4
+        Y2MvIiwgInRhc2tfaWQiOiAiODcxYTk2NzEtNjI2My00NzE3LWJiYmEtM2Y5
+        ZWU4Nzk4OGNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6MjU6NTlaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
+        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiSU5fUFJPR1JF
+        U1MifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
+        Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRl
+        IjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1YzA0YmU2NzQ5OGVkYjgyNTViYjJmODQifSwgImlkIjogIjVjMDRi
+        ZTY3NDk4ZWRiODI1NWJiMmY4NCJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:25:59 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/871a9671-6263-4717-bbba-3f9ee87988cc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:25:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"9b84eade50190a468daa609dd3b2c4a7-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1188'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84NzFhOTY3MS02MjYzLTQ3MTctYmJiYS0zZjllZTg3OTg4
+        Y2MvIiwgInRhc2tfaWQiOiAiODcxYTk2NzEtNjI2My00NzE3LWJiYmEtM2Y5
+        ZWU4Nzk4OGNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6MjU6NTlaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
+        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
+        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzA0YmU2NzQ5OGVkYjgyNTViYjJmODQifSwgImlkIjogIjVjMDRiZTY3
+        NDk4ZWRiODI1NWJiMmY4NCJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:25:59 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/871a9671-6263-4717-bbba-3f9ee87988cc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:25:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"9b84eade50190a468daa609dd3b2c4a7-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1188'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84NzFhOTY3MS02MjYzLTQ3MTctYmJiYS0zZjllZTg3OTg4
+        Y2MvIiwgInRhc2tfaWQiOiAiODcxYTk2NzEtNjI2My00NzE3LWJiYmEtM2Y5
+        ZWU4Nzk4OGNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6MjU6NTlaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
+        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
+        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzA0YmU2NzQ5OGVkYjgyNTViYjJmODQifSwgImlkIjogIjVjMDRiZTY3
+        NDk4ZWRiODI1NWJiMmY4NCJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:25:59 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/871a9671-6263-4717-bbba-3f9ee87988cc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:25:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"9b84eade50190a468daa609dd3b2c4a7-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1188'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84NzFhOTY3MS02MjYzLTQ3MTctYmJiYS0zZjllZTg3OTg4
+        Y2MvIiwgInRhc2tfaWQiOiAiODcxYTk2NzEtNjI2My00NzE3LWJiYmEtM2Y5
+        ZWU4Nzk4OGNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6MjU6NTlaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
+        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
+        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzA0YmU2NzQ5OGVkYjgyNTViYjJmODQifSwgImlkIjogIjVjMDRiZTY3
+        NDk4ZWRiODI1NWJiMmY4NCJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:25:59 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/871a9671-6263-4717-bbba-3f9ee87988cc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:25:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"0ceb3a8af39e7033a6583742b476fd8c-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1179'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84NzFhOTY3MS02MjYzLTQ3MTctYmJiYS0zZjllZTg3OTg4
+        Y2MvIiwgInRhc2tfaWQiOiAiODcxYTk2NzEtNjI2My00NzE3LWJiYmEtM2Y5
+        ZWU4Nzk4OGNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6MjU6NTlaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIklOX1BST0dSRVNT
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVl
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZl
+        bDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmci
+        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
+        Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YmU2
+        NzQ5OGVkYjgyNTViYjJmODQifSwgImlkIjogIjVjMDRiZTY3NDk4ZWRiODI1
+        NWJiMmY4NCJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:25:59 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/871a9671-6263-4717-bbba-3f9ee87988cc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:25:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"d873d9e4d22e7afa0332403b794fbc6b-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1173'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84NzFhOTY3MS02MjYzLTQ3MTctYmJiYS0zZjllZTg3OTg4
+        Y2MvIiwgInRhc2tfaWQiOiAiODcxYTk2NzEtNjI2My00NzE3LWJiYmEtM2Y5
+        ZWU4Nzk4OGNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6MjU6NTlaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IklOX1BST0dSRVNTIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29y
+        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9z
+        Ny1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwg
+        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YmU2NzQ5OGVk
+        YjgyNTViYjJmODQifSwgImlkIjogIjVjMDRiZTY3NDk4ZWRiODI1NWJiMmY4
+        NCJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:25:59 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/871a9671-6263-4717-bbba-3f9ee87988cc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:25:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"4472484fe776ebf8f47bfeb4d492d490-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1170'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84NzFhOTY3MS02MjYzLTQ3MTctYmJiYS0zZjllZTg3OTg4
+        Y2MvIiwgInRhc2tfaWQiOiAiODcxYTk2NzEtNjI2My00NzE3LWJiYmEtM2Y5
+        ZWU4Nzk4OGNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6MjU6NTlaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2Vy
+        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
+        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YmU2NzQ5OGVkYjgy
+        NTViYjJmODQifSwgImlkIjogIjVjMDRiZTY3NDk4ZWRiODI1NWJiMmY4NCJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:25:59 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/871a9671-6263-4717-bbba-3f9ee87988cc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:25:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"0223b9af32fb2f54401319113f74c472-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84NzFhOTY3MS02MjYzLTQ3MTctYmJiYS0zZjllZTg3OTg4
+        Y2MvIiwgInRhc2tfaWQiOiAiODcxYTk2NzEtNjI2My00NzE3LWJiYmEtM2Y5
+        ZWU4Nzk4OGNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6MjU6NTlaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MjU6NTlaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzLzhlOGE3N2M3LTBlYTYtNGRlZS04YmUwLTIyYzFm
+        NGNhZjk2MC8iLCAidGFza19pZCI6ICI4ZThhNzdjNy0wZWE2LTRkZWUtOGJl
+        MC0yMmMxZjRjYWY5NjAifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToyNTo1OVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjI1OjU5WiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmU2NzA1ZjVlZTA1YzNmZDg0YTAiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZTY3NDk4ZWRiODI1NWJiMmY4
+        NCJ9LCAiaWQiOiAiNWMwNGJlNjc0OThlZGI4MjU1YmIyZjg0In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:25:59 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/8e8a77c7-0ea6-4dee-8be0-22c1f4caf960/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:25:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"fa1db5f609ea70a6de52b6bd3796f6ca-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '691'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy84ZThhNzdjNy0wZWE2LTRkZWUtOGJlMC0yMmMx
+        ZjRjYWY5NjAvIiwgInRhc2tfaWQiOiAiOGU4YTc3YzctMGVhNi00ZGVlLThi
+        ZTAtMjJjMWY0Y2FmOTYwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MjU6NTlaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
+        NWMwNGJlNjc0OThlZGI4MjU1YmIzMTIwIn0sICJpZCI6ICI1YzA0YmU2NzQ5
+        OGVkYjgyNTViYjMxMjAifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:25:59 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/871a9671-6263-4717-bbba-3f9ee87988cc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:25:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"0223b9af32fb2f54401319113f74c472-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84NzFhOTY3MS02MjYzLTQ3MTctYmJiYS0zZjllZTg3OTg4
+        Y2MvIiwgInRhc2tfaWQiOiAiODcxYTk2NzEtNjI2My00NzE3LWJiYmEtM2Y5
+        ZWU4Nzk4OGNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6MjU6NTlaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MjU6NTlaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzLzhlOGE3N2M3LTBlYTYtNGRlZS04YmUwLTIyYzFm
+        NGNhZjk2MC8iLCAidGFza19pZCI6ICI4ZThhNzdjNy0wZWE2LTRkZWUtOGJl
+        MC0yMmMxZjRjYWY5NjAifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToyNTo1OVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjI1OjU5WiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmU2NzA1ZjVlZTA1YzNmZDg0YTAiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZTY3NDk4ZWRiODI1NWJiMmY4
+        NCJ9LCAiaWQiOiAiNWMwNGJlNjc0OThlZGI4MjU1YmIyZjg0In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:25:59 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/8e8a77c7-0ea6-4dee-8be0-22c1f4caf960/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:25:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"e0f054931c5b7be49d81fa7901240b8f-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4550'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy84ZThhNzdjNy0wZWE2LTRkZWUtOGJlMC0yMmMx
+        ZjRjYWY5NjAvIiwgInRhc2tfaWQiOiAiOGU4YTc3YzctMGVhNi00ZGVlLThi
+        ZTAtMjJjMWY0Y2FmOTYwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MjU6NTlaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJlMzRmNjg1NC02ZDZlLTQzMTMtOGQyOS0w
+        NDIwMjRhZmM0ZmYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMTgzMjU3M2MtMTU2Ni00ZDZkLTk2YzIt
+        MmFlNTllNTA5NDVhIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImVkODAyNDU3LTJiNjYtNDc0MC04ZTczLTg4ZTE5YmY2
+        ODFjNiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIklOX1BS
+        T0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjhjNDU1M2EzLWQyNzgt
+        NDU3ZC05NzE0LTYwYWU1OTM0NmZkYiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJiODE0MzdhMy02NjBkLTQyNTItYmFmZC1hN2UyYzkzMzZk
+        ZDYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTdjZDk5N2UtYTE2
+        NC00NjNmLWJlM2MtZGRhOWRhNGY3ZjM0IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiNDc0NTNjZjYtNjdhZS00M2JiLThkZTAtMmJjN2E0MzA2
+        MzBjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJiNWNkNTQ2
+        LWFkY2YtNDJmNi04ZTU4LTJlOWI3MWNkODc2MiIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImUzMTNiMTA1LWQ0ZjMtNGNiYS1hY2VhLTI5
+        NTI4ZTcxNjYyMiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
+        IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjdjMWYyMmMxLTkxYWMtNGU4OC1hN2M4LTE5MzM5Yzc5
+        ODFkYSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAi
+        c3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJkMjE2OGVmNS03MzMxLTQ4YTItOTdlNi03NzUxNjkwOWU5NzIiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUi
+        OiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJm
+        YmRlY2JkZC1hNmZlLTQ0NTEtOTNkMC02ZTM0OTFlODVkZWMiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVw
+        b3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTU0OGExYWItYTg3OS00ZmI4
+        LWI1NmYtZDEwMmMzZGRjZDM0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZp
+        bGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rvcnki
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiOTNiOTFjY2ItYmQ0YS00MDUwLWJkOWIt
+        MTA4N2Y5MmRmYmM3IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZp
+        bGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI4N2ExMDc4Mi01ZTZiLTQ0ZTAtYjBjMC1l
+        MzI4NmVjNDlmOGIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRldmVsMi5z
+        YW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50
+        b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZTY3NDk4
+        ZWRiODI1NWJiMzEyMCJ9LCAiaWQiOiAiNWMwNGJlNjc0OThlZGI4MjU1YmIz
+        MTIwIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:25:59 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/871a9671-6263-4717-bbba-3f9ee87988cc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:25:59 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"0223b9af32fb2f54401319113f74c472-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84NzFhOTY3MS02MjYzLTQ3MTctYmJiYS0zZjllZTg3OTg4
+        Y2MvIiwgInRhc2tfaWQiOiAiODcxYTk2NzEtNjI2My00NzE3LWJiYmEtM2Y5
+        ZWU4Nzk4OGNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6MjU6NTlaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MjU6NTlaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzLzhlOGE3N2M3LTBlYTYtNGRlZS04YmUwLTIyYzFm
+        NGNhZjk2MC8iLCAidGFza19pZCI6ICI4ZThhNzdjNy0wZWE2LTRkZWUtOGJl
+        MC0yMmMxZjRjYWY5NjAifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToyNTo1OVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjI1OjU5WiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmU2NzA1ZjVlZTA1YzNmZDg0YTAiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZTY3NDk4ZWRiODI1NWJiMmY4
+        NCJ9LCAiaWQiOiAiNWMwNGJlNjc0OThlZGI4MjU1YmIyZjg0In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:26:00 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/8e8a77c7-0ea6-4dee-8be0-22c1f4caf960/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:26:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"a3c6406d63a070900a5664c32b32a6b1-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4550'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy84ZThhNzdjNy0wZWE2LTRkZWUtOGJlMC0yMmMx
+        ZjRjYWY5NjAvIiwgInRhc2tfaWQiOiAiOGU4YTc3YzctMGVhNi00ZGVlLThi
+        ZTAtMjJjMWY0Y2FmOTYwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MjU6NTlaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJlMzRmNjg1NC02ZDZlLTQzMTMtOGQyOS0w
+        NDIwMjRhZmM0ZmYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMTgzMjU3M2MtMTU2Ni00ZDZkLTk2YzIt
+        MmFlNTllNTA5NDVhIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImVkODAyNDU3LTJiNjYtNDc0MC04ZTczLTg4ZTE5YmY2
+        ODFjNiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIklOX1BS
+        T0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjhjNDU1M2EzLWQyNzgt
+        NDU3ZC05NzE0LTYwYWU1OTM0NmZkYiIsICJudW1fcHJvY2Vzc2VkIjogOH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJiODE0MzdhMy02NjBkLTQyNTItYmFmZC1hN2UyYzkzMzZk
+        ZDYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTdjZDk5N2UtYTE2
+        NC00NjNmLWJlM2MtZGRhOWRhNGY3ZjM0IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiNDc0NTNjZjYtNjdhZS00M2JiLThkZTAtMmJjN2E0MzA2
+        MzBjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJiNWNkNTQ2
+        LWFkY2YtNDJmNi04ZTU4LTJlOWI3MWNkODc2MiIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImUzMTNiMTA1LWQ0ZjMtNGNiYS1hY2VhLTI5
+        NTI4ZTcxNjYyMiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
+        IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjdjMWYyMmMxLTkxYWMtNGU4OC1hN2M4LTE5MzM5Yzc5
+        ODFkYSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAi
+        c3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJkMjE2OGVmNS03MzMxLTQ4YTItOTdlNi03NzUxNjkwOWU5NzIiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUi
+        OiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJm
+        YmRlY2JkZC1hNmZlLTQ0NTEtOTNkMC02ZTM0OTFlODVkZWMiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVw
+        b3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTU0OGExYWItYTg3OS00ZmI4
+        LWI1NmYtZDEwMmMzZGRjZDM0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZp
+        bGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rvcnki
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiOTNiOTFjY2ItYmQ0YS00MDUwLWJkOWIt
+        MTA4N2Y5MmRmYmM3IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZp
+        bGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI4N2ExMDc4Mi01ZTZiLTQ0ZTAtYjBjMC1l
+        MzI4NmVjNDlmOGIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRldmVsMi5z
+        YW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50
+        b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZTY3NDk4
+        ZWRiODI1NWJiMzEyMCJ9LCAiaWQiOiAiNWMwNGJlNjc0OThlZGI4MjU1YmIz
+        MTIwIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:26:00 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/871a9671-6263-4717-bbba-3f9ee87988cc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:26:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"0223b9af32fb2f54401319113f74c472-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84NzFhOTY3MS02MjYzLTQ3MTctYmJiYS0zZjllZTg3OTg4
+        Y2MvIiwgInRhc2tfaWQiOiAiODcxYTk2NzEtNjI2My00NzE3LWJiYmEtM2Y5
+        ZWU4Nzk4OGNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6MjU6NTlaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MjU6NTlaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzLzhlOGE3N2M3LTBlYTYtNGRlZS04YmUwLTIyYzFm
+        NGNhZjk2MC8iLCAidGFza19pZCI6ICI4ZThhNzdjNy0wZWE2LTRkZWUtOGJl
+        MC0yMmMxZjRjYWY5NjAifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToyNTo1OVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjI1OjU5WiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmU2NzA1ZjVlZTA1YzNmZDg0YTAiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZTY3NDk4ZWRiODI1NWJiMmY4
+        NCJ9LCAiaWQiOiAiNWMwNGJlNjc0OThlZGI4MjU1YmIyZjg0In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:26:00 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/8e8a77c7-0ea6-4dee-8be0-22c1f4caf960/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:26:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"4247a3be36fc34c0d070e246dd28f78b-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4537'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy84ZThhNzdjNy0wZWE2LTRkZWUtOGJlMC0yMmMx
+        ZjRjYWY5NjAvIiwgInRhc2tfaWQiOiAiOGU4YTc3YzctMGVhNi00ZGVlLThi
+        ZTAtMjJjMWY0Y2FmOTYwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MjU6NTlaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJlMzRmNjg1NC02ZDZlLTQzMTMtOGQyOS0w
+        NDIwMjRhZmM0ZmYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMTgzMjU3M2MtMTU2Ni00ZDZkLTk2YzIt
+        MmFlNTllNTA5NDVhIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImVkODAyNDU3LTJiNjYtNDc0MC04ZTczLTg4ZTE5YmY2
+        ODFjNiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjhjNDU1M2EzLWQyNzgtNDU3
+        ZC05NzE0LTYwYWU1OTM0NmZkYiIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImI4MTQzN2EzLTY2MGQtNDI1Mi1iYWZkLWE3ZTJjOTMzNmRkNiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
+        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhN2NkOTk3ZS1hMTY0LTQ2M2YtYmUz
+        Yy1kZGE5ZGE0ZjdmMzQiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
+        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0
+        NzQ1M2NmNi02N2FlLTQzYmItOGRlMC0yYmM3YTQzMDYzMGMiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMiwgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
+        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiSU5fUFJPR1JFU1Mi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmI1Y2Q1NDYtYWRjZi00MmY2LThl
+        NTgtMmU5YjcxY2Q4NzYyIiwgIm51bV9wcm9jZXNzZWQiOiAyfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFk
+        YXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiZTMxM2IxMDUtZDRmMy00Y2JhLWFjZWEtMjk1MjhlNzE2NjIyIiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBl
+        IjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        N2MxZjIyYzEtOTFhYy00ZTg4LWE3YzgtMTkzMzljNzk4MWRhIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
+        Z2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQyMTY4ZWY1
+        LTczMzEtNDhhMi05N2U2LTc3NTE2OTA5ZTk3MiIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUmVt
+        b3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xk
+        X3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZiZGVjYmRkLWE2ZmUt
+        NDQ1MS05M2QwLTZlMzQ5MWU4NWRlYyIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
+        ZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVt
+        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIxNTQ4YTFhYi1hODc5LTRmYjgtYjU2Zi1kMTAyYzNk
+        ZGNkMzQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwg
+        InN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI5M2I5MWNjYi1iZDRhLTQwNTAtYmQ5Yi0xMDg3ZjkyZGZiYzci
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjg3YTEwNzgyLTVlNmItNDRlMC1iMGMwLWUzMjg2ZWM0OWY4YiIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUu
+        Y29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNh
+        bWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51
+        bGwsICJfaWQiOiB7IiRvaWQiOiAiNWMwNGJlNjc0OThlZGI4MjU1YmIzMTIw
+        In0sICJpZCI6ICI1YzA0YmU2NzQ5OGVkYjgyNTViYjMxMjAifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:26:00 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/871a9671-6263-4717-bbba-3f9ee87988cc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:26:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"0223b9af32fb2f54401319113f74c472-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84NzFhOTY3MS02MjYzLTQ3MTctYmJiYS0zZjllZTg3OTg4
+        Y2MvIiwgInRhc2tfaWQiOiAiODcxYTk2NzEtNjI2My00NzE3LWJiYmEtM2Y5
+        ZWU4Nzk4OGNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6MjU6NTlaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MjU6NTlaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzLzhlOGE3N2M3LTBlYTYtNGRlZS04YmUwLTIyYzFm
+        NGNhZjk2MC8iLCAidGFza19pZCI6ICI4ZThhNzdjNy0wZWE2LTRkZWUtOGJl
+        MC0yMmMxZjRjYWY5NjAifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToyNTo1OVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjI1OjU5WiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmU2NzA1ZjVlZTA1YzNmZDg0YTAiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZTY3NDk4ZWRiODI1NWJiMmY4
+        NCJ9LCAiaWQiOiAiNWMwNGJlNjc0OThlZGI4MjU1YmIyZjg0In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:26:00 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/8e8a77c7-0ea6-4dee-8be0-22c1f4caf960/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:26:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"de1ab932fd0f98c0e3ffa3ae18cf0088-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4511'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy84ZThhNzdjNy0wZWE2LTRkZWUtOGJlMC0yMmMx
+        ZjRjYWY5NjAvIiwgInRhc2tfaWQiOiAiOGU4YTc3YzctMGVhNi00ZGVlLThi
+        ZTAtMjJjMWY0Y2FmOTYwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6MjU6NTlaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJlMzRmNjg1NC02ZDZlLTQzMTMtOGQyOS0w
+        NDIwMjRhZmM0ZmYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMTgzMjU3M2MtMTU2Ni00ZDZkLTk2YzIt
+        MmFlNTllNTA5NDVhIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImVkODAyNDU3LTJiNjYtNDc0MC04ZTczLTg4ZTE5YmY2
+        ODFjNiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjhjNDU1M2EzLWQyNzgtNDU3
+        ZC05NzE0LTYwYWU1OTM0NmZkYiIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImI4MTQzN2EzLTY2MGQtNDI1Mi1iYWZkLWE3ZTJjOTMzNmRkNiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
+        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhN2NkOTk3ZS1hMTY0LTQ2M2YtYmUz
+        Yy1kZGE5ZGE0ZjdmMzQiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
+        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0
+        NzQ1M2NmNi02N2FlLTQzYmItOGRlMC0yYmM3YTQzMDYzMGMiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
+        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMmI1Y2Q1NDYtYWRjZi00MmY2LThlNTgt
+        MmU5YjcxY2Q4NzYyIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRh
+        LiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        ZTMxM2IxMDUtZDRmMy00Y2JhLWFjZWEtMjk1MjhlNzE2NjIyIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
+        biI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNs
+        b3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiN2MxZjIyYzEt
+        OTFhYy00ZTg4LWE3YzgtMTkzMzljNzk4MWRhIiwgIm51bV9wcm9jZXNzZWQi
+        OiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5l
+        cmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUg
+        c3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDIxNjhlZjUtNzMzMS00OGEyLTk3
+        ZTYtNzc1MTY5MDllOTcyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVw
+        b2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAi
+        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiZmJkZWNiZGQtYTZmZS00NDUxLTkzZDAtNmUzNDkx
+        ZTg1ZGVjIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAi
+        c3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTU0OGEx
+        YWItYTg3OS00ZmI4LWI1NmYtZDEwMmMzZGRjZDM0IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
+        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklO
+        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTNiOTFjY2ItYmQ0YS00
+        MDUwLWJkOWItMTA4N2Y5MmRmYmM3IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwg
+        eyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
+        c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
+        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4N2ExMDc4Mi01ZTZiLTQ0ZTAt
+        YjBjMC1lMzI4NmVjNDlmOGIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9XX0sICJx
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRl
+        dmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJyZXN1bHQi
+        OiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRi
+        ZTY3NDk4ZWRiODI1NWJiMzEyMCJ9LCAiaWQiOiAiNWMwNGJlNjc0OThlZGI4
+        MjU1YmIzMTIwIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:26:00 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/871a9671-6263-4717-bbba-3f9ee87988cc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:26:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"0223b9af32fb2f54401319113f74c472-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy84NzFhOTY3MS02MjYzLTQ3MTctYmJiYS0zZjllZTg3OTg4
+        Y2MvIiwgInRhc2tfaWQiOiAiODcxYTk2NzEtNjI2My00NzE3LWJiYmEtM2Y5
+        ZWU4Nzk4OGNjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6MjU6NTlaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MjU6NTlaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzLzhlOGE3N2M3LTBlYTYtNGRlZS04YmUwLTIyYzFm
+        NGNhZjk2MC8iLCAidGFza19pZCI6ICI4ZThhNzdjNy0wZWE2LTRkZWUtOGJl
+        MC0yMmMxZjRjYWY5NjAifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToyNTo1OVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjI1OjU5WiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmU2NzA1ZjVlZTA1YzNmZDg0YTAiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZTY3NDk4ZWRiODI1NWJiMmY4
+        NCJ9LCAiaWQiOiAiNWMwNGJlNjc0OThlZGI4MjU1YmIyZjg0In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:26:00 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/8e8a77c7-0ea6-4dee-8be0-22c1f4caf960/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:26:00 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"8c4f10a58c7192fafca67bfd6cedb3de-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '9057'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy84ZThhNzdjNy0wZWE2LTRkZWUtOGJlMC0yMmMx
+        ZjRjYWY5NjAvIiwgInRhc2tfaWQiOiAiOGU4YTc3YzctMGVhNi00ZGVlLThi
+        ZTAtMjJjMWY0Y2FmOTYwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTgtMTItMDNUMDU6MjY6MDBaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6MjU6NTla
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0
+        ZXBfdHlwZSI6ICJzYXZlX3RhciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlMzRmNjg1
+        NC02ZDZlLTQzMTMtOGQyOS0wNDIwMjRhZmM0ZmYiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIklu
+        aXRpYWxpemluZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTgzMjU3
+        M2MtMTU2Ni00ZDZkLTk2YzItMmFlNTllNTA5NDVhIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIERpc3RyaWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
+        ZGlzdHJpYnV0aW9uIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVkODAyNDU3LTJiNjYt
+        NDc0MC04ZTczLTg4ZTE5YmY2ODFjNiIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        IHsibnVtX3N1Y2Nlc3MiOiA4LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjog
+        OCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjhjNDU1M2EzLWQyNzgtNDU3ZC05NzE0LTYwYWU1OTM0NmZkYiIsICJudW1f
+        cHJvY2Vzc2VkIjogOH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJk
+        cnBtcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImI4MTQzN2EzLTY2MGQtNDI1Mi1iYWZk
+        LWE3ZTJjOTMzNmRkNiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEi
+        LCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhN2Nk
+        OTk3ZS1hMTY0LTQ2M2YtYmUzYy1kZGE5ZGE0ZjdmMzQiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgTW9kdWxlcyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI0NzQ1M2NmNi02N2FlLTQzYmItOGRlMC0yYmM3
+        YTQzMDYzMGMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIs
+        ICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmI1Y2Q1
+        NDYtYWRjZi00MmY2LThlNTgtMmU5YjcxY2Q4NzYyIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiZTMxM2IxMDUtZDRmMy00Y2JhLWFjZWEtMjk1
+        MjhlNzE2NjIyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiN2MxZjIyYzEtOTFhYy00ZTg4LWE3YzgtMTkzMzljNzk4MWRh
+        IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
+        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDIx
+        NjhlZjUtNzMzMS00OGEyLTk3ZTYtNzc1MTY5MDllOTcyIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
+        ICJSZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92
+        ZV9vbGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmJkZWNiZGQtYTZm
+        ZS00NDUxLTkzZDAtNmUzNDkxZTg1ZGVjIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
+        aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiMTU0OGExYWItYTg3OS00ZmI4LWI1NmYtZDEwMmMzZGRj
+        ZDM0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJz
+        dGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiOTNiOTFjY2ItYmQ0YS00MDUwLWJkOWItMTA4N2Y5MmRmYmM3IiwgIm51
+        bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjog
+        ImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4
+        N2ExMDc4Mi01ZTZiLTQ0ZTAtYjBjMC1lMzI4NmVjNDlmOGIiLCAibnVtX3By
+        b2Nlc3NlZCI6IDF9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJl
+        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0Iiwg
+        InN0YXJ0ZWQiOiAiMjAxOC0xMi0wM1QwNToyNTo1OVoiLCAiX25zIjogInJl
+        cG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE4LTEyLTAz
+        VDA1OjI2OjAwWiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3Jf
+        dHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6IHsiZ2Vu
+        ZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQiLCAicnBtcyI6ICJGSU5JU0hFRCIs
+        ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicmVt
+        b3ZlX29sZF9yZXBvZGF0YSI6ICJGSU5JU0hFRCIsICJtb2R1bGVzIjogIkZJ
+        TklTSEVEIiwgInNhdmVfdGFyIjogIkZJTklTSEVEIiwgImNsb3NlX3JlcG9f
+        bWV0YWRhdGEiOiAiRklOSVNIRUQiLCAiZHJwbXMiOiAiU0tJUFBFRCIsICJj
+        b21wcyI6ICJGSU5JU0hFRCIsICJkaXN0cmlidXRpb24iOiAiRklOSVNIRUQi
+        LCAicmVwb3ZpZXciOiAiU0tJUFBFRCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6
+        ICJGSU5JU0hFRCIsICJlcnJhdGEiOiAiRklOSVNIRUQiLCAibWV0YWRhdGEi
+        OiAiRklOSVNIRUQifSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJp
+        YnV0b3JfaWQiOiAic2NlbmFyaW9fdGVzdCIsICJpZCI6ICI1YzA0YmU2ODA1
+        ZjVlZTA1YzNmZDg0YTEiLCAiZGV0YWlscyI6IFt7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIkNvcHlpbmcgZmlsZXMiLCAic3RlcF90eXBl
+        IjogInNhdmVfdGFyIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUzNGY2ODU0LTZkNmUt
+        NDMxMy04ZDI5LTA0MjAyNGFmYzRmZiIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6
+        aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVf
+        cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxODMyNTczYy0xNTY2
+        LTRkNmQtOTZjMi0yYWU1OWU1MDk0NWEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmli
+        dXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWQ4MDI0NTctMmI2Ni00NzQwLThl
+        NzMtODhlMTliZjY4MWM2IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1f
+        c3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMi
+        LCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOGM0NTUz
+        YTMtZDI3OC00NTdkLTk3MTQtNjBhZTU5MzQ2ZmRiIiwgIm51bV9wcm9jZXNz
+        ZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiYjgxNDM3YTMtNjYwZC00MjUyLWJhZmQtYTdlMmM5
+        MzM2ZGQ2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVw
+        X3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE3Y2Q5OTdlLWEx
+        NjQtNDYzZi1iZTNjLWRkYTlkYTRmN2YzNCIsICJudW1fcHJvY2Vzc2VkIjog
+        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjQ3NDUzY2Y2LTY3YWUtNDNiYi04ZGUwLTJiYzdhNDMwNjMw
+        YyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBf
+        dHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyYjVjZDU0Ni1hZGNm
+        LTQyZjYtOGU1OC0yZTliNzFjZDg3NjIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJlMzEzYjEwNS1kNGYzLTRjYmEtYWNlYS0yOTUyOGU3MTY2
+        MjIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwg
+        ImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVw
+        X3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICI3YzFmMjJjMS05MWFjLTRlODgtYTdjOC0xOTMzOWM3OTgxZGEiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkMjE2OGVmNS03
+        MzMxLTQ4YTItOTdlNi03NzUxNjkwOWU5NzIiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92
+        aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9y
+        ZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmYmRlY2JkZC1hNmZlLTQ0NTEt
+        OTNkMC02ZTM0OTFlODVkZWMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRN
+        TCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICIxNTQ4YTFhYi1hODc5LTRmYjgtYjU2Zi1kMTAyYzNkZGNkMzQiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2Ny
+        aXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlw
+        ZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5M2I5
+        MWNjYi1iZDRhLTQwNTAtYmQ5Yi0xMDg3ZjkyZGZiYzciLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
+        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjg3YTEwNzgy
+        LTVlNmItNDRlMC1iMGMwLWUzMjg2ZWM0OWY4YiIsICJudW1fcHJvY2Vzc2Vk
+        IjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0
+        YmU2NzQ5OGVkYjgyNTViYjMxMjAifSwgImlkIjogIjVjMDRiZTY3NDk4ZWRi
+        ODI1NWJiMzEyMCJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:26:00 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/916a8107-25ef-47e4-b657-f972acc0481a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:20 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"ac5667fee450fcbf1515eb9976dba119-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '664'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85MTZhODEwNy0yNWVmLTQ3ZTQtYjY1Ny1mOTcyYWNjMDQ4
+        MWEvIiwgInRhc2tfaWQiOiAiOTE2YTgxMDctMjVlZi00N2U0LWI2NTctZjk3
+        MmFjYzA0ODFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogbnVs
+        bCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291
+        cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29t
+        LmRxMiIsICJzdGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogInJl
+        c2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWly
+        LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNWMwNGJlZjQ0OThlZGI4MjU1YmIzNWMzIn0s
+        ICJpZCI6ICI1YzA0YmVmNDQ5OGVkYjgyNTViYjM1YzMifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:20 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/916a8107-25ef-47e4-b657-f972acc0481a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:20 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"9c12130f6c9ae4f7e73667d0b634f651-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1191'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85MTZhODEwNy0yNWVmLTQ3ZTQtYjY1Ny1mOTcyYWNjMDQ4
+        MWEvIiwgInRhc2tfaWQiOiAiOTE2YTgxMDctMjVlZi00N2U0LWI2NTctZjk3
+        MmFjYzA0ODFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6Mjg6MjBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
+        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiSU5fUFJPR1JF
+        U1MifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
+        Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRl
+        IjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1YzA0YmVmNDQ5OGVkYjgyNTViYjM1YzMifSwgImlkIjogIjVjMDRi
+        ZWY0NDk4ZWRiODI1NWJiMzVjMyJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:20 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/916a8107-25ef-47e4-b657-f972acc0481a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:20 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"6bfe7d14046c4f221e12e95db767c5c5-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1188'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85MTZhODEwNy0yNWVmLTQ3ZTQtYjY1Ny1mOTcyYWNjMDQ4
+        MWEvIiwgInRhc2tfaWQiOiAiOTE2YTgxMDctMjVlZi00N2U0LWI2NTctZjk3
+        MmFjYzA0ODFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6Mjg6MjBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
+        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
+        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzA0YmVmNDQ5OGVkYjgyNTViYjM1YzMifSwgImlkIjogIjVjMDRiZWY0
+        NDk4ZWRiODI1NWJiMzVjMyJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:20 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/916a8107-25ef-47e4-b657-f972acc0481a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:20 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"6bfe7d14046c4f221e12e95db767c5c5-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1188'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85MTZhODEwNy0yNWVmLTQ3ZTQtYjY1Ny1mOTcyYWNjMDQ4
+        MWEvIiwgInRhc2tfaWQiOiAiOTE2YTgxMDctMjVlZi00N2U0LWI2NTctZjk3
+        MmFjYzA0ODFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6Mjg6MjBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
+        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
+        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzA0YmVmNDQ5OGVkYjgyNTViYjM1YzMifSwgImlkIjogIjVjMDRiZWY0
+        NDk4ZWRiODI1NWJiMzVjMyJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:20 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/916a8107-25ef-47e4-b657-f972acc0481a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"6bfe7d14046c4f221e12e95db767c5c5-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1188'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85MTZhODEwNy0yNWVmLTQ3ZTQtYjY1Ny1mOTcyYWNjMDQ4
+        MWEvIiwgInRhc2tfaWQiOiAiOTE2YTgxMDctMjVlZi00N2U0LWI2NTctZjk3
+        MmFjYzA0ODFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6Mjg6MjBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
+        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
+        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzA0YmVmNDQ5OGVkYjgyNTViYjM1YzMifSwgImlkIjogIjVjMDRiZWY0
+        NDk4ZWRiODI1NWJiMzVjMyJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:21 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/916a8107-25ef-47e4-b657-f972acc0481a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"c4d23baa6ced1d46e4a9840179708249-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1185'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85MTZhODEwNy0yNWVmLTQ3ZTQtYjY1Ny1mOTcyYWNjMDQ4
+        MWEvIiwgInRhc2tfaWQiOiAiOTE2YTgxMDctMjVlZi00N2U0LWI2NTctZjk3
+        MmFjYzA0ODFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6Mjg6MjBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRl
+        IjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5PVF9T
+        VEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
+        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9z
+        Ny1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1
+        bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
+        a2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        YzA0YmVmNDQ5OGVkYjgyNTViYjM1YzMifSwgImlkIjogIjVjMDRiZWY0NDk4
+        ZWRiODI1NWJiMzVjMyJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:21 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/916a8107-25ef-47e4-b657-f972acc0481a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"e9483bc4dc05c90e809c2c111be63dbf-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1179'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85MTZhODEwNy0yNWVmLTQ3ZTQtYjY1Ny1mOTcyYWNjMDQ4
+        MWEvIiwgInRhc2tfaWQiOiAiOTE2YTgxMDctMjVlZi00N2U0LWI2NTctZjk3
+        MmFjYzA0ODFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6Mjg6MjBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIklOX1BST0dSRVNT
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVl
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZl
+        bDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmci
+        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
+        Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YmVm
+        NDQ5OGVkYjgyNTViYjM1YzMifSwgImlkIjogIjVjMDRiZWY0NDk4ZWRiODI1
+        NWJiMzVjMyJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:21 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/916a8107-25ef-47e4-b657-f972acc0481a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"8473dd5e2ecb46dfaaef3d821616cd4e-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1176'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85MTZhODEwNy0yNWVmLTQ3ZTQtYjY1Ny1mOTcyYWNjMDQ4
+        MWEvIiwgInRhc2tfaWQiOiAiOTE2YTgxMDctMjVlZi00N2U0LWI2NTctZjk3
+        MmFjYzA0ODFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6Mjg6MjBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiSU5fUFJPR1JFU1MifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIu
+        c2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAi
+        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
+        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVs
+        bCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YmVmNDQ5
+        OGVkYjgyNTViYjM1YzMifSwgImlkIjogIjVjMDRiZWY0NDk4ZWRiODI1NWJi
+        MzVjMyJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:21 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/916a8107-25ef-47e4-b657-f972acc0481a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"f392986336600b3957b66f2093647d95-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1170'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85MTZhODEwNy0yNWVmLTQ3ZTQtYjY1Ny1mOTcyYWNjMDQ4
+        MWEvIiwgInRhc2tfaWQiOiAiOTE2YTgxMDctMjVlZi00N2U0LWI2NTctZjk3
+        MmFjYzA0ODFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6Mjg6MjBaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2Vy
+        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
+        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YmVmNDQ5OGVkYjgy
+        NTViYjM1YzMifSwgImlkIjogIjVjMDRiZWY0NDk4ZWRiODI1NWJiMzVjMyJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:21 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/916a8107-25ef-47e4-b657-f972acc0481a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"6afde616d2a5b736e4b3af4fb3cdfaf7-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85MTZhODEwNy0yNWVmLTQ3ZTQtYjY1Ny1mOTcyYWNjMDQ4
+        MWEvIiwgInRhc2tfaWQiOiAiOTE2YTgxMDctMjVlZi00N2U0LWI2NTctZjk3
+        MmFjYzA0ODFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6Mjg6MjFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6Mjg6MjBaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2UyY2NkYmI5LTg5ZDUtNDU0Yy05MjY3LTIxYThj
+        MzlhMDkzNy8iLCAidGFza19pZCI6ICJlMmNjZGJiOS04OWQ1LTQ1NGMtOTI2
+        Ny0yMWE4YzM5YTA5MzcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToyODoyMFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjI4OjIxWiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmVmNTA1ZjVlZTA1YzNmZDg0YjciLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZWY0NDk4ZWRiODI1NWJiMzVj
+        MyJ9LCAiaWQiOiAiNWMwNGJlZjQ0OThlZGI4MjU1YmIzNWMzIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:21 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/e2ccdbb9-89d5-454c-9267-21a8c39a0937/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"e87d41db20f62b1b7588fb2dd5b7a9fe-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '673'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9lMmNjZGJiOS04OWQ1LTQ1NGMtOTI2Ny0yMWE4
+        YzM5YTA5MzcvIiwgInRhc2tfaWQiOiAiZTJjY2RiYjktODlkNS00NTRjLTky
+        NjctMjFhOGMzOWEwOTM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2Vy
+        dmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9u
+        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2
+        ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJv
+        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWMwNGJlZjU0OThlZGI4MjU1
+        YmIzNzY1In0sICJpZCI6ICI1YzA0YmVmNTQ5OGVkYjgyNTViYjM3NjUifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:21 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/916a8107-25ef-47e4-b657-f972acc0481a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"6afde616d2a5b736e4b3af4fb3cdfaf7-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85MTZhODEwNy0yNWVmLTQ3ZTQtYjY1Ny1mOTcyYWNjMDQ4
+        MWEvIiwgInRhc2tfaWQiOiAiOTE2YTgxMDctMjVlZi00N2U0LWI2NTctZjk3
+        MmFjYzA0ODFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6Mjg6MjFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6Mjg6MjBaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2UyY2NkYmI5LTg5ZDUtNDU0Yy05MjY3LTIxYThj
+        MzlhMDkzNy8iLCAidGFza19pZCI6ICJlMmNjZGJiOS04OWQ1LTQ1NGMtOTI2
+        Ny0yMWE4YzM5YTA5MzcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToyODoyMFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjI4OjIxWiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmVmNTA1ZjVlZTA1YzNmZDg0YjciLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZWY0NDk4ZWRiODI1NWJiMzVj
+        MyJ9LCAiaWQiOiAiNWMwNGJlZjQ0OThlZGI4MjU1YmIzNWMzIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:21 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/e2ccdbb9-89d5-454c-9267-21a8c39a0937/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"93a5a213431983df2ad2077053cc6d96-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4553'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9lMmNjZGJiOS04OWQ1LTQ1NGMtOTI2Ny0yMWE4
+        YzM5YTA5MzcvIiwgInRhc2tfaWQiOiAiZTJjY2RiYjktODlkNS00NTRjLTky
+        NjctMjFhOGMzOWEwOTM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6Mjg6MjFaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJiMWFmYmVjZS1kYThkLTQwZWYtYmFiNS05
+        YTZmODllODMyYmEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZmZiYzgwNDAtYjk3YS00YzU0LTgwMTgt
+        N2ZiODlmYTM0MGJkIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjNiOWVhY2VkLTY1NWQtNDhlZC04ZDdlLTkxNWY0
+        OWY2NTNjNSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBf
+        dHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
+        VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNhNjE5NWNiLTMx
+        ODMtNGU2MC1hN2QxLTAxYTI5NThkNTc1MSIsICJudW1fcHJvY2Vzc2VkIjog
+        MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVt
+        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIzODcyZTgxNS1jNDcxLTRlNzgtODA2NS1kNDBhNWM0
+        NjMxYTYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBf
+        dHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNWYwYzk3OWIt
+        ZWU1Ni00OGY2LWI3YzAtMzMwZjVmOTI2NmI0IiwgIm51bV9wcm9jZXNzZWQi
+        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
+        aXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiMWU2ZDExMzItOWY3Zi00MWRkLTlhZTItMDhlZmMz
+        NDFiYjU0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAi
+        c3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVlOTM2
+        ZTI3LTZmMTMtNGVkMS04OTM3LTg0MmYxNWQzMjU1MyIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        UHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjhjMTZmMDRjLTYzYWMtNDYxMC1hNzZm
+        LTU5MzFhMGIyNmJkYiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFk
+        YXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImE2NmNjYTVjLTZlOTYtNGVmYi05YTkxLTA5NTY0
+        NjBlNTVhMSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
+        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJhZWU3YjUxZi01OGI5LTRmMDUtYTY1Mi0yMmE4NTY1NDI3MTci
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5
+        cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICIzYmFmODViYS03MDhmLTQxMTYtOGFlYy01NmU5MjQ4Zjg0MDMiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
+        cmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
+        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzM3N2IzMWUtNzUzMC00
+        MGU3LWFlZTYtM2FlMTI2ZDk3NjNlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
+        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
+        IGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rv
+        cnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzI1YTI1ZDYtZDZjMS00NzAyLWE1
+        MDQtNGU5OGQzOGNlZjcwIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3Rpbmdz
+        IEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0
+        YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNmMxNjYwNy0xNDMwLTRiMDEtYTIz
+        ZS1hNGUwNDI1Yzg5NTYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRldmVs
+        Mi5zYW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBj
+        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBu
+        dWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZWY1
+        NDk4ZWRiODI1NWJiMzc2NSJ9LCAiaWQiOiAiNWMwNGJlZjU0OThlZGI4MjU1
+        YmIzNzY1In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:21 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/916a8107-25ef-47e4-b657-f972acc0481a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"6afde616d2a5b736e4b3af4fb3cdfaf7-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85MTZhODEwNy0yNWVmLTQ3ZTQtYjY1Ny1mOTcyYWNjMDQ4
+        MWEvIiwgInRhc2tfaWQiOiAiOTE2YTgxMDctMjVlZi00N2U0LWI2NTctZjk3
+        MmFjYzA0ODFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6Mjg6MjFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6Mjg6MjBaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2UyY2NkYmI5LTg5ZDUtNDU0Yy05MjY3LTIxYThj
+        MzlhMDkzNy8iLCAidGFza19pZCI6ICJlMmNjZGJiOS04OWQ1LTQ1NGMtOTI2
+        Ny0yMWE4YzM5YTA5MzcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToyODoyMFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjI4OjIxWiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmVmNTA1ZjVlZTA1YzNmZDg0YjciLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZWY0NDk4ZWRiODI1NWJiMzVj
+        MyJ9LCAiaWQiOiAiNWMwNGJlZjQ0OThlZGI4MjU1YmIzNWMzIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:21 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/e2ccdbb9-89d5-454c-9267-21a8c39a0937/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"cc186e0876f12d1431b314dc024ca492-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4550'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9lMmNjZGJiOS04OWQ1LTQ1NGMtOTI2Ny0yMWE4
+        YzM5YTA5MzcvIiwgInRhc2tfaWQiOiAiZTJjY2RiYjktODlkNS00NTRjLTky
+        NjctMjFhOGMzOWEwOTM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6Mjg6MjFaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJiMWFmYmVjZS1kYThkLTQwZWYtYmFiNS05
+        YTZmODllODMyYmEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZmZiYzgwNDAtYjk3YS00YzU0LTgwMTgt
+        N2ZiODlmYTM0MGJkIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjNiOWVhY2VkLTY1NWQtNDhlZC04ZDdlLTkxNWY0OWY2
+        NTNjNSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA2
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIklOX1BS
+        T0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNhNjE5NWNiLTMxODMt
+        NGU2MC1hN2QxLTAxYTI5NThkNTc1MSIsICJudW1fcHJvY2Vzc2VkIjogNn0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIzODcyZTgxNS1jNDcxLTRlNzgtODA2NS1kNDBhNWM0NjMx
+        YTYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNWYwYzk3OWItZWU1
+        Ni00OGY2LWI3YzAtMzMwZjVmOTI2NmI0IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiMWU2ZDExMzItOWY3Zi00MWRkLTlhZTItMDhlZmMzNDFi
+        YjU0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVlOTM2ZTI3
+        LTZmMTMtNGVkMS04OTM3LTg0MmYxNWQzMjU1MyIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjhjMTZmMDRjLTYzYWMtNDYxMC1hNzZmLTU5
+        MzFhMGIyNmJkYiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
+        IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImE2NmNjYTVjLTZlOTYtNGVmYi05YTkxLTA5NTY0NjBl
+        NTVhMSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAi
+        c3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJhZWU3YjUxZi01OGI5LTRmMDUtYTY1Mi0yMmE4NTY1NDI3MTciLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUi
+        OiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIz
+        YmFmODViYS03MDhmLTQxMTYtOGFlYy01NmU5MjQ4Zjg0MDMiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVw
+        b3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzM3N2IzMWUtNzUzMC00MGU3
+        LWFlZTYtM2FlMTI2ZDk3NjNlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZp
+        bGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rvcnki
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiYzI1YTI1ZDYtZDZjMS00NzAyLWE1MDQt
+        NGU5OGQzOGNlZjcwIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZp
+        bGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJhNmMxNjYwNy0xNDMwLTRiMDEtYTIzZS1h
+        NGUwNDI1Yzg5NTYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRldmVsMi5z
+        YW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50
+        b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZWY1NDk4
+        ZWRiODI1NWJiMzc2NSJ9LCAiaWQiOiAiNWMwNGJlZjU0OThlZGI4MjU1YmIz
+        NzY1In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:21 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/916a8107-25ef-47e4-b657-f972acc0481a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"6afde616d2a5b736e4b3af4fb3cdfaf7-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85MTZhODEwNy0yNWVmLTQ3ZTQtYjY1Ny1mOTcyYWNjMDQ4
+        MWEvIiwgInRhc2tfaWQiOiAiOTE2YTgxMDctMjVlZi00N2U0LWI2NTctZjk3
+        MmFjYzA0ODFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6Mjg6MjFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6Mjg6MjBaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2UyY2NkYmI5LTg5ZDUtNDU0Yy05MjY3LTIxYThj
+        MzlhMDkzNy8iLCAidGFza19pZCI6ICJlMmNjZGJiOS04OWQ1LTQ1NGMtOTI2
+        Ny0yMWE4YzM5YTA5MzcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToyODoyMFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjI4OjIxWiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmVmNTA1ZjVlZTA1YzNmZDg0YjciLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZWY0NDk4ZWRiODI1NWJiMzVj
+        MyJ9LCAiaWQiOiAiNWMwNGJlZjQ0OThlZGI4MjU1YmIzNWMzIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:21 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/e2ccdbb9-89d5-454c-9267-21a8c39a0937/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"66516d7835f45854e31f64113b866ca3-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4540'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9lMmNjZGJiOS04OWQ1LTQ1NGMtOTI2Ny0yMWE4
+        YzM5YTA5MzcvIiwgInRhc2tfaWQiOiAiZTJjY2RiYjktODlkNS00NTRjLTky
+        NjctMjFhOGMzOWEwOTM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6Mjg6MjFaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJiMWFmYmVjZS1kYThkLTQwZWYtYmFiNS05
+        YTZmODllODMyYmEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZmZiYzgwNDAtYjk3YS00YzU0LTgwMTgt
+        N2ZiODlmYTM0MGJkIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjNiOWVhY2VkLTY1NWQtNDhlZC04ZDdlLTkxNWY0OWY2
+        NTNjNSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNhNjE5NWNiLTMxODMtNGU2
+        MC1hN2QxLTAxYTI5NThkNTc1MSIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjM4NzJlODE1LWM0NzEtNGU3OC04MDY1LWQ0MGE1YzQ2MzFhNiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
+        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1ZjBjOTc5Yi1lZTU2LTQ4ZjYtYjdj
+        MC0zMzBmNWY5MjY2YjQiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
+        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICIxZTZkMTEzMi05ZjdmLTQxZGQtOWFlMi0wOGVmYzM0MWJiNTQiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAi
+        Y29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWU5MzZlMjctNmYxMy00ZWQx
+        LTg5MzctODQyZjE1ZDMyNTUzIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1l
+        dGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiOGMxNmYwNGMtNjNhYy00NjEwLWE3NmYtNTkzMWEwYjI2YmRi
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90
+        eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAx
+        LCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiYTY2Y2NhNWMtNmU5Ni00ZWZiLTlhOTEtMDk1NjQ2MGU1NWExIiwgIm51
+        bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUi
+        OiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFlZTdi
+        NTFmLTU4YjktNGYwNS1hNjUyLTIyYTg1NjU0MjcxNyIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        UmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVf
+        b2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
+        VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNiYWY4NWJhLTcw
+        OGYtNDExNi04YWVjLTU2ZTkyNDhmODQwMyIsICJudW1fcHJvY2Vzc2VkIjog
+        MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
+        dGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJjMzc3YjMxZS03NTMwLTQwZTctYWVlNi0zYWUx
+        MjZkOTc2M2UiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2Vi
+        IiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJjMjVhMjVkNi1kNmMxLTQ3MDItYTUwNC00ZTk4ZDM4Y2Vm
+        NzAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVw
+        X3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3Rv
+        dGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImE2YzE2NjA3LTE0MzAtNGIwMS1hMjNlLWE0ZTA0MjVjODk1
+        NiIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2VydmVk
+        X3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1w
+        bGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1l
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwy
+        LnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWMwNGJlZjU0OThlZGI4MjU1YmIz
+        NzY1In0sICJpZCI6ICI1YzA0YmVmNTQ5OGVkYjgyNTViYjM3NjUifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:21 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/916a8107-25ef-47e4-b657-f972acc0481a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"6afde616d2a5b736e4b3af4fb3cdfaf7-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85MTZhODEwNy0yNWVmLTQ3ZTQtYjY1Ny1mOTcyYWNjMDQ4
+        MWEvIiwgInRhc2tfaWQiOiAiOTE2YTgxMDctMjVlZi00N2U0LWI2NTctZjk3
+        MmFjYzA0ODFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6Mjg6MjFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6Mjg6MjBaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2UyY2NkYmI5LTg5ZDUtNDU0Yy05MjY3LTIxYThj
+        MzlhMDkzNy8iLCAidGFza19pZCI6ICJlMmNjZGJiOS04OWQ1LTQ1NGMtOTI2
+        Ny0yMWE4YzM5YTA5MzcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToyODoyMFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjI4OjIxWiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmVmNTA1ZjVlZTA1YzNmZDg0YjciLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZWY0NDk4ZWRiODI1NWJiMzVj
+        MyJ9LCAiaWQiOiAiNWMwNGJlZjQ0OThlZGI4MjU1YmIzNWMzIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:21 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/e2ccdbb9-89d5-454c-9267-21a8c39a0937/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"0f981f17acde4ed192e5d381a823d5fd-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4517'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9lMmNjZGJiOS04OWQ1LTQ1NGMtOTI2Ny0yMWE4
+        YzM5YTA5MzcvIiwgInRhc2tfaWQiOiAiZTJjY2RiYjktODlkNS00NTRjLTky
+        NjctMjFhOGMzOWEwOTM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6Mjg6MjFaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJiMWFmYmVjZS1kYThkLTQwZWYtYmFiNS05
+        YTZmODllODMyYmEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZmZiYzgwNDAtYjk3YS00YzU0LTgwMTgt
+        N2ZiODlmYTM0MGJkIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjNiOWVhY2VkLTY1NWQtNDhlZC04ZDdlLTkxNWY0OWY2
+        NTNjNSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNhNjE5NWNiLTMxODMtNGU2
+        MC1hN2QxLTAxYTI5NThkNTc1MSIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjM4NzJlODE1LWM0NzEtNGU3OC04MDY1LWQ0MGE1YzQ2MzFhNiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
+        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1ZjBjOTc5Yi1lZTU2LTQ4ZjYtYjdj
+        MC0zMzBmNWY5MjY2YjQiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
+        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIx
+        ZTZkMTEzMi05ZjdmLTQxZGQtOWFlMi0wOGVmYzM0MWJiNTQiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
+        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZWU5MzZlMjctNmYxMy00ZWQxLTg5Mzct
+        ODQyZjE1ZDMyNTUzIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRh
+        LiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        OGMxNmYwNGMtNjNhYy00NjEwLWE3NmYtNTkzMWEwYjI2YmRiIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
+        biI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNs
+        b3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTY2Y2NhNWMt
+        NmU5Ni00ZWZiLTlhOTEtMDk1NjQ2MGU1NWExIiwgIm51bV9wcm9jZXNzZWQi
+        OiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5l
+        cmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUg
+        c3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWVlN2I1MWYtNThiOS00ZjA1LWE2
+        NTItMjJhODU2NTQyNzE3IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVw
+        b2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAi
+        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiM2JhZjg1YmEtNzA4Zi00MTE2LThhZWMtNTZlOTI0
+        OGY4NDAzIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAi
+        c3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzM3N2Iz
+        MWUtNzUzMC00MGU3LWFlZTYtM2FlMTI2ZDk3NjNlIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
+        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiSU5f
+        UFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzI1YTI1ZDYtZDZj
+        MS00NzAyLWE1MDQtNGU5OGQzOGNlZjcwIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5n
+        IExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVw
+        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
+        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNmMxNjYwNy0xNDMw
+        LTRiMDEtYTIzZS1hNGUwNDI1Yzg5NTYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50
+        b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAi
+        cnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJy
+        ZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjog
+        IjVjMDRiZWY1NDk4ZWRiODI1NWJiMzc2NSJ9LCAiaWQiOiAiNWMwNGJlZjU0
+        OThlZGI4MjU1YmIzNzY1In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:21 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/916a8107-25ef-47e4-b657-f972acc0481a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"6afde616d2a5b736e4b3af4fb3cdfaf7-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85MTZhODEwNy0yNWVmLTQ3ZTQtYjY1Ny1mOTcyYWNjMDQ4
+        MWEvIiwgInRhc2tfaWQiOiAiOTE2YTgxMDctMjVlZi00N2U0LWI2NTctZjk3
+        MmFjYzA0ODFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6Mjg6MjFaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6Mjg6MjBaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2UyY2NkYmI5LTg5ZDUtNDU0Yy05MjY3LTIxYThj
+        MzlhMDkzNy8iLCAidGFza19pZCI6ICJlMmNjZGJiOS04OWQ1LTQ1NGMtOTI2
+        Ny0yMWE4YzM5YTA5MzcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNToyODoyMFoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjI4OjIxWiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YmVmNTA1ZjVlZTA1YzNmZDg0YjciLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRiZWY0NDk4ZWRiODI1NWJiMzVj
+        MyJ9LCAiaWQiOiAiNWMwNGJlZjQ0OThlZGI4MjU1YmIzNWMzIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:21 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/e2ccdbb9-89d5-454c-9267-21a8c39a0937/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"90181bb3763156b0076ef89995abed06-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '9057'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9lMmNjZGJiOS04OWQ1LTQ1NGMtOTI2Ny0yMWE4
+        YzM5YTA5MzcvIiwgInRhc2tfaWQiOiAiZTJjY2RiYjktODlkNS00NTRjLTky
+        NjctMjFhOGMzOWEwOTM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTgtMTItMDNUMDU6Mjg6MjFaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6Mjg6MjFa
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0
+        ZXBfdHlwZSI6ICJzYXZlX3RhciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMWFmYmVj
+        ZS1kYThkLTQwZWYtYmFiNS05YTZmODllODMyYmEiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIklu
+        aXRpYWxpemluZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmZiYzgw
+        NDAtYjk3YS00YzU0LTgwMTgtN2ZiODlmYTM0MGJkIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIERpc3RyaWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
+        ZGlzdHJpYnV0aW9uIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNiOWVhY2VkLTY1NWQt
+        NDhlZC04ZDdlLTkxNWY0OWY2NTNjNSIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        IHsibnVtX3N1Y2Nlc3MiOiA4LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjog
+        OCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        ImNhNjE5NWNiLTMxODMtNGU2MC1hN2QxLTAxYTI5NThkNTc1MSIsICJudW1f
+        cHJvY2Vzc2VkIjogOH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJk
+        cnBtcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjM4NzJlODE1LWM0NzEtNGU3OC04MDY1
+        LWQ0MGE1YzQ2MzFhNiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEi
+        LCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1ZjBj
+        OTc5Yi1lZTU2LTQ4ZjYtYjdjMC0zMzBmNWY5MjY2YjQiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgTW9kdWxlcyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICIxZTZkMTEzMi05ZjdmLTQxZGQtOWFlMi0wOGVm
+        YzM0MWJiNTQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIs
+        ICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWU5MzZl
+        MjctNmYxMy00ZWQxLTg5MzctODQyZjE1ZDMyNTUzIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiOGMxNmYwNGMtNjNhYy00NjEwLWE3NmYtNTkz
+        MWEwYjI2YmRiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiYTY2Y2NhNWMtNmU5Ni00ZWZiLTlhOTEtMDk1NjQ2MGU1NWEx
+        IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
+        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWVl
+        N2I1MWYtNThiOS00ZjA1LWE2NTItMjJhODU2NTQyNzE3IiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
+        ICJSZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92
+        ZV9vbGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2JhZjg1YmEtNzA4
+        Zi00MTE2LThhZWMtNTZlOTI0OGY4NDAzIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
+        aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiYzM3N2IzMWUtNzUzMC00MGU3LWFlZTYtM2FlMTI2ZDk3
+        NjNlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJz
+        dGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiYzI1YTI1ZDYtZDZjMS00NzAyLWE1MDQtNGU5OGQzOGNlZjcwIiwgIm51
+        bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjog
+        ImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJh
+        NmMxNjYwNy0xNDMwLTRiMDEtYTIzZS1hNGUwNDI1Yzg5NTYiLCAibnVtX3By
+        b2Nlc3NlZCI6IDF9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJl
+        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0Iiwg
+        InN0YXJ0ZWQiOiAiMjAxOC0xMi0wM1QwNToyODoyMVoiLCAiX25zIjogInJl
+        cG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE4LTEyLTAz
+        VDA1OjI4OjIxWiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3Jf
+        dHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6IHsiZ2Vu
+        ZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQiLCAicnBtcyI6ICJGSU5JU0hFRCIs
+        ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicmVt
+        b3ZlX29sZF9yZXBvZGF0YSI6ICJGSU5JU0hFRCIsICJtb2R1bGVzIjogIkZJ
+        TklTSEVEIiwgInNhdmVfdGFyIjogIkZJTklTSEVEIiwgImNsb3NlX3JlcG9f
+        bWV0YWRhdGEiOiAiRklOSVNIRUQiLCAiZHJwbXMiOiAiU0tJUFBFRCIsICJj
+        b21wcyI6ICJGSU5JU0hFRCIsICJkaXN0cmlidXRpb24iOiAiRklOSVNIRUQi
+        LCAicmVwb3ZpZXciOiAiU0tJUFBFRCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6
+        ICJGSU5JU0hFRCIsICJlcnJhdGEiOiAiRklOSVNIRUQiLCAibWV0YWRhdGEi
+        OiAiRklOSVNIRUQifSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJp
+        YnV0b3JfaWQiOiAic2NlbmFyaW9fdGVzdCIsICJpZCI6ICI1YzA0YmVmNTA1
+        ZjVlZTA1YzNmZDg0YjgiLCAiZGV0YWlscyI6IFt7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIkNvcHlpbmcgZmlsZXMiLCAic3RlcF90eXBl
+        IjogInNhdmVfdGFyIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImIxYWZiZWNlLWRhOGQt
+        NDBlZi1iYWI1LTlhNmY4OWU4MzJiYSIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6
+        aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVf
+        cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZmJjODA0MC1iOTdh
+        LTRjNTQtODAxOC03ZmI4OWZhMzQwYmQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmli
+        dXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2I5ZWFjZWQtNjU1ZC00OGVkLThk
+        N2UtOTE1ZjQ5ZjY1M2M1IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1f
+        c3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMi
+        LCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2E2MTk1
+        Y2ItMzE4My00ZTYwLWE3ZDEtMDFhMjk1OGQ1NzUxIiwgIm51bV9wcm9jZXNz
+        ZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiMzg3MmU4MTUtYzQ3MS00ZTc4LTgwNjUtZDQwYTVj
+        NDYzMWE2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVw
+        X3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjVmMGM5NzliLWVl
+        NTYtNDhmNi1iN2MwLTMzMGY1ZjkyNjZiNCIsICJudW1fcHJvY2Vzc2VkIjog
+        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjFlNmQxMTMyLTlmN2YtNDFkZC05YWUyLTA4ZWZjMzQxYmI1
+        NCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBf
+        dHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlZTkzNmUyNy02ZjEz
+        LTRlZDEtODkzNy04NDJmMTVkMzI1NTMiLCAibnVtX3Byb2Nlc3NlZCI6IDN9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI4YzE2ZjA0Yy02M2FjLTQ2MTAtYTc2Zi01OTMxYTBiMjZi
+        ZGIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwg
+        ImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVw
+        X3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJhNjZjY2E1Yy02ZTk2LTRlZmItOWE5MS0wOTU2NDYwZTU1YTEiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZWU3YjUxZi01
+        OGI5LTRmMDUtYTY1Mi0yMmE4NTY1NDI3MTciLCAibnVtX3Byb2Nlc3NlZCI6
+        IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92
+        aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9y
+        ZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzYmFmODViYS03MDhmLTQxMTYt
+        OGFlYy01NmU5MjQ4Zjg0MDMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRN
+        TCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJjMzc3YjMxZS03NTMwLTQwZTctYWVlNi0zYWUxMjZkOTc2M2UiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2Ny
+        aXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlw
+        ZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjMjVh
+        MjVkNi1kNmMxLTQ3MDItYTUwNC00ZTk4ZDM4Y2VmNzAiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
+        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE2YzE2NjA3
+        LTE0MzAtNGIwMS1hMjNlLWE0ZTA0MjVjODk1NiIsICJudW1fcHJvY2Vzc2Vk
+        IjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0
+        YmVmNTQ5OGVkYjgyNTViYjM3NjUifSwgImlkIjogIjVjMDRiZWY1NDk4ZWRi
+        ODI1NWJiMzc2NSJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:21 GMT
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/actions/content/regenerate_applicability//
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwYXJhbGxlbCI6dHJ1ZSwicmVwb19jcml0ZXJpYSI6eyJmaWx0ZXJzIjp7
+        ImlkIjp7IiRpbiI6InNjZW5hcmlvX3Rlc3QifX19fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '76'
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:28:21 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '2367'
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIlBPU1QiLCAiZXhjZXB0aW9uIjog
+        WyJPcGVyYXRpb25GYWlsdXJlOiAkaW4gbmVlZHMgYW4gYXJyYXlcbiJdLCAi
+        ZXJyb3JfbWVzc2FnZSI6ICIkaW4gbmVlZHMgYW4gYXJyYXkiLCAiX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9hY3Rpb25zL2NvbnRlbnQv
+        cmVnZW5lcmF0ZV9hcHBsaWNhYmlsaXR5Ly8iLCAiaHR0cF9zdGF0dXMiOiA1
+        MDAsICJ0cmFjZWJhY2siOiBbIiAgRmlsZSBcIi91c3IvbGliL3B5dGhvbjIu
+        Ny9zaXRlLXBhY2thZ2VzL2RqYW5nby9jb3JlL2hhbmRsZXJzL2Jhc2UucHlc
+        IiwgbGluZSAxODUsIGluIF9nZXRfcmVzcG9uc2VcbiAgICByZXNwb25zZSA9
+        IHdyYXBwZWRfY2FsbGJhY2socmVxdWVzdCwgKmNhbGxiYWNrX2FyZ3MsICoq
+        Y2FsbGJhY2tfa3dhcmdzKVxuIiwgIiAgRmlsZSBcIi91c3IvbGliL3B5dGhv
+        bjIuNy9zaXRlLXBhY2thZ2VzL2RqYW5nby92aWV3cy9nZW5lcmljL2Jhc2Uu
+        cHlcIiwgbGluZSA2OCwgaW4gdmlld1xuICAgIHJldHVybiBzZWxmLmRpc3Bh
+        dGNoKHJlcXVlc3QsICphcmdzLCAqKmt3YXJncylcbiIsICIgIEZpbGUgXCIv
+        dXNyL2xpYi9weXRob24yLjcvc2l0ZS1wYWNrYWdlcy9kamFuZ28vdmlld3Mv
+        Z2VuZXJpYy9iYXNlLnB5XCIsIGxpbmUgODgsIGluIGRpc3BhdGNoXG4gICAg
+        cmV0dXJuIGhhbmRsZXIocmVxdWVzdCwgKmFyZ3MsICoqa3dhcmdzKVxuIiwg
+        IiAgRmlsZSBcIi91c3IvbGliL3B5dGhvbjIuNy9zaXRlLXBhY2thZ2VzL3B1
+        bHAvc2VydmVyL3dlYnNlcnZpY2VzL3ZpZXdzL2RlY29yYXRvcnMucHlcIiwg
+        bGluZSAyNDEsIGluIF9hdXRoX2RlY29yYXRvclxuICAgIHJldHVybiBfdmVy
+        aWZ5X2F1dGgoc2VsZiwgb3BlcmF0aW9uLCBzdXBlcl91c2VyX29ubHksIG1l
+        dGhvZCwgKmFyZ3MsICoqa3dhcmdzKVxuIiwgIiAgRmlsZSBcIi91c3IvbGli
+        L3B5dGhvbjIuNy9zaXRlLXBhY2thZ2VzL3B1bHAvc2VydmVyL3dlYnNlcnZp
+        Y2VzL3ZpZXdzL2RlY29yYXRvcnMucHlcIiwgbGluZSAxOTUsIGluIF92ZXJp
+        ZnlfYXV0aFxuICAgIHZhbHVlID0gbWV0aG9kKHNlbGYsICphcmdzLCAqKmt3
+        YXJncylcbiIsICIgIEZpbGUgXCIvdXNyL2xpYi9weXRob24yLjcvc2l0ZS1w
+        YWNrYWdlcy9wdWxwL3NlcnZlci93ZWJzZXJ2aWNlcy92aWV3cy91dGlsLnB5
+        XCIsIGxpbmUgMTMwLCBpbiB3cmFwcGVyXG4gICAgcmV0dXJuIGZ1bmMoKmFy
+        Z3MsICoqa3dhcmdzKVxuIiwgIiAgRmlsZSBcIi91c3IvbGliL3B5dGhvbjIu
+        Ny9zaXRlLXBhY2thZ2VzL3B1bHAvc2VydmVyL3dlYnNlcnZpY2VzL3ZpZXdz
+        L3JlcG9zaXRvcmllcy5weVwiLCBsaW5lIDkxMywgaW4gcG9zdFxuICAgIHF1
+        ZXVlX3JlZ2VuZXJhdGVfYXBwbGljYWJpbGl0eV9mb3JfcmVwb3MocmVwb19j
+        cml0ZXJpYS5hc19kaWN0KCkpXG4iLCAiICBGaWxlIFwiL3Vzci9saWIvcHl0
+        aG9uMi43L3NpdGUtcGFja2FnZXMvcHVscC9zZXJ2ZXIvbWFuYWdlcnMvY29u
+        c3VtZXIvYXBwbGljYWJpbGl0eS5weVwiLCBsaW5lIDE2MSwgaW4gcXVldWVf
+        cmVnZW5lcmF0ZV9hcHBsaWNhYmlsaXR5X2Zvcl9yZXBvc1xuICAgIHJlcG9f
+        aWRzID0gW3IucmVwb19pZCBmb3IgciBpbiBtb2RlbC5SZXBvc2l0b3J5Lm9i
+        amVjdHMuZmluZF9ieV9jcml0ZXJpYShyZXBvX2NyaXRlcmlhKV1cbiIsICIg
+        IEZpbGUgXCIvdXNyL2xpYi9weXRob24yLjcvc2l0ZS1wYWNrYWdlcy9tb25n
+        b2VuZ2luZS9xdWVyeXNldC9iYXNlLnB5XCIsIGxpbmUgMTQwNywgaW4gbmV4
+        dFxuICAgIHJhd19kb2MgPSBzZWxmLl9jdXJzb3IubmV4dCgpXG4iLCAiICBG
+        aWxlIFwiL3Vzci9saWI2NC9weXRob24yLjcvc2l0ZS1wYWNrYWdlcy9weW1v
+        bmdvL2N1cnNvci5weVwiLCBsaW5lIDEwOTcsIGluIG5leHRcbiAgICBpZiBs
+        ZW4oc2VsZi5fX2RhdGEpIG9yIHNlbGYuX3JlZnJlc2goKTpcbiIsICIgIEZp
+        bGUgXCIvdXNyL2xpYjY0L3B5dGhvbjIuNy9zaXRlLXBhY2thZ2VzL3B5bW9u
+        Z28vY3Vyc29yLnB5XCIsIGxpbmUgMTAxOSwgaW4gX3JlZnJlc2hcbiAgICBz
+        ZWxmLl9fcmVhZF9jb25jZXJuKSlcbiIsICIgIEZpbGUgXCIvdXNyL2xpYjY0
+        L3B5dGhvbjIuNy9zaXRlLXBhY2thZ2VzL3B5bW9uZ28vY3Vyc29yLnB5XCIs
+        IGxpbmUgOTA1LCBpbiBfX3NlbmRfbWVzc2FnZVxuICAgIGhlbHBlcnMuX2No
+        ZWNrX2NvbW1hbmRfcmVzcG9uc2UoZG9jWydkYXRhJ11bMF0pXG4iLCAiICBG
+        aWxlIFwiL3Vzci9saWI2NC9weXRob24yLjcvc2l0ZS1wYWNrYWdlcy9weW1v
+        bmdvL2hlbHBlcnMucHlcIiwgbGluZSAxOTYsIGluIF9jaGVja19jb21tYW5k
+        X3Jlc3BvbnNlXG4gICAgcmFpc2UgT3BlcmF0aW9uRmFpbHVyZShtc2cgJSBl
+        cnJtc2csIGNvZGUsIHJlc3BvbnNlKVxuIl19
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:28:21 GMT
+- request:
+    method: post
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/actions/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
+        Ijp0cnVlfX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '53'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzFhNjZjNGM4LWZmYjMtNGY5Yy04OTBkLWRlMDEwYzJhMjU2NC8iLCAi
+        dGFza19pZCI6ICIxYTY2YzRjOC1mZmIzLTRmOWMtODkwZC1kZTAxMGMyYTI1
+        NjQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/1a66c4c8-ffb3-4f9c-890d-de010c2a2564/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"1543a4138336ae3246bd46607da479bd-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '544'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xYTY2YzRjOC1mZmIzLTRmOWMtODkwZC1kZTAxMGMyYTI1
+        NjQvIiwgInRhc2tfaWQiOiAiMWE2NmM0YzgtZmZiMy00ZjljLTg5MGQtZGUw
+        MTBjMmEyNTY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogbnVs
+        bCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIiIsICJzdGF0ZSI6ICJ3
+        YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51bGws
+        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWMwNGMxODU0OThl
+        ZGI4MjU1YmI0NTNkIn0sICJpZCI6ICI1YzA0YzE4NTQ5OGVkYjgyNTViYjQ1
+        M2QifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/1a66c4c8-ffb3-4f9c-890d-de010c2a2564/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"f23505ccbc2b165c7faae64d92b8bee8-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1191'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xYTY2YzRjOC1mZmIzLTRmOWMtODkwZC1kZTAxMGMyYTI1
+        NjQvIiwgInRhc2tfaWQiOiAiMWE2NmM0YzgtZmZiMy00ZjljLTg5MGQtZGUw
+        MTBjMmEyNTY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6Mzk6MTdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
+        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiSU5fUFJPR1JF
+        U1MifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
+        Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRl
+        IjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1YzA0YzE4NTQ5OGVkYjgyNTViYjQ1M2QifSwgImlkIjogIjVjMDRj
+        MTg1NDk4ZWRiODI1NWJiNDUzZCJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/1a66c4c8-ffb3-4f9c-890d-de010c2a2564/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"845dfa5f81b7cd97586eb490d88417cd-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1188'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xYTY2YzRjOC1mZmIzLTRmOWMtODkwZC1kZTAxMGMyYTI1
+        NjQvIiwgInRhc2tfaWQiOiAiMWE2NmM0YzgtZmZiMy00ZjljLTg5MGQtZGUw
+        MTBjMmEyNTY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6Mzk6MTdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
+        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
+        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzA0YzE4NTQ5OGVkYjgyNTViYjQ1M2QifSwgImlkIjogIjVjMDRjMTg1
+        NDk4ZWRiODI1NWJiNDUzZCJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/1a66c4c8-ffb3-4f9c-890d-de010c2a2564/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"845dfa5f81b7cd97586eb490d88417cd-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1188'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xYTY2YzRjOC1mZmIzLTRmOWMtODkwZC1kZTAxMGMyYTI1
+        NjQvIiwgInRhc2tfaWQiOiAiMWE2NmM0YzgtZmZiMy00ZjljLTg5MGQtZGUw
+        MTBjMmEyNTY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6Mzk6MTdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
+        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
+        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzA0YzE4NTQ5OGVkYjgyNTViYjQ1M2QifSwgImlkIjogIjVjMDRjMTg1
+        NDk4ZWRiODI1NWJiNDUzZCJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/1a66c4c8-ffb3-4f9c-890d-de010c2a2564/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"10a9df6dd9d571525c184474e7a6d7cf-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1179'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xYTY2YzRjOC1mZmIzLTRmOWMtODkwZC1kZTAxMGMyYTI1
+        NjQvIiwgInRhc2tfaWQiOiAiMWE2NmM0YzgtZmZiMy00ZjljLTg5MGQtZGUw
+        MTBjMmEyNTY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6Mzk6MTdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIklOX1BST0dSRVNT
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVl
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZl
+        bDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmci
+        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
+        Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YzE4
+        NTQ5OGVkYjgyNTViYjQ1M2QifSwgImlkIjogIjVjMDRjMTg1NDk4ZWRiODI1
+        NWJiNDUzZCJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/1a66c4c8-ffb3-4f9c-890d-de010c2a2564/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"6f9e8cde5a8bd94f7ce3f215f5765214-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1176'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xYTY2YzRjOC1mZmIzLTRmOWMtODkwZC1kZTAxMGMyYTI1
+        NjQvIiwgInRhc2tfaWQiOiAiMWE2NmM0YzgtZmZiMy00ZjljLTg5MGQtZGUw
+        MTBjMmEyNTY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6Mzk6MTdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiSU5fUFJPR1JFU1MifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIu
+        c2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAi
+        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
+        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVs
+        bCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YzE4NTQ5
+        OGVkYjgyNTViYjQ1M2QifSwgImlkIjogIjVjMDRjMTg1NDk4ZWRiODI1NWJi
+        NDUzZCJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/1a66c4c8-ffb3-4f9c-890d-de010c2a2564/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"ef898c5c26cc12078f605231174b74ac-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1170'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xYTY2YzRjOC1mZmIzLTRmOWMtODkwZC1kZTAxMGMyYTI1
+        NjQvIiwgInRhc2tfaWQiOiAiMWE2NmM0YzgtZmZiMy00ZjljLTg5MGQtZGUw
+        MTBjMmEyNTY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTgtMTItMDNUMDU6Mzk6MTdaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2Vy
+        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
+        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0YzE4NTQ5OGVkYjgy
+        NTViYjQ1M2QifSwgImlkIjogIjVjMDRjMTg1NDk4ZWRiODI1NWJiNDUzZCJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/1a66c4c8-ffb3-4f9c-890d-de010c2a2564/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"8f5f7d8f5b4348bb1c187f0f0317a910-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xYTY2YzRjOC1mZmIzLTRmOWMtODkwZC1kZTAxMGMyYTI1
+        NjQvIiwgInRhc2tfaWQiOiAiMWE2NmM0YzgtZmZiMy00ZjljLTg5MGQtZGUw
+        MTBjMmEyNTY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6Mzk6MTdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6Mzk6MTdaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzLzRkYjFlNGU1LWVhMjItNGNjNS04MmI1LTgwYjlh
+        NDAzY2Q4Yy8iLCAidGFza19pZCI6ICI0ZGIxZTRlNS1lYTIyLTRjYzUtODJi
+        NS04MGI5YTQwM2NkOGMifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNTozOToxN1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjM5OjE3WiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YzE4NTA1ZjVlZTA1YzNmZDg0Y2UiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRjMTg1NDk4ZWRiODI1NWJiNDUz
+        ZCJ9LCAiaWQiOiAiNWMwNGMxODU0OThlZGI4MjU1YmI0NTNkIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/4db1e4e5-ea22-4cc5-82b5-80b9a403cd8c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"a2862bf795ea5cbb0c36e291ac9e972f-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '691'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy80ZGIxZTRlNS1lYTIyLTRjYzUtODJiNS04MGI5
+        YTQwM2NkOGMvIiwgInRhc2tfaWQiOiAiNGRiMWU0ZTUtZWEyMi00Y2M1LTgy
+        YjUtODBiOWE0MDNjZDhjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6Mzk6MTdaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
+        NWMwNGMxODU0OThlZGI4MjU1YmI0NmQ0In0sICJpZCI6ICI1YzA0YzE4NTQ5
+        OGVkYjgyNTViYjQ2ZDQifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/1a66c4c8-ffb3-4f9c-890d-de010c2a2564/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"8f5f7d8f5b4348bb1c187f0f0317a910-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xYTY2YzRjOC1mZmIzLTRmOWMtODkwZC1kZTAxMGMyYTI1
+        NjQvIiwgInRhc2tfaWQiOiAiMWE2NmM0YzgtZmZiMy00ZjljLTg5MGQtZGUw
+        MTBjMmEyNTY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6Mzk6MTdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6Mzk6MTdaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzLzRkYjFlNGU1LWVhMjItNGNjNS04MmI1LTgwYjlh
+        NDAzY2Q4Yy8iLCAidGFza19pZCI6ICI0ZGIxZTRlNS1lYTIyLTRjYzUtODJi
+        NS04MGI5YTQwM2NkOGMifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNTozOToxN1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjM5OjE3WiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YzE4NTA1ZjVlZTA1YzNmZDg0Y2UiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRjMTg1NDk4ZWRiODI1NWJiNDUz
+        ZCJ9LCAiaWQiOiAiNWMwNGMxODU0OThlZGI4MjU1YmI0NTNkIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/4db1e4e5-ea22-4cc5-82b5-80b9a403cd8c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"240052d11336ea78d60a9aad9786d130-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4550'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy80ZGIxZTRlNS1lYTIyLTRjYzUtODJiNS04MGI5
+        YTQwM2NkOGMvIiwgInRhc2tfaWQiOiAiNGRiMWU0ZTUtZWEyMi00Y2M1LTgy
+        YjUtODBiOWE0MDNjZDhjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6Mzk6MTdaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJjMzZmOTIzOS1jNjhkLTQyNGUtYWYzMi04
+        Yjg2NTYxMzJjMmIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMzQ5MjQ3YjItOTEzYi00YTM5LWIzMmYt
+        NWI3MGQ4ZDRjMmNmIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjJlZWRjYzU5LTJkYzEtNGIwOC05NTUwLWM1ZDEyNWE1
+        YmU4ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIklOX1BS
+        T0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjgxNWQyY2QwLTA0NTAt
+        NGZkMy05NTBkLThmODNkOTBkZjZiMyIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJlZDM1NTY0OS1lYjhhLTQ5MGUtYTQ5MS1hYzAyOGExMTUw
+        ZWIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGEwNzA4MDQtNTRj
+        Ny00Nzk0LTg3YzQtZDAxM2RkNTU3M2YyIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiYzVmMWZjN2ItMzc4Zi00NGNiLWFkY2MtYjA1NmU3NjZj
+        NDc5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM2M2FhY2Rl
+        LWY1ZWItNGUwNy1iOGQwLTYzN2ZkM2QzNWUxNCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjdjNGJlOGY4LTg2N2EtNDliYi05MWJjLTk0
+        MWU5MTA2Njk1MCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
+        IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImZjODNkM2VjLTc4MTAtNDA1MC1hNmQ1LTllZmRlY2Jm
+        Yzc2NyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAi
+        c3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICIwZDYzODk3My0xZjE5LTRjNzgtYjhhMy03Zjc3YzFiODQ4NGMiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUi
+        OiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3
+        OWM5MDE2NS1hMThmLTRmY2EtYjI2Mi0xZTQ0NmFmNjAxMzciLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVw
+        b3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZGRiZWZmYTgtYzMzMi00ZWY2
+        LWIzMjktMmQ5OGY2NTM3OTRjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZp
+        bGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rvcnki
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNzQ1N2E2MTgtZWRlZC00NTQ1LTliM2Et
+        ZTA1NGQwMjQwMTBhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZp
+        bGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI3NmQxNmRjOC1iNDRiLTQyZDktOTc3MC05
+        ZWY0YTA3MTFiNDUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRldmVsMi5z
+        YW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50
+        b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRjMTg1NDk4
+        ZWRiODI1NWJiNDZkNCJ9LCAiaWQiOiAiNWMwNGMxODU0OThlZGI4MjU1YmI0
+        NmQ0In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/1a66c4c8-ffb3-4f9c-890d-de010c2a2564/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"8f5f7d8f5b4348bb1c187f0f0317a910-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xYTY2YzRjOC1mZmIzLTRmOWMtODkwZC1kZTAxMGMyYTI1
+        NjQvIiwgInRhc2tfaWQiOiAiMWE2NmM0YzgtZmZiMy00ZjljLTg5MGQtZGUw
+        MTBjMmEyNTY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6Mzk6MTdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6Mzk6MTdaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzLzRkYjFlNGU1LWVhMjItNGNjNS04MmI1LTgwYjlh
+        NDAzY2Q4Yy8iLCAidGFza19pZCI6ICI0ZGIxZTRlNS1lYTIyLTRjYzUtODJi
+        NS04MGI5YTQwM2NkOGMifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNTozOToxN1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjM5OjE3WiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YzE4NTA1ZjVlZTA1YzNmZDg0Y2UiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRjMTg1NDk4ZWRiODI1NWJiNDUz
+        ZCJ9LCAiaWQiOiAiNWMwNGMxODU0OThlZGI4MjU1YmI0NTNkIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/4db1e4e5-ea22-4cc5-82b5-80b9a403cd8c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"d720d8d24f5847658a3e7c2f417051f1-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4550'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy80ZGIxZTRlNS1lYTIyLTRjYzUtODJiNS04MGI5
+        YTQwM2NkOGMvIiwgInRhc2tfaWQiOiAiNGRiMWU0ZTUtZWEyMi00Y2M1LTgy
+        YjUtODBiOWE0MDNjZDhjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6Mzk6MTdaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJjMzZmOTIzOS1jNjhkLTQyNGUtYWYzMi04
+        Yjg2NTYxMzJjMmIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMzQ5MjQ3YjItOTEzYi00YTM5LWIzMmYt
+        NWI3MGQ4ZDRjMmNmIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjJlZWRjYzU5LTJkYzEtNGIwOC05NTUwLWM1ZDEyNWE1
+        YmU4ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIklOX1BS
+        T0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjgxNWQyY2QwLTA0NTAt
+        NGZkMy05NTBkLThmODNkOTBkZjZiMyIsICJudW1fcHJvY2Vzc2VkIjogOH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJlZDM1NTY0OS1lYjhhLTQ5MGUtYTQ5MS1hYzAyOGExMTUw
+        ZWIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGEwNzA4MDQtNTRj
+        Ny00Nzk0LTg3YzQtZDAxM2RkNTU3M2YyIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiYzVmMWZjN2ItMzc4Zi00NGNiLWFkY2MtYjA1NmU3NjZj
+        NDc5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM2M2FhY2Rl
+        LWY1ZWItNGUwNy1iOGQwLTYzN2ZkM2QzNWUxNCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjdjNGJlOGY4LTg2N2EtNDliYi05MWJjLTk0
+        MWU5MTA2Njk1MCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
+        IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImZjODNkM2VjLTc4MTAtNDA1MC1hNmQ1LTllZmRlY2Jm
+        Yzc2NyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAi
+        c3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICIwZDYzODk3My0xZjE5LTRjNzgtYjhhMy03Zjc3YzFiODQ4NGMiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUi
+        OiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3
+        OWM5MDE2NS1hMThmLTRmY2EtYjI2Mi0xZTQ0NmFmNjAxMzciLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVw
+        b3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZGRiZWZmYTgtYzMzMi00ZWY2
+        LWIzMjktMmQ5OGY2NTM3OTRjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZp
+        bGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rvcnki
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNzQ1N2E2MTgtZWRlZC00NTQ1LTliM2Et
+        ZTA1NGQwMjQwMTBhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZp
+        bGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI3NmQxNmRjOC1iNDRiLTQyZDktOTc3MC05
+        ZWY0YTA3MTFiNDUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRldmVsMi5z
+        YW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50
+        b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRjMTg1NDk4
+        ZWRiODI1NWJiNDZkNCJ9LCAiaWQiOiAiNWMwNGMxODU0OThlZGI4MjU1YmI0
+        NmQ0In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/1a66c4c8-ffb3-4f9c-890d-de010c2a2564/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"8f5f7d8f5b4348bb1c187f0f0317a910-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xYTY2YzRjOC1mZmIzLTRmOWMtODkwZC1kZTAxMGMyYTI1
+        NjQvIiwgInRhc2tfaWQiOiAiMWE2NmM0YzgtZmZiMy00ZjljLTg5MGQtZGUw
+        MTBjMmEyNTY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6Mzk6MTdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6Mzk6MTdaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzLzRkYjFlNGU1LWVhMjItNGNjNS04MmI1LTgwYjlh
+        NDAzY2Q4Yy8iLCAidGFza19pZCI6ICI0ZGIxZTRlNS1lYTIyLTRjYzUtODJi
+        NS04MGI5YTQwM2NkOGMifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNTozOToxN1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjM5OjE3WiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YzE4NTA1ZjVlZTA1YzNmZDg0Y2UiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRjMTg1NDk4ZWRiODI1NWJiNDUz
+        ZCJ9LCAiaWQiOiAiNWMwNGMxODU0OThlZGI4MjU1YmI0NTNkIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/4db1e4e5-ea22-4cc5-82b5-80b9a403cd8c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"0ef70b653ccf2b74f1909207a0c352ec-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4537'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy80ZGIxZTRlNS1lYTIyLTRjYzUtODJiNS04MGI5
+        YTQwM2NkOGMvIiwgInRhc2tfaWQiOiAiNGRiMWU0ZTUtZWEyMi00Y2M1LTgy
+        YjUtODBiOWE0MDNjZDhjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6Mzk6MTdaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJjMzZmOTIzOS1jNjhkLTQyNGUtYWYzMi04
+        Yjg2NTYxMzJjMmIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMzQ5MjQ3YjItOTEzYi00YTM5LWIzMmYt
+        NWI3MGQ4ZDRjMmNmIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjJlZWRjYzU5LTJkYzEtNGIwOC05NTUwLWM1ZDEyNWE1
+        YmU4ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjgxNWQyY2QwLTA0NTAtNGZk
+        My05NTBkLThmODNkOTBkZjZiMyIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImVkMzU1NjQ5LWViOGEtNDkwZS1hNDkxLWFjMDI4YTExNTBlYiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
+        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYTA3MDgwNC01NGM3LTQ3OTQtODdj
+        NC1kMDEzZGQ1NTczZjIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
+        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJj
+        NWYxZmM3Yi0zNzhmLTQ0Y2ItYWRjYy1iMDU2ZTc2NmM0NzkiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
+        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiSU5fUFJPR1JFU1Mi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzYzYWFjZGUtZjVlYi00ZTA3LWI4
+        ZDAtNjM3ZmQzZDM1ZTE0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFk
+        YXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiN2M0YmU4ZjgtODY3YS00OWJiLTkxYmMtOTQxZTkxMDY2OTUwIiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBl
+        IjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        ZmM4M2QzZWMtNzgxMC00MDUwLWE2ZDUtOWVmZGVjYmZjNzY3IiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
+        Z2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBkNjM4OTcz
+        LTFmMTktNGM3OC1iOGEzLTdmNzdjMWI4NDg0YyIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUmVt
+        b3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xk
+        X3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc5YzkwMTY1LWExOGYt
+        NGZjYS1iMjYyLTFlNDQ2YWY2MDEzNyIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
+        ZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVt
+        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJkZGJlZmZhOC1jMzMyLTRlZjYtYjMyOS0yZDk4ZjY1
+        Mzc5NGMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwg
+        InN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI3NDU3YTYxOC1lZGVkLTQ1NDUtOWIzYS1lMDU0ZDAyNDAxMGEi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjc2ZDE2ZGM4LWI0NGItNDJkOS05NzcwLTllZjRhMDcxMWI0NSIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUu
+        Y29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjog
+        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNh
+        bWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51
+        bGwsICJfaWQiOiB7IiRvaWQiOiAiNWMwNGMxODU0OThlZGI4MjU1YmI0NmQ0
+        In0sICJpZCI6ICI1YzA0YzE4NTQ5OGVkYjgyNTViYjQ2ZDQifQ==
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/1a66c4c8-ffb3-4f9c-890d-de010c2a2564/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"8f5f7d8f5b4348bb1c187f0f0317a910-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xYTY2YzRjOC1mZmIzLTRmOWMtODkwZC1kZTAxMGMyYTI1
+        NjQvIiwgInRhc2tfaWQiOiAiMWE2NmM0YzgtZmZiMy00ZjljLTg5MGQtZGUw
+        MTBjMmEyNTY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6Mzk6MTdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6Mzk6MTdaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzLzRkYjFlNGU1LWVhMjItNGNjNS04MmI1LTgwYjlh
+        NDAzY2Q4Yy8iLCAidGFza19pZCI6ICI0ZGIxZTRlNS1lYTIyLTRjYzUtODJi
+        NS04MGI5YTQwM2NkOGMifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNTozOToxN1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjM5OjE3WiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YzE4NTA1ZjVlZTA1YzNmZDg0Y2UiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRjMTg1NDk4ZWRiODI1NWJiNDUz
+        ZCJ9LCAiaWQiOiAiNWMwNGMxODU0OThlZGI4MjU1YmI0NTNkIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/4db1e4e5-ea22-4cc5-82b5-80b9a403cd8c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"6cef81a70417edf15fef143f889c7045-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4517'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy80ZGIxZTRlNS1lYTIyLTRjYzUtODJiNS04MGI5
+        YTQwM2NkOGMvIiwgInRhc2tfaWQiOiAiNGRiMWU0ZTUtZWEyMi00Y2M1LTgy
+        YjUtODBiOWE0MDNjZDhjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTgtMTItMDNUMDU6Mzk6MTdaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJjMzZmOTIzOS1jNjhkLTQyNGUtYWYzMi04
+        Yjg2NTYxMzJjMmIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMzQ5MjQ3YjItOTEzYi00YTM5LWIzMmYt
+        NWI3MGQ4ZDRjMmNmIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjJlZWRjYzU5LTJkYzEtNGIwOC05NTUwLWM1ZDEyNWE1
+        YmU4ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjgxNWQyY2QwLTA0NTAtNGZk
+        My05NTBkLThmODNkOTBkZjZiMyIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImVkMzU1NjQ5LWViOGEtNDkwZS1hNDkxLWFjMDI4YTExNTBlYiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
+        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYTA3MDgwNC01NGM3LTQ3OTQtODdj
+        NC1kMDEzZGQ1NTczZjIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
+        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJj
+        NWYxZmM3Yi0zNzhmLTQ0Y2ItYWRjYy1iMDU2ZTc2NmM0NzkiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
+        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMzYzYWFjZGUtZjVlYi00ZTA3LWI4ZDAt
+        NjM3ZmQzZDM1ZTE0IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRh
+        LiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        N2M0YmU4ZjgtODY3YS00OWJiLTkxYmMtOTQxZTkxMDY2OTUwIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
+        biI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNs
+        b3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmM4M2QzZWMt
+        NzgxMC00MDUwLWE2ZDUtOWVmZGVjYmZjNzY3IiwgIm51bV9wcm9jZXNzZWQi
+        OiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5l
+        cmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUg
+        c3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGQ2Mzg5NzMtMWYxOS00Yzc4LWI4
+        YTMtN2Y3N2MxYjg0ODRjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVw
+        b2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAi
+        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiNzljOTAxNjUtYTE4Zi00ZmNhLWIyNjItMWU0NDZh
+        ZjYwMTM3IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAi
+        c3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZGRiZWZm
+        YTgtYzMzMi00ZWY2LWIzMjktMmQ5OGY2NTM3OTRjIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
+        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiSU5f
+        UFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzQ1N2E2MTgtZWRl
+        ZC00NTQ1LTliM2EtZTA1NGQwMjQwMTBhIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5n
+        IExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVw
+        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
+        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3NmQxNmRjOC1iNDRi
+        LTQyZDktOTc3MC05ZWY0YTA3MTFiNDUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50
+        b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAi
+        cnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJy
+        ZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjog
+        IjVjMDRjMTg1NDk4ZWRiODI1NWJiNDZkNCJ9LCAiaWQiOiAiNWMwNGMxODU0
+        OThlZGI4MjU1YmI0NmQ0In0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/1a66c4c8-ffb3-4f9c-890d-de010c2a2564/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"8f5f7d8f5b4348bb1c187f0f0317a910-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2423'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xYTY2YzRjOC1mZmIzLTRmOWMtODkwZC1kZTAxMGMyYTI1
+        NjQvIiwgInRhc2tfaWQiOiAiMWE2NmM0YzgtZmZiMy00ZjljLTg5MGQtZGUw
+        MTBjMmEyNTY0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTgtMTItMDNUMDU6Mzk6MTdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6Mzk6MTdaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzLzRkYjFlNGU1LWVhMjItNGNjNS04MmI1LTgwYjlh
+        NDAzY2Q4Yy8iLCAidGFza19pZCI6ICI0ZGIxZTRlNS1lYTIyLTRjYzUtODJi
+        NS04MGI5YTQwM2NkOGMifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
+        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
+        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
+        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
+        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOC0xMi0w
+        M1QwNTozOToxN1oiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
+        bXBsZXRlZCI6ICIyMDE4LTEyLTAzVDA1OjM5OjE3WiIsICJpbXBvcnRlcl90
+        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
+        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
+        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
+        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
+        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
+        b3VudCI6IDAsICJpZCI6ICI1YzA0YzE4NTA1ZjVlZTA1YzNmZDg0Y2UiLCAi
+        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
+        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
+        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
+        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
+        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
+        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjMDRjMTg1NDk4ZWRiODI1NWJiNDUz
+        ZCJ9LCAiaWQiOiAiNWMwNGMxODU0OThlZGI4MjU1YmI0NTNkIn0=
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/4db1e4e5-ea22-4cc5-82b5-80b9a403cd8c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:39:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"71b8115a95c4204a7bbc1485991a0a6e-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '9057'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy80ZGIxZTRlNS1lYTIyLTRjYzUtODJiNS04MGI5
+        YTQwM2NkOGMvIiwgInRhc2tfaWQiOiAiNGRiMWU0ZTUtZWEyMi00Y2M1LTgy
+        YjUtODBiOWE0MDNjZDhjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTgtMTItMDNUMDU6Mzk6MTdaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTgtMTItMDNUMDU6Mzk6MTda
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0
+        ZXBfdHlwZSI6ICJzYXZlX3RhciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjMzZmOTIz
+        OS1jNjhkLTQyNGUtYWYzMi04Yjg2NTYxMzJjMmIiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIklu
+        aXRpYWxpemluZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzQ5MjQ3
+        YjItOTEzYi00YTM5LWIzMmYtNWI3MGQ4ZDRjMmNmIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIERpc3RyaWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
+        ZGlzdHJpYnV0aW9uIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJlZWRjYzU5LTJkYzEt
+        NGIwOC05NTUwLWM1ZDEyNWE1YmU4ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        IHsibnVtX3N1Y2Nlc3MiOiA4LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjog
+        OCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjgxNWQyY2QwLTA0NTAtNGZkMy05NTBkLThmODNkOTBkZjZiMyIsICJudW1f
+        cHJvY2Vzc2VkIjogOH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJk
+        cnBtcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImVkMzU1NjQ5LWViOGEtNDkwZS1hNDkx
+        LWFjMDI4YTExNTBlYiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEi
+        LCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYTA3
+        MDgwNC01NGM3LTQ3OTQtODdjNC1kMDEzZGQ1NTczZjIiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgTW9kdWxlcyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJjNWYxZmM3Yi0zNzhmLTQ0Y2ItYWRjYy1iMDU2
+        ZTc2NmM0NzkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIs
+        ICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzYzYWFj
+        ZGUtZjVlYi00ZTA3LWI4ZDAtNjM3ZmQzZDM1ZTE0IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiN2M0YmU4ZjgtODY3YS00OWJiLTkxYmMtOTQx
+        ZTkxMDY2OTUwIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiZmM4M2QzZWMtNzgxMC00MDUwLWE2ZDUtOWVmZGVjYmZjNzY3
+        IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
+        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGQ2
+        Mzg5NzMtMWYxOS00Yzc4LWI4YTMtN2Y3N2MxYjg0ODRjIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
+        ICJSZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92
+        ZV9vbGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzljOTAxNjUtYTE4
+        Zi00ZmNhLWIyNjItMWU0NDZhZjYwMTM3IiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
+        aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiZGRiZWZmYTgtYzMzMi00ZWY2LWIzMjktMmQ5OGY2NTM3
+        OTRjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJz
+        dGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiNzQ1N2E2MTgtZWRlZC00NTQ1LTliM2EtZTA1NGQwMjQwMTBhIiwgIm51
+        bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjog
+        ImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3
+        NmQxNmRjOC1iNDRiLTQyZDktOTc3MC05ZWY0YTA3MTFiNDUiLCAibnVtX3By
+        b2Nlc3NlZCI6IDF9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJl
+        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0Iiwg
+        InN0YXJ0ZWQiOiAiMjAxOC0xMi0wM1QwNTozOToxN1oiLCAiX25zIjogInJl
+        cG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE4LTEyLTAz
+        VDA1OjM5OjE3WiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3Jf
+        dHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6IHsiZ2Vu
+        ZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQiLCAicnBtcyI6ICJGSU5JU0hFRCIs
+        ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicmVt
+        b3ZlX29sZF9yZXBvZGF0YSI6ICJGSU5JU0hFRCIsICJtb2R1bGVzIjogIkZJ
+        TklTSEVEIiwgInNhdmVfdGFyIjogIkZJTklTSEVEIiwgImNsb3NlX3JlcG9f
+        bWV0YWRhdGEiOiAiRklOSVNIRUQiLCAiZHJwbXMiOiAiU0tJUFBFRCIsICJj
+        b21wcyI6ICJGSU5JU0hFRCIsICJkaXN0cmlidXRpb24iOiAiRklOSVNIRUQi
+        LCAicmVwb3ZpZXciOiAiU0tJUFBFRCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6
+        ICJGSU5JU0hFRCIsICJlcnJhdGEiOiAiRklOSVNIRUQiLCAibWV0YWRhdGEi
+        OiAiRklOSVNIRUQifSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJp
+        YnV0b3JfaWQiOiAic2NlbmFyaW9fdGVzdCIsICJpZCI6ICI1YzA0YzE4NTA1
+        ZjVlZTA1YzNmZDg0Y2YiLCAiZGV0YWlscyI6IFt7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIkNvcHlpbmcgZmlsZXMiLCAic3RlcF90eXBl
+        IjogInNhdmVfdGFyIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImMzNmY5MjM5LWM2OGQt
+        NDI0ZS1hZjMyLThiODY1NjEzMmMyYiIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6
+        aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVf
+        cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzNDkyNDdiMi05MTNi
+        LTRhMzktYjMyZi01YjcwZDhkNGMyY2YiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmli
+        dXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmVlZGNjNTktMmRjMS00YjA4LTk1
+        NTAtYzVkMTI1YTViZThmIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1f
+        c3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMi
+        LCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODE1ZDJj
+        ZDAtMDQ1MC00ZmQzLTk1MGQtOGY4M2Q5MGRmNmIzIiwgIm51bV9wcm9jZXNz
+        ZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiZWQzNTU2NDktZWI4YS00OTBlLWE0OTEtYWMwMjhh
+        MTE1MGViIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVw
+        X3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBhMDcwODA0LTU0
+        YzctNDc5NC04N2M0LWQwMTNkZDU1NzNmMiIsICJudW1fcHJvY2Vzc2VkIjog
+        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImM1ZjFmYzdiLTM3OGYtNDRjYi1hZGNjLWIwNTZlNzY2YzQ3
+        OSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBf
+        dHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzNjNhYWNkZS1mNWVi
+        LTRlMDctYjhkMC02MzdmZDNkMzVlMTQiLCAibnVtX3Byb2Nlc3NlZCI6IDN9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI3YzRiZThmOC04NjdhLTQ5YmItOTFiYy05NDFlOTEwNjY5
+        NTAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwg
+        ImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVw
+        X3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJmYzgzZDNlYy03ODEwLTQwNTAtYTZkNS05ZWZkZWNiZmM3NjciLCAibnVt
+        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwZDYzODk3My0x
+        ZjE5LTRjNzgtYjhhMy03Zjc3YzFiODQ4NGMiLCAibnVtX3Byb2Nlc3NlZCI6
+        IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92
+        aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9y
+        ZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3OWM5MDE2NS1hMThmLTRmY2Et
+        YjI2Mi0xZTQ0NmFmNjAxMzciLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRN
+        TCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJkZGJlZmZhOC1jMzMyLTRlZjYtYjMyOS0yZDk4ZjY1Mzc5NGMiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2Ny
+        aXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlw
+        ZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3NDU3
+        YTYxOC1lZGVkLTQ1NDUtOWIzYS1lMDU0ZDAyNDAxMGEiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
+        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc2ZDE2ZGM4
+        LWI0NGItNDJkOS05NzcwLTllZjRhMDcxMWI0NSIsICJudW1fcHJvY2Vzc2Vk
+        IjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0
+        YzE4NTQ5OGVkYjgyNTViYjQ2ZDQifSwgImlkIjogIjVjMDRjMTg1NDk4ZWRi
+        ODI1NWJiNDZkNCJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
+- request:
+    method: post
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2041,7 +9872,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2052,77 +9883,75 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:49 GMT
+      - Mon, 03 Dec 2018 05:39:17 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
       - '1672'
-      Connection:
-      - close
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIyMDRjM2QxZS0zMWNiLTRhYWQtOGJk
-        My1lOWI5ZDJkMmYxNmYiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
-        Il9pZCI6IHsiJG9pZCI6ICI1YmNlMDQyMDJmYTE4M2YxYzBkMGVhNTAifSwg
-        InVuaXRfaWQiOiAiMjA0YzNkMWUtMzFjYi00YWFkLThiZDMtZTliOWQyZDJm
-        MTZmIiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogIjIxMjM3ZGVmLWNkZjctNGJjZC1hNWY5LTFhYzA1YmQyMzA4ZiIs
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI0MDMzMTdlNS04YjE5LTQzY2ItYmQ3
+        YS02ZGFkODYzZjRlYjMiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1YzA0YzE4NTQ5OGVkYjgyNTViYjQ1ODIifSwg
+        InVuaXRfaWQiOiAiNDAzMzE3ZTUtOGIxOS00M2NiLWJkN2EtNmRhZDg2M2Y0
+        ZWIzIiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
+        X2lkIjogIjQ4YWIwMGY4LTk2MGQtNGQxOS04ODYwLTRjZTZmOTk4MzA5NyIs
         ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
-        IjViY2UwNDIwMmZhMTgzZjFjMGQwZWE1NCJ9LCAidW5pdF9pZCI6ICIyMTIz
-        N2RlZi1jZGY3LTRiY2QtYTVmOS0xYWMwNWJkMjMwOGYiLCAidW5pdF90eXBl
-        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNDczZWFlMzAt
-        OTQ2YS00YjY1LWI5OTctZTQ1MTVhNTgzYjA3IiwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNWJjZTA0MjAyZmExODNm
-        MWMwZDBlYTU1In0sICJ1bml0X2lkIjogIjQ3M2VhZTMwLTk0NmEtNGI2NS1i
-        OTk3LWU0NTE1YTU4M2IwNyIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
-        bWV0YWRhdGEiOiB7Il9pZCI6ICI2YjY2MmE3Yy05ZWU1LTQ0OTMtODYwYS01
-        NWFmMzc5MDEyMjMiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1YmNlMDQyMDJmYTE4M2YxYzBkMGVhNTcifSwgInVu
-        aXRfaWQiOiAiNmI2NjJhN2MtOWVlNS00NDkzLTg2MGEtNTVhZjM3OTAxMjIz
+        IjVjMDRjMTg1NDk4ZWRiODI1NWJiNDU5OSJ9LCAidW5pdF9pZCI6ICI0OGFi
+        MDBmOC05NjBkLTRkMTktODg2MC00Y2U2Zjk5ODMwOTciLCAidW5pdF90eXBl
+        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNGI5NjZjYjUt
+        MWE3NS00YjA3LTliZmEtMjliNjAxNGRiOWU3IiwgIl9jb250ZW50X3R5cGVf
+        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNWMwNGMxODU0OThlZGI4
+        MjU1YmI0NTc5In0sICJ1bml0X2lkIjogIjRiOTY2Y2I1LTFhNzUtNGIwNy05
+        YmZhLTI5YjYwMTRkYjllNyIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
+        bWV0YWRhdGEiOiB7Il9pZCI6ICI3Yjg3Y2IwNC1iNzA1LTQ0MzgtYjkzMy0z
+        MzM5NDhhNTVkNDciLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1YzA0YzE4NTQ5OGVkYjgyNTViYjQ1YjQifSwgInVu
+        aXRfaWQiOiAiN2I4N2NiMDQtYjcwNS00NDM4LWI5MzMtMzMzOTQ4YTU1ZDQ3
         IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
-        IjogIjg4N2Q1ZTRlLWVkNDEtNGYyOS04MTcwLTY5NzI4MmExZDU3ZCIsICJf
-        Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjVi
-        Y2UwNDIwMmZhMTgzZjFjMGQwZWE1MiJ9LCAidW5pdF9pZCI6ICI4ODdkNWU0
-        ZS1lZDQxLTRmMjktODE3MC02OTcyODJhMWQ1N2QiLCAidW5pdF90eXBlX2lk
-        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiOTMzNzczODEtNzIx
-        OC00OTJjLTgzZmUtMjRmNmYxYzkyMTM4IiwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNWJjZTA0MjAyZmExODNmMWMw
-        ZDBlYTUxIn0sICJ1bml0X2lkIjogIjkzMzc3MzgxLTcyMTgtNDkyYy04M2Zl
-        LTI0ZjZmMWM5MjEzOCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
-        YWRhdGEiOiB7Il9pZCI6ICJkYmE5NjlkZC0yMjUwLTQzNjItYTM1NS0wYmQx
-        YTNiZDRhODEiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1YmNlMDQyMDJmYTE4M2YxYzBkMGVhNTYifSwgInVuaXRf
-        aWQiOiAiZGJhOTY5ZGQtMjI1MC00MzYyLWEzNTUtMGJkMWEzYmQ0YTgxIiwg
+        IjogIjk1ZjQzZDliLWZjZTMtNGJiYi05YzBmLWEzNDJhN2IzOTZmNyIsICJf
+        Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjVj
+        MDRjMTg1NDk4ZWRiODI1NWJiNDVhYiJ9LCAidW5pdF9pZCI6ICI5NWY0M2Q5
+        Yi1mY2UzLTRiYmItOWMwZi1hMzQyYTdiMzk2ZjciLCAidW5pdF90eXBlX2lk
+        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYmFhY2E1ZTAtNTA3
+        Zi00YzJkLThlMGItYmUwNzA4Zjg5MmIwIiwgIl9jb250ZW50X3R5cGVfaWQi
+        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNWMwNGMxODU0OThlZGI4MjU1
+        YmI0NWJkIn0sICJ1bml0X2lkIjogImJhYWNhNWUwLTUwN2YtNGMyZC04ZTBi
+        LWJlMDcwOGY4OTJiMCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
+        YWRhdGEiOiB7Il9pZCI6ICJmYTdlYTljMy02NTAxLTQyYjQtYTcyYS1kODJm
+        NzM1ODIzNmEiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
+        IHsiJG9pZCI6ICI1YzA0YzE4NTQ5OGVkYjgyNTViYjQ1YTIifSwgInVuaXRf
+        aWQiOiAiZmE3ZWE5YzMtNjUwMS00MmI0LWE3MmEtZDgyZjczNTgyMzZhIiwg
         InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
-        ImZmOWE5ZDllLWI0YWYtNDI2NC1iOGFhLThiMWE1YjQ2NWNiNSIsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjViY2Uw
-        NDIwMmZhMTgzZjFjMGQwZWE1MyJ9LCAidW5pdF9pZCI6ICJmZjlhOWQ5ZS1i
-        NGFmLTQyNjQtYjhhYS04YjFhNWI0NjVjYjUiLCAidW5pdF90eXBlX2lkIjog
+        ImZlOTRmYTE2LTNjYWMtNDZhYy1iNzJlLTlmOGM5YTBhMjE4OSIsICJfY29u
+        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjVjMDRj
+        MTg1NDk4ZWRiODI1NWJiNDU4YiJ9LCAidW5pdF9pZCI6ICJmZTk0ZmExNi0z
+        Y2FjLTQ2YWMtYjcyZS05ZjhjOWEwYTIxODkiLCAidW5pdF90eXBlX2lkIjog
         InJwbSJ9XQ==
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:49 GMT
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/content/units/rpm/search/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/content/units/rpm/search/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjcml0ZXJpYSI6eyJsaW1pdCI6OCwic2tpcCI6MCwiZmllbGRzIjpbIm5h
         bWUiLCJ2ZXJzaW9uIiwicmVsZWFzZSIsImFyY2giLCJlcG9jaCIsInN1bW1h
         cnkiLCJzb3VyY2VycG0iLCJjaGVja3N1bSIsImZpbGVuYW1lIiwiX2lkIl0s
-        ImZpbHRlcnMiOnsiX2lkIjp7IiRpbiI6WyIyMDRjM2QxZS0zMWNiLTRhYWQt
-        OGJkMy1lOWI5ZDJkMmYxNmYiLCIyMTIzN2RlZi1jZGY3LTRiY2QtYTVmOS0x
-        YWMwNWJkMjMwOGYiLCI0NzNlYWUzMC05NDZhLTRiNjUtYjk5Ny1lNDUxNWE1
-        ODNiMDciLCI2YjY2MmE3Yy05ZWU1LTQ0OTMtODYwYS01NWFmMzc5MDEyMjMi
-        LCI4ODdkNWU0ZS1lZDQxLTRmMjktODE3MC02OTcyODJhMWQ1N2QiLCI5MzM3
-        NzM4MS03MjE4LTQ5MmMtODNmZS0yNGY2ZjFjOTIxMzgiLCJkYmE5NjlkZC0y
-        MjUwLTQzNjItYTM1NS0wYmQxYTNiZDRhODEiLCJmZjlhOWQ5ZS1iNGFmLTQy
-        NjQtYjhhYS04YjFhNWI0NjVjYjUiXX19fSwiaW5jbHVkZV9yZXBvcyI6dHJ1
+        ImZpbHRlcnMiOnsiX2lkIjp7IiRpbiI6WyI0MDMzMTdlNS04YjE5LTQzY2It
+        YmQ3YS02ZGFkODYzZjRlYjMiLCI0OGFiMDBmOC05NjBkLTRkMTktODg2MC00
+        Y2U2Zjk5ODMwOTciLCI0Yjk2NmNiNS0xYTc1LTRiMDctOWJmYS0yOWI2MDE0
+        ZGI5ZTciLCI3Yjg3Y2IwNC1iNzA1LTQ0MzgtYjkzMy0zMzM5NDhhNTVkNDci
+        LCI5NWY0M2Q5Yi1mY2UzLTRiYmItOWMwZi1hMzQyYTdiMzk2ZjciLCJiYWFj
+        YTVlMC01MDdmLTRjMmQtOGUwYi1iZTA3MDhmODkyYjAiLCJmYTdlYTljMy02
+        NTAxLTQyYjQtYTcyYS1kODJmNzM1ODIzNmEiLCJmZTk0ZmExNi0zY2FjLTQ2
+        YWMtYjcyZS05ZjhjOWEwYTIxODkiXX19fSwiaW5jbHVkZV9yZXBvcyI6dHJ1
         ZX0=
     headers:
       Accept:
@@ -2130,7 +9959,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2141,111 +9970,346 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:49 GMT
+      - Mon, 03 Dec 2018 05:39:17 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '3836'
-      Connection:
-      - close
+      - '14492'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVzdCJd
-        LCAic291cmNlcnBtIjogImdpcmFmZmUtMC4zLTAuOC5zcmMucnBtIiwgIm5h
-        bWUiOiAiZ2lyYWZmZSIsICJjaGVja3N1bSI6ICJmMjVkNjdkMWQ5ZGEwNGYx
-        MmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5
-        ZjE0IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUi
-        LCAiZmlsZW5hbWUiOiAiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCAi
-        ZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAu
-        OCIsICJfaWQiOiAiMjA0YzNkMWUtMzFjYi00YWFkLThiZDMtZTliOWQyZDJm
-        MTZmIiwgImFyY2giOiAibm9hcmNoIiwgImNoaWxkcmVuIjoge30sICJfaHJl
-        ZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vMjA0YzNkMWUt
-        MzFjYi00YWFkLThiZDMtZTliOWQyZDJmMTZmLyJ9LCB7InJlcG9zaXRvcnlf
-        bWVtYmVyc2hpcHMiOiBbInNjZW5hcmlvX3Rlc3QiXSwgInNvdXJjZXJwbSI6
-        ICJwZW5ndWluLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogInBlbmd1aW4i
-        LCAiY2hlY2tzdW0iOiAiM2ZjYjJjOTI3ZGU5ZTEzYmY2ODQ2OTAzMmEyOGIx
-        MzlkM2U1YWQyZTU4NTY0ZmMyMTBmZDZlNDg2MzViZTY5NCIsICJzdW1tYXJ5
-        IjogIkEgZHVtbXkgcGFja2FnZSBvZiBwZW5ndWluIiwgImZpbGVuYW1lIjog
-        InBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAi
-        dmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjIx
-        MjM3ZGVmLWNkZjctNGJjZC1hNWY5LTFhYzA1YmQyMzA4ZiIsICJhcmNoIjog
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiMS1jdl9sYXRlc3RfdG9f
+        ZGVsLXYxXzAtNWNmY2NhYTQtNGI0My00MDhiLTg0NjAtNDY3YTVmY2RjYWI3
+        IiwgIjEtY3YtdjFfMC01Y2ZjY2FhNC00YjQzLTQwOGItODQ2MC00NjdhNWZj
+        ZGNhYjciLCAiNTcwYjlmNjItNTVlMC00N2UzLTgzMzAtY2YzYmVkOGViZjQ3
+        IiwgIjEtY3ZfMl9kZWxldGUtdjFfMC01Y2ZjY2FhNC00YjQzLTQwOGItODQ2
+        MC00NjdhNWZjZGNhYjciLCAiMS1jdl90b19kZWxfMS12MV8wLTVjZmNjYWE0
+        LTRiNDMtNDA4Yi04NDYwLTQ2N2E1ZmNkY2FiNyIsICIxLWN2X3RvX2RlbC12
+        Ml8wLTVjZmNjYWE0LTRiNDMtNDA4Yi04NDYwLTQ2N2E1ZmNkY2FiNyIsICIx
+        LWN2X3RvX2RlbC12MV8wLTU3MGI5ZjYyLTU1ZTAtNDdlMy04MzMwLWNmM2Jl
+        ZDhlYmY0NyIsICIxLWN2X3RvX2RlbC12MV8wLTVjZmNjYWE0LTRiNDMtNDA4
+        Yi04NDYwLTQ2N2E1ZmNkY2FiNyIsICIxLWN2LXYyXzAtNWNmY2NhYTQtNGI0
+        My00MDhiLTg0NjAtNDY3YTVmY2RjYWI3IiwgIjMxMmQ5MGNmLTJhMGItNGM2
+        MS1iNTgwLWIwMGNmNGI2ZjUxZSIsICIxLWRldi12MV8wLWY0NTg0OWNjLTlm
+        NjUtNDEyMy1iMTgxLWJlZTAxMDcyNDBmOCIsICIxLWN2LXYyXzAtNTcwYjlm
+        NjItNTVlMC00N2UzLTgzMzAtY2YzYmVkOGViZjQ3IiwgIjEtY3ZfdG9fZGVs
+        XzEtdjJfMC01NzBiOWY2Mi01NWUwLTQ3ZTMtODMzMC1jZjNiZWQ4ZWJmNDci
+        LCAic2NlbmFyaW9fdGVzdCIsICIxLWN2X3RvX2RlbC12Ml8wLTU3MGI5ZjYy
+        LTU1ZTAtNDdlMy04MzMwLWNmM2JlZDhlYmY0NyIsICIxLWRldi12MV8wLTYw
+        NTUwMWVkLTk4M2MtNDUzMi1iMjZjLTdkZmM0YTAyM2NhZCIsICIxZWMyNmY2
+        Yy00YzViLTQ1NWMtYmE0Zi00MGYyMjI0MDJmZjYiLCAiNjA1NTAxZWQtOTgz
+        Yy00NTMyLWIyNmMtN2RmYzRhMDIzY2FkIiwgIjEtY3ZfdG9fZGVsXzEtdjJf
+        MC01Y2ZjY2FhNC00YjQzLTQwOGItODQ2MC00NjdhNWZjZGNhYjciLCAiNWNm
+        Y2NhYTQtNGI0My00MDhiLTg0NjAtNDY3YTVmY2RjYWI3IiwgIjEtY3YtdjFf
+        MC01NzBiOWY2Mi01NWUwLTQ3ZTMtODMzMC1jZjNiZWQ4ZWJmNDciLCAiZjQ1
+        ODQ5Y2MtOWY2NS00MTIzLWIxODEtYmVlMDEwNzI0MGY4IiwgImFlZDJkMmE5
+        LTRkNzEtNDAyNy1iODdmLWY2ZTRiYTdmOTkxYyIsICIxLWN2X3RvX2RlbF8x
+        LXYxXzAtNTcwYjlmNjItNTVlMC00N2UzLTgzMzAtY2YzYmVkOGViZjQ3Iiwg
+        ImRmN2NmMzYxLTVlMDQtNGFkNC1hYTg2LWE3MTUzNzIyM2E3OCIsICIxLWN2
+        X2xhdGVzdF90b19kZWwtdjFfMC01NzBiOWY2Mi01NWUwLTQ3ZTMtODMzMC1j
+        ZjNiZWQ4ZWJmNDciLCAiMS1jdl8yX2RlbGV0ZS12MV8wLTU3MGI5ZjYyLTU1
+        ZTAtNDdlMy04MzMwLWNmM2JlZDhlYmY0NyJdLCAic291cmNlcnBtIjogImVs
+        ZXBoYW50LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogImVsZXBoYW50Iiwg
+        ImNoZWNrc3VtIjogIjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0
+        NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCAic3VtbWFyeSI6
+        ICJBIGR1bW15IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCAiZmlsZW5hbWUiOiAi
+        ZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAi
+        dmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjQw
+        MzMxN2U1LThiMTktNDNjYi1iZDdhLTZkYWQ4NjNmNGViMyIsICJhcmNoIjog
         Im5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBp
-        L3YyL2NvbnRlbnQvdW5pdHMvcnBtLzIxMjM3ZGVmLWNkZjctNGJjZC1hNWY5
-        LTFhYzA1YmQyMzA4Zi8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjog
-        WyJzY2VuYXJpb190ZXN0Il0sICJzb3VyY2VycG0iOiAiY2hlZXRhaC0wLjMt
-        MC44LnNyYy5ycG0iLCAibmFtZSI6ICJjaGVldGFoIiwgImNoZWNrc3VtIjog
-        IjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIzZTE3ZjU3OGY5MjRmNzQ4
-        ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBh
-        Y2thZ2Ugb2YgY2hlZXRhaCIsICJmaWxlbmFtZSI6ICJjaGVldGFoLTAuMy0w
+        L3YyL2NvbnRlbnQvdW5pdHMvcnBtLzQwMzMxN2U1LThiMTktNDNjYi1iZDdh
+        LTZkYWQ4NjNmNGViMy8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjog
+        WyIxLWN2X2xhdGVzdF90b19kZWwtdjFfMC01Y2ZjY2FhNC00YjQzLTQwOGIt
+        ODQ2MC00NjdhNWZjZGNhYjciLCAiMS1jdi12MV8wLTVjZmNjYWE0LTRiNDMt
+        NDA4Yi04NDYwLTQ2N2E1ZmNkY2FiNyIsICI1NzBiOWY2Mi01NWUwLTQ3ZTMt
+        ODMzMC1jZjNiZWQ4ZWJmNDciLCAiMS1jdl8yX2RlbGV0ZS12MV8wLTVjZmNj
+        YWE0LTRiNDMtNDA4Yi04NDYwLTQ2N2E1ZmNkY2FiNyIsICIxLWN2X3RvX2Rl
+        bF8xLXYxXzAtNWNmY2NhYTQtNGI0My00MDhiLTg0NjAtNDY3YTVmY2RjYWI3
+        IiwgIjEtY3ZfdG9fZGVsLXYyXzAtNWNmY2NhYTQtNGI0My00MDhiLTg0NjAt
+        NDY3YTVmY2RjYWI3IiwgIjEtY3ZfdG9fZGVsLXYxXzAtNTcwYjlmNjItNTVl
+        MC00N2UzLTgzMzAtY2YzYmVkOGViZjQ3IiwgIjEtY3ZfdG9fZGVsLXYxXzAt
+        NWNmY2NhYTQtNGI0My00MDhiLTg0NjAtNDY3YTVmY2RjYWI3IiwgIjEtY3Yt
+        djJfMC01Y2ZjY2FhNC00YjQzLTQwOGItODQ2MC00NjdhNWZjZGNhYjciLCAi
+        MzEyZDkwY2YtMmEwYi00YzYxLWI1ODAtYjAwY2Y0YjZmNTFlIiwgIjEtZGV2
+        LXYxXzAtZjQ1ODQ5Y2MtOWY2NS00MTIzLWIxODEtYmVlMDEwNzI0MGY4Iiwg
+        IjEtY3YtdjJfMC01NzBiOWY2Mi01NWUwLTQ3ZTMtODMzMC1jZjNiZWQ4ZWJm
+        NDciLCAiMS1jdl90b19kZWxfMS12Ml8wLTU3MGI5ZjYyLTU1ZTAtNDdlMy04
+        MzMwLWNmM2JlZDhlYmY0NyIsICJzY2VuYXJpb190ZXN0IiwgIjEtY3ZfdG9f
+        ZGVsLXYyXzAtNTcwYjlmNjItNTVlMC00N2UzLTgzMzAtY2YzYmVkOGViZjQ3
+        IiwgIjEtZGV2LXYxXzAtNjA1NTAxZWQtOTgzYy00NTMyLWIyNmMtN2RmYzRh
+        MDIzY2FkIiwgIjFlYzI2ZjZjLTRjNWItNDU1Yy1iYTRmLTQwZjIyMjQwMmZm
+        NiIsICI2MDU1MDFlZC05ODNjLTQ1MzItYjI2Yy03ZGZjNGEwMjNjYWQiLCAi
+        MS1jdl90b19kZWxfMS12Ml8wLTVjZmNjYWE0LTRiNDMtNDA4Yi04NDYwLTQ2
+        N2E1ZmNkY2FiNyIsICI1Y2ZjY2FhNC00YjQzLTQwOGItODQ2MC00NjdhNWZj
+        ZGNhYjciLCAiMS1jdi12MV8wLTU3MGI5ZjYyLTU1ZTAtNDdlMy04MzMwLWNm
+        M2JlZDhlYmY0NyIsICJmNDU4NDljYy05ZjY1LTQxMjMtYjE4MS1iZWUwMTA3
+        MjQwZjgiLCAiYWVkMmQyYTktNGQ3MS00MDI3LWI4N2YtZjZlNGJhN2Y5OTFj
+        IiwgIjEtY3ZfdG9fZGVsXzEtdjFfMC01NzBiOWY2Mi01NWUwLTQ3ZTMtODMz
+        MC1jZjNiZWQ4ZWJmNDciLCAiZGY3Y2YzNjEtNWUwNC00YWQ0LWFhODYtYTcx
+        NTM3MjIzYTc4IiwgIjEtY3ZfbGF0ZXN0X3RvX2RlbC12MV8wLTU3MGI5ZjYy
+        LTU1ZTAtNDdlMy04MzMwLWNmM2JlZDhlYmY0NyIsICIxLWN2XzJfZGVsZXRl
+        LXYxXzAtNTcwYjlmNjItNTVlMC00N2UzLTgzMzAtY2YzYmVkOGViZjQ3Il0s
+        ICJzb3VyY2VycG0iOiAibW9ua2V5LTAuMy0wLjguc3JjLnJwbSIsICJuYW1l
+        IjogIm1vbmtleSIsICJjaGVja3N1bSI6ICIwZThmYTUwZDAxMjhmYmFiYzdj
+        Y2M1NjMyZTNmYTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIx
+        IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIsICJm
+        aWxlbmFtZSI6ICJtb25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2No
+        IjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAi
+        X2lkIjogIjQ4YWIwMGY4LTk2MGQtNGQxOS04ODYwLTRjZTZmOTk4MzA5NyIs
+        ICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAi
+        L3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtLzQ4YWIwMGY4LTk2MGQt
+        NGQxOS04ODYwLTRjZTZmOTk4MzA5Ny8ifSwgeyJyZXBvc2l0b3J5X21lbWJl
+        cnNoaXBzIjogWyIxLWN2X2xhdGVzdF90b19kZWwtdjFfMC01Y2ZjY2FhNC00
+        YjQzLTQwOGItODQ2MC00NjdhNWZjZGNhYjciLCAiMS1jdi12MV8wLTVjZmNj
+        YWE0LTRiNDMtNDA4Yi04NDYwLTQ2N2E1ZmNkY2FiNyIsICI1NzBiOWY2Mi01
+        NWUwLTQ3ZTMtODMzMC1jZjNiZWQ4ZWJmNDciLCAiMS1jdl8yX2RlbGV0ZS12
+        MV8wLTVjZmNjYWE0LTRiNDMtNDA4Yi04NDYwLTQ2N2E1ZmNkY2FiNyIsICIx
+        LWN2X3RvX2RlbF8xLXYxXzAtNWNmY2NhYTQtNGI0My00MDhiLTg0NjAtNDY3
+        YTVmY2RjYWI3IiwgIjEtY3ZfdG9fZGVsLXYyXzAtNWNmY2NhYTQtNGI0My00
+        MDhiLTg0NjAtNDY3YTVmY2RjYWI3IiwgIjEtY3ZfdG9fZGVsLXYxXzAtNTcw
+        YjlmNjItNTVlMC00N2UzLTgzMzAtY2YzYmVkOGViZjQ3IiwgIjEtY3ZfdG9f
+        ZGVsLXYxXzAtNWNmY2NhYTQtNGI0My00MDhiLTg0NjAtNDY3YTVmY2RjYWI3
+        IiwgIjEtY3YtdjJfMC01Y2ZjY2FhNC00YjQzLTQwOGItODQ2MC00NjdhNWZj
+        ZGNhYjciLCAiMzEyZDkwY2YtMmEwYi00YzYxLWI1ODAtYjAwY2Y0YjZmNTFl
+        IiwgIjEtZGV2LXYxXzAtZjQ1ODQ5Y2MtOWY2NS00MTIzLWIxODEtYmVlMDEw
+        NzI0MGY4IiwgIjEtY3YtdjJfMC01NzBiOWY2Mi01NWUwLTQ3ZTMtODMzMC1j
+        ZjNiZWQ4ZWJmNDciLCAiMS1jdl90b19kZWxfMS12Ml8wLTU3MGI5ZjYyLTU1
+        ZTAtNDdlMy04MzMwLWNmM2JlZDhlYmY0NyIsICJzY2VuYXJpb190ZXN0Iiwg
+        IjEtY3ZfdG9fZGVsLXYyXzAtNTcwYjlmNjItNTVlMC00N2UzLTgzMzAtY2Yz
+        YmVkOGViZjQ3IiwgIjEtZGV2LXYxXzAtNjA1NTAxZWQtOTgzYy00NTMyLWIy
+        NmMtN2RmYzRhMDIzY2FkIiwgIjFlYzI2ZjZjLTRjNWItNDU1Yy1iYTRmLTQw
+        ZjIyMjQwMmZmNiIsICI2MDU1MDFlZC05ODNjLTQ1MzItYjI2Yy03ZGZjNGEw
+        MjNjYWQiLCAiMS1jdl90b19kZWxfMS12Ml8wLTVjZmNjYWE0LTRiNDMtNDA4
+        Yi04NDYwLTQ2N2E1ZmNkY2FiNyIsICI1Y2ZjY2FhNC00YjQzLTQwOGItODQ2
+        MC00NjdhNWZjZGNhYjciLCAiMS1jdi12MV8wLTU3MGI5ZjYyLTU1ZTAtNDdl
+        My04MzMwLWNmM2JlZDhlYmY0NyIsICJmNDU4NDljYy05ZjY1LTQxMjMtYjE4
+        MS1iZWUwMTA3MjQwZjgiLCAiYWVkMmQyYTktNGQ3MS00MDI3LWI4N2YtZjZl
+        NGJhN2Y5OTFjIiwgIjEtY3ZfdG9fZGVsXzEtdjFfMC01NzBiOWY2Mi01NWUw
+        LTQ3ZTMtODMzMC1jZjNiZWQ4ZWJmNDciLCAiZGY3Y2YzNjEtNWUwNC00YWQ0
+        LWFhODYtYTcxNTM3MjIzYTc4IiwgIjEtY3ZfbGF0ZXN0X3RvX2RlbC12MV8w
+        LTU3MGI5ZjYyLTU1ZTAtNDdlMy04MzMwLWNmM2JlZDhlYmY0NyIsICIxLWN2
+        XzJfZGVsZXRlLXYxXzAtNTcwYjlmNjItNTVlMC00N2UzLTgzMzAtY2YzYmVk
+        OGViZjQ3Il0sICJzb3VyY2VycG0iOiAiZ2lyYWZmZS0wLjMtMC44LnNyYy5y
+        cG0iLCAibmFtZSI6ICJnaXJhZmZlIiwgImNoZWNrc3VtIjogImYyNWQ2N2Qx
+        ZDlkYTA0ZjEyZTU3Y2EzMjMyNDdiNDM4OTFhYzQ2NTMzZTM1NWI4MmRlNmQx
+        OTIyMDA5ZjlmMTQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Yg
+        Z2lyYWZmZSIsICJmaWxlbmFtZSI6ICJnaXJhZmZlLTAuMy0wLjgubm9hcmNo
+        LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVh
+        c2UiOiAiMC44IiwgIl9pZCI6ICI0Yjk2NmNiNS0xYTc1LTRiMDctOWJmYS0y
+        OWI2MDE0ZGI5ZTciLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7
+        fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS80
+        Yjk2NmNiNS0xYTc1LTRiMDctOWJmYS0yOWI2MDE0ZGI5ZTcvIn0sIHsicmVw
+        b3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiMS1jdl9sYXRlc3RfdG9fZGVsLXYx
+        XzAtNWNmY2NhYTQtNGI0My00MDhiLTg0NjAtNDY3YTVmY2RjYWI3IiwgIjEt
+        Y3YtdjFfMC01Y2ZjY2FhNC00YjQzLTQwOGItODQ2MC00NjdhNWZjZGNhYjci
+        LCAiNTcwYjlmNjItNTVlMC00N2UzLTgzMzAtY2YzYmVkOGViZjQ3IiwgIjEt
+        Y3ZfMl9kZWxldGUtdjFfMC01Y2ZjY2FhNC00YjQzLTQwOGItODQ2MC00Njdh
+        NWZjZGNhYjciLCAiMS1jdl90b19kZWxfMS12MV8wLTVjZmNjYWE0LTRiNDMt
+        NDA4Yi04NDYwLTQ2N2E1ZmNkY2FiNyIsICIxLWN2X3RvX2RlbC12Ml8wLTVj
+        ZmNjYWE0LTRiNDMtNDA4Yi04NDYwLTQ2N2E1ZmNkY2FiNyIsICIxLWN2X3Rv
+        X2RlbC12MV8wLTU3MGI5ZjYyLTU1ZTAtNDdlMy04MzMwLWNmM2JlZDhlYmY0
+        NyIsICIxLWN2X3RvX2RlbC12MV8wLTVjZmNjYWE0LTRiNDMtNDA4Yi04NDYw
+        LTQ2N2E1ZmNkY2FiNyIsICIxLWN2LXYyXzAtNWNmY2NhYTQtNGI0My00MDhi
+        LTg0NjAtNDY3YTVmY2RjYWI3IiwgIjMxMmQ5MGNmLTJhMGItNGM2MS1iNTgw
+        LWIwMGNmNGI2ZjUxZSIsICIxLWRldi12MV8wLWY0NTg0OWNjLTlmNjUtNDEy
+        My1iMTgxLWJlZTAxMDcyNDBmOCIsICIxLWN2LXYyXzAtNTcwYjlmNjItNTVl
+        MC00N2UzLTgzMzAtY2YzYmVkOGViZjQ3IiwgIjEtY3ZfdG9fZGVsXzEtdjJf
+        MC01NzBiOWY2Mi01NWUwLTQ3ZTMtODMzMC1jZjNiZWQ4ZWJmNDciLCAic2Nl
+        bmFyaW9fdGVzdCIsICIxLWN2X3RvX2RlbC12Ml8wLTU3MGI5ZjYyLTU1ZTAt
+        NDdlMy04MzMwLWNmM2JlZDhlYmY0NyIsICIxLWRldi12MV8wLTYwNTUwMWVk
+        LTk4M2MtNDUzMi1iMjZjLTdkZmM0YTAyM2NhZCIsICIxZWMyNmY2Yy00YzVi
+        LTQ1NWMtYmE0Zi00MGYyMjI0MDJmZjYiLCAiNjA1NTAxZWQtOTgzYy00NTMy
+        LWIyNmMtN2RmYzRhMDIzY2FkIiwgIjEtY3ZfdG9fZGVsXzEtdjJfMC01Y2Zj
+        Y2FhNC00YjQzLTQwOGItODQ2MC00NjdhNWZjZGNhYjciLCAiNWNmY2NhYTQt
+        NGI0My00MDhiLTg0NjAtNDY3YTVmY2RjYWI3IiwgIjEtY3YtdjFfMC01NzBi
+        OWY2Mi01NWUwLTQ3ZTMtODMzMC1jZjNiZWQ4ZWJmNDciLCAiZjQ1ODQ5Y2Mt
+        OWY2NS00MTIzLWIxODEtYmVlMDEwNzI0MGY4IiwgImFlZDJkMmE5LTRkNzEt
+        NDAyNy1iODdmLWY2ZTRiYTdmOTkxYyIsICIxLWN2X3RvX2RlbF8xLXYxXzAt
+        NTcwYjlmNjItNTVlMC00N2UzLTgzMzAtY2YzYmVkOGViZjQ3IiwgImRmN2Nm
+        MzYxLTVlMDQtNGFkNC1hYTg2LWE3MTUzNzIyM2E3OCIsICIxLWN2X2xhdGVz
+        dF90b19kZWwtdjFfMC01NzBiOWY2Mi01NWUwLTQ3ZTMtODMzMC1jZjNiZWQ4
+        ZWJmNDciLCAiMS1jdl8yX2RlbGV0ZS12MV8wLTU3MGI5ZjYyLTU1ZTAtNDdl
+        My04MzMwLWNmM2JlZDhlYmY0NyJdLCAic291cmNlcnBtIjogIndhbHJ1cy0w
+        LjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJ3YWxydXMiLCAiY2hlY2tzdW0i
+        OiAiNmU4ZDZkYzA1N2UzZTJjOTgxOWYwZGM3ZTZjN2I3Zjg2YmYyZTg1NzFi
+        YmE0MTRhZGVjN2ZiNjIxYTQ2MWRmZCIsICJzdW1tYXJ5IjogIkEgZHVtbXkg
+        cGFja2FnZSBvZiB3YWxydXMiLCAiZmlsZW5hbWUiOiAid2FscnVzLTAuMy0w
         Ljgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4z
-        IiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICI0NzNlYWUzMC05NDZhLTRi
-        NjUtYjk5Ny1lNDUxNWE1ODNiMDciLCAiYXJjaCI6ICJub2FyY2giLCAiY2hp
+        IiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICI3Yjg3Y2IwNC1iNzA1LTQ0
+        MzgtYjkzMy0zMzM5NDhhNTVkNDciLCAiYXJjaCI6ICJub2FyY2giLCAiY2hp
         bGRyZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3Vu
-        aXRzL3JwbS80NzNlYWUzMC05NDZhLTRiNjUtYjk5Ny1lNDUxNWE1ODNiMDcv
-        In0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVz
-        dCJdLCAic291cmNlcnBtIjogInNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIs
-        ICJuYW1lIjogInNxdWlycmVsIiwgImNoZWNrc3VtIjogIjI1MTc2OGJkZDE1
-        ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFl
-        ODc4YTE3ZDIiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1
-        aXJyZWwiLCAiZmlsZW5hbWUiOiAic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gu
-        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFz
-        ZSI6ICIwLjgiLCAiX2lkIjogIjZiNjYyYTdjLTllZTUtNDQ5My04NjBhLTU1
-        YWYzNzkwMTIyMyIsICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtLzZi
-        NjYyYTdjLTllZTUtNDQ5My04NjBhLTU1YWYzNzkwMTIyMy8ifSwgeyJyZXBv
-        c2l0b3J5X21lbWJlcnNoaXBzIjogWyJzY2VuYXJpb190ZXN0Il0sICJzb3Vy
-        Y2VycG0iOiAibGlvbi0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJsaW9u
-        IiwgImNoZWNrc3VtIjogIjEyNDAwZGM5NWMyM2E0YzE2MDcyNWE5MDg3MTZj
-        ZDNmY2RkN2E4OTgxNTg1NDM3YWI2NGNkNjJlZmEzZTRhZTQiLCAic3VtbWFy
-        eSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgbGlvbiIsICJmaWxlbmFtZSI6ICJs
-        aW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNp
-        b24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICI4ODdkNWU0
-        ZS1lZDQxLTRmMjktODE3MC02OTcyODJhMWQ1N2QiLCAiYXJjaCI6ICJub2Fy
-        Y2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9j
-        b250ZW50L3VuaXRzL3JwbS84ODdkNWU0ZS1lZDQxLTRmMjktODE3MC02OTcy
-        ODJhMWQ1N2QvIn0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2Nl
-        bmFyaW9fdGVzdCJdLCAic291cmNlcnBtIjogImVsZXBoYW50LTAuMy0wLjgu
-        c3JjLnJwbSIsICJuYW1lIjogImVsZXBoYW50IiwgImNoZWNrc3VtIjogIjNl
-        MWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIw
-        OTVmYzMxMzcyYTBhNzAxZjMiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2th
-        Z2Ugb2YgZWxlcGhhbnQiLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAu
+        aXRzL3JwbS83Yjg3Y2IwNC1iNzA1LTQ0MzgtYjkzMy0zMzM5NDhhNTVkNDcv
+        In0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiMS1jdl9sYXRlc3Rf
+        dG9fZGVsLXYxXzAtNWNmY2NhYTQtNGI0My00MDhiLTg0NjAtNDY3YTVmY2Rj
+        YWI3IiwgIjEtY3YtdjFfMC01Y2ZjY2FhNC00YjQzLTQwOGItODQ2MC00Njdh
+        NWZjZGNhYjciLCAiNTcwYjlmNjItNTVlMC00N2UzLTgzMzAtY2YzYmVkOGVi
+        ZjQ3IiwgIjEtY3ZfMl9kZWxldGUtdjFfMC01Y2ZjY2FhNC00YjQzLTQwOGIt
+        ODQ2MC00NjdhNWZjZGNhYjciLCAiMS1jdl90b19kZWxfMS12MV8wLTVjZmNj
+        YWE0LTRiNDMtNDA4Yi04NDYwLTQ2N2E1ZmNkY2FiNyIsICIxLWN2X3RvX2Rl
+        bC12Ml8wLTVjZmNjYWE0LTRiNDMtNDA4Yi04NDYwLTQ2N2E1ZmNkY2FiNyIs
+        ICIxLWN2X3RvX2RlbC12MV8wLTU3MGI5ZjYyLTU1ZTAtNDdlMy04MzMwLWNm
+        M2JlZDhlYmY0NyIsICIxLWN2X3RvX2RlbC12MV8wLTVjZmNjYWE0LTRiNDMt
+        NDA4Yi04NDYwLTQ2N2E1ZmNkY2FiNyIsICIxLWN2LXYyXzAtNWNmY2NhYTQt
+        NGI0My00MDhiLTg0NjAtNDY3YTVmY2RjYWI3IiwgIjMxMmQ5MGNmLTJhMGIt
+        NGM2MS1iNTgwLWIwMGNmNGI2ZjUxZSIsICIxLWRldi12MV8wLWY0NTg0OWNj
+        LTlmNjUtNDEyMy1iMTgxLWJlZTAxMDcyNDBmOCIsICIxLWN2LXYyXzAtNTcw
+        YjlmNjItNTVlMC00N2UzLTgzMzAtY2YzYmVkOGViZjQ3IiwgIjEtY3ZfdG9f
+        ZGVsXzEtdjJfMC01NzBiOWY2Mi01NWUwLTQ3ZTMtODMzMC1jZjNiZWQ4ZWJm
+        NDciLCAic2NlbmFyaW9fdGVzdCIsICIxLWN2X3RvX2RlbC12Ml8wLTU3MGI5
+        ZjYyLTU1ZTAtNDdlMy04MzMwLWNmM2JlZDhlYmY0NyIsICIxLWRldi12MV8w
+        LTYwNTUwMWVkLTk4M2MtNDUzMi1iMjZjLTdkZmM0YTAyM2NhZCIsICIxZWMy
+        NmY2Yy00YzViLTQ1NWMtYmE0Zi00MGYyMjI0MDJmZjYiLCAiNjA1NTAxZWQt
+        OTgzYy00NTMyLWIyNmMtN2RmYzRhMDIzY2FkIiwgIjEtY3ZfdG9fZGVsXzEt
+        djJfMC01Y2ZjY2FhNC00YjQzLTQwOGItODQ2MC00NjdhNWZjZGNhYjciLCAi
+        NWNmY2NhYTQtNGI0My00MDhiLTg0NjAtNDY3YTVmY2RjYWI3IiwgIjEtY3Yt
+        djFfMC01NzBiOWY2Mi01NWUwLTQ3ZTMtODMzMC1jZjNiZWQ4ZWJmNDciLCAi
+        ZjQ1ODQ5Y2MtOWY2NS00MTIzLWIxODEtYmVlMDEwNzI0MGY4IiwgImFlZDJk
+        MmE5LTRkNzEtNDAyNy1iODdmLWY2ZTRiYTdmOTkxYyIsICIxLWN2X3RvX2Rl
+        bF8xLXYxXzAtNTcwYjlmNjItNTVlMC00N2UzLTgzMzAtY2YzYmVkOGViZjQ3
+        IiwgImRmN2NmMzYxLTVlMDQtNGFkNC1hYTg2LWE3MTUzNzIyM2E3OCIsICIx
+        LWN2X2xhdGVzdF90b19kZWwtdjFfMC01NzBiOWY2Mi01NWUwLTQ3ZTMtODMz
+        MC1jZjNiZWQ4ZWJmNDciLCAiMS1jdl8yX2RlbGV0ZS12MV8wLTU3MGI5ZjYy
+        LTU1ZTAtNDdlMy04MzMwLWNmM2JlZDhlYmY0NyJdLCAic291cmNlcnBtIjog
+        ImNoZWV0YWgtMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAiY2hlZXRhaCIs
+        ICJjaGVja3N1bSI6ICI0MjJkMGJhYTBjZDlkNzcxM2FlNzk2ZTg4NmEyM2Ux
+        N2Y1NzhmOTI0Zjc0ODgwZGViZGJiN2Q2NWZiMzY4ZGFlIiwgInN1bW1hcnki
+        OiAiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCAiZmlsZW5hbWUiOiAi
+        Y2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2
+        ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiOTVm
+        NDNkOWItZmNlMy00YmJiLTljMGYtYTM0MmE3YjM5NmY3IiwgImFyY2giOiAi
+        bm9hcmNoIiwgImNoaWxkcmVuIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkv
+        djIvY29udGVudC91bml0cy9ycG0vOTVmNDNkOWItZmNlMy00YmJiLTljMGYt
+        YTM0MmE3YjM5NmY3LyJ9LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBb
+        IjEtY3ZfbGF0ZXN0X3RvX2RlbC12MV8wLTVjZmNjYWE0LTRiNDMtNDA4Yi04
+        NDYwLTQ2N2E1ZmNkY2FiNyIsICIxLWN2LXYxXzAtNWNmY2NhYTQtNGI0My00
+        MDhiLTg0NjAtNDY3YTVmY2RjYWI3IiwgIjU3MGI5ZjYyLTU1ZTAtNDdlMy04
+        MzMwLWNmM2JlZDhlYmY0NyIsICIxLWN2XzJfZGVsZXRlLXYxXzAtNWNmY2Nh
+        YTQtNGI0My00MDhiLTg0NjAtNDY3YTVmY2RjYWI3IiwgIjEtY3ZfdG9fZGVs
+        XzEtdjFfMC01Y2ZjY2FhNC00YjQzLTQwOGItODQ2MC00NjdhNWZjZGNhYjci
+        LCAiMS1jdl90b19kZWwtdjJfMC01Y2ZjY2FhNC00YjQzLTQwOGItODQ2MC00
+        NjdhNWZjZGNhYjciLCAiMS1jdl90b19kZWwtdjFfMC01NzBiOWY2Mi01NWUw
+        LTQ3ZTMtODMzMC1jZjNiZWQ4ZWJmNDciLCAiMS1jdl90b19kZWwtdjFfMC01
+        Y2ZjY2FhNC00YjQzLTQwOGItODQ2MC00NjdhNWZjZGNhYjciLCAiMS1jdi12
+        Ml8wLTVjZmNjYWE0LTRiNDMtNDA4Yi04NDYwLTQ2N2E1ZmNkY2FiNyIsICIz
+        MTJkOTBjZi0yYTBiLTRjNjEtYjU4MC1iMDBjZjRiNmY1MWUiLCAiMS1kZXYt
+        djFfMC1mNDU4NDljYy05ZjY1LTQxMjMtYjE4MS1iZWUwMTA3MjQwZjgiLCAi
+        MS1jdi12Ml8wLTU3MGI5ZjYyLTU1ZTAtNDdlMy04MzMwLWNmM2JlZDhlYmY0
+        NyIsICIxLWN2X3RvX2RlbF8xLXYyXzAtNTcwYjlmNjItNTVlMC00N2UzLTgz
+        MzAtY2YzYmVkOGViZjQ3IiwgInNjZW5hcmlvX3Rlc3QiLCAiMS1jdl90b19k
+        ZWwtdjJfMC01NzBiOWY2Mi01NWUwLTQ3ZTMtODMzMC1jZjNiZWQ4ZWJmNDci
+        LCAiMS1kZXYtdjFfMC02MDU1MDFlZC05ODNjLTQ1MzItYjI2Yy03ZGZjNGEw
+        MjNjYWQiLCAiMWVjMjZmNmMtNGM1Yi00NTVjLWJhNGYtNDBmMjIyNDAyZmY2
+        IiwgIjYwNTUwMWVkLTk4M2MtNDUzMi1iMjZjLTdkZmM0YTAyM2NhZCIsICIx
+        LWN2X3RvX2RlbF8xLXYyXzAtNWNmY2NhYTQtNGI0My00MDhiLTg0NjAtNDY3
+        YTVmY2RjYWI3IiwgIjVjZmNjYWE0LTRiNDMtNDA4Yi04NDYwLTQ2N2E1ZmNk
+        Y2FiNyIsICIxLWN2LXYxXzAtNTcwYjlmNjItNTVlMC00N2UzLTgzMzAtY2Yz
+        YmVkOGViZjQ3IiwgImY0NTg0OWNjLTlmNjUtNDEyMy1iMTgxLWJlZTAxMDcy
+        NDBmOCIsICJhZWQyZDJhOS00ZDcxLTQwMjctYjg3Zi1mNmU0YmE3Zjk5MWMi
+        LCAiMS1jdl90b19kZWxfMS12MV8wLTU3MGI5ZjYyLTU1ZTAtNDdlMy04MzMw
+        LWNmM2JlZDhlYmY0NyIsICJkZjdjZjM2MS01ZTA0LTRhZDQtYWE4Ni1hNzE1
+        MzcyMjNhNzgiLCAiMS1jdl9sYXRlc3RfdG9fZGVsLXYxXzAtNTcwYjlmNjIt
+        NTVlMC00N2UzLTgzMzAtY2YzYmVkOGViZjQ3IiwgIjEtY3ZfMl9kZWxldGUt
+        djFfMC01NzBiOWY2Mi01NWUwLTQ3ZTMtODMzMC1jZjNiZWQ4ZWJmNDciXSwg
+        InNvdXJjZXJwbSI6ICJzcXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCAibmFt
+        ZSI6ICJzcXVpcnJlbCIsICJjaGVja3N1bSI6ICIyNTE3NjhiZGQxNWYxM2Q3
+        ODQ4N2MyNzYzOGFhNmFlY2QwMTU1MWUyNTM3NTYwOTNjZGUxYzBhZTg3OGEx
+        N2QyIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHNxdWlycmVs
+        IiwgImZpbGVuYW1lIjogInNxdWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIs
+        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAi
+        MC44IiwgIl9pZCI6ICJiYWFjYTVlMC01MDdmLTRjMmQtOGUwYi1iZTA3MDhm
+        ODkyYjAiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9o
+        cmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9iYWFjYTVl
+        MC01MDdmLTRjMmQtOGUwYi1iZTA3MDhmODkyYjAvIn0sIHsicmVwb3NpdG9y
+        eV9tZW1iZXJzaGlwcyI6IFsiMS1jdl9sYXRlc3RfdG9fZGVsLXYxXzAtNWNm
+        Y2NhYTQtNGI0My00MDhiLTg0NjAtNDY3YTVmY2RjYWI3IiwgIjEtY3YtdjFf
+        MC01Y2ZjY2FhNC00YjQzLTQwOGItODQ2MC00NjdhNWZjZGNhYjciLCAiNTcw
+        YjlmNjItNTVlMC00N2UzLTgzMzAtY2YzYmVkOGViZjQ3IiwgIjEtY3ZfMl9k
+        ZWxldGUtdjFfMC01Y2ZjY2FhNC00YjQzLTQwOGItODQ2MC00NjdhNWZjZGNh
+        YjciLCAiMS1jdl90b19kZWxfMS12MV8wLTVjZmNjYWE0LTRiNDMtNDA4Yi04
+        NDYwLTQ2N2E1ZmNkY2FiNyIsICIxLWN2X3RvX2RlbC12Ml8wLTVjZmNjYWE0
+        LTRiNDMtNDA4Yi04NDYwLTQ2N2E1ZmNkY2FiNyIsICIxLWN2X3RvX2RlbC12
+        MV8wLTU3MGI5ZjYyLTU1ZTAtNDdlMy04MzMwLWNmM2JlZDhlYmY0NyIsICIx
+        LWN2X3RvX2RlbC12MV8wLTVjZmNjYWE0LTRiNDMtNDA4Yi04NDYwLTQ2N2E1
+        ZmNkY2FiNyIsICIxLWN2LXYyXzAtNWNmY2NhYTQtNGI0My00MDhiLTg0NjAt
+        NDY3YTVmY2RjYWI3IiwgIjMxMmQ5MGNmLTJhMGItNGM2MS1iNTgwLWIwMGNm
+        NGI2ZjUxZSIsICIxLWRldi12MV8wLWY0NTg0OWNjLTlmNjUtNDEyMy1iMTgx
+        LWJlZTAxMDcyNDBmOCIsICIxLWN2LXYyXzAtNTcwYjlmNjItNTVlMC00N2Uz
+        LTgzMzAtY2YzYmVkOGViZjQ3IiwgIjEtY3ZfdG9fZGVsXzEtdjJfMC01NzBi
+        OWY2Mi01NWUwLTQ3ZTMtODMzMC1jZjNiZWQ4ZWJmNDciLCAic2NlbmFyaW9f
+        dGVzdCIsICIxLWN2X3RvX2RlbC12Ml8wLTU3MGI5ZjYyLTU1ZTAtNDdlMy04
+        MzMwLWNmM2JlZDhlYmY0NyIsICIxLWRldi12MV8wLTYwNTUwMWVkLTk4M2Mt
+        NDUzMi1iMjZjLTdkZmM0YTAyM2NhZCIsICIxZWMyNmY2Yy00YzViLTQ1NWMt
+        YmE0Zi00MGYyMjI0MDJmZjYiLCAiNjA1NTAxZWQtOTgzYy00NTMyLWIyNmMt
+        N2RmYzRhMDIzY2FkIiwgIjEtY3ZfdG9fZGVsXzEtdjJfMC01Y2ZjY2FhNC00
+        YjQzLTQwOGItODQ2MC00NjdhNWZjZGNhYjciLCAiNWNmY2NhYTQtNGI0My00
+        MDhiLTg0NjAtNDY3YTVmY2RjYWI3IiwgIjEtY3YtdjFfMC01NzBiOWY2Mi01
+        NWUwLTQ3ZTMtODMzMC1jZjNiZWQ4ZWJmNDciLCAiZjQ1ODQ5Y2MtOWY2NS00
+        MTIzLWIxODEtYmVlMDEwNzI0MGY4IiwgImFlZDJkMmE5LTRkNzEtNDAyNy1i
+        ODdmLWY2ZTRiYTdmOTkxYyIsICIxLWN2X3RvX2RlbF8xLXYxXzAtNTcwYjlm
+        NjItNTVlMC00N2UzLTgzMzAtY2YzYmVkOGViZjQ3IiwgImRmN2NmMzYxLTVl
+        MDQtNGFkNC1hYTg2LWE3MTUzNzIyM2E3OCIsICIxLWN2X2xhdGVzdF90b19k
+        ZWwtdjFfMC01NzBiOWY2Mi01NWUwLTQ3ZTMtODMzMC1jZjNiZWQ4ZWJmNDci
+        LCAiMS1jdl8yX2RlbGV0ZS12MV8wLTU3MGI5ZjYyLTU1ZTAtNDdlMy04MzMw
+        LWNmM2JlZDhlYmY0NyJdLCAic291cmNlcnBtIjogInBlbmd1aW4tMC4zLTAu
+        OC5zcmMucnBtIiwgIm5hbWUiOiAicGVuZ3VpbiIsICJjaGVja3N1bSI6ICIz
+        ZmNiMmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRm
+        YzIxMGZkNmU0ODYzNWJlNjk0IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNr
+        YWdlIG9mIHBlbmd1aW4iLCAiZmlsZW5hbWUiOiAicGVuZ3Vpbi0wLjMtMC44
+        Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIs
+        ICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiZmE3ZWE5YzMtNjUwMS00MmI0
+        LWE3MmEtZDgyZjczNTgyMzZhIiwgImFyY2giOiAibm9hcmNoIiwgImNoaWxk
+        cmVuIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0
+        cy9ycG0vZmE3ZWE5YzMtNjUwMS00MmI0LWE3MmEtZDgyZjczNTgyMzZhLyJ9
+        LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbIjEtY3ZfbGF0ZXN0X3Rv
+        X2RlbC12MV8wLTVjZmNjYWE0LTRiNDMtNDA4Yi04NDYwLTQ2N2E1ZmNkY2Fi
+        NyIsICIxLWN2LXYxXzAtNWNmY2NhYTQtNGI0My00MDhiLTg0NjAtNDY3YTVm
+        Y2RjYWI3IiwgIjU3MGI5ZjYyLTU1ZTAtNDdlMy04MzMwLWNmM2JlZDhlYmY0
+        NyIsICIxLWN2XzJfZGVsZXRlLXYxXzAtNWNmY2NhYTQtNGI0My00MDhiLTg0
+        NjAtNDY3YTVmY2RjYWI3IiwgIjEtY3ZfdG9fZGVsXzEtdjFfMC01Y2ZjY2Fh
+        NC00YjQzLTQwOGItODQ2MC00NjdhNWZjZGNhYjciLCAiMS1jdl90b19kZWwt
+        djJfMC01Y2ZjY2FhNC00YjQzLTQwOGItODQ2MC00NjdhNWZjZGNhYjciLCAi
+        MS1jdl90b19kZWwtdjFfMC01NzBiOWY2Mi01NWUwLTQ3ZTMtODMzMC1jZjNi
+        ZWQ4ZWJmNDciLCAiMS1jdl90b19kZWwtdjFfMC01Y2ZjY2FhNC00YjQzLTQw
+        OGItODQ2MC00NjdhNWZjZGNhYjciLCAiMS1jdi12Ml8wLTVjZmNjYWE0LTRi
+        NDMtNDA4Yi04NDYwLTQ2N2E1ZmNkY2FiNyIsICIzMTJkOTBjZi0yYTBiLTRj
+        NjEtYjU4MC1iMDBjZjRiNmY1MWUiLCAiMS1kZXYtdjFfMC1mNDU4NDljYy05
+        ZjY1LTQxMjMtYjE4MS1iZWUwMTA3MjQwZjgiLCAiMS1jdi12Ml8wLTU3MGI5
+        ZjYyLTU1ZTAtNDdlMy04MzMwLWNmM2JlZDhlYmY0NyIsICIxLWN2X3RvX2Rl
+        bF8xLXYyXzAtNTcwYjlmNjItNTVlMC00N2UzLTgzMzAtY2YzYmVkOGViZjQ3
+        IiwgInNjZW5hcmlvX3Rlc3QiLCAiMS1jdl90b19kZWwtdjJfMC01NzBiOWY2
+        Mi01NWUwLTQ3ZTMtODMzMC1jZjNiZWQ4ZWJmNDciLCAiMS1kZXYtdjFfMC02
+        MDU1MDFlZC05ODNjLTQ1MzItYjI2Yy03ZGZjNGEwMjNjYWQiLCAiMWVjMjZm
+        NmMtNGM1Yi00NTVjLWJhNGYtNDBmMjIyNDAyZmY2IiwgIjYwNTUwMWVkLTk4
+        M2MtNDUzMi1iMjZjLTdkZmM0YTAyM2NhZCIsICIxLWN2X3RvX2RlbF8xLXYy
+        XzAtNWNmY2NhYTQtNGI0My00MDhiLTg0NjAtNDY3YTVmY2RjYWI3IiwgIjVj
+        ZmNjYWE0LTRiNDMtNDA4Yi04NDYwLTQ2N2E1ZmNkY2FiNyIsICIxLWN2LXYx
+        XzAtNTcwYjlmNjItNTVlMC00N2UzLTgzMzAtY2YzYmVkOGViZjQ3IiwgImY0
+        NTg0OWNjLTlmNjUtNDEyMy1iMTgxLWJlZTAxMDcyNDBmOCIsICJhZWQyZDJh
+        OS00ZDcxLTQwMjctYjg3Zi1mNmU0YmE3Zjk5MWMiLCAiMS1jdl90b19kZWxf
+        MS12MV8wLTU3MGI5ZjYyLTU1ZTAtNDdlMy04MzMwLWNmM2JlZDhlYmY0NyIs
+        ICJkZjdjZjM2MS01ZTA0LTRhZDQtYWE4Ni1hNzE1MzcyMjNhNzgiLCAiMS1j
+        dl9sYXRlc3RfdG9fZGVsLXYxXzAtNTcwYjlmNjItNTVlMC00N2UzLTgzMzAt
+        Y2YzYmVkOGViZjQ3IiwgIjEtY3ZfMl9kZWxldGUtdjFfMC01NzBiOWY2Mi01
+        NWUwLTQ3ZTMtODMzMC1jZjNiZWQ4ZWJmNDciXSwgInNvdXJjZXJwbSI6ICJs
+        aW9uLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogImxpb24iLCAiY2hlY2tz
+        dW0iOiAiMTI0MDBkYzk1YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5
+        ODE1ODU0MzdhYjY0Y2Q2MmVmYTNlNGFlNCIsICJzdW1tYXJ5IjogIkEgZHVt
+        bXkgcGFja2FnZSBvZiBsaW9uIiwgImZpbGVuYW1lIjogImxpb24tMC4zLTAu
         OC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMi
-        LCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjkzMzc3MzgxLTcyMTgtNDky
-        Yy04M2ZlLTI0ZjZmMWM5MjEzOCIsICJhcmNoIjogIm5vYXJjaCIsICJjaGls
+        LCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogImZlOTRmYTE2LTNjYWMtNDZh
+        Yy1iNzJlLTlmOGM5YTBhMjE4OSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGls
         ZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5p
-        dHMvcnBtLzkzMzc3MzgxLTcyMTgtNDkyYy04M2ZlLTI0ZjZmMWM5MjEzOC8i
-        fSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJzY2VuYXJpb190ZXN0
-        Il0sICJzb3VyY2VycG0iOiAid2FscnVzLTAuMy0wLjguc3JjLnJwbSIsICJu
-        YW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6ICI2ZThkNmRjMDU3ZTNlMmM5
-        ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYx
-        ZGZkIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHdhbHJ1cyIs
-        ICJmaWxlbmFtZSI6ICJ3YWxydXMtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVw
-        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgi
-        LCAiX2lkIjogImRiYTk2OWRkLTIyNTAtNDM2Mi1hMzU1LTBiZDFhM2JkNGE4
-        MSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYi
-        OiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtL2RiYTk2OWRkLTIy
-        NTAtNDM2Mi1hMzU1LTBiZDFhM2JkNGE4MS8ifSwgeyJyZXBvc2l0b3J5X21l
-        bWJlcnNoaXBzIjogWyJzY2VuYXJpb190ZXN0Il0sICJzb3VyY2VycG0iOiAi
-        bW9ua2V5LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogIm1vbmtleSIsICJj
-        aGVja3N1bSI6ICIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1ZDM5
-        YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwgInN1bW1hcnkiOiAi
-        QSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIsICJmaWxlbmFtZSI6ICJtb25r
-        ZXktMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lv
-        biI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogImZmOWE5ZDll
-        LWI0YWYtNDI2NC1iOGFhLThiMWE1YjQ2NWNiNSIsICJhcmNoIjogIm5vYXJj
-        aCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2Nv
-        bnRlbnQvdW5pdHMvcnBtL2ZmOWE5ZDllLWI0YWYtNDI2NC1iOGFhLThiMWE1
-        YjQ2NWNiNS8ifV0=
+        dHMvcnBtL2ZlOTRmYTE2LTNjYWMtNDZhYy1iNzJlLTlmOGM5YTBhMjE4OS8i
+        fV0=
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:49 GMT
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2257,7 +10321,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2268,13 +10332,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:49 GMT
+      - Mon, 03 Dec 2018 05:39:17 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '2'
-      Connection:
-      - close
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2283,10 +10345,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:49 GMT
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2298,7 +10360,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2309,13 +10371,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:49 GMT
+      - Mon, 03 Dec 2018 05:39:17 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '2'
-      Connection:
-      - close
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2324,10 +10384,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:49 GMT
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2339,7 +10399,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2350,47 +10410,45 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:49 GMT
+      - Mon, 03 Dec 2018 05:39:17 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
       - '651'
-      Connection:
-      - close
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIzYTJlNjQ3NC0zMmY4LTRiODYtYTAy
-        My04MTZiNzgzZjU0ZjIiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
-        In0sICJfaWQiOiB7IiRvaWQiOiAiNWJjZTA0MjAyZmExODNmMWMwZDBlYTVi
-        In0sICJ1bml0X2lkIjogIjNhMmU2NDc0LTMyZjgtNGI4Ni1hMDIzLTgxNmI3
-        ODNmNTRmMiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
-        YXRhIjogeyJfaWQiOiAiODk1M2E3OGEtYTNhNi00NGZlLTgxZWUtZjIwMjY4
-        ZmM2ZGEzIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
-        IjogeyIkb2lkIjogIjViY2UwNDIwMmZhMTgzZjFjMGQwZWE1OSJ9LCAidW5p
-        dF9pZCI6ICI4OTUzYTc4YS1hM2E2LTQ0ZmUtODFlZS1mMjAyNjhmYzZkYTMi
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI5YzIwODljZS0yNTE4LTRmN2YtYmU3
+        Mi02ZDE4ZGY5ZTk1NDgiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
+        In0sICJfaWQiOiB7IiRvaWQiOiAiNWMwNGMxODU0OThlZGI4MjU1YmI0NjRm
+        In0sICJ1bml0X2lkIjogIjljMjA4OWNlLTI1MTgtNGY3Zi1iZTcyLTZkMThk
+        ZjllOTU0OCIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
+        YXRhIjogeyJfaWQiOiAiY2ZiYzBmZWYtMjBlZi00ZGU3LWE0ZTktOWZhN2Nm
+        MGRiMjVlIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
+        IjogeyIkb2lkIjogIjVjMDRjMTg1NDk4ZWRiODI1NWJiNDYzNSJ9LCAidW5p
+        dF9pZCI6ICJjZmJjMGZlZi0yMGVmLTRkZTctYTRlOS05ZmE3Y2YwZGIyNWUi
         LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogImU0ZjU4ODNiLTg3ZDUtNGUwMC1hNmExLTg0NTA1MjcxNDI2NSIs
+        X2lkIjogImU2MWM3ZWY4LTJmZGYtNDkyMS05NzZkLTc4ZWEyMzA3NGMzNyIs
         ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0ifSwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1YmNlMDQyMDJmYTE4M2YxYzBkMGVhNWEifSwgInVuaXRfaWQiOiAi
-        ZTRmNTg4M2ItODdkNS00ZTAwLWE2YTEtODQ1MDUyNzE0MjY1IiwgInVuaXRf
+        ZCI6ICI1YzA0YzE4NTQ5OGVkYjgyNTViYjQ2MWIifSwgInVuaXRfaWQiOiAi
+        ZTYxYzdlZjgtMmZkZi00OTIxLTk3NmQtNzhlYTIzMDc0YzM3IiwgInVuaXRf
         dHlwZV9pZCI6ICJlcnJhdHVtIn1d
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:49 GMT
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/content/units/erratum/search/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/content/units/erratum/search/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjcml0ZXJpYSI6eyJsaW1pdCI6Mywic2tpcCI6MCwiZmlsdGVycyI6eyJf
-        aWQiOnsiJGluIjpbIjNhMmU2NDc0LTMyZjgtNGI4Ni1hMDIzLTgxNmI3ODNm
-        NTRmMiIsIjg5NTNhNzhhLWEzYTYtNDRmZS04MWVlLWYyMDI2OGZjNmRhMyIs
-        ImU0ZjU4ODNiLTg3ZDUtNGUwMC1hNmExLTg0NTA1MjcxNDI2NSJdfX19LCJp
+        aWQiOnsiJGluIjpbIjljMjA4OWNlLTI1MTgtNGY3Zi1iZTcyLTZkMThkZjll
+        OTU0OCIsImNmYmMwZmVmLTIwZWYtNGRlNy1hNGU5LTlmYTdjZjBkYjI1ZSIs
+        ImU2MWM3ZWY4LTJmZGYtNDkyMS05NzZkLTc4ZWEyMzA3NGMzNyJdfX19LCJp
         bmNsdWRlX3JlcG9zIjp0cnVlfQ==
     headers:
       Accept:
@@ -2398,7 +10456,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2409,135 +10467,166 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:49 GMT
+      - Mon, 03 Dec 2018 05:39:17 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '4908'
-      Connection:
-      - close
+      - '6429'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVzdCJd
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvZXJyYXR1
-        bS8zYTJlNjQ3NC0zMmY4LTRiODYtYTAyMy04MTZiNzgzZjU0ZjIvIiwgImlz
-        c3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAxIiwgInJlbG9naW5fc3VnZ2Vz
-        dGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjogW10sICJwdWxwX3VzZXJfbWV0
-        YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJp
-        ZCI6ICJSSEVBLTIwMTA6MDAwMiIsICJmcm9tIjogImx6YXArcHViQHJlZGhh
-        dC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIk9uZSBwYWNrYWdl
-        IGVycmF0YSIsICJjaGlsZHJlbiI6IHt9LCAidmVyc2lvbiI6ICIxIiwgInJl
-        Ym9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAi
-        cGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogImh0dHA6Ly93d3cu
-        ZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJlbGVwaGFudCIsICJzdW0i
-        OiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gu
-        cnBtIiwgImVwb2NoIjogbnVsbCwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVh
-        c2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJjb2xs
-        ZWN0aW9uLTAiLCAic2hvcnQiOiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIs
-        ICJ1cGRhdGVkIjogIiIsICJkZXNjcmlwdGlvbiI6ICJPbmUgcGFja2FnZSBl
-        cnJhdGEiLCAiX2xhc3RfdXBkYXRlZCI6ICIyMDE4LTEwLTIyVDE3OjA4OjQ4
-        WiIsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50Ijog
-        IiIsICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5Ijog
-        IiIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjNhMmU2NDc0LTMyZjgtNGI4
-        Ni1hMDIzLTgxNmI3ODNmNTRmMiJ9LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hp
-        cHMiOiBbInNjZW5hcmlvX3Rlc3QiXSwgIl9ocmVmIjogIi9wdWxwL2FwaS92
-        Mi9jb250ZW50L3VuaXRzL2VycmF0dW0vODk1M2E3OGEtYTNhNi00NGZlLTgx
-        ZWUtZjIwMjY4ZmM2ZGEzLyIsICJpc3N1ZWQiOiAiMjAxMC0wMS0wMSAwMTow
-        MTowMSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVmZXJlbmNl
-        cyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90
-        eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiUkhFQS0yMDEwOjAwMDEiLCAi
-        ZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIs
-        ICJ0aXRsZSI6ICJFbXB0eSBlcnJhdGEiLCAiY2hpbGRyZW4iOiB7fSwgInZl
-        cnNpb24iOiAiMSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBl
-        IjogInNlY3VyaXR5IiwgInBrZ2xpc3QiOiBbXSwgInN0YXR1cyI6ICJzdGFi
-        bGUiLCAidXBkYXRlZCI6ICIiLCAiZGVzY3JpcHRpb24iOiAiRW1wdHkgZXJy
-        YXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAiMjAxOC0xMC0yMlQxNzowODo0OFoi
-        LCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6ICIi
-        LCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIi
-        LCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI4OTUzYTc4YS1hM2E2LTQ0ZmUt
-        ODFlZS1mMjAyNjhmYzZkYTMifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBz
-        IjogWyJzY2VuYXJpb190ZXN0Il0sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIv
-        Y29udGVudC91bml0cy9lcnJhdHVtL2U0ZjU4ODNiLTg3ZDUtNGUwMC1hNmEx
-        LTg0NTA1MjcxNDI2NS8iLCAiaXNzdWVkIjogIjIwMTAtMTEtMTAgMDA6MDA6
-        MDAiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMi
-        OiBbeyJocmVmIjogImh0dHBzOi8vcmhuLnJlZGhhdC5jb20vZXJyYXRhL1JI
-        U0EtMjAxMC0wODU4Lmh0bWwiLCAidHlwZSI6ICJzZWxmIiwgImlkIjogbnVs
-        bCwgInRpdGxlIjogIlJIU0EtMjAxMDowODU4In0sIHsiaHJlZiI6ICJodHRw
-        czovL2J1Z3ppbGxhLnJlZGhhdC5jb20vYnVnemlsbGEvc2hvd19idWcuY2dp
-        P2lkPTYyNzg4MiIsICJ0eXBlIjogImJ1Z3ppbGxhIiwgImlkIjogIjYyNzg4
-        MiIsICJ0aXRsZSI6ICJDVkUtMjAxMC0wNDA1IGJ6aXAyOiBpbnRlZ2VyIG92
-        ZXJmbG93IGZsYXcgaW4gQloyX2RlY29tcHJlc3MifSwgeyJocmVmIjogImh0
-        dHBzOi8vd3d3LnJlZGhhdC5jb20vc2VjdXJpdHkvZGF0YS9jdmUvQ1ZFLTIw
-        MTAtMDQwNS5odG1sIiwgInR5cGUiOiAiY3ZlIiwgImlkIjogIkNWRS0yMDEw
-        LTA0MDUiLCAidGl0bGUiOiAiQ1ZFLTIwMTAtMDQwNSJ9LCB7ImhyZWYiOiAi
-        aHR0cDovL3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5L3VwZGF0ZXMvY2xhc3Np
-        ZmljYXRpb24vI2ltcG9ydGFudCIsICJ0eXBlIjogIm90aGVyIiwgImlkIjog
-        bnVsbCwgInRpdGxlIjogbnVsbH1dLCAicHVscF91c2VyX21ldGFkYXRhIjog
-        e30sICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiUkhT
-        QS0yMDEwOjA4NTgiLCAiZnJvbSI6ICJzZWN1cml0eUByZWRoYXQuY29tIiwg
-        InNldmVyaXR5IjogIkltcG9ydGFudCIsICJ0aXRsZSI6ICJJbXBvcnRhbnQ6
-        IGJ6aXAyIHNlY3VyaXR5IHVwZGF0ZSIsICJjaGlsZHJlbiI6IHt9LCAidmVy
-        c2lvbiI6ICIzIiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUi
-        OiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3Jj
-        IjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6
-        aXAyLWRldmVsIiwgInN1bSI6IFsic2hhMjU2IiwgImVhNjdjNjY0ZGExZmY5
-        NmE2ZGM5NGQzMzAwOWI3M2Q4ZmFiMzFiNTk4MjQxODNmYjQ1ZTliYTJlYmY4
-        MmQ1ODMiXSwgImZpbGVuYW1lIjogImJ6aXAyLWRldmVsLTEuMC41LTcuZWw2
-        XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41
-        IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogImk2ODYifSwgeyJz
-        cmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAi
-        YnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1NiIsICJjOWYwNjRhNjg2MjU3
-        M2ZiOWYyYTZhZmY3YzM2MjFmMTk0MGI0OTJkZjJlZGZjMmViYmRjMGI4MzA1
-        ZjUxMTQ3Il0sICJmaWxlbmFtZSI6ICJiemlwMi1saWJzLTEuMC41LTcuZWw2
-        XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41
-        IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogImk2ODYifSwgeyJz
-        cmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAi
-        YnppcDIiLCAic3VtIjogWyJzaGEyNTYiLCAiYjhhM2Y3MmJjMmIwZDg5YmE3
-        MzcwOTlhYzk4YmY4ZDJhZjRiZWEwMmQzMTg4NGMwMmRiOTdmN2Y2NmMzZDVj
-        MiJdLCAiZmlsZW5hbWUiOiAiYnppcDItMS4wLjUtNy5lbDZfMC54ODZfNjQu
-        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxl
-        YXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJzcmMiOiAi
-        YnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDIt
-        ZGV2ZWwiLCAic3VtIjogWyJzaGEyNTYiLCAiN2Y2MzEyNGU0NjU1YjdjOTJk
-        MjNlYzRjMzgyMjZmNWQzNzQ2NTY4ODUzZGZmNzUwZmM4NWUwNThlNzRiNWNm
-        NiJdLCAiZmlsZW5hbWUiOiAiYnppcDItZGV2ZWwtMS4wLjUtNy5lbDZfMC54
-        ODZfNjQucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIs
-        ICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJz
-        cmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAi
-        YnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1NiIsICI4MDJmNDM5OWRiZGQw
-        MTQ3NmUyNTRjM2IzMmM0MGFmZjU5Y2Y1ZDIzYTQ1ZmE0ODhjNjkxN2NlODkw
-        NGQ2YjRkIl0sICJmaWxlbmFtZSI6ICJiemlwMi1saWJzLTEuMC41LTcuZWw2
-        XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4w
-        LjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAieDg2XzY0In1d
-        LCAibmFtZSI6ICJjb2xsZWN0aW9uLTAiLCAic2hvcnQiOiAiIn1dLCAic3Rh
-        dHVzIjogImZpbmFsIiwgInVwZGF0ZWQiOiAiMjAxMC0xMS0xMCAwMDowMDow
-        MCIsICJkZXNjcmlwdGlvbiI6ICJiemlwMiBpcyBhIGZyZWVseSBhdmFpbGFi
-        bGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNvbXByZXNzb3IuIEl0IHByb3ZpZGVz
-        IGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11c3QgYmUgcmVzdGFydGVkIGZvciB0
-        aGUgdXBkYXRlIHRvIHRha2UgZWZmZWN0LiIsICJfbGFzdF91cGRhdGVkIjog
-        IjIwMTgtMTAtMjJUMTc6MDg6NDhaIiwgInJlc3RhcnRfc3VnZ2VzdGVkIjog
-        ZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICJDb3B5cmlnaHQg
-        MjAxMCBSZWQgSGF0IEluYyIsICJzb2x1dGlvbiI6ICJCZWZvcmUgYXBwbHlp
-        bmcgdGhpcyB1cGRhdGUsIG1ha2Ugc3VyZSBhbGwgcHJldmlvdXNseS1yZWxl
-        YXNlZCBlcnJhdGFcbnJlbGV2YW50IHRvIHlvdXIgc3lzdGVtIGhhdmUgYmVl
-        biBhcHBsaWVkLlxuXG5UaGlzIHVwZGF0ZSBpcyBhdmFpbGFibGUgdmlhIHRo
-        ZSBSZWQgSGF0IE5ldHdvcmsuIERldGFpbHMgb24gaG93IHRvXG51c2UgdGhl
-        IFJlZCBIYXQgTmV0d29yayB0byBhcHBseSB0aGlzIHVwZGF0ZSBhcmUgYXZh
-        aWxhYmxlIGF0XG5odHRwOi8va2Jhc2UucmVkaGF0LmNvbS9mYXEvZG9jcy9E
-        T0MtMTEyNTkiLCAic3VtbWFyeSI6ICJVcGRhdGVkIGJ6aXAyIHBhY2thZ2Vz
-        IHRoYXQgZml4IG9uZSBzZWN1cml0eSBpc3N1ZSIsICJyZWxlYXNlIjogIiIs
-        ICJfaWQiOiAiZTRmNTg4M2ItODdkNS00ZTAwLWE2YTEtODQ1MDUyNzE0MjY1
-        In1d
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiMS1jdl9sYXRlc3RfdG9f
+        ZGVsLXYxXzAtNWNmY2NhYTQtNGI0My00MDhiLTg0NjAtNDY3YTVmY2RjYWI3
+        IiwgIjEtY3YtdjFfMC01Y2ZjY2FhNC00YjQzLTQwOGItODQ2MC00NjdhNWZj
+        ZGNhYjciLCAiNTcwYjlmNjItNTVlMC00N2UzLTgzMzAtY2YzYmVkOGViZjQ3
+        IiwgIjEtY3ZfMl9kZWxldGUtdjFfMC01Y2ZjY2FhNC00YjQzLTQwOGItODQ2
+        MC00NjdhNWZjZGNhYjciLCAiMS1jdl90b19kZWxfMS12MV8wLTVjZmNjYWE0
+        LTRiNDMtNDA4Yi04NDYwLTQ2N2E1ZmNkY2FiNyIsICIxLWN2X3RvX2RlbC12
+        Ml8wLTVjZmNjYWE0LTRiNDMtNDA4Yi04NDYwLTQ2N2E1ZmNkY2FiNyIsICIx
+        LWN2X3RvX2RlbC12MV8wLTU3MGI5ZjYyLTU1ZTAtNDdlMy04MzMwLWNmM2Jl
+        ZDhlYmY0NyIsICIxLWN2X3RvX2RlbC12MV8wLTVjZmNjYWE0LTRiNDMtNDA4
+        Yi04NDYwLTQ2N2E1ZmNkY2FiNyIsICIxLWN2LXYyXzAtNWNmY2NhYTQtNGI0
+        My00MDhiLTg0NjAtNDY3YTVmY2RjYWI3IiwgIjMxMmQ5MGNmLTJhMGItNGM2
+        MS1iNTgwLWIwMGNmNGI2ZjUxZSIsICIxLWRldi12MV8wLWY0NTg0OWNjLTlm
+        NjUtNDEyMy1iMTgxLWJlZTAxMDcyNDBmOCIsICIxLWN2LXYyXzAtNTcwYjlm
+        NjItNTVlMC00N2UzLTgzMzAtY2YzYmVkOGViZjQ3IiwgIjEtY3ZfdG9fZGVs
+        XzEtdjJfMC01NzBiOWY2Mi01NWUwLTQ3ZTMtODMzMC1jZjNiZWQ4ZWJmNDci
+        LCAic2NlbmFyaW9fdGVzdCIsICIxLWN2X3RvX2RlbC12Ml8wLTU3MGI5ZjYy
+        LTU1ZTAtNDdlMy04MzMwLWNmM2JlZDhlYmY0NyIsICIxZWMyNmY2Yy00YzVi
+        LTQ1NWMtYmE0Zi00MGYyMjI0MDJmZjYiLCAiMS1jdl90b19kZWxfMS12Ml8w
+        LTVjZmNjYWE0LTRiNDMtNDA4Yi04NDYwLTQ2N2E1ZmNkY2FiNyIsICI1Y2Zj
+        Y2FhNC00YjQzLTQwOGItODQ2MC00NjdhNWZjZGNhYjciLCAiMS1jdi12MV8w
+        LTU3MGI5ZjYyLTU1ZTAtNDdlMy04MzMwLWNmM2JlZDhlYmY0NyIsICJmNDU4
+        NDljYy05ZjY1LTQxMjMtYjE4MS1iZWUwMTA3MjQwZjgiLCAiYWVkMmQyYTkt
+        NGQ3MS00MDI3LWI4N2YtZjZlNGJhN2Y5OTFjIiwgIjEtY3ZfdG9fZGVsXzEt
+        djFfMC01NzBiOWY2Mi01NWUwLTQ3ZTMtODMzMC1jZjNiZWQ4ZWJmNDciLCAi
+        ZGY3Y2YzNjEtNWUwNC00YWQ0LWFhODYtYTcxNTM3MjIzYTc4IiwgIjEtY3Zf
+        bGF0ZXN0X3RvX2RlbC12MV8wLTU3MGI5ZjYyLTU1ZTAtNDdlMy04MzMwLWNm
+        M2JlZDhlYmY0NyIsICIxLWN2XzJfZGVsZXRlLXYxXzAtNTcwYjlmNjItNTVl
+        MC00N2UzLTgzMzAtY2YzYmVkOGViZjQ3Il0sICJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvY29udGVudC91bml0cy9lcnJhdHVtLzljMjA4OWNlLTI1MTgtNGY3
+        Zi1iZTcyLTZkMThkZjllOTU0OC8iLCAiaXNzdWVkIjogIjIwMTAtMDEtMDEg
+        MDE6MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVy
+        ZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRl
+        bnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIlJIRUEtMjAxMDowMDAy
+        IiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6
+        ICIiLCAidGl0bGUiOiAiT25lIHBhY2thZ2UgZXJyYXRhIiwgImNoaWxkcmVu
+        Ijoge30sICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZh
+        bHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFja2Fn
+        ZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIs
+        ICJuYW1lIjogImVsZXBoYW50IiwgInN1bSI6IG51bGwsICJmaWxlbmFtZSI6
+        ICJlbGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiBudWxs
+        LCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6
+        ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6
+        ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRl
+        c2NyaXB0aW9uIjogIk9uZSBwYWNrYWdlIGVycmF0YSIsICJfbGFzdF91cGRh
+        dGVkIjogIjIwMTgtMTItMDNUMDU6Mzk6MTdaIiwgInJlc3RhcnRfc3VnZ2Vz
+        dGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAi
+        c29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVhc2UiOiAiMSIs
+        ICJfaWQiOiAiOWMyMDg5Y2UtMjUxOC00ZjdmLWJlNzItNmQxOGRmOWU5NTQ4
+        In0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVz
+        dCJdLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvZXJy
+        YXR1bS9jZmJjMGZlZi0yMGVmLTRkZTctYTRlOS05ZmE3Y2YwZGIyNWUvIiwg
+        Imlzc3VlZCI6ICIyMDEwLTExLTEwIDAwOjAwOjAwIiwgInJlbG9naW5fc3Vn
+        Z2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjogW3siaHJlZiI6ICJodHRw
+        czovL3Jobi5yZWRoYXQuY29tL2VycmF0YS9SSFNBLTIwMTAtMDg1OC5odG1s
+        IiwgInR5cGUiOiAic2VsZiIsICJpZCI6IG51bGwsICJ0aXRsZSI6ICJSSFNB
+        LTIwMTA6MDg1OCJ9LCB7ImhyZWYiOiAiaHR0cHM6Ly9idWd6aWxsYS5yZWRo
+        YXQuY29tL2J1Z3ppbGxhL3Nob3dfYnVnLmNnaT9pZD02Mjc4ODIiLCAidHlw
+        ZSI6ICJidWd6aWxsYSIsICJpZCI6ICI2Mjc4ODIiLCAidGl0bGUiOiAiQ1ZF
+        LTIwMTAtMDQwNSBiemlwMjogaW50ZWdlciBvdmVyZmxvdyBmbGF3IGluIEJa
+        Ml9kZWNvbXByZXNzIn0sIHsiaHJlZiI6ICJodHRwczovL3d3dy5yZWRoYXQu
+        Y29tL3NlY3VyaXR5L2RhdGEvY3ZlL0NWRS0yMDEwLTA0MDUuaHRtbCIsICJ0
+        eXBlIjogImN2ZSIsICJpZCI6ICJDVkUtMjAxMC0wNDA1IiwgInRpdGxlIjog
+        IkNWRS0yMDEwLTA0MDUifSwgeyJocmVmIjogImh0dHA6Ly93d3cucmVkaGF0
+        LmNvbS9zZWN1cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRh
+        bnQiLCAidHlwZSI6ICJvdGhlciIsICJpZCI6IG51bGwsICJ0aXRsZSI6IG51
+        bGx9XSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlw
+        ZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIlJIU0EtMjAxMDowODU4IiwgImZy
+        b20iOiAic2VjdXJpdHlAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6ICJJbXBv
+        cnRhbnQiLCAidGl0bGUiOiAiSW1wb3J0YW50OiBiemlwMiBzZWN1cml0eSB1
+        cGRhdGUiLCAiY2hpbGRyZW4iOiB7fSwgInZlcnNpb24iOiAiMyIsICJyZWJv
+        b3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBr
+        Z2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJiemlwMi0xLjAuNS03
+        LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1kZXZlbCIsICJzdW0i
+        OiBbInNoYTI1NiIsICJlYTY3YzY2NGRhMWZmOTZhNmRjOTRkMzMwMDliNzNk
+        OGZhYjMxYjU5ODI0MTgzZmI0NWU5YmEyZWJmODJkNTgzIl0sICJmaWxlbmFt
+        ZSI6ICJiemlwMi1kZXZlbC0xLjAuNS03LmVsNl8wLmk2ODYucnBtIiwgImVw
+        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcu
+        ZWw2XzAiLCAiYXJjaCI6ICJpNjg2In0sIHsic3JjIjogImJ6aXAyLTEuMC41
+        LTcuZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6aXAyLWxpYnMiLCAic3Vt
+        IjogWyJzaGEyNTYiLCAiYzlmMDY0YTY4NjI1NzNmYjlmMmE2YWZmN2MzNjIx
+        ZjE5NDBiNDkyZGYyZWRmYzJlYmJkYzBiODMwNWY1MTE0NyJdLCAiZmlsZW5h
+        bWUiOiAiYnppcDItbGlicy0xLjAuNS03LmVsNl8wLmk2ODYucnBtIiwgImVw
+        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcu
+        ZWw2XzAiLCAiYXJjaCI6ICJpNjg2In0sIHsic3JjIjogImJ6aXAyLTEuMC41
+        LTcuZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6aXAyIiwgInN1bSI6IFsi
+        c2hhMjU2IiwgImI4YTNmNzJiYzJiMGQ4OWJhNzM3MDk5YWM5OGJmOGQyYWY0
+        YmVhMDJkMzE4ODRjMDJkYjk3ZjdmNjZjM2Q1YzIiXSwgImZpbGVuYW1lIjog
+        ImJ6aXAyLTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6ICIw
+        IiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwg
+        ImFyY2giOiAieDg2XzY0In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2
+        XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6aXAyLWRldmVsIiwgInN1bSI6IFsi
+        c2hhMjU2IiwgIjdmNjMxMjRlNDY1NWI3YzkyZDIzZWM0YzM4MjI2ZjVkMzc0
+        NjU2ODg1M2RmZjc1MGZjODVlMDU4ZTc0YjVjZjYiXSwgImZpbGVuYW1lIjog
+        ImJ6aXAyLWRldmVsLTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIsICJlcG9j
+        aCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVs
+        Nl8wIiwgImFyY2giOiAieDg2XzY0In0sIHsic3JjIjogImJ6aXAyLTEuMC41
+        LTcuZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6aXAyLWxpYnMiLCAic3Vt
+        IjogWyJzaGEyNTYiLCAiODAyZjQzOTlkYmRkMDE0NzZlMjU0YzNiMzJjNDBh
+        ZmY1OWNmNWQyM2E0NWZhNDg4YzY5MTdjZTg5MDRkNmI0ZCJdLCAiZmlsZW5h
+        bWUiOiAiYnppcDItbGlicy0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0iLCAi
+        ZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAi
+        Ny5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9XSwgIm5hbWUiOiAiY29sbGVj
+        dGlvbi0wIiwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6ICJmaW5hbCIsICJ1
+        cGRhdGVkIjogIjIwMTAtMTEtMTAgMDA6MDA6MDAiLCAiZGVzY3JpcHRpb24i
+        OiAiYnppcDIgaXMgYSBmcmVlbHkgYXZhaWxhYmxlLCBoaWdoLXF1YWxpdHkg
+        ZGF0YSBjb21wcmVzc29yLiBJdCBwcm92aWRlcyBib3RoXG5saWJiejIgbGli
+        cmFyeSBtdXN0IGJlIHJlc3RhcnRlZCBmb3IgdGhlIHVwZGF0ZSB0byB0YWtl
+        IGVmZmVjdC4iLCAiX2xhc3RfdXBkYXRlZCI6ICIyMDE4LTEyLTAzVDA1OjM5
+        OjE3WiIsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50
+        IjogIiIsICJyaWdodHMiOiAiQ29weXJpZ2h0IDIwMTAgUmVkIEhhdCBJbmMi
+        LCAic29sdXRpb24iOiAiQmVmb3JlIGFwcGx5aW5nIHRoaXMgdXBkYXRlLCBt
+        YWtlIHN1cmUgYWxsIHByZXZpb3VzbHktcmVsZWFzZWQgZXJyYXRhXG5yZWxl
+        dmFudCB0byB5b3VyIHN5c3RlbSBoYXZlIGJlZW4gYXBwbGllZC5cblxuVGhp
+        cyB1cGRhdGUgaXMgYXZhaWxhYmxlIHZpYSB0aGUgUmVkIEhhdCBOZXR3b3Jr
+        LiBEZXRhaWxzIG9uIGhvdyB0b1xudXNlIHRoZSBSZWQgSGF0IE5ldHdvcmsg
+        dG8gYXBwbHkgdGhpcyB1cGRhdGUgYXJlIGF2YWlsYWJsZSBhdFxuaHR0cDov
+        L2tiYXNlLnJlZGhhdC5jb20vZmFxL2RvY3MvRE9DLTExMjU5IiwgInN1bW1h
+        cnkiOiAiVXBkYXRlZCBiemlwMiBwYWNrYWdlcyB0aGF0IGZpeCBvbmUgc2Vj
+        dXJpdHkgaXNzdWUiLCAicmVsZWFzZSI6ICIiLCAiX2lkIjogImNmYmMwZmVm
+        LTIwZWYtNGRlNy1hNGU5LTlmYTdjZjBkYjI1ZSJ9LCB7InJlcG9zaXRvcnlf
+        bWVtYmVyc2hpcHMiOiBbInNjZW5hcmlvX3Rlc3QiLCAiMWVjMjZmNmMtNGM1
+        Yi00NTVjLWJhNGYtNDBmMjIyNDAyZmY2IiwgImRmN2NmMzYxLTVlMDQtNGFk
+        NC1hYTg2LWE3MTUzNzIyM2E3OCIsICI1NzBiOWY2Mi01NWUwLTQ3ZTMtODMz
+        MC1jZjNiZWQ4ZWJmNDciLCAiMzEyZDkwY2YtMmEwYi00YzYxLWI1ODAtYjAw
+        Y2Y0YjZmNTFlIiwgIjVjZmNjYWE0LTRiNDMtNDA4Yi04NDYwLTQ2N2E1ZmNk
+        Y2FiNyIsICJmNDU4NDljYy05ZjY1LTQxMjMtYjE4MS1iZWUwMTA3MjQwZjgi
+        LCAiYWVkMmQyYTktNGQ3MS00MDI3LWI4N2YtZjZlNGJhN2Y5OTFjIl0sICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9lcnJhdHVtL2U2
+        MWM3ZWY4LTJmZGYtNDkyMS05NzZkLTc4ZWEyMzA3NGMzNy8iLCAiaXNzdWVk
+        IjogIjIwMTAtMDEtMDEgMDE6MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0ZWQi
+        OiBmYWxzZSwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0
+        YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjog
+        IlJIRUEtMjAxMDowMDAxIiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNv
+        bSIsICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAiRW1wdHkgZXJyYXRhIiwg
+        ImNoaWxkcmVuIjoge30sICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dl
+        c3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0Ijog
+        W10sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2Ny
+        aXB0aW9uIjogIkVtcHR5IGVycmF0YSIsICJfbGFzdF91cGRhdGVkIjogIjIw
+        MTgtMTItMDNUMDU6Mzk6MTdaIiwgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFs
+        c2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24i
+        OiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAi
+        ZTYxYzdlZjgtMmZkZi00OTIxLTk3NmQtNzhlYTIzMDc0YzM3In1d
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:49 GMT
+  recorded_at: Mon, 03 Dec 2018 05:39:17 GMT
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2549,7 +10638,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2560,42 +10649,40 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:49 GMT
+      - Mon, 03 Dec 2018 05:39:18 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
       - '458'
-      Connection:
-      - close
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI5NWY3ZWJhMy04ZjMwLTRiMWItODA0
-        Mi0zZTNiYzllMzBmOWMiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNrYWdl
-        X2dyb3VwIn0sICJfaWQiOiB7IiRvaWQiOiAiNWJjZTA0MjAyZmExODNmMWMw
-        ZDBlYTVjIn0sICJ1bml0X2lkIjogIjk1ZjdlYmEzLThmMzAtNGIxYi04MDQy
-        LTNlM2JjOWUzMGY5YyIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91
-        cCJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiZTc4NzEyNWQtOTE2Zi00Mzdh
-        LTllZjEtMjdjMzk4ZDUyYWJkIiwgIl9jb250ZW50X3R5cGVfaWQiOiAicGFj
-        a2FnZV9ncm91cCJ9LCAiX2lkIjogeyIkb2lkIjogIjViY2UwNDIwMmZhMTgz
-        ZjFjMGQwZWE1ZCJ9LCAidW5pdF9pZCI6ICJlNzg3MTI1ZC05MTZmLTQzN2Et
-        OWVmMS0yN2MzOThkNTJhYmQiLCAidW5pdF90eXBlX2lkIjogInBhY2thZ2Vf
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIwYTQ5YmZjNS04YmJkLTQyYWEtYTFm
+        YS0wMjg3MTVkNzIxODEiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNrYWdl
+        X2dyb3VwIn0sICJfaWQiOiB7IiRvaWQiOiAiNWMwNGMxODU0OThlZGI4MjU1
+        YmI0NjcwIn0sICJ1bml0X2lkIjogIjBhNDliZmM1LThiYmQtNDJhYS1hMWZh
+        LTAyODcxNWQ3MjE4MSIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91
+        cCJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiMjM5MGIwYTgtMjRlNS00MzEy
+        LTg1NjYtNWVlMjgwZjI1YjYxIiwgIl9jb250ZW50X3R5cGVfaWQiOiAicGFj
+        a2FnZV9ncm91cCJ9LCAiX2lkIjogeyIkb2lkIjogIjVjMDRjMTg1NDk4ZWRi
+        ODI1NWJiNDY2NCJ9LCAidW5pdF9pZCI6ICIyMzkwYjBhOC0yNGU1LTQzMTIt
+        ODU2Ni01ZWUyODBmMjViNjEiLCAidW5pdF90eXBlX2lkIjogInBhY2thZ2Vf
         Z3JvdXAifV0=
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:49 GMT
+  recorded_at: Mon, 03 Dec 2018 05:39:18 GMT
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/content/units/package_group/search/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/content/units/package_group/search/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjcml0ZXJpYSI6eyJsaW1pdCI6Miwic2tpcCI6MCwiZmlsdGVycyI6eyJf
-        aWQiOnsiJGluIjpbIjk1ZjdlYmEzLThmMzAtNGIxYi04MDQyLTNlM2JjOWUz
-        MGY5YyIsImU3ODcxMjVkLTkxNmYtNDM3YS05ZWYxLTI3YzM5OGQ1MmFiZCJd
+        aWQiOnsiJGluIjpbIjBhNDliZmM1LThiYmQtNDJhYS1hMWZhLTAyODcxNWQ3
+        MjE4MSIsIjIzOTBiMGE4LTI0ZTUtNDMxMi04NTY2LTVlZTI4MGYyNWI2MSJd
         fX19LCJpbmNsdWRlX3JlcG9zIjp0cnVlfQ==
     headers:
       Accept:
@@ -2603,7 +10690,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2614,54 +10701,52 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:49 GMT
+      - Mon, 03 Dec 2018 05:39:18 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
       - '1288'
-      Connection:
-      - close
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
         W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVzdCJd
-        LCAibWFuZGF0b3J5X3BhY2thZ2VfbmFtZXMiOiBbInBlbmd1aW4iXSwgInJl
-        cG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJuYW1lIjogImJpcmQiLCAidXNl
-        cl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAiX2xhc3RfdXBk
-        YXRlZCI6ICIyMDE4LTEwLTIyVDE3OjA4OjQ4WiIsICJjaGlsZHJlbiI6IHt9
-        LCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdLCAidHJhbnNsYXRlZF9u
-        YW1lIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0
-        cy9wYWNrYWdlX2dyb3VwLzk1ZjdlYmEzLThmMzAtNGIxYi04MDQyLTNlM2Jj
-        OWUzMGY5Yy8iLCAidHJhbnNsYXRlZF9kZXNjcmlwdGlvbiI6IHt9LCAicHVs
-        cF91c2VyX21ldGFkYXRhIjoge30sICJkZWZhdWx0X3BhY2thZ2VfbmFtZXMi
-        OiBbXSwgIl9jb250ZW50X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJp
-        ZCI6ICJiaXJkIiwgIl9pZCI6ICI5NWY3ZWJhMy04ZjMwLTRiMWItODA0Mi0z
-        ZTNiYzllMzBmOWMiLCAiZGlzcGxheV9vcmRlciI6IDEwMjQsICJjb25kaXRp
-        b25hbF9wYWNrYWdlX25hbWVzIjogW119LCB7InJlcG9zaXRvcnlfbWVtYmVy
-        c2hpcHMiOiBbInNjZW5hcmlvX3Rlc3QiXSwgIm1hbmRhdG9yeV9wYWNrYWdl
-        X25hbWVzIjogWyJlbGVwaGFudCxnaXJhZmZlLGNoZWV0YWgsbGlvbixtb25r
-        ZXkscGVuZ3VpbixzcXVpcnJlbCx3YWxydXMiLCAicGVuZ3VpbiJdLCAicmVw
-        b19pZCI6ICJzY2VuYXJpb190ZXN0IiwgIm5hbWUiOiAibWFtbWFsIiwgInVz
-        ZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9sYXN0X3Vw
-        ZGF0ZWQiOiAiMjAxOC0xMC0yMlQxNzowODo0OFoiLCAiY2hpbGRyZW4iOiB7
-        fSwgIm9wdGlvbmFsX3BhY2thZ2VfbmFtZXMiOiBbXSwgInRyYW5zbGF0ZWRf
-        bmFtZSI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5p
-        dHMvcGFja2FnZV9ncm91cC9lNzg3MTI1ZC05MTZmLTQzN2EtOWVmMS0yN2Mz
-        OThkNTJhYmQvIiwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgInB1
-        bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNrYWdlX25hbWVz
-        IjogW10sICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAi
-        aWQiOiAibWFtbWFsIiwgIl9pZCI6ICJlNzg3MTI1ZC05MTZmLTQzN2EtOWVm
-        MS0yN2MzOThkNTJhYmQiLCAiZGlzcGxheV9vcmRlciI6IDEwMjQsICJjb25k
+        LCAibWFuZGF0b3J5X3BhY2thZ2VfbmFtZXMiOiBbImVsZXBoYW50LGdpcmFm
+        ZmUsY2hlZXRhaCxsaW9uLG1vbmtleSxwZW5ndWluLHNxdWlycmVsLHdhbHJ1
+        cyIsICJwZW5ndWluIl0sICJyZXBvX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAi
+        bmFtZSI6ICJtYW1tYWwiLCAidXNlcl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1
+        bHQiOiB0cnVlLCAiX2xhc3RfdXBkYXRlZCI6ICIyMDE4LTExLTAxVDE3OjEy
+        OjM2WiIsICJjaGlsZHJlbiI6IHt9LCAib3B0aW9uYWxfcGFja2FnZV9uYW1l
+        cyI6IFtdLCAidHJhbnNsYXRlZF9uYW1lIjoge30sICJfaHJlZiI6ICIvcHVs
+        cC9hcGkvdjIvY29udGVudC91bml0cy9wYWNrYWdlX2dyb3VwLzBhNDliZmM1
+        LThiYmQtNDJhYS1hMWZhLTAyODcxNWQ3MjE4MS8iLCAidHJhbnNsYXRlZF9k
+        ZXNjcmlwdGlvbiI6IHt9LCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJk
+        ZWZhdWx0X3BhY2thZ2VfbmFtZXMiOiBbXSwgIl9jb250ZW50X3R5cGVfaWQi
+        OiAicGFja2FnZV9ncm91cCIsICJpZCI6ICJtYW1tYWwiLCAiX2lkIjogIjBh
+        NDliZmM1LThiYmQtNDJhYS1hMWZhLTAyODcxNWQ3MjE4MSIsICJkaXNwbGF5
+        X29yZGVyIjogMTAyNCwgImNvbmRpdGlvbmFsX3BhY2thZ2VfbmFtZXMiOiBb
+        XX0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVz
+        dCJdLCAibWFuZGF0b3J5X3BhY2thZ2VfbmFtZXMiOiBbInBlbmd1aW4iXSwg
+        InJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJuYW1lIjogImJpcmQiLCAi
+        dXNlcl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAiX2xhc3Rf
+        dXBkYXRlZCI6ICIyMDE4LTExLTAxVDE3OjEyOjM2WiIsICJjaGlsZHJlbiI6
+        IHt9LCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdLCAidHJhbnNsYXRl
+        ZF9uYW1lIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91
+        bml0cy9wYWNrYWdlX2dyb3VwLzIzOTBiMGE4LTI0ZTUtNDMxMi04NTY2LTVl
+        ZTI4MGYyNWI2MS8iLCAidHJhbnNsYXRlZF9kZXNjcmlwdGlvbiI6IHt9LCAi
+        cHVscF91c2VyX21ldGFkYXRhIjoge30sICJkZWZhdWx0X3BhY2thZ2VfbmFt
+        ZXMiOiBbXSwgIl9jb250ZW50X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIs
+        ICJpZCI6ICJiaXJkIiwgIl9pZCI6ICIyMzkwYjBhOC0yNGU1LTQzMTItODU2
+        Ni01ZWUyODBmMjViNjEiLCAiZGlzcGxheV9vcmRlciI6IDEwMjQsICJjb25k
         aXRpb25hbF9wYWNrYWdlX25hbWVzIjogW119XQ==
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:49 GMT
+  recorded_at: Mon, 03 Dec 2018 05:39:18 GMT
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: 'eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkaXN0cmlidXRpb24iXX19
@@ -2673,7 +10758,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2684,15 +10769,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:49 GMT
+      - Mon, 03 Dec 2018 05:39:18 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
       - '1201'
-      Connection:
-      - close
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2712,24 +10795,24 @@ http_interactions:
         cy9kaXN0cmlidXRpb24vOWIvODMxMjU2YTEyNDcxOGJmMzkxNjZiNTY0ZDhl
         Njg5OTU0ZmYwYThmMGY0NzliYTI0Y2ZhMjYzNTAxMDliYzUiLCAiZmFtaWx5
         IjogIlRlc3QgRmFtaWx5IiwgImRvd25sb2FkZWQiOiB0cnVlLCAidGltZXN0
-        YW1wIjogMTMyMzExMjE1My4wOSwgIl9sYXN0X3VwZGF0ZWQiOiAxNTQwMjI4
-        MTI4LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJkaXN0cmlidXRpb24iLCAidmFy
+        YW1wIjogMTMyMzExMjE1My4wOSwgIl9sYXN0X3VwZGF0ZWQiOiAxNTQzODE1
+        NTU3LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJkaXN0cmlidXRpb24iLCAidmFy
         aWFudCI6ICJUZXN0VmFyaWFudCIsICJpZCI6ICJrcy1UZXN0IEZhbWlseS1U
         ZXN0VmFyaWFudC0xNi14ODZfNjQiLCAidmVyc2lvbiI6ICIxNiIsICJ2ZXJz
         aW9uX3NvcnRfaW5kZXgiOiAiMDItMTYiLCAicHVscF91c2VyX21ldGFkYXRh
-        Ijoge30sICJwYWNrYWdlZGlyIjogIiIsICJfaWQiOiAiYmRjMjM4ZGMtOTQw
-        Ni00NzdhLWJjMzAtNGE3NmNlYTY4ZTk1IiwgImFyY2giOiAieDg2XzY0Iiwg
+        Ijoge30sICJwYWNrYWdlZGlyIjogIiIsICJfaWQiOiAiMTkzYmQxOWQtYjFh
+        OC00ZjAzLTlhN2EtMmVlN2VlZTgyYTk5IiwgImFyY2giOiAieDg2XzY0Iiwg
         Il9ucyI6ICJ1bml0c19kaXN0cmlidXRpb24ifSwgInVwZGF0ZWQiOiAiMjAx
-        OC0xMC0yMlQxNzowODo0OFoiLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0
-        IiwgImNyZWF0ZWQiOiAiMjAxOC0xMC0yMlQxNzowODo0OFoiLCAidW5pdF90
-        eXBlX2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogImJkYzIzOGRj
-        LTk0MDYtNDc3YS1iYzMwLTRhNzZjZWE2OGU5NSIsICJfaWQiOiB7IiRvaWQi
-        OiAiNWJjZTA0MjAyZmExODNmMWMwZDBlYTU4In19XQ==
+        OC0xMi0wM1QwNTozOToxN1oiLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0
+        IiwgImNyZWF0ZWQiOiAiMjAxOC0xMi0wM1QwNTozOToxN1oiLCAidW5pdF90
+        eXBlX2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogIjE5M2JkMTlk
+        LWIxYTgtNGYwMy05YTdhLTJlZTdlZWU4MmE5OSIsICJfaWQiOiB7IiRvaWQi
+        OiAiNWMwNGMxODU0OThlZGI4MjU1YmI0NWYyIn19XQ==
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:49 GMT
+  recorded_at: Mon, 03 Dec 2018 05:39:18 GMT
 - request:
     method: post
-    uri: https://dev.example.com/pulp/api/v2/repositories/actions/content/regenerate_applicability//
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/actions/content/regenerate_applicability//
     body:
       encoding: UTF-8
       base64_string: |
@@ -2741,7 +10824,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2752,26 +10835,24 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:49 GMT
+      - Mon, 03 Dec 2018 05:39:18 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
       - '127'
-      Connection:
-      - close
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: UTF-8
       base64_string: |
-        eyJncm91cF9pZCI6ICJkOGZlOGQ1MC0xNmQwLTQyZjMtYWUyMy1mMDkzNzUz
-        NGRhZjQiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tfZ3JvdXBzL2Q4
-        ZmU4ZDUwLTE2ZDAtNDJmMy1hZTIzLWYwOTM3NTM0ZGFmNC8ifQ==
+        eyJncm91cF9pZCI6ICI5YmQ2ODJmYi1lNThkLTQ3YTgtOGM0Zi1iZDdmZDI1
+        OWE5ZDAiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tfZ3JvdXBzLzli
+        ZDY4MmZiLWU1OGQtNDdhOC04YzRmLWJkN2ZkMjU5YTlkMC8ifQ==
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:49 GMT
+  recorded_at: Mon, 03 Dec 2018 05:39:18 GMT
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/task_groups/d8fe8d50-16d0-42f3-ae23-f0937534daf4/state_summary/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/task_groups/9bd682fb-e58d-47a8-8c4f-bd7fd259a9d0/state_summary/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2781,7 +10862,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -2790,7 +10871,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:49 GMT
+      - Mon, 03 Dec 2018 05:39:18 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Etag:
@@ -2799,8 +10880,6 @@ http_interactions:
       - Accept-Encoding
       Content-Length:
       - '127'
-      Connection:
-      - close
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2810,5 +10889,5 @@ http_interactions:
         ImNhbmNlbGVkIjogMCwgIndhaXRpbmciOiAwLCAic2tpcHBlZCI6IDAsICJz
         dXNwZW5kZWQiOiAwLCAiZXJyb3IiOiAwLCAidG90YWwiOiAwfQ==
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:49 GMT
+  recorded_at: Mon, 03 Dec 2018 05:39:18 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/support/destroy_org_if_exists.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/support/destroy_org_if_exists.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -12,11 +12,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="32PLqnJA0HPwUAatU3Oc9x9XCgWWIxLTPkKMyzJLw",
-        oauth_signature="kKIFhxCxelvug%2BNAUmUE3Frnnrc%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1540228105", oauth_version="1.0"
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="G8F5zbb7in3sokTSHB12PKt6KMmDJ1UCI3NWkJTLCw",
+        oauth_signature="IfgiTyNwDYDMZ3806zXI%2B2OZb1w%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543815534", oauth_version="1.0"
       Cp-User:
       - foreman_admin
   response:
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - b8633e85-bfbf-4223-a1eb-82bf91525a3c
+      - 4278c84f-4584-4524-b7ab-3a887950cfec
       X-Version:
       - 2.5.6-1
       Content-Type:
@@ -35,13 +35,13 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 22 Oct 2018 17:08:25 GMT
+      - Mon, 03 Dec 2018 05:38:54 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOC0xMC0yMlQxNzowNjoyMyswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTgtMTAtMjJUMTc6MDY6MjMrMDAwMCIsImlkIjoiNDAyOGY5NTE2
-        Njg4N2Q2ZjAxNjY5Y2JkZTk4YjAwM2MiLCJrZXkiOiJzY2VuYXJpb190ZXN0
+        eyJjcmVhdGVkIjoiMjAxOC0xMi0wM1QwNToyNzo1OCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTgtMTItMDNUMDU6Mjc6NTgrMDAwMCIsImlkIjoiNDAyOGY5NjY2
+        NzcxOTU3ZDAxNjc3Mjg5OTVjNTAwNDEiLCJrZXkiOiJzY2VuYXJpb190ZXN0
         IiwiZGlzcGxheU5hbWUiOiJzY2VuYXJpb190ZXN0IiwicGFyZW50T3duZXIi
         Om51bGwsImNvbnRlbnRQcmVmaXgiOiIvc2NlbmFyaW9fdGVzdC8kZW52Iiwi
         ZGVmYXVsdFNlcnZpY2VMZXZlbCI6bnVsbCwidXBzdHJlYW1Db25zdW1lciI6
@@ -50,10 +50,10 @@ http_interactions:
         Y2Vzc01vZGVMaXN0IjoiZW50aXRsZW1lbnQiLCJsYXN0UmVmcmVzaGVkIjpu
         dWxsLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0=
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:25 GMT
+  recorded_at: Mon, 03 Dec 2018 05:38:54 GMT
 - request:
     method: delete
-    uri: https://dev.example.com:8443/candlepin/owners/scenario_test
+    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -63,11 +63,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="5xjexjFsNy2Jg2VCvapxSWPpkYWabRcp", oauth_nonce="HelIMHw6VBCfqTjV9oJsZtBw2Dnty58ipiPzpKZRQ",
-        oauth_signature="Pw%2F%2FVrNgjSyJLLI6BqfhXWqvobw%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1540228105", oauth_version="1.0"
+      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="5Iunxe0ZJpF48GY6tsWUmywqszftU1R3vhX7hUzrw2c",
+        oauth_signature="7WM7htM95scwmz3bqhSBhyC0%2BvY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1543815534", oauth_version="1.0"
       Cp-User:
       - foreman_admin
   response:
@@ -78,14 +78,14 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 1b72ae42-fd0b-48a1-a911-bd56ae25594c
+      - 8848ded8-54be-4115-8c81-36e4a77eba7c
       X-Version:
       - 2.5.6-1
       Date:
-      - Mon, 22 Oct 2018 17:08:25 GMT
+      - Mon, 03 Dec 2018 05:38:54 GMT
     body:
       encoding: UTF-8
       base64_string: ''
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:25 GMT
+  recorded_at: Mon, 03 Dec 2018 05:38:54 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/support/destroy_repo_if_exists.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/support/destroy_repo_if_exists.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://dev.example.com/pulp/api/v2/repositories/scenario_test/
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -12,39 +12,77 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.0p0
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 200
+      message: OK
     headers:
       Date:
-      - Mon, 22 Oct 2018 17:08:27 GMT
+      - Mon, 03 Dec 2018 05:38:55 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"b119bfba767b7a356efe7bee2f21a865-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '459'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiJ9LCAi
+        ZGlzcGxheV9uYW1lIjogIlNjZW5hcmlvIHl1bSBwcm9kdWN0IiwgImRlc2Ny
+        aXB0aW9uIjogbnVsbCwgImxhc3RfdW5pdF9hZGRlZCI6ICIyMDE4LTEyLTAz
+        VDA1OjI4OjIxWiIsICJub3RlcyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVw
+        byJ9LCAibGFzdF91bml0X3JlbW92ZWQiOiBudWxsLCAiY29udGVudF91bml0
+        X2NvdW50cyI6IHsicGFja2FnZV9ncm91cCI6IDIsICJkaXN0cmlidXRpb24i
+        OiAxLCAicGFja2FnZV9jYXRlZ29yeSI6IDEsICJycG0iOiA4LCAiZXJyYXR1
+        bSI6IDN9LCAiX25zIjogInJlcG9zIiwgIl9pZCI6IHsiJG9pZCI6ICI1YzA0
+        YmVkZjA1ZjVlZTMxNmQ5Y2FlOTYifSwgImlkIjogInNjZW5hcmlvX3Rlc3Qi
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJp
+        b190ZXN0LyJ9
+    http_version: 
+  recorded_at: Mon, 03 Dec 2018 05:38:55 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 03 Dec 2018 05:38:55 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Content-Length:
-      - '422'
-      Etag:
-      - '"5ac546ec21028925462ba3914390e451"'
-      Connection:
-      - close
+      - '172'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: UTF-8
       base64_string: |
-        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkdFVCIsICJleGNlcHRpb24iOiBu
-        dWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiBy
-        ZXBvc2l0b3J5PXNjZW5hcmlvX3Rlc3QiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
-        L3YyL3JlcG9zaXRvcmllcy9zY2VuYXJpb190ZXN0Lz8iLCAiaHR0cF9zdGF0
-        dXMiOiA0MDQsICJlcnJvciI6IHsiY29kZSI6ICJQTFAwMDA5IiwgImRhdGEi
-        OiB7InJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJzY2VuYXJpb190ZXN0
-        In19LCAiZGVzY3JpcHRpb24iOiAiTWlzc2luZyByZXNvdXJjZShzKTogcmVw
-        b3NpdG9yeT1zY2VuYXJpb190ZXN0IiwgInN1Yl9lcnJvcnMiOiBbXX0sICJ0
-        cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
-        InNjZW5hcmlvX3Rlc3QifX0=
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2QyNzA2OTYyLTVhZjctNDc1My04MjI2LTU0ODU2ZDkxOWNkMC8iLCAi
+        dGFza19pZCI6ICJkMjcwNjk2Mi01YWY3LTQ3NTMtODIyNi01NDg1NmQ5MTlj
+        ZDAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 22 Oct 2018 17:08:27 GMT
+  recorded_at: Mon, 03 Dec 2018 05:38:55 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
[Pulp 3]
Move regenerate applicability to service class. This is needed only for yum repository types hence method lives in yum service class.