### PR TITLE
Refs #25696 - add compatibility with concurrent-ruby 1.1

### DIFF
--- a/app/lib/katello/util/cdn_var_substitutor.rb
+++ b/app/lib/katello/util/cdn_var_substitutor.rb
@@ -60,7 +60,8 @@ module Katello
         return resolved if to_resolve.empty?
 
         futures = to_resolve.map do |path_with_substitution|
-          Concurrent.future do
+          future_namespace = defined?(Concurrent::Promises) ? Concurrent::Promises : Concurrent
+          future_namespace.future do
             path_with_substitution.resolve_substitutions(@resource)
           end
         end


### PR DESCRIPTION
Still backward compatible with concurrent-ruby 1.0.

To be released to nightlies before dynflow 1.2 is released, so that the
dynflow 1.2 doesn't break anything