### PR TITLE
Revert "Fixes #25314 - use helpers for including webpacked js and css"

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -152,3 +152,6 @@ Lint/UriEscapeUnescape:
 
 Style/SafeNavigation:
   Enabled: false
+
+Style/MethodMissing:
+  Enabled: false

--- a/app/views/katello/layouts/react.html.erb
+++ b/app/views/katello/layouts/react.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:stylesheets) do %>
-    <%= webpacked_plugins_css_for :katello %>
+    <%= stylesheet_link_tag *webpack_asset_paths('katello', :extension => 'css'), "data-turbolinks-track" => true %>
 <% end %>
 
 <% content_for(:javascripts) do %>
-    <%= webpacked_plugins_js_for :katello %>
+    <%= javascript_include_tag *webpack_asset_paths('katello', :extension => 'js') %>
 <% end %>
 
 <% content_for(:content) do %>

--- a/webpack/__mocks__/foremanReact/components/common/EmptyState.js
+++ b/webpack/__mocks__/foremanReact/components/common/EmptyState.js
@@ -1,8 +1,0 @@
-import React from 'react';
-
-const EmptyState = props => (
-  <div>
-    {`EmptyState: ${JSON.stringify(props)}`}
-  </div>
-);
-export default EmptyState;

--- a/webpack/move_to_foreman/components/common/EmptyState/index.js
+++ b/webpack/move_to_foreman/components/common/EmptyState/index.js
@@ -1,0 +1,68 @@
+/* eslint-disable */
+import React from 'react';
+import { EmptyState as PfEmptyState, Button } from 'patternfly-react';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { LinkContainer } from 'react-router-bootstrap';
+
+const EmptyState = (props) => {
+  const {
+    icon = 'add-circle-o',
+    header,
+    description,
+    customDocumentation,
+    documentationLabel = __('For more information please see'),
+    documentationButton = __('Documentation'),
+    docUrl,
+    action,
+    actionButton,
+    secondayActions,
+  } = props;
+  const defaultDocumantion = `${documentationLabel} <a href=${docUrl}>${documentationButton}</a>`;
+  const showDocsLink = !!(docUrl || customDocumentation);
+
+  return (
+    <PfEmptyState>
+      <PfEmptyState.Icon type="pf" name={icon} />
+      <PfEmptyState.Title>{header}</PfEmptyState.Title>
+      <PfEmptyState.Info>{description}</PfEmptyState.Info>
+      {showDocsLink && (
+        <PfEmptyState.Help>
+          {customDocumentation || <span dangerouslySetInnerHTML={{ __html: defaultDocumantion }} />}
+        </PfEmptyState.Help>
+      )}
+      {action && (
+        <PfEmptyState.Action>
+          {action.url && (
+            <LinkContainer to={action.url}>
+              <Button href={action.url} bsStyle="primary" bsSize="large">
+                {action.title}
+              </Button>
+            </LinkContainer>
+          )}
+          {action.onClick && (
+            <Button onClick={action.onClick} bsStyle="primary" bsSize="large">
+              {action.title}
+            </Button>
+          )}
+        </PfEmptyState.Action>
+      )}
+      {actionButton && (
+        <PfEmptyState.Action>
+          {actionButton}
+        </PfEmptyState.Action>
+      )}
+      {secondayActions && (
+        <PfEmptyState.Action secondary>
+          {secondayActions.map(item => (
+            <LinkContainer to={item.url}>
+              <Button href={item.url} title={item.title}>
+                {item.title}
+              </Button>
+            </LinkContainer>
+          ))}
+        </PfEmptyState.Action>
+        )}
+    </PfEmptyState>
+  );
+};
+export default EmptyState;

--- a/webpack/move_to_foreman/components/common/table/components/Table.js
+++ b/webpack/move_to_foreman/components/common/table/components/Table.js
@@ -2,8 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Table as PfTable } from 'patternfly-react';
 import { noop } from 'foremanReact/common/helpers';
-import EmptyState from 'foremanReact/components/common/EmptyState';
-
+import EmptyState from '../../EmptyState';
 import PaginationRow from '../../../../../components/PaginationRow/index';
 
 import TableBody from './TableBody';

--- a/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
+++ b/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
@@ -112,7 +112,7 @@ class ManageManifestModal extends Component {
       header: __('There is no Manifest History to display.'),
       description: __('Import a Manifest using the manifest tab above.'),
       documentation: {
-        label: __('Learn more about adding Subscription Manifests'),
+        title: __('Learn more about adding Subscription Manifests'),
         url: 'http://redhat.com',
       },
     });

--- a/webpack/scenes/Subscriptions/Manifest/__tests__/__snapshots__/ManageManifestModal.test.js.snap
+++ b/webpack/scenes/Subscriptions/Manifest/__tests__/__snapshots__/ManageManifestModal.test.js.snap
@@ -312,7 +312,7 @@ exports[`manage manifest modal should render 1`] = `
               Object {
                 "description": "Import a Manifest using the manifest tab above.",
                 "documentation": Object {
-                  "label": "Learn more about adding Subscription Manifests",
+                  "title": "Learn more about adding Subscription Manifests",
                   "url": "http://redhat.com",
                 },
                 "header": "There is no Manifest History to display.",

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsPage.js
@@ -185,6 +185,7 @@ class UpstreamSubscriptionsPage extends Component {
       header: __('There are no Subscription Allocations to display'),
       description: __('Subscription Allocations allow you to export subscriptions from the Red Hat Customer Portal to ' +
           'an on-premise subscription management application such as Red Hat Satellite.'),
+      docUrl: 'http://redhat.com',
       action: {
         title: __('Import a Manifest to Begin'),
         url: '/subscriptions',

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/__snapshots__/UpstreamSubscriptionsPage.test.js.snap
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/__snapshots__/UpstreamSubscriptionsPage.test.js.snap
@@ -146,6 +146,7 @@ exports[`upstream subscriptions page should render 1`] = `
                 "url": "/subscriptions",
               },
               "description": "Subscription Allocations allow you to export subscriptions from the Red Hat Customer Portal to an on-premise subscription management application such as Red Hat Satellite.",
+              "docUrl": "http://redhat.com",
               "header": "There are no Subscription Allocations to display",
             }
           }

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/__snapshots__/SubscriptionsTable.test.js.snap
@@ -414,7 +414,26 @@ exports[`subscriptions table should render a table 1`] = `
 `;
 
 exports[`subscriptions table should render an empty state 1`] = `
-<div>
-  EmptyState: {"header":"Yay empty state","description":"There is nothing to see here"}
+<div
+  class="blank-slate-pf"
+>
+  <div
+    class="blank-slate-pf-icon"
+  >
+    <span
+      aria-hidden="true"
+      class="pficon pficon-add-circle-o"
+    />
+  </div>
+  <h4
+    class="h1 blank-slate-pf-title"
+  >
+    Yay empty state
+  </h4>
+  <p
+    class="blank-slate-pf-info"
+  >
+    There is nothing to see here
+  </p>
 </div>
 `;


### PR DESCRIPTION
This reverts commit 2a2ca3d0aaefc44cd3d07800b8eff8ee2fe1b692.

@tbrisker @cfouant 

Since these helpers are not in Foreman 1.20-stable, and the cherry pick for them alters the webpack vendor.js we'd like to pull this commit out of the stable branch.