### PR TITLE
Fixes #25793 - Fail on non-yum download policy

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -197,7 +197,7 @@ module Katello
     param_group :repo_create
     param_group :repo
     def create
-      repo_params = filtered_repository_params
+      repo_params = repository_params
       unless RepositoryTypeManager.creatable_by_user?(repo_params[:content_type])
         msg = _("Invalid params provided - content_type must be one of %s") % RepositoryTypeManager.creatable_repository_types.keys.join(",")
         fail HttpErrors::UnprocessableEntity, msg
@@ -449,14 +449,6 @@ module Katello
           fail HttpErrors::NotFound, _("Couldn't find %{content_type} with id '%{id}'") % { :content_type => content_type, :id => params[credential_id] }
         end
       end
-    end
-
-    def filtered_repository_params
-      params = repository_params
-      ::Katello::RootRepository::CONTENT_ATTRIBUTE_RESTRICTIONS.each do |attribute, types|
-        params.delete(attribute) unless types.include?(params[:content_type])
-      end
-      params
     end
 
     def repository_params


### PR DESCRIPTION
**Steps to repro:**

Create a non-yum repo with download policy set (Follow comments on issue)

**Expected:**

Throw validation error when setting download policy on non-yum repositories.

_**PS**: 
We have similar scenarios for ostree_upstream_sync_policy and ostree_upstream_sync_depth on non-ostree repos and deb_releases, deb_components, deb_architectures on non-deb repos. Currently these params are simply ignored when not ostree or deb._ https://github.com/Katello/katello/blob/6dd89e862945a20e56d972a4b030868ac744b66b/app/controllers/katello/api/v2/repositories_controller.rb#L501