### PR TITLE
Fixes #25626 - race condition when creating repos

### DIFF
--- a/app/lib/actions/candlepin/environment/add_content_to_environment.rb
+++ b/app/lib/actions/candlepin/environment/add_content_to_environment.rb
@@ -1,0 +1,18 @@
+module Actions
+  module Candlepin
+    module Environment
+      class AddContentToEnvironment < Candlepin::Abstract
+        input_format do
+          param :view_env_cp_id
+          param :content_id
+        end
+
+        def run
+          output[:add_response] = ::Katello::Resources::Candlepin::Environment.add_content(input[:view_env_cp_id], [input[:content_id]])
+        rescue RestClient::Conflict
+          Rails.logger.info("attempted to add content ID #{input[:content_id]} to environment, but content ID already exists.")
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/repository/create.rb
+++ b/app/lib/actions/katello/repository/create.rb
@@ -18,13 +18,12 @@ module Actions
             # when creating a clone, the following actions are handled by the
             # publish/promote process
             unless clone
+              view_env = org.default_content_view.content_view_environment(org.library)
               if repository.product.redhat?
-                plan_action(ContentView::UpdateEnvironment, org.default_content_view,
-                            org.library, repository.content_id)
+                plan_action(Actions::Candlepin::Environment::AddContentToEnvironment, :view_env_cp_id => view_env.cp_id, :content_id => repository.content_id)
               else
                 content_create = plan_action(Katello::Product::ContentCreate, root)
-                plan_action(ContentView::UpdateEnvironment, org.default_content_view,
-                            org.library, content_create.input[:content_id])
+                plan_action(Actions::Candlepin::Environment::AddContentToEnvironment, :view_env_cp_id => view_env.cp_id, :content_id => content_create.input[:content_id])
               end
             end
 

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -27,6 +27,7 @@ module ::Actions::Katello::Repository
 
   class CreateTest < TestBase
     let(:action_class) { ::Actions::Katello::Repository::Create }
+    let(:candlepin_action_class) { ::Actions::Candlepin::Environment::AddContentToEnvironment }
 
     before do
       FactoryBot.create(:smart_proxy, :default_smart_proxy)
@@ -39,6 +40,7 @@ module ::Actions::Katello::Repository
 
     it 'plans' do
       plan_action action, repository
+      assert_action_planed_with action, candlepin_action_class, view_env_cp_id: "1", content_id: "69"
     end
 
     it 'no clone flag means generate metadata in run phase' do
@@ -51,6 +53,7 @@ module ::Actions::Katello::Repository
       plan = plan_action action, repository, true
       run_action plan
       plan.run.must_equal nil
+      refute_action_planed action, candlepin_action_class
     end
   end
 


### PR DESCRIPTION
If you attempt to create multiple repos at the same time for the same product, you may hit a race condition (see issue for full details and repro script).

This patch fixes the issue by avoiding `Candlepin::Environment::SetContent`, and adds a new `AddContentToEnvironment` task. The new task simply makes an attempt to add a single content id to a product, and if the content already exists (409 from candlepin), it logs an info message and no-ops.