### PR TITLE
Fixes #25599 - Activation key search by id

### DIFF
--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -59,7 +59,8 @@ module Katello
     scoped_search :on => :content_view_id, :complete_value => true, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
     scoped_search :on => :description, :complete_value => true
     scoped_search :on => :name, :relation => :subscriptions, :rename => :subscription_name, :complete_value => true, :ext_method => :find_by_subscription_name
-    scoped_search :on => :id, :relation => :subscriptions, :rename => :subscription_id, :complete_value => true, :ext_method => :find_by_subscription_id
+    scoped_search :on => :id, :relation => :subscriptions, :rename => :subscription_id, :complete_value => true,
+                  :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER, :ext_method => :find_by_subscription_id
 
     def environment_exists
       if environment_id && environment.nil?

--- a/test/models/activation_key_test.rb
+++ b/test/models/activation_key_test.rb
@@ -135,6 +135,12 @@ module Katello
       assert_includes activation_keys, @dev_key
     end
 
+    def test_search_subscription_id_handles_non_integer
+      assert_raises ScopedSearch::QueryNotSupported do
+        ActivationKey.search_for("subscription_id = \"notaninteger\"")
+      end
+    end
+
     def test_search_subscription_name
       activation_keys = ActivationKey.search_for("subscription_name = \"#{@pool_one.subscription.name}\"")
       assert_includes activation_keys, @dev_key


### PR DESCRIPTION
This was broken since it allowed a SQL query to query
non-integers on an integer column. I added a test that
reproduces the behavior

I'm not sure how long this has been broken. It could
have broke from semi-recent changes to the method,
rails version update, postgres version change, etc...