### PR TITLE
Fixes #25818 - Show virt-who hypervisor type

### DIFF
--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -29,6 +29,11 @@ module Katello
 
       attr_accessor :facts
 
+      def host_type
+        host_facts = self.host.facts
+        host_facts["virt::host_type"] || host_facts["hypervisor::type"]
+      end
+
       def update_from_consumer_attributes(consumer_params)
         import_database_attributes(consumer_params)
         self.facts = consumer_params['facts'] unless consumer_params['facts'].blank?

--- a/app/views/katello/api/v2/subscription_facet/show.json.rabl
+++ b/app/views/katello/api/v2/subscription_facet/show.json.rabl
@@ -21,4 +21,6 @@ child :subscription_facet => :subscription_facet_attributes do |_facet|
   child :activation_keys => :activation_keys do
     attributes :id, :name
   end
+
+  attributes :host_type
 end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details-info.controller.js
@@ -148,16 +148,10 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsInfoContro
             return (virt === true || virt === 'true');
         };
 
-        $scope.hostType = function (host) {
-          if (host && host.facts) {
-            return host.facts["virt::host_type"] || host.facts["hypervisor::type"] || "";
-          }
-        };
-
         $scope.hostRam = function (host) {
-          if (host && host.facts) {
-            return !!host.facts["memory::memtotal"] ? $scope.convertMemToGB(host.facts["memory::memtotal"]) : "";
-          }
+            if (host && host.facts) {
+                return host.facts["memory::memtotal"] ? $scope.convertMemToGB(host.facts["memory::memtotal"]) : "";
+            }
         };
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details-info.controller.js
@@ -147,5 +147,17 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsInfoContro
         $scope.virtual = function (virt) {
             return (virt === true || virt === 'true');
         };
+
+        $scope.hostType = function (host) {
+          if (host && host.facts) {
+            return host.facts["virt::host_type"] || host.facts["hypervisor::type"] || "";
+          }
+        };
+
+        $scope.hostRam = function (host) {
+          if (host && host.facts) {
+            return !!host.facts["memory::memtotal"] ? $scope.convertMemToGB(host.facts["memory::memtotal"]) : "";
+          }
+        };
     }]
 );

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -26,7 +26,7 @@
         </dd>
 
         <dt translate>Type</dt>
-        <dd>{{ hostType(host) }}</dd>
+        <dd>{{ host.subscription_facet_attributes.host_type }}</dd>
 
         <dt bst-feature-flag="remote_actions">
           <span translate>Katello Agent</span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -26,7 +26,7 @@
         </dd>
 
         <dt translate>Type</dt>
-        <dd>{{ host.facts["virt::host_type"] || host.facts["hypervisor::type"] }}</dd>
+        <dd>{{ hostType(host) }}</dd>
 
         <dt bst-feature-flag="remote_actions">
           <span translate>Katello Agent</span>
@@ -172,7 +172,7 @@
         <dd>{{ host.facts['cpu::core(s)_per_socket'] }}</dd>
 
         <dt translate>RAM (GB)</dt>
-        <dd>{{ !!host.facts["memory::memtotal"] ? convertMemToGB(host.facts["memory::memtotal"]) : "" }}</dd>
+        <dd>{{ hostRam(host) }}</dd>
 
         <dt translate>Virtual Guest</dt>
         <dd>{{ virtual(host.facts['virt::is_guest']) | booleanToYesNo }}</dd>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -26,7 +26,7 @@
         </dd>
 
         <dt translate>Type</dt>
-        <dd>{{ host.facts["virt::host_type"] }}</dd>
+        <dd>{{ host.facts["virt::host_type"] || host.facts["hypervisor::type"] }}</dd>
 
         <dt bst-feature-flag="remote_actions">
           <span translate>Katello Agent</span>
@@ -172,7 +172,7 @@
         <dd>{{ host.facts['cpu::core(s)_per_socket'] }}</dd>
 
         <dt translate>RAM (GB)</dt>
-        <dd>{{ convertMemToGB(host.facts["memory::memtotal"]) }}</dd>
+        <dd>{{ !!host.facts["memory::memtotal"] ? convertMemToGB(host.facts["memory::memtotal"]) : "" }}</dd>
 
         <dt translate>Virtual Guest</dt>
         <dd>{{ virtual(host.facts['virt::is_guest']) | booleanToYesNo }}</dd>

--- a/test/models/host/subscription_facet_test.rb
+++ b/test/models/host/subscription_facet_test.rb
@@ -405,5 +405,30 @@ module Katello
       assert host.valid_content_override_label?('some-label')
       refute host.valid_content_override_label?('some-label1')
     end
+
+    def test_host_type
+      kvm = "kvm"
+      host = FactoryBot.create(:host, :with_content, :with_subscription, content_view: view,
+                               lifecycle_environment: library, organization: org)
+      host.expects(:facts).returns("virt::host_type" => kvm)
+
+      assert_equal host.subscription_facet.host_type, kvm
+    end
+
+    def test_host_type_hypervisor
+      qemu = "QEMU"
+      hypervisor = FactoryBot.create(:host, :with_content, :with_subscription, content_view: view,
+                                     lifecycle_environment: library, organization: org)
+      hypervisor.expects(:facts).returns("hypervisor::type" => qemu)
+
+      assert_equal hypervisor.subscription_facet.host_type, qemu
+    end
+
+    def test_host_type_nil
+      host = FactoryBot.create(:host, :with_content, :with_subscription, content_view: view,
+                               lifecycle_environment: library, organization: org)
+
+      assert_nil host.subscription_facet.host_type
+    end
   end
 end


### PR DESCRIPTION
virt-who hypervisors use "hypervisor::type" fact rather than
"virt::host_type" for type. This commit updates the UI
to check for both.

To review, [register a virt-who hypervisor](https://gist.github.com/johnpmitsch/fc7d15b314fbb395486ec5051974e649) and check
the type field in the content host details page is
filled out.

This PR is based on https://github.com/Katello/katello/pull/7821, which is currently in this PR. I'll rebase when it is merged.
It also requires a [foreman PR](https://github.com/theforeman/foreman/pull/6398), you will need to check that out manually