### PR TITLE
Fixes #25781: Disallow repo url in reg name patrn

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -765,7 +765,7 @@ module Katello
     end
 
     class Jail < ::Safemode::Jail
-      allow :name, :label, :docker_upstream_name, :url
+      allow :name, :label, :docker_upstream_name
     end
   end
 end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-details.html
@@ -54,7 +54,6 @@ organization.label
 repository.name
 repository.label
 repository.docker_upstream_name
-repository.url
 content_view.label
 content_view.name
 content_view.version


### PR DESCRIPTION
Disallow repository url in the registry name pattern.

This PR doesn't specifically disallow using repository.url, but the regex will always flag it as invalid. I'm open to suggestions here - I'd much rather strictly limit what users can put in the ERB, but we might be at the mercy of [the safemode gem](https://github.com/svenfuchs/safemode), which states "This library is still highly experimental. Only use it at your own risk for anything beyond experiments and playing".

To test:

Update any lifecycle environment's registry name pattern with some erb containing `<%= repository.url %>`, and expect validation failure.