### PR TITLE
Fixes #25834 - Skip org validations on all manifest tasks

### DIFF
--- a/app/lib/actions/katello/organization/manifest_delete.rb
+++ b/app/lib/actions/katello/organization/manifest_delete.rb
@@ -39,9 +39,7 @@ module Actions
         end
 
         def finalize
-          subject_organization.update_attributes!(
-            :manifest_refreshed_at => Time.now,
-            :audit_comment => _('Manifest deleted'))
+          subject_organization.audit_manifest_action(_('Manifest deleted'))
         end
       end
     end

--- a/app/lib/actions/katello/organization/manifest_import.rb
+++ b/app/lib/actions/katello/organization/manifest_import.rb
@@ -44,9 +44,7 @@ module Actions
         end
 
         def finalize
-          subject_organization.update_attributes!(
-            :manifest_refreshed_at => Time.now,
-            :audit_comment => _('Manifest imported'))
+          subject_organization.audit_manifest_action(_('Manifest imported'))
         end
       end
     end

--- a/app/lib/actions/katello/organization/manifest_refresh.rb
+++ b/app/lib/actions/katello/organization/manifest_refresh.rb
@@ -60,9 +60,7 @@ module Actions
         end
 
         def finalize
-          subject_organization.manifest_refreshed_at = Time.now
-          subject_organization.audit_comment = _('Manifest refreshed')
-          subject_organization.save(validate: false)
+          subject_organization.audit_manifest_action(_('Manifest refreshed'))
         end
       end
     end

--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -203,6 +203,16 @@ module Katello
           users.pluck(:id)
         end
 
+        def audit_manifest_action(message)
+          self.manifest_refreshed_at = Time.now
+          self.audit_comment = message
+          # we skip validating here because the complex taxonomy relationships can cause a lot of unexpected issues.
+          # This should be a simple transaction that happens on an important action in the user's workflow.
+          # It would be hard to create any new invalid relationships at this step, so the validation
+          # doesn't provide much benefit for the frustration it creates.
+          self.save(validate: false)
+        end
+
         class Jail < ::Safemode::Jail
           allow :name, :label
         end

--- a/test/models/concerns/organization_extensions_test.rb
+++ b/test/models/concerns/organization_extensions_test.rb
@@ -19,5 +19,13 @@ module Katello
       pools_count = @org.active_pools_count
       assert_equal pools_count, 2
     end
+
+    def test_audit_manifest_action
+      current_time = Time.now
+      travel_to current_time do
+        @org.audit_manifest_action("manifest updated")
+      end
+      assert_equal @org.manifest_refreshed_at.to_i, current_time.to_i
+    end
   end
 end


### PR DESCRIPTION
This was originally introduced here:
https://github.com/Katello/katello/pull/7402

The change was made for manifest refresh, but the users are still
facing the same issue on import and deleting a manifest. This commit
DRYs it up and skips the validation for all manifest actions.

It's not *the best* solution, but the alternative is fixing the compl
ex relationships in taxonomies and their inconsistencies, which I know
we have had larger discussions about and taxonomies is pretty tightly
coupled to everything else in our app. I think it would be highly
unlikely that a manifest audit would cause any invalid transactions
so this seems like a realistic solution.

I'm open to other suggestions, but since we introduced this pattern
elsewhere and it's blocking major actions in Katello, I think we
should skip validations for all manifest actions and then potentially
discuss larger changes in this area.