### PR TITLE
Fixes #25562 - Product rendering issue without recurring logic

### DIFF
--- a/app/models/katello/sync_plan.rb
+++ b/app/models/katello/sync_plan.rb
@@ -118,8 +118,8 @@ module Katello
     end
 
     def next_sync_date
-      return nil unless (self.enabled || !self.foreman_tasks_recurring_logic.tasks.nil?)
-      self.foreman_tasks_recurring_logic.tasks.order(:start_at).last.try(:start_at)
+      return nil unless self.enabled
+      self.foreman_tasks_recurring_logic&.tasks&.order(:start_at)&.last&.start_at
     end
 
     def next_sync


### PR DESCRIPTION
This happens when there is a sync plan without a recurring logic. This should not happen in general but we need to handle the rendering issue regardless.

**To reproduce:**
1. Create a sync plan.
2. Log into Katello db and delete the recurring logic of the sync plan from the db.
3. Go to Products or sync plan index page.