### PR TITLE
Fixes #25856 - Show erratum by org

### DIFF
--- a/app/controllers/katello/api/v2/errata_controller.rb
+++ b/app/controllers/katello/api/v2/errata_controller.rb
@@ -4,7 +4,7 @@ module Katello
     include Katello::Concerns::Api::V2::RepositoryContentController
 
     before_action :find_host, :only => [:index, :available_errata]
-    before_action :find_optional_organization, :only => :available_errata
+    before_action :find_optional_organization, :only => [:index, :auto_complete_search, :available_errata]
     before_action :find_environment, :only => :available_errata
     before_action :find_filter, :only => :available_errata
 

--- a/test/controllers/api/v2/errata_controller_test.rb
+++ b/test/controllers/api/v2/errata_controller_test.rb
@@ -127,6 +127,20 @@ module Katello
       end
     end
 
+    def test_index_with_org_search
+      test_repo2 = Repository.find(katello_repositories(:fedora_17_x86_64).id)
+      test_repo2.environment = katello_environments(:organization1_library)
+      get :index, params: { :organization_id => test_repo2.organization.id }
+
+      assert_response :success
+      assert_equal JSON.parse(response.body)['results'].map { |item| item['errata_id'] }, []
+
+      get :index, params: { :organization_id => @test_repo.organization.id }
+
+      assert_response :success
+      assert_equal JSON.parse(response.body)['results'].map { |item| item['errata_id'] }, ["RHSA-1999-1231", "RHBA-2014-013"]
+    end
+
     def test_show
       errata = @test_repo.errata.first
 


### PR DESCRIPTION
Description of problem:
When trying to list organization erratum, all the the organizations erratum is displayed, from hammer or from UI

Steps to Reproduce:
1.Create two organizations with products and repositories that contains erratum
2.execute hammer command to display erratum of the first org
```
hammer erratum list --organization-id <org_1 id>
```

All the erratum are displayed from org_1 and from org_2, but we expect only erratum from org_1 to be displayed.

This fix will display only the erratum from the organization requested in search params.

