### PR TITLE
Fixes #25574: alter default columns on subs page

### DIFF
--- a/webpack/scenes/Subscriptions/SubscriptionConstants.js
+++ b/webpack/scenes/Subscriptions/SubscriptionConstants.js
@@ -95,4 +95,6 @@ export const SUBSCRIPTION_TABLE_DEFAULT_COLUMNS = [
   'contract_number',
   'start_date',
   'end_date',
+  'consumed',
+  'quantity',
 ];

--- a/webpack/scenes/Subscriptions/__tests__/subscriptions.fixtures.js
+++ b/webpack/scenes/Subscriptions/__tests__/subscriptions.fixtures.js
@@ -421,12 +421,12 @@ export const tableColumns = [
   {
     key: 'consumed',
     label: 'Consumed',
-    value: false,
+    value: true,
   },
   {
     key: 'quantity',
     label: 'Entitlements',
-    value: false,
+    value: true,
   },
 ];
 export const loadTableColumnsSuccessAction = [
@@ -439,6 +439,8 @@ export const loadTableColumnsSuccessAction = [
         'contract_number',
         'start_date',
         'end_date',
+        'consumed',
+        'quantity',
       ],
     },
   },


### PR DESCRIPTION
Add the consumed and entitlements columns to the list of default columns
on the subscriptions page.

https://projects.theforeman.org/issues/25574