### PR TITLE
Fixes #25228 - Sync status page sets org correctly

### DIFF
--- a/app/controllers/katello/application_controller.rb
+++ b/app/controllers/katello/application_controller.rb
@@ -11,8 +11,7 @@ module Katello
     helper ::ApplicationHelper
 
     before_action :set_gettext_locale
-    helper_method :current_organization
-    helper_method :current_organization_data
+    helper_method :current_organization_object
     before_action :require_org
 
     protect_from_forgery # See ActionController::RequestForgeryProtection for details
@@ -50,7 +49,7 @@ module Katello
       'generic'
     end
 
-    def current_organization_data
+    def current_organization_object
       if !session[:current_organization_id]
         @current_org = Organization.current
         return @current_org
@@ -73,18 +72,14 @@ module Katello
       end
     end
 
-    def current_organization
-      current_organization_data&.name
-    end
-
-    def current_organization_data=(org)
+    def current_organization_object=(org)
       session[:current_organization_id] = org.try(:id)
     end
 
     private # why bother? methods below are not testable/tested
 
     def require_org
-      unless session && current_organization_data
+      unless session && current_organization_object
         redirect_to '/select_organization?toState=' + request.path
       end
     end

--- a/app/controllers/katello/application_controller.rb
+++ b/app/controllers/katello/application_controller.rb
@@ -12,6 +12,7 @@ module Katello
 
     before_action :set_gettext_locale
     helper_method :current_organization
+    helper_method :current_organization_data
     before_action :require_org
 
     protect_from_forgery # See ActionController::RequestForgeryProtection for details
@@ -49,7 +50,7 @@ module Katello
       'generic'
     end
 
-    def current_organization
+    def current_organization_data
       if !session[:current_organization_id]
         @current_org = Organization.current
         return @current_org
@@ -72,14 +73,18 @@ module Katello
       end
     end
 
-    def current_organization=(org)
+    def current_organization
+      current_organization_data&.name
+    end
+
+    def current_organization_data=(org)
       session[:current_organization_id] = org.try(:id)
     end
 
     private # why bother? methods below are not testable/tested
 
     def require_org
-      unless session && current_organization
+      unless session && current_organization_data
         redirect_to '/select_organization?toState=' + request.path
       end
     end

--- a/app/controllers/katello/sync_management_controller.rb
+++ b/app/controllers/katello/sync_management_controller.rb
@@ -17,7 +17,7 @@ module Katello
     end
 
     def index
-      org = current_organization_data
+      org = current_organization_object
       @products = org.library.products.readable
       redhat_products, custom_products = @products.partition(&:redhat?)
       redhat_products.sort_by { |p| p.name.downcase }

--- a/app/controllers/katello/sync_management_controller.rb
+++ b/app/controllers/katello/sync_management_controller.rb
@@ -17,7 +17,7 @@ module Katello
     end
 
     def index
-      org = current_organization
+      org = current_organization_data
       @products = org.library.products.readable
       redhat_products, custom_products = @products.partition(&:redhat?)
       redhat_products.sort_by { |p| p.name.downcase }

--- a/app/helpers/katello/sync_management_helper.rb
+++ b/app/helpers/katello/sync_management_helper.rb
@@ -25,7 +25,7 @@ module Katello
     end
 
     def any_syncable?
-      Product.syncable? && current_organization_data.syncable_content?
+      Product.syncable? && current_organization_object.syncable_content?
     end
 
     def error_state?(status)

--- a/app/helpers/katello/sync_management_helper.rb
+++ b/app/helpers/katello/sync_management_helper.rb
@@ -25,7 +25,7 @@ module Katello
     end
 
     def any_syncable?
-      Product.syncable? && current_organization.syncable_content?
+      Product.syncable? && current_organization_data.syncable_content?
     end
 
     def error_state?(status)


### PR DESCRIPTION
Foreman expects a string with the name of the
current organization for 'current_organization'.
More details on this can be found in the issue.

The reason we haven't seen this earlier is because
we are not using Katello::ApplicationController for
most Katello pages. We instead use ::ApplicationController
which is correctly setting the 'current_organization'.

It looks like sync status is the only active page that uses
the Katello controller, so we saw the issue there.

This changes the 'current_organization' method to be
'current_organization_data' and the 'current_organization'
method now returns a string with the organization name.

There may be more thorough fixes (the code in the controller
is quite old), but seeing as sync status is the only
active page that uses it, this seems like an appropiate fix.

Of course I am always open to suggestions for improvement :)