### PR TITLE
Fixes #25660 - Content credential page search

### DIFF
--- a/app/views/katello/api/v2/content_credentials/show.json.rabl
+++ b/app/views/katello/api/v2/content_credentials/show.json.rabl
@@ -19,7 +19,7 @@ child :products => :gpg_key_products do
   end
 end
 
-child :repositories => :gpg_key_repos do
+child :root_repositories => :gpg_key_repos do
   attribute :id
   attribute :name
   attribute :content_type
@@ -40,7 +40,7 @@ child :ssl_ca_products => :ssl_ca_products do
   end
 end
 
-child :ssl_ca_repos => :ssl_ca_repos do
+child :ssl_ca_root_repos => :ssl_ca_root_repos do
   attribute :id
   attribute :name
   attribute :content_type
@@ -61,7 +61,7 @@ child :ssl_client_products => :ssl_client_products do
   end
 end
 
-child :ssl_client_repos => :ssl_client_repos do
+child :ssl_client_root_repos => :ssl_client_root_repos do
   attribute :id
   attribute :name
   attribute :content_type
@@ -82,7 +82,7 @@ child :ssl_key_products => :ssl_key_products do
   end
 end
 
-child :ssl_key_repos => :ssl_key_repos do
+child :ssl_key_root_repos => :ssl_key_root_repos do
   attribute :id
   attribute :name
   attribute :content_type

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/details/views/content-credential-products.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/details/views/content-credential-products.html
@@ -5,25 +5,32 @@
     You currently don't have any Products associated with this Content Credential.
   </span>
 
+  <div data-block="search">
+    <input type="text" class="form-control" stop-event="click"
+            placeholder="{{ 'Filter...' | translate }}"
+            ng-model="contentCredentialProductFilter"/>
+  </div>
+
+
   <div data-block="table">
     <table bst-table="table" class="table table-striped table-bordered">
       <thead>
         <tr bst-table-head>
           <th bst-table-column="name" sortable><span translate>Name</span></th>
-          <th bst-table-column="used_as" sortable><span translate>Used as</span></th>
+          <th bst-table-column="usedAs" sortable><span translate>Used as</span></th>
           <th bst-table-column class="number-cell" translate>Repositories</th>
         </tr>
       </thead>
 
       <tbody>
-        <tr bst-table-row ng-repeat="product in table.rows">
+        <tr bst-table-row ng-repeat="product in table.rows | filter:contentCredentialProductFilter">
           <td bst-table-cell>
             <a ui-sref="product.info({productId: product.id})">
               {{ product.name }}
             </a>
           </td>
           <td bst-table-cell>
-              {{ product.used_as }}
+              {{ product.usedAs }}
           </td>
           <td bst-table-cell class="number-cell">
             <a ui-sref="product.repositories({productId: product.id})">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/details/views/content-credential-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/details/views/content-credential-repositories.html
@@ -5,6 +5,12 @@
     You currently don't have any Repositories associated with this Content Credential.
   </span>
 
+  <div data-block="search">
+    <input type="text" class="form-control" stop-event="click"
+            placeholder="{{ 'Filter...' | translate }}"
+            ng-model="contentCredentialRepositoryFilter"/>
+  </div>
+
   <div data-block="table">
       <table class="table table-striped table-bordered">
       <thead>
@@ -17,7 +23,7 @@
       </thead>
 
       <tbody>
-        <tr ng-repeat="repository in table.rows">
+        <tr ng-repeat="repository in table.rows | filter:contentCredentialRepositoryFilter">
           <td>
             <a ui-sref="product.repository.info({productId: repository.product.id, repositoryId: repository.id})">{{ repository.name }}</a>
           </td>
@@ -27,7 +33,7 @@
             </a>
           </td>
           <td>{{ repository.content_type }}</td>
-          <td>{{ repository.used_as }}</td>
+          <td>{{ repository.usedAs }}</td>
         </tr>
       </tbody>
     </table>

--- a/test/controllers/api/v2/content_credentials_controller_test.rb
+++ b/test/controllers/api/v2/content_credentials_controller_test.rb
@@ -33,6 +33,13 @@ module Katello
       assert_template 'api/v2/content_credentials/index'
     end
 
+    def test_show
+      get :show, params: { organization_id: @organization.id, id: @gpg_key.id }
+
+      assert_response :success
+      assert_template 'api/v2/content_credentials/show'
+    end
+
     def test_index_protected
       allowed_perms = [@view_permission]
       denied_perms = [@create_permission, @update_permission, @destroy_permission]


### PR DESCRIPTION
This fix does many things:
- Update the rabl template for content credentials to use the
  correct renamed methods.
- Update the rabl template for content credentials to use root
  repositories. This way the user isn't returned all repositories
  from content views, rather just the library instance.
- Update the javascript functions to build the product and repo
  list to give to display on the page.
- Since we don't use the 'repositories' endpoint for gpg keys,
  I added a simple UI filter for the repo and product pages in
  content credential pages.

To test, create gpg keys and add to repos and products. It helps
if those repos are in content views to ensure that the CV repos
aren't showing up in the results. Check the content credential
detail page and ensure the product and repo associations listed
are correct.