### PR TITLE
Fixes #25676 - Ignore non existent module errata

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -217,7 +217,8 @@ module Katello
         module_stream_attributes = []
         json.each do |package_item|
           if package_item['module']
-            module_stream = ModuleStream.where(package_item['module']).first_or_create!
+            module_stream = ModuleStream.where(package_item['module']).first
+            next if module_stream.blank?
             nvreas = package_item["packages"].map { |hash| Util::Package.build_nvra(hash) }
             module_stream_id_column = "#{ModuleStreamErratumPackage.table_name}.module_stream_id"
             existing = ErratumPackage.joins(:module_streams).


### PR DESCRIPTION
Before this Commit:
When indexing errata that contained modules, katello would try to do a
first_or_create on a ModuleStream. i.e if the module is not already
present in the ModuleStreams table then create it.
This cause non-null violations in cases where Errata contained modules
that are not part of the same repo and hence don't exist in pulp.

After this commit:
We donot associating errata to a module if the module does not exist.
From a dnf perspective, dnf would probably ignore applying the module if
it did not exist in any case.