### PR TITLE
Fixes #25639 - Upgrade 3.8 -> 3.10 fails

### DIFF
--- a/lib/katello/tasks/upgrades/3.9/migrate_sync_plans.rake
+++ b/lib/katello/tasks/upgrades/3.9/migrate_sync_plans.rake
@@ -1,24 +1,44 @@
 namespace :katello do
   namespace :upgrades do
     namespace '3.9' do
+      def importer_type(repo)
+        case repo.content_type
+        when Katello::Repository::YUM_TYPE
+          Runcible::Models::YumImporter::ID
+        when Katello::Repository::FILE_TYPE
+          Runcible::Models::IsoImporter::ID
+        when Katello::Repository::PUPPET_TYPE
+          Runcible::Models::PuppetImporter::ID
+        when Katello::Repository::DOCKER_TYPE
+          Runcible::Models::DockerImporter::ID
+        when Katello::Repository::OSTREE_TYPE
+          Runcible::Models::OstreeImporter::ID
+        when Katello::Repository::DEB_TYPE
+          Runcible::Models::DebImporter::ID
+        else
+          fail _("Unexpected repo type %s") % repo.content_type
+        end
+      end
+
       desc "Migrate Pulp Sync Plans to new recurring logics"
       task :migrate_sync_plans => ["environment"] do
         User.current = User.anonymous_admin
         puts "Starting recurring logic for migrated sync plans and deleting Pulp schedules"
 
         Katello::SyncPlan.find_each do |sync_plan|
-          sync_plan.associate_recurring_logic
-          sync_plan.save!
-          if sync_plan.foreman_tasks_recurring_logic.state.nil?
-            sync_plan.start_recurring_logic
-            sync_plan.foreman_tasks_recurring_logic.enabled = false unless sync_plan.enabled
+          if sync_plan.foreman_tasks_recurring_logic.nil?
+            sync_plan.associate_recurring_logic
+            sync_plan.save!
+            if sync_plan.foreman_tasks_recurring_logic.state.nil?
+              sync_plan.start_recurring_logic
+              sync_plan.foreman_tasks_recurring_logic.enabled = false unless sync_plan.enabled
+            end
           end
-
           sync_plan.products.each do |product|
             product.repos(product.library).each do |repo_k|
               repo = ::Katello::Repository.find(repo_k.id)
               begin
-                Katello.pulp_server.extensions.repository.remove_schedules(repo.pulp_id, repo.importer_type)
+                Katello.pulp_server.extensions.repository.remove_schedules(repo.pulp_id, importer_type(repo))
               rescue RestClient::ResourceNotFound
                 puts "Could not update repository #{repo.id}, missing in pulp."
               end

--- a/test/lib/tasks/migrate_sync_plan_test.rb
+++ b/test/lib/tasks/migrate_sync_plan_test.rb
@@ -1,0 +1,43 @@
+require 'katello_test_helper'
+require 'rake'
+
+module Katello
+  class MigrateSyncPlanTest < ActiveSupport::TestCase
+    def setup
+      Rake.application.rake_require 'katello/tasks/upgrades/3.9/migrate_sync_plans'
+      Rake::Task['katello:upgrades:3.9:migrate_sync_plans'].reenable
+      Rake::Task.define_task(:environment)
+      @organization = get_organization
+      @plan = SyncPlan.new(:name => 'Norman Rockwell', :organization => @organization, :sync_date => Time.now, :interval => 'daily')
+      @plan.save!
+    end
+
+    def test_migrate_sync_plans
+      assert_nil @plan.foreman_tasks_recurring_logic
+      Rake.application.invoke_task('katello:upgrades:3.9:migrate_sync_plans')
+      assert_migration_successful @plan
+    end
+
+    def test_disabled_sync_plan_migration
+      @plan.enabled = false
+      @plan.save!
+      assert_nil @plan.foreman_tasks_recurring_logic
+      Rake.application.invoke_task('katello:upgrades:3.9:migrate_sync_plans')
+      assert_migration_successful @plan
+    end
+
+    def test_pulp_schedule_deletion
+      product = katello_products(:redhat)
+      @plan.products << product
+      assert_nil @plan.foreman_tasks_recurring_logic
+      Runcible::Extensions::Repository.any_instance.expects(:remove_schedules).times(3).returns("success!!")
+      Rake.application.invoke_task('katello:upgrades:3.9:migrate_sync_plans')
+      assert_migration_successful @plan
+    end
+
+    def assert_migration_successful(sync_plan)
+      sync_plan.reload
+      assert_not_nil sync_plan.foreman_tasks_recurring_logic
+    end
+  end
+end


### PR DESCRIPTION
I am not sure if this goes into 3.9 but it wouldn't hurt. Definitely needs to be in 3.10 since the refactoring lands in 3.10.

**How I tested this:**
1. Checked out foreman 1.19 stable and katello 3.8.
2. `rails katello:reset db`
3. Created products/repos and sync plans.
4. Checked out foreman develop and katello master(3.10) 
5. `rails db:migrate`
6. `rake katello:upgrades:3.9:migrate_sync_plans`
