### PR TITLE
Fixes #25234: Move content uploads to a service class

### DIFF
--- a/app/lib/actions/katello/repository/import_upload.rb
+++ b/app/lib/actions/katello/repository/import_upload.rb
@@ -3,13 +3,15 @@ module Actions
   module Katello
     module Repository
       class ImportUpload < Actions::EntryAction
-        def plan(repository, upload_ids, options = {})
+        def plan(repository, uploads, options = {})
           action_subject(repository)
+          repo_service = repository.backend_service(::SmartProxy.pulp_master)
 
-          unit_keys = options.fetch(:unit_keys, {})
+          upload_ids = uploads.pluck('id')
+          unit_keys = repo_service.unit_keys(uploads)
           generate_metadata = options.fetch(:generate_metadata, true)
           sync_capsule = options.fetch(:sync_capsule, true)
-          unit_type_id = options.fetch(:unit_type_id, repository.unit_type_id)
+          unit_type_id = repo_service.unit_type_id(uploads)
 
           sequence do
             upload_results = concurrence do

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -159,6 +159,10 @@ module Katello
       @service ||= Katello::Pulp::Repository.instance_for_type(self, smart_proxy)
     end
 
+    def backend_content_service(smart_proxy)
+      backend_service(smart_proxy).content_service
+    end
+
     def organization
       if self.environment
         self.environment.organization

--- a/app/services/katello/abstract/pulp/content.rb
+++ b/app/services/katello/abstract/pulp/content.rb
@@ -1,0 +1,19 @@
+module Katello
+  module Abstract
+    module Pulp
+      module Content
+        def create_upload
+          fail NotImplementedError
+        end
+
+        def upload_chunk
+          fail NotImplementedError
+        end
+
+        def delete_upload
+          fail NotImplementedError
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp/content.rb
+++ b/app/services/katello/pulp/content.rb
@@ -1,0 +1,17 @@
+module Katello
+  module Pulp
+    class Content
+      extend Katello::Abstract::Pulp::Content
+      class << self
+        extend Forwardable
+        def_delegator :pulp_content, :create_upload_request, :create_upload
+        def_delegator :pulp_content, :delete_upload_request, :delete_upload
+        def_delegator :pulp_content, :upload_bits, :upload_chunk
+
+        private def pulp_content
+          SmartProxy.pulp_master.pulp_api.resources.content
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp/repository.rb
+++ b/app/services/katello/pulp/repository.rb
@@ -57,6 +57,10 @@ module Katello
         fail NotImplementedError
       end
 
+      def content_service
+        Katello::Pulp::Content
+      end
+
       def should_purge_empty_contents?
         false
       end

--- a/app/services/katello/pulp/repository.rb
+++ b/app/services/katello/pulp/repository.rb
@@ -21,6 +21,16 @@ module Katello
         Katello::RepositoryTypeManager.repository_types[repo.root.content_type].service_class.new(repo, smart_proxy)
       end
 
+      def unit_type_id(_uploads = [])
+        @repo.unit_type_id
+      end
+
+      def unit_keys(uploads)
+        uploads.map do |upload|
+          upload.except('id', 'name')
+        end
+      end
+
       def partial_repo_path
         fail NotImplementedError
       end

--- a/app/services/katello/pulp/repository/docker.rb
+++ b/app/services/katello/pulp/repository/docker.rb
@@ -2,6 +2,16 @@ module Katello
   module Pulp
     class Repository
       class Docker < ::Katello::Pulp::Repository
