### PR TITLE
Fixes #25559 - update seeds to assume taxonomies are seeded in core

### DIFF
--- a/db/seeds.d/101-locations.rb
+++ b/db/seeds.d/101-locations.rb
@@ -4,17 +4,15 @@
 # !!! PLEASE KEEP THIS SCRIPT IDEMPOTENT !!!
 #
 
-if Location.exists? || ENV['SEED_LOCATION'].present?
-  # Create a new location to be used as the Katello Default.
-  if ENV['SEED_LOCATION'].blank?
-    default_location = Location.first
-  else
-    default_location = Location.where(:name => ENV['SEED_LOCATION']).first_or_create
-  end
-  if Setting[:default_location_subscribed_hosts].empty?
-    Setting[:default_location_subscribed_hosts] = default_location.title
-  end
-  if Setting[:default_location_puppet_content].empty?
-    Setting[:default_location_puppet_content] = default_location.title
-  end
+# Create a new location to be used as the Katello Default.
+if ENV['SEED_LOCATION'].blank?
+  default_location = Location.first
+else
+  default_location = Location.where(:name => ENV['SEED_LOCATION']).first_or_create
+end
+if Setting[:default_location_subscribed_hosts].empty?
+  Setting[:default_location_subscribed_hosts] = default_location.title
+end
+if Setting[:default_location_puppet_content].empty?
+  Setting[:default_location_puppet_content] = default_location.title
 end

--- a/test/lib/tasks/seeds_test.rb
+++ b/test/lib/tasks/seeds_test.rb
@@ -29,29 +29,17 @@ module Katello
       Location.destroy_all
     end
 
-    test "don't create a default location if no locations exist" do
-      Location.stubs(:exists?).returns(false)
-      seed
-      refute Location.default_location_ids.present?
+    test 'with SEED_LOCATION' do
+      with_env('SEED_LOCATION' => 'test_location_seed') { seed }
+      assert Location.find_by_title('test_location_seed').present?
     end
 
-    test "with nothing" do
-      Setting[:default_location_puppet_content] = nil
-      Setting[:default_location_subscribed_hosts] = nil
-      Location.delete_all
-
+    test 'without SEED_LOCATION' do
       seed
-      assert_empty Location.all
-    end
-
-    test "create a default location on seed on a fresh install" do
-      with_env('SEED_LOCATION' => 'seed_test') do
-        seed
-      end
-      Setting.unstub(:[])
-      assert Location.default_location_ids.present?
-      default_location = Location.find(Location.default_location_ids.first)
-      assert_equal 'seed_test', default_location.title
+      # check that default_location_subscribed_hosts gets set
+      assert_equal Setting.find_by_name('default_location_subscribed_hosts').value, Location.first.title
+      # check that default_location_puppet_content gets set
+      assert_equal Setting.find_by_name('default_location_puppet_content').value, Location.first.title
     end
   end
 


### PR DESCRIPTION
This patch makes sure that the seeds for katello are updated with the changes made in core: https://github.com/theforeman/foreman/pull/6283.