### PR TITLE
Fixes #25638 - Update system purpose Candlepin API usage

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
@@ -146,7 +146,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsController
             var deferred = $q.defer();
 
             Organization.get({id: CurrentOrganization}, function (organization) {
-                deferred.resolve(organization.system_purposes.role);
+                deferred.resolve(organization.system_purposes.roles);
             });
 
             return deferred.promise;


### PR DESCRIPTION
The content host details page uses the organizations API in order to get valid system purpose values through candlepin. The candlepin API response has changed. The 'role' field is now called 'roles' to be more accurate.

How to test:

0. make sure you have candlepin-2.5.8 in your env (yum update) & restart tomcat

1. create a custom product (can be existing, but up to you)
2. connect to the 'candlepin' postgres DB and find the UUID of the product you created:

```
select uuid from cp2_products where name = 'my product';
```
3. using the product UUID, give it some system purpose roles:

```
insert into cp2_product_attributes(name, value, product_uuid) values ('roles', 'Role1, Role2, Role3', '$UUID_FROM_EARLIER');
```

4. Validate the API by checking the 'system_purposes' key in the response of /organizations/:id

5. Validate the UI by going to a content host in the same Org and see that your role(s) are present in the dropdown for System Purpose