+        def unit_type_id(uploads = [])
+          uploads.pluck('digest').any? ? 'docker_tag' : super
+        end
+
+        def unit_keys(uploads)
+          uploads.map do |upload|
+            upload.except('id')
+          end
+        end
+
         def generate_master_importer
           config = {
             feed: root.url,

--- a/app/services/katello/pulp/repository/file.rb
+++ b/app/services/katello/pulp/repository/file.rb
@@ -2,6 +2,12 @@ module Katello
   module Pulp
     class Repository
       class File < ::Katello::Pulp::Repository
+        def unit_keys(uploads)
+          uploads.map do |upload|
+            upload.except('id')
+          end
+        end
+
         def generate_master_importer
           config = { feed: root.url }
           importer_class.new(config.merge(master_importer_connection_options))

--- a/test/actions/katello/repository/import_upload_test.rb
+++ b/test/actions/katello/repository/import_upload_test.rb
@@ -1,0 +1,26 @@
+require 'katello_test_helper'
+
+module Actions
+  describe Katello::Repository::ImportUpload do
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include FactoryBot::Syntax::Methods
+
+    let(:action_class) { ::Actions::Katello::Repository::ImportUpload }
+    let(:pulp_import_class) { ::Actions::Pulp::Repository::ImportUpload }
+    let(:repo) { katello_repositories(:fedora_17_x86_64) }
+
+    it 'plans' do
+      upload = {'id' => '1', 'size' => '12333', 'checksum' => 'asf23421324', 'name' => 'test'}
+      action = create_action(action_class)
+      action.expects(:action_subject).with(repo)
+      plan_action(action, repo, [upload])
+
+      assert_action_planed_with(action, pulp_import_class, :pulp_id => repo.pulp_id,
+                                unit_type_id: repo.unit_type_id,
+                                unit_key: upload.except('id', 'name'),
+                                upload_id: '1',
+                                unit_metadata: nil)
+    end
+  end
+end

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -267,9 +267,7 @@ module ::Actions::Katello::Repository
 
       uploads = [{'id' => 1, 'size' => '12333', 'checksum' => 'asf23421324', 'name' => 'test'}]
 
-      plan_action action, docker_repository,
-              uploads.map { |u| u['id'] }, unit_type_id: 'docker_manifest',
-              unit_keys: uploads.map { |u| u.except('id') },
+      plan_action action, docker_repository, uploads,
               generate_metadata: true, sync_capsule: true
 
       assert_action_planned_with(action, ::Actions::Pulp::Repository::ImportUpload,
@@ -283,19 +281,17 @@ module ::Actions::Katello::Repository
     it 'plans' do
       action.expects(:action_subject).with(docker_repository)
 
-      uploads = [{'id' => 1, 'size' => '12333', 'checksum' => 'asf23421324', 'name' => 'test'}]
+      uploads = [{'id' => 1, 'size' => '12333', 'checksum' => 'asf23421324', 'name' => 'test', 'digest' => 'sha256:1234'}]
 
       unit_keys = uploads.map { |u| u.except('id') }
 
-      plan_action action, docker_repository,
-              uploads.map { |u| u['id'] }, unit_type_id: 'docker_tag',
-              unit_keys: unit_keys,
+      plan_action action, docker_repository, uploads,
               generate_metadata: true, sync_capsule: true
 
       assert_action_planned_with(action, ::Actions::Pulp::Repository::ImportUpload,
                                  pulp_id: docker_repository.pulp_id,
                                  unit_type_id: 'docker_tag',
-                                 unit_key: {'size' => '12333', 'checksum' => 'asf23421324', 'name' => 'test'},
+                                 unit_key: unit_keys[0],
                                  upload_id: 1, unit_metadata: unit_keys[0]
                                 )
     end

--- a/test/controllers/api/registry/registry_proxies_controller_test.rb
+++ b/test/controllers/api/registry/registry_proxies_controller_test.rb
@@ -1,6 +1,5 @@
 require "katello_test_helper"
 
-#rubocop:disable Metrics/ModuleLength
 module Katello
   #rubocop:disable Metrics/BlockLength
   describe Api::Registry::RegistryProxiesController do
@@ -352,17 +351,10 @@ module Katello
         @controller.expects(:sync_task)
           .times(2)
           .returns(stub('task', :output => {'upload_results' => [{ 'digest' => 'sha256:1234' }]}), true)
-          .with do |action_class, repository, upload_ids, params|
+          .with do |action_class, repository, uploads, params|
             assert_equal ::Actions::Katello::Repository::ImportUpload, action_class
             assert_equal @repository, repository
-            assert_equal [123], upload_ids
-            if params[:unit_type_id] == 'docker_manifest'
-              assert_equal [:checksum, :name, :size], params[:unit_keys][0].keys.sort
-            elsif params[:unit_type_id] == 'docker_tag'
-              assert_equal [{name: 'tag', digest: 'sha256:1234'}], params[:unit_keys]
-            else
-              assert_equal "unknown unit_type_id", params[:unit_type_id]
-            end
+            assert_equal [123], uploads.pluck(:id)
             assert_equal true, params[:generate_metadata]
             assert_equal true, params[:sync_capsule]
           end

--- a/test/controllers/api/v2/content_uploads_controller_test.rb
+++ b/test/controllers/api/v2/content_uploads_controller_test.rb
@@ -79,7 +79,8 @@ module Katello
       content = mock(content_hash)
       resources = mock(:content => content)
       pulp_server = mock(:resources => resources)
-      Katello.expects(:pulp_server).returns(pulp_server)
+      pulp_master = mock(pulp_api: pulp_server)
+      SmartProxy.expects(:pulp_master).at_least_once.returns(pulp_master)
     end
   end
 end

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -705,10 +705,8 @@ module Katello
     def test_import_upload_ids
       uploads = [{'id' => '1'}]
       @controller.expects(:sync_task)
-        .with(::Actions::Katello::Repository::ImportUpload, @repository,
-              uploads.map { |u| u['id'] }, unit_type_id: 'rpm',
-              unit_keys: uploads.map { |u| u.except('id') }, generate_metadata: false,
-              sync_capsule: false)
+        .with(::Actions::Katello::Repository::ImportUpload, @repository, uploads,
+              generate_metadata: false, sync_capsule: false)
         .returns(build_task_stub)
 
       put(:import_uploads, params: { :id => @repository.id, :upload_ids => uploads.map { |u| u['id'] }, :publish_repository => 'false', sync_capsule: 'false' })
@@ -719,10 +717,8 @@ module Katello
     def test_two_import_upload_ids
       uploads = [{'id' => '1'}, {'id' => '2'}]
       @controller.expects(:sync_task)
-        .with(::Actions::Katello::Repository::ImportUpload, @repository,
-              uploads.map { |u| u['id'] }, unit_type_id: 'rpm',
-              unit_keys: uploads.map { |u| u.except('id') }, generate_metadata: false,
-              sync_capsule: false)
+        .with(::Actions::Katello::Repository::ImportUpload, @repository, uploads,
+              generate_metadata: false, sync_capsule: false)
         .returns(build_task_stub)
 
       put(:import_uploads, params: { :id => @repository.id, :upload_ids => uploads.map { |u| u['id'] }, :publish_repository => 'false', sync_capsule: 'false' })
@@ -735,9 +731,7 @@ module Katello
       # make sure name gets ignored for non-file repos
       # this is yum repo. So unit keys should except name
       @controller.expects(:sync_task)
-        .with(::Actions::Katello::Repository::ImportUpload, @repository,
-              uploads.map { |u| u['id'] }, unit_type_id: 'rpm',
-              unit_keys: uploads.map { |u| u.except('id').except('name') },
+        .with(::Actions::Katello::Repository::ImportUpload, @repository, uploads,
               generate_metadata: true, sync_capsule: true)
         .returns(build_task_stub)
 
@@ -752,9 +746,7 @@ module Katello
       file_repo = katello_repositories(:generic_file)
       uploads = [{'id' => '1', 'size' => '12333', 'checksum' => 'asf23421324', 'name' => 'test'}]
       @controller.expects(:sync_task)
-        .with(::Actions::Katello::Repository::ImportUpload, file_repo,
-              uploads.map { |u| u['id'] }, unit_type_id: 'iso',
-              unit_keys: uploads.map { |u| u.except('id') },
+        .with(::Actions::Katello::Repository::ImportUpload, file_repo, uploads,
               generate_metadata: true, sync_capsule: true)
         .returns(build_task_stub)
 
@@ -768,9 +760,7 @@ module Katello
       # this is docker repo. So unit keys should accept name
       uploads = [{'id' => '1', 'size' => '12333', 'checksum' => 'asf23421324', 'name' => 'test'}]
       @controller.expects(:sync_task)
-        .with(::Actions::Katello::Repository::ImportUpload, @docker_repo,
-              uploads.map { |u| u['id'] }, unit_type_id: 'docker_manifest',
-              unit_keys: uploads.map { |u| u.except('id') },
+        .with(::Actions::Katello::Repository::ImportUpload, @docker_repo, uploads,
               generate_metadata: true, sync_capsule: true)
         .returns(build_task_stub)
 
@@ -784,9 +774,7 @@ module Katello
       # make sure name is not ignored for docker repos
       # this is docker repo so unit keys should acccept name
       @controller.expects(:sync_task)
-        .with(::Actions::Katello::Repository::ImportUpload, @docker_repo,
-              uploads.map { |u| u['id'] }, unit_type_id: 'docker_tag',
-              unit_keys: uploads.map { |u| u.except('id') },
+        .with(::Actions::Katello::Repository::ImportUpload, @docker_repo, uploads,
               generate_metadata: true, sync_capsule: true)
         .returns(build_task_stub)
 

--- a/test/services/katello/pulp/repository/docker_test.rb
+++ b/test/services/katello/pulp/repository/docker_test.rb
@@ -41,6 +41,21 @@ module Katello
         ensure
           delete_repo(@repo)
         end
+
+        def test_unit_keys
+          upload = {'id' => '1', 'size' => '12333', 'checksum' => 'asf23421324', 'name' => 'test'}
+          assert_equal [upload.except('id')], @repo.backend_service(@master).unit_keys([upload])
+        end
+
+        def test_unit_type_id_docker_manifest
+          uploads = [{'id' => '1', 'size' => '12333', 'checksum' => 'asf23421324', 'name' => 'test'}]
+          assert_equal 'docker_manifest', @repo.backend_service(@master).unit_type_id(uploads)
+        end
+
+        def test_unit_type_id_docker_tag
+          uploads = [{'id' => '1', 'size' => '12333', 'checksum' => 'asf23421324', 'name' => 'test', 'digest' => 'sha256:1234'}]
+          assert_equal 'docker_tag', @repo.backend_service(@master).unit_type_id(uploads)
+        end
       end
     end
   end

--- a/test/services/katello/pulp/repository/file_test.rb
+++ b/test/services/katello/pulp/repository/file_test.rb
@@ -1,0 +1,24 @@
+require 'katello_test_helper'
+
+module Katello
+  module Service
+    class Repository
+      class FileBaseTest < ::ActiveSupport::TestCase
+        include VCR::TestCase
+        include RepositorySupport
+
+        def setup
+          @master = FactoryBot.create(:smart_proxy, :default_smart_proxy)
+          @custom = katello_repositories(:generic_file)
+        end
+      end
+
+      class FileTest < FileBaseTest
+        def test_unit_keys
+          upload = {'id' => '1', 'size' => '12333', 'checksum' => 'asf23421324', 'name' => 'test'}
+          assert_equal [upload.except('id')], @custom.backend_service(@master).unit_keys([upload])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
To test (also tests ImportUpload, but this PR doesn't touch that):

```sh
hammer repository upload-content --id 1 --file /tmp/file.txt
```