### PR TITLE
Fixes #25761: Invoke Capsule sync of a repo after package upload

### DIFF
--- a/app/lib/actions/katello/repository/upload_files.rb
+++ b/app/lib/actions/katello/repository/upload_files.rb
@@ -1,3 +1,4 @@
+# rubocop:disable HandleExceptions
 require 'fileutils'
 require 'English'
 
@@ -33,6 +34,11 @@ module Actions
           # Delete tmp files when some exception occurred. Would be
           # nice to have other ways to do that: https://github.com/Dynflow/dynflow/issues/130
           delete_tmp_files(tmp_files) if $ERROR_INFO && tmp_files
+        end
+
+        def run
+          ForemanTasks.async_task(Repository::CapsuleSync, ::Katello::Repository.find(input[:repository][:id]))
+        rescue ::Katello::Errors::CapsuleCannotBeReached # skip any capsules that cannot be connected to
         end
 
         def humanized_name


### PR DESCRIPTION
When a user uploads a package to a repository, the repo should be
synced to Capsules in the repo's Lifecycle Environment.

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>