### PR TITLE
Fixes #25224 - Fix RHEL8 arches in RH repo page

### DIFF
--- a/app/lib/katello/util/path_with_substitutions.rb
+++ b/app/lib/katello/util/path_with_substitutions.rb
@@ -12,12 +12,35 @@ module Katello
         @substitutions = substitutions
         @path = path
         @resolved = []
+        create_rhel_eight_substitutions
+      end
+
+      def split_path
+        @split ||= @path.split('/').reject(&:blank?)
       end
 
       def substitutions_needed
         # e.g. if content_url = "/content/dist/rhel/server/7/$releasever/$basearch/kickstart"
         #      return ['releasever', 'basearch']
-        path.split('/').map { |word| word.start_with?('$') ? word[1..-1] : nil }.compact
+        split_path.map { |word| word.start_with?('$') ? word[1..-1] : nil }.compact
+      end
+
+      def create_rhel_eight_substitutions
+        @substitutions["basearch"] = rhel_eight_arch if rhel_eight?
+      end
+
+      def rhel_eight?
+        # url for RHEL8 repos can be either format:
+        # /content/dist/rhel8/8.0/x86_64/baseos/os/ OR
+        # /content/dist/layered/rhel8/x86_64/product
+        rhel8 = "rhel8"
+        split_path[2] == rhel8 || split_path[3] == rhel8
+      end
+
+      def rhel_eight_arch
+        # arch for RHEL8 repo paths is always the in the 5th position of the url i.e.
+        # /content/dist/rhel8/8.0/x86_64/baseos/os/ OR
+        split_path[4]
       end
 
       def substitutable?

--- a/app/lib/katello/util/path_with_substitutions.rb
+++ b/app/lib/katello/util/path_with_substitutions.rb
@@ -14,14 +14,18 @@ module Katello
         @substitutions = substitutions
         @path = path
         @resolved = []
-        generate_substitutions_from_path if @substitutions.empty? && substitutions_needed.empty?
+        check_for_subs_in_path if no_base_arch_passed?
+      end
+
+      def no_base_arch_passed?
+        @substitutions.keys.exclude?("basearch") && substitutions_needed.exclude?("basearch")
       end
 
       def split_path
         @split ||= @path.split('/').map(&:downcase).reject(&:blank?)
       end
 
-      def generate_substitutions_from_path
+      def check_for_subs_in_path
         arches = split_path & ARCHITECTURES
         arch = arches.first
         @substitutions["basearch"] = arch if arch

--- a/app/lib/katello/util/path_with_substitutions.rb
+++ b/app/lib/katello/util/path_with_substitutions.rb
@@ -14,7 +14,7 @@ module Katello
         @substitutions = substitutions
         @path = path
         @resolved = []
-        generate_substitutions_from_path if @substitutions.empty?
+        generate_substitutions_from_path if @substitutions.empty? && substitutions_needed.empty?
       end
 
       def split_path

--- a/app/lib/katello/util/path_with_substitutions.rb
+++ b/app/lib/katello/util/path_with_substitutions.rb
@@ -1,7 +1,7 @@
 module Katello
   module Util
     class PathWithSubstitutions
-      ARCHITECTURES = ["x86_64", "s390x", "ppc64le", "aarch64" ].freeze
+      ARCHITECTURES = ["x86_64", "s390x", "ppc64le", "aarch64", "multiarch", "ppc64"].freeze
 
       include Comparable
 
@@ -18,18 +18,13 @@ module Katello
       end
 
       def split_path
-        @split ||= @path.split('/').reject(&:blank?)
+        @split ||= @path.split('/').map(&:downcase).reject(&:blank?)
       end
 
       def generate_substitutions_from_path
-        # in RHEL8, arch is typically in the 5th position of the path, so we check here first
-        if split_path.length >= 5 && ARCHITECTURES.include?(split_path[4])
-          @substitutions["basearch"] = split_path[4]
-        else
-          arches = split_path & ARCHITECTURES
-          arch = arches.first
-          @substitutions["basearch"] = arch if arch
-        end
+        arches = split_path & ARCHITECTURES
+        arch = arches.first
+        @substitutions["basearch"] = arch if arch
       end
 
       def substitutions_needed

--- a/test/lib/util/cdn_var_subsitutor_test.rb
+++ b/test/lib/util/cdn_var_subsitutor_test.rb
@@ -67,7 +67,7 @@ module Katello
 
       def test_validating_subscriptions_needs_params
         fake_content_params = ["Red Hat Enterprise Linux Atomic Host (Kickstart)",
-                               "/content/dist/$basearch/atomic/7/7Server/fakearch/kickstart"]
+                               "/content/dist/$basearch/atomic/7/7Server/x86_64/kickstart"]
         content = FakeContent.new(*fake_content_params)
         substitutions = {}
         error_message = "Missing arguments basearch for #{content.content_url}"

--- a/test/lib/util/cdn_var_subsitutor_test.rb
+++ b/test/lib/util/cdn_var_subsitutor_test.rb
@@ -67,7 +67,7 @@ module Katello
 
       def test_validating_subscriptions_needs_params
         fake_content_params = ["Red Hat Enterprise Linux Atomic Host (Kickstart)",
-                               "/content/dist/$basearch/atomic/7/7Server/x86_64/kickstart"]
+                               "/content/dist/$basearch/atomic/7/7Server/fakearch/kickstart"]
         content = FakeContent.new(*fake_content_params)
         substitutions = {}
         error_message = "Missing arguments basearch for #{content.content_url}"

--- a/test/lib/util/path_with_substitutions_test.rb
+++ b/test/lib/util/path_with_substitutions_test.rb
@@ -8,6 +8,7 @@ module Katello
         @non_sub_path = '/content/dist/rhel/server/5/5Server/x86_64/os'
         @el8_path = '/content/dist/rhel8/8.0/x86_64/baseos/os/'
         @el8_layered_path = '/content/dist/layered/rhel8/x86_64/product'
+        @el8_arch_misplaced = '/content/dist/rhel8/x86_64/product'
         @releasever_list = ['5Server', '5.8']
         @arch_list = ['x86_64', 'i386']
         @cdn = Katello::Resources::CDN::CdnResource.new('http://someurl/')
@@ -23,22 +24,13 @@ module Katello
         refute PathWithSubstitutions.new(@non_sub_path, {}).substitutable?
       end
 
-      def test_rhel_eight
-        assert PathWithSubstitutions.new(@el8_path, {}).rhel_eight?
-        assert PathWithSubstitutions.new(@el8_layered_path, {}).rhel_eight?
-        refute PathWithSubstitutions.new(@el5_path, {}).rhel_eight?
-      end
-
-      def test_rhel_eight_arch
-        assert_equal PathWithSubstitutions.new(@el8_path, {}).rhel_eight_arch, "x86_64"
-        assert_equal PathWithSubstitutions.new(@el8_layered_path, {}).rhel_eight_arch, "x86_64"
-      end
-
       def test_rhel_eight_substitutions
         el8_path_with_sub = PathWithSubstitutions.new(@el8_path, {})
         el8_layered_path_with_sub = PathWithSubstitutions.new(@el8_layered_path, {})
+        el8_arch_misplaced_path_with_sub = PathWithSubstitutions.new(@el8_arch_misplaced, {})
         assert_equal el8_path_with_sub.substitutions["basearch"], "x86_64"
         assert_equal el8_layered_path_with_sub.substitutions["basearch"], "x86_64"
+        assert_equal el8_arch_misplaced_path_with_sub.substitutions["basearch"], "x86_64"
       end
 
       def test_resolve_substitutions_releasever

--- a/test/lib/util/path_with_substitutions_test.rb
+++ b/test/lib/util/path_with_substitutions_test.rb
@@ -6,6 +6,8 @@ module Katello
       def setup
         @el5_path = '/content/dist/rhel/server/5/$releasever/$basearch/os'
         @non_sub_path = '/content/dist/rhel/server/5/5Server/x86_64/os'
+        @el8_path = '/content/dist/rhel8/8.0/x86_64/baseos/os/'
+        @el8_layered_path = '/content/dist/layered/rhel8/x86_64/product'
         @releasever_list = ['5Server', '5.8']
         @arch_list = ['x86_64', 'i386']
         @cdn = Katello::Resources::CDN::CdnResource.new('http://someurl/')
@@ -19,6 +21,24 @@ module Katello
       def test_substitutable?
         assert PathWithSubstitutions.new(@el5_path, {}).substitutable?
         refute PathWithSubstitutions.new(@non_sub_path, {}).substitutable?
+      end
+
+      def test_rhel_eight
+        assert PathWithSubstitutions.new(@el8_path, {}).rhel_eight?
+        assert PathWithSubstitutions.new(@el8_layered_path, {}).rhel_eight?
+        refute PathWithSubstitutions.new(@el5_path, {}).rhel_eight?
+      end
+
+      def test_rhel_eight_arch
+        assert_equal PathWithSubstitutions.new(@el8_path, {}).rhel_eight_arch, "x86_64"
+        assert_equal PathWithSubstitutions.new(@el8_layered_path, {}).rhel_eight_arch, "x86_64"
+      end
+
+      def test_rhel_eight_substitutions
+        el8_path_with_sub = PathWithSubstitutions.new(@el8_path, {})
+        el8_layered_path_with_sub = PathWithSubstitutions.new(@el8_layered_path, {})
+        assert_equal el8_path_with_sub.substitutions["basearch"], "x86_64"
+        assert_equal el8_layered_path_with_sub.substitutions["basearch"], "x86_64"
       end
 
       def test_resolve_substitutions_releasever

--- a/test/lib/util/path_with_substitutions_test.rb
+++ b/test/lib/util/path_with_substitutions_test.rb
@@ -33,6 +33,15 @@ module Katello
         assert_equal el8_arch_misplaced_path_with_sub.substitutions["basearch"], "x86_64"
       end
 
+      def test_no_basearch_substitutions
+        relver = 'rhel8'
+        arch = 'x86_64'
+        no_base_arch_path = "/content/dist/$releasever/#{arch}/product"
+        no_base_arch = PathWithSubstitutions.new(no_base_arch_path, "releasever" => relver)
+        assert_equal no_base_arch.substitutions["basearch"], arch
+        assert_equal no_base_arch.substitutions["releasever"], relver
+      end
+
       def test_resolve_substitutions_releasever
         path = PathWithSubstitutions.new(@el5_path, {})
         @cdn.expects(:fetch_substitutions).with('/content/dist/rhel/server/5/').returns(@releasever_list)


### PR DESCRIPTION
RHEL8 paths in the CDN no longer use substitutions, i.e.
$basearch. The paths are now fixed, set paths that looks
like "content/dist/rhel8/8.0/x86_64/baseos/os/"

We make a lot of assumptions on  both the back-end and
front-end that the EL6 and EL7 substitution paths exist.
Because of this, I added methods to grab the info from
the url and add it to the substitutions hash we have
been using.

To review, check that:
- EL5, 6, and 7 repos act as expected on the RH repos page
- You can now view the arch for the RHEL8 repos