### PR TITLE
Fixes #25688 - Validates docker white tags in repo

### DIFF
--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -47,6 +47,7 @@ module Katello
     validate :ensure_ostree_repo_protected, :if => :ostree?
     validate :ensure_compatible_download_policy, :if => :yum?
     validate :ensure_valid_ignorable_content
+    validate :ensure_valid_docker_tags_whitelist
     validate :ensure_content_attribute_restrictions
     validate :ensure_valid_upstream_authorization
     validates :url, presence: true, if: :ostree?
@@ -170,6 +171,15 @@ module Katello
         errors.add(:ignorable_content, N_("Invalid value specified for ignorable content."))
       elsif ignorable_content.any? { |item| !IGNORABLE_CONTENT_UNIT_TYPES.include?(item) }
         errors.add(:ignorable_content, N_("Invalid value specified for ignorable content. Permissible values %s") % IGNORABLE_CONTENT_UNIT_TYPES.join(","))
+      end
+    end
+
+    def ensure_valid_docker_tags_whitelist
+      return if docker_tags_whitelist.blank?
+      if !docker?
+        errors.add(:docker_tags_whitelist, N_("White list can be only set for Container Image repositories."))
+      elsif !docker_tags_whitelist.is_a?(Array)
+        errors.add(:docker_tags_whitelist, N_("Invalid value specified for Container Image repositories."))
       end
     end
 

--- a/test/models/root_repository_test.rb
+++ b/test/models/root_repository_test.rb
@@ -617,6 +617,19 @@ module Katello
       @root.ignorable_content = nil
       assert @root.valid?
     end
+
+    def test_docker_white_tags
+      @docker_root.url = "http://foo.com"
+      @docker_root.docker_tags_whitelist = nil
+      assert @root.valid?
+      @docker_root.docker_tags_whitelist = ["latest", "1.1"]
+      assert @docker_root.valid?
+
+      @root.content_type = Repository::OSTREE_TYPE
+      @root.docker_tags_whitelist = ["boo"]
+      refute @root.valid?
+      assert @root.errors.include?(:docker_tags_whitelist)
+    end
   end
 
   class RootRepositoryInstanceTest < RepositoryTestBase


### PR DESCRIPTION
This commit contains some validation logic to prevent people from
setting docker white tagslist for non docker repos