### PR TITLE
Fixes # 25816 - Can't update CDN URL

### DIFF
--- a/app/lib/actions/katello/provider/update.rb
+++ b/app/lib/actions/katello/provider/update.rb
@@ -30,7 +30,7 @@ module Actions
             next unless repository.url
             path = repository.url.split(current_base_url)[1]
             url = "#{new_base_url}#{path}"
-            plan_action(::Actions::Katello::Repository::Update, repository, :url => url)
+            plan_action(::Actions::Katello::Repository::Update, repository.root, :url => url)
           end
         end
       end

--- a/lib/katello/tasks/repository.rake
+++ b/lib/katello/tasks/repository.rake
@@ -98,7 +98,7 @@ namespace :katello do
     repos.find_each.with_index do |repo, index|
       puts "Processing Repository #{index + 1}/#{repos.count}: #{repo.name} (#{repo.id})"
       begin
-        ForemanTasks.sync_task(::Actions::Katello::Repository::Update, repo,
+        ForemanTasks.sync_task(::Actions::Katello::Repository::Update, repo.root,
                                download_policy: policy)
       rescue => e
         puts "Failed to update repository #{repo.name} (#{repo.id}): #{e.message}"

--- a/test/actions/katello/provider/update_test.rb
+++ b/test/actions/katello/provider/update_test.rb
@@ -19,13 +19,13 @@ module Actions
       plan_action(action, @provider, :redhat_repository_url => 'http://localhost')
       repositories = @provider.products.enabled.collect { |product| product.repositories }
       repositories.flatten!
-      repositories = repositories.collect do |repository|
+      root_repositories = repositories.collect do |repository|
         next unless repository.url
-        [repository, {:url => "http://localhost"}]
+        [repository.root, {:url => "http://localhost"}]
       end
 
       assert_action_planed_with(action, repository_update_class) do |repository|
-        assert_includes repositories, repository
+        assert_includes root_repositories, repository
       end
     end
   end

--- a/test/lib/tasks/repository_test.rb
+++ b/test/lib/tasks/repository_test.rb
@@ -134,7 +134,7 @@ module Katello
       ENV['DOWNLOAD_POLICY'] = 'background'
       Katello::Repository.stubs(:yum_type).returns(Katello::Repository.where(:id => @library_repo))
       ForemanTasks.expects(:sync_task).with(::Actions::Katello::Repository::Update,
-                                            @library_repo,
+                                            @library_repo.root,
                                             download_policy: 'background')
 
       Rake.application.invoke_task('katello:change_download_policy')


### PR DESCRIPTION
**To test:**
1. Go to Subscription>Manage Manifest>Update Redhat CDN

_We are passing repo root to the action Repository Update starting 3.10. There are 2 places I found where the action was called with repository instead of root. This PR aims to fix all places that happens._
 