### PR TITLE
Fixes #25687 - No sync interval set for product

### DIFF
--- a/app/views/katello/api/v2/products/base.json.rabl
+++ b/app/views/katello/api/v2/products/base.json.rabl
@@ -18,7 +18,7 @@ child({:available_content => :available_content}, :if => params[:include_availab
 end
 
 child :sync_plan do
-  attributes :id, :name, :description, :sync_date, :interval, :next_sync
+  attributes :id, :name, :description, :sync_date, :interval, :next_sync, :cron_expression
 end
 
 node :repository_count do |product|

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/partials/sync-status.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/partials/sync-status.html
@@ -14,6 +14,11 @@
     Weekly on {{ product.sync_plan.sync_date | date:'EEEE' }} at {{ product.sync_plan.sync_date | date:'mediumTime' }} (Server Time)
   </span>
 </dd>
+<dd ng-if="product.sync_plan.cron_expression">
+  <span translate>
+    Custom Cron : {{ product.sync_plan.cron_expression }}
+  </span>
+</dd>
 <dd ng-hide="product.sync_plan.next_sync">
   <span translate>
     Synced manually, no interval set.


### PR DESCRIPTION
### Steps to reproduce
1. Create a sync plan with a custom cron and add a product to it.
2. Go to the product and check the details page.
3. Nothing appears for the Sync Interval field (Data from fields below is instead shifted up)
