### PR TITLE
[WIP] Fixes 24275 - Correct OSTree branch order

### DIFF
--- a/app/views/katello/api/v2/ostree_branches/index.json.rabl
+++ b/app/views/katello/api/v2/ostree_branches/index.json.rabl
@@ -2,6 +2,10 @@ object false
 
 extends "katello/api/v2/common/metadata"
 
-child @collection[:results] => :results do
+sorted = @collection[:results].sort_by { 
+  |v| Gem::Version.new(v['version'])
+}.reverse!
+
+child :sorted do
   extends 'katello/api/v2/ostree_branches/show'
 end

--- a/test/controllers/api/v2/ostree_branches_controller_test.rb
+++ b/test/controllers/api/v2/ostree_branches_controller_test.rb
@@ -67,10 +67,21 @@ module Katello
 
     def test_branch_order
       @repo.ostree_branches.create!(:name => "def456", :uuid => "456uvw", :version => "1.0")
+      @repo.ostree_branches.create!(:name => "ghi789", :uuid => "789rst", :version => "1.11")
+      @repo.ostree_branches.create!(:name => "jkl123", :uuid => "123opq", :version => "1.10")
+      @repo.ostree_branches.create!(:name => "mno456", :uuid => "456lmn", :version => "1.11.12")
+      @repo.ostree_branches.create!(:name => "pqr789", :uuid => "789ijk", :version => "1.11.120")
+      @repo.ostree_branches.create!(:name => "stu123", :uuid => "123fgh", :version => "1.11.119")
 
       get :index
-      tree_branch_uuid = JSON.parse(response.body)['results'][0]['uuid']
-      assert_equal "123xyz", tree_branch_uuid
+      results = JSON.parse(response.body)['results']
+      
+      actual_branch_order = results.collect do |branch|
+        branch['uuid']
+      end
+
+      expected_branch_order = ["789ijk", "123fgh", "456lmn", "789rst", "123opq", "123xyz", "456uvw"]
+      assert_equal expected_branch_order, actual_branch_order
     end
   end
 end


### PR DESCRIPTION
Refer to previous fix for context: https://github.com/Katello/katello/pull/7535

When using custom Fedora ostree repo (with a bit different numbering scheme), it seems that the ordering does not expect minor version numbers with more than one digit, therefore the ordering looks like:
```
1353 | fedora/27/x86_64/atomic-host          | 27.120 
1228 | fedora/27/x86_64/testing/atomic-host  | 27.120 
1050 | fedora/27/x86_64/updates/atomic-host  | 27.120 
2038 | fedora/27/x86_64/updates/atomic-host  | 27.12  
294  | fedora/27/x86_64/atomic-host          | 27.12  
94   | fedora/27/x86_64/testing/atomic-host  | 27.12  
2356 | fedora/27/aarch64/testing/atomic-host | 27.119 
2317 | fedora/27/x86_64/atomic-host          | 27.119 
2223 | fedora/27/ppc64le/atomic-host         | 27.119 
```
This applies to both the default output and with ostree-branch list --order 'version'