### PR TITLE
Fixes #25615 - Updates pulp on tags whitelist

### DIFF
--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -234,7 +234,7 @@ module Katello
     def pulp_update_needed?
       changeable_attributes = %w(url unprotected checksum_type docker_upstream_name download_policy mirror_on_sync verify_ssl_on_sync
                                  upstream_username upstream_password ostree_upstream_sync_policy ostree_upstream_sync_depth ignore_global_proxy ignorable_content)
-      changeable_attributes += %w(name container_repository_name) if docker?
+      changeable_attributes += %w(name container_repository_name docker_tags_whitelist) if docker?
       changeable_attributes += %w(deb_releases deb_components deb_architectures gpg_key_id) if deb?
       changeable_attributes.any? { |key| previous_changes.key?(key) }
     end

--- a/test/models/repository_base.rb
+++ b/test/models/repository_base.rb
@@ -6,7 +6,8 @@ module Katello
       @acme_corporation                 = get_organization
       @fedora_root                      = katello_root_repositories(:fedora_17_x86_64_root)
       @rhel6_root                       = katello_root_repositories(:rhel_6_x86_64_root)
-      @ostree_root = katello_root_repositories(:ostree_root)
+      @ostree_root                      = katello_root_repositories(:ostree_root)
+      @docker_root                      = katello_root_repositories(:busybox_root)
       @fedora_17_x86_64                 = katello_repositories(:fedora_17_x86_64)
       @fedora_17_x86_64_dev             = katello_repositories(:fedora_17_x86_64_dev)
       @fedora_17_library_library_view   = katello_repositories(:fedora_17_library_library_view)

--- a/test/models/root_repository_test.rb
+++ b/test/models/root_repository_test.rb
@@ -391,6 +391,13 @@ module Katello
       end
     end
 
+    def test_pulp_update_needed_with_docker_white_tags?
+      refute @docker_root.pulp_update_needed?
+      @docker_root.docker_tags_whitelist = ['3.7']
+      @docker_root.save!
+      assert @docker_root.pulp_update_needed?
+    end
+
     def test_pulp_update_needed_with_upstream_auth_change?
       repo = katello_root_repositories(:fedora_17_x86_64_root)
       refute repo.pulp_update_needed?


### PR DESCRIPTION
This commit updates pulp when docker_tags_whitelist is updated.

Look at the issue number to track the steps.