### PR TITLE
Fixes #25627 - Host module stream filter by status

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-module-streams.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-module-streams.controller.js
@@ -61,6 +61,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostModuleStreamsCont
               return scope.nutupaneParams.status;
           },
           function() {
+              $scope.nutupaneParams.page = 1;
               $scope.moduleStreamsNutupane.refresh();
           }
         );


### PR DESCRIPTION
This commit resets the page when changing the status
filter.

To reproduce:
1.Navigate to myhost/content_hosts/4/module-streams
2.Install module stream in client host
3.On Content Host-> Module Stream Page
  Use Pagiantion e.g. naviagate to last page
4.try to use filter "Filter by Status:"

The correct results should show up and the
page should be reset to 1