### PR TITLE
Fixes #25667 - Unprotect suse repos from CDN

### DIFF
--- a/app/models/katello/candlepin/repository_mapper.rb
+++ b/app/models/katello/candlepin/repository_mapper.rb
@@ -106,7 +106,11 @@ module Katello
       end
 
       def unprotected?
-        kickstart? || file?
+        kickstart? || file? || suse?
+      end
+
+      def suse?
+        content.content_type == Repository::YUM_TYPE && path.downcase.include?("/suse")
       end
 
       def file?

--- a/app/models/katello/candlepin/repository_mapper.rb
+++ b/app/models/katello/candlepin/repository_mapper.rb
@@ -110,7 +110,7 @@ module Katello
       end
 
       def suse?
-        content.content_type == Repository::YUM_TYPE && path.downcase.include?("/suse")
+        content.content_type == Repository::YUM_TYPE && path.downcase.match(/suse/)
       end
 
       def file?

--- a/test/models/candlepin/repository_mapper_test.rb
+++ b/test/models/candlepin/repository_mapper_test.rb
@@ -1,0 +1,19 @@
+require 'katello_test_helper'
+
+module Katello
+  class RepositoryMapperTest < ActiveSupport::TestCase
+    def setup
+      @repo1 = katello_repositories(:fedora_17_x86_64)
+      @product1 = @repo1.product
+    end
+
+    def test_unprotected_suse
+      mapper = Candlepin::RepositoryMapper.new(@product1, @repo1, {})
+      mapper.expects(:path).returns("/special/suse")
+      assert mapper.unprotected?
+
+      mapper.expects(:path).returns("/special/redhat")
+      refute mapper.unprotected?
+    end
+  end
+end


### PR DESCRIPTION
This commit expose suse client repos via http that will be delivered by
CDN as unprotected.