### PR TITLE
Fixes #25805 - correct value for redhat repo

### DIFF
--- a/app/views/katello/api/v2/repositories/base.json.rabl
+++ b/app/views/katello/api/v2/repositories/base.json.rabl
@@ -12,6 +12,7 @@ glue(@object.root) do
   child :product do |_product|
     attributes :id, :cp_id, :name
     attributes :orphaned? => :orphaned
+    attributes :redhat? => :redhat
     node :sync_plan do |_sync_plan|
       attributes :name, :description, :sync_date, :interval, :next_sync
     end


### PR DESCRIPTION
**Adding redhat flag to the repo json so that a redhat repo can be correctly identified.**

The required hammer fix is https://github.com/Katello/hammer-cli-katello/pull/612
****
**To test:**

Enable a redhat repo from redhat repositories page
In hammer > hammer repository info --id redhat_repo_id
Field Redhat Repository is set to No even for redhat repos
