### PR TITLE
Fixes #25695 - finish migration to concurrent-ruby-1.1

### DIFF
--- a/app/lib/katello/util/cdn_var_substitutor.rb
+++ b/app/lib/katello/util/cdn_var_substitutor.rb
@@ -60,8 +60,7 @@ module Katello
         return resolved if to_resolve.empty?
 
         futures = to_resolve.map do |path_with_substitution|
-          future_namespace = defined?(Concurrent::Promises) ? Concurrent::Promises : Concurrent
-          future_namespace.future do
+          Concurrent::Promises.future do
             path_with_substitution.resolve_substitutions(@resource)
           end
         end

--- a/app/models/katello/ping.rb
+++ b/app/models/katello/ping.rb
@@ -71,7 +71,7 @@ module Katello
 
           checks = executors.map { |executor| world.ping(executor.id, timeout) }
           checks.each(&:wait)
-          if checks.any?(&:failed?)
+          if checks.any?(&:rejected?)
             fail _("some executors are not responding, check %{status_url}") % { :status_url => '/foreman_tasks/dynflow/status' }
           end
         end

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "rabl"
   gem.add_dependency "foreman-tasks", "~> 0.13", ">= 0.14.1"
-  gem.add_dependency "dynflow", ">= 1.1.3"
+  gem.add_dependency "dynflow", ">= 1.2.0"
   gem.add_dependency "foreman_docker", ">= 0.2.0"
 
   gem.add_dependency "qpid_messaging"


### PR DESCRIPTION
Remove the backward compatibility with concurrent-ruby-1.0

To be merged once dynflow 1.2 is released.