### PR TITLE
fixes #25518 - fix invalid repos in 3.10 upgrade

### DIFF
--- a/db/seeds.d/111-upgrade_tasks.rb
+++ b/db/seeds.d/111-upgrade_tasks.rb
@@ -4,6 +4,7 @@ UpgradeTask.define_tasks(:katello) do
     {:name => 'katello:correct_puppet_environments', :long_running => true, :skip_failure => true, :always_run => true},
     {:name => 'katello:clean_backend_objects', :long_running => true, :skip_failure => true, :always_run => true},
     {:name => 'katello:upgrades:3.8:clear_checksum_type'},
-    {:name => 'katello:upgrades:3.9:migrate_sync_plans'}
+    {:name => 'katello:upgrades:3.9:migrate_sync_plans'},
+    {:name => 'katello:upgrades:3.10:clear_invalid_repo_credentials'}
   ]
 end

--- a/lib/katello/tasks/upgrades/3.10/clear_invalid_repo_credentials.rake
+++ b/lib/katello/tasks/upgrades/3.10/clear_invalid_repo_credentials.rake
@@ -1,0 +1,27 @@
+# Before 3.8, you could successfully edit only the username, or only the
+# password, but since we added a validation now those old repos are now
+# invalid.  This finds those repos and clears their credentials.
+
+namespace :katello do
+  namespace :upgrades do
+    namespace '3.10' do
+      desc "Clear invalid credentials for repositories"
+      task :clear_invalid_repo_credentials => %w(environment) do
+        User.current = User.anonymous_admin
+
+        # Where one, but not both, is set
+        root_repos = Katello::RootRepository.where('(upstream_username IS NULL AND upstream_password is NOT NULL) OR (upstream_username IS NOT NULL AND upstream_password is NULL)')
+
+        root_repos.each do |root_repo|
+          puts "Clearing invalid credentials for #{root_repo.label} (#{root_repo.id})"
+          root_repo.update_attributes(upstream_username: nil, upstream_password: nil)
+
+          root_repo.repositories.each do |repo|
+            puts "Refreshing repository #{repo.label} (#{repo.id})"
+            ForemanTasks.sync_task(::Actions::Pulp::Repository::Refresh, repo)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
To test this, you'll need to createa  repo that has the bogus data that could've been created in older Katellos (prior to 3.9).  To do that, go ahead and modify one of your existing repos and force set the username or password, but not both, like this:

```
$ rake console
> repo = Katello::RootRepository.last # or the repo you created
> repo.upstream_username = 'potato'
> repo.save!(validate: false)
> ^D
$ rake katello:upgrades:3.10:clear_invalid_repo_credentials
```

And notice the repo has the username unset and pulp is refreshed upon running the rake task.
