### PR TITLE
Fixes #25699 - subscriptions table blank with view_permissions

### DIFF
--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -69,7 +69,7 @@ class SubscriptionsPage extends Component {
       }
     }
 
-    if (!isEqual(organization.owner_details, prevProps.organization.owner_details)) {
+    if (!isEqual(organization, prevProps.organization)) {
       this.pollTasks();
     }
   }
@@ -95,11 +95,13 @@ class SubscriptionsPage extends Component {
   pollTasks() {
     const { pollBulkSearch, organization } = this.props;
 
-    pollBulkSearch({
-      action: `organization '${organization.owner_details.displayName}'`,
-      result: 'pending',
-      label: BLOCKING_FOREMAN_TASK_TYPES.join(' or '),
-    }, BULK_TASK_SEARCH_INTERVAL, organization.id);
+    if (organization && organization.owner_details) {
+      pollBulkSearch({
+        action: `organization '${organization.owner_details.displayName}'`,
+        result: 'pending',
+        label: BLOCKING_FOREMAN_TASK_TYPES.join(' or '),
+      }, BULK_TASK_SEARCH_INTERVAL, organization.id);
+    }
 
     this.props.loadSetting('content_disconnected');
     this.props.loadSubscriptions();

--- a/webpack/scenes/Subscriptions/__tests__/SubscriptionsPage.test.js
+++ b/webpack/scenes/Subscriptions/__tests__/SubscriptionsPage.test.js
@@ -17,36 +17,44 @@ const loadTables = () => new Promise((resolve) => {
 describe('subscriptions page', () => {
   const noop = () => {};
   const organization = { owner_details: { upstreamConsumer: 'blah' } };
+  const page = shallow(<SubscriptionsPage
+    organization={organization}
+    subscriptions={successState}
+    subscriptionTableSettings={settingsSuccessState}
+    loadSetting={loadSetting}
+    loadTables={loadTables}
+    loadTableColumns={loadTableColumns}
+    createColumns={createColumns}
+    updateColumns={updateColumns}
+    loadSubscriptions={loadSubscriptions}
+    updateQuantity={updateQuantity}
+    pollTaskUntilDone={noop}
+    pollBulkSearch={noop}
+    deleteSubscriptions={() => {}}
+    resetTasks={noop}
+    uploadManifest={noop}
+    deleteManifest={noop}
+    refreshManifest={noop}
+    updateSearchQuery={noop}
+    openManageManifestModal={noop}
+    closeManageManifestModal={noop}
+    openDeleteModal={noop}
+    closeDeleteModal={noop}
+    openTaskModal={noop}
+    closeTaskModal={noop}
+    disableDeleteButton={noop}
+    enableDeleteButton={noop}
+  />);
 
   it('should render', async () => {
-    const page = shallow(<SubscriptionsPage
-      organization={organization}
-      subscriptions={successState}
-      subscriptionTableSettings={settingsSuccessState}
-      loadSetting={loadSetting}
-      loadTables={loadTables}
-      loadTableColumns={loadTableColumns}
-      createColumns={createColumns}
-      updateColumns={updateColumns}
-      loadSubscriptions={loadSubscriptions}
-      updateQuantity={updateQuantity}
-      pollTaskUntilDone={noop}
-      pollBulkSearch={noop}
-      deleteSubscriptions={() => {}}
-      resetTasks={noop}
-      uploadManifest={noop}
-      deleteManifest={noop}
-      refreshManifest={noop}
-      updateSearchQuery={noop}
-      openManageManifestModal={noop}
-      closeManageManifestModal={noop}
-      openDeleteModal={noop}
-      closeDeleteModal={noop}
-      openTaskModal={noop}
-      closeTaskModal={noop}
-      disableDeleteButton={noop}
-      enableDeleteButton={noop}
-    />);
     expect(toJson(page)).toMatchSnapshot();
+  });
+
+  it('should poll tasks when org changes', async () => {
+    jest.spyOn(page.instance(), 'pollTasks');
+
+    page.setProps({ organization: { id: 1 } });
+
+    expect(page.instance().pollTasks).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
The issue here is that a user with only view_permissions cannot load the organization when viewing the subscriptions page. As a result the method `pollTasks` would not fire, causing the table to not fully load.

Also fixed the call within `pollTasks` to `pollBulkSearch` to not be called when the org is not present to prevent errors