### PR TITLE
Fixes #25860 - remove old product init code

### DIFF
--- a/app/models/katello/glue/candlepin/product.rb
+++ b/app/models/katello/glue/candlepin/product.rb
@@ -90,23 +90,6 @@ module Katello
     end
 
     module InstanceMethods
-      def initialize(attribs = nil)
-        unless attribs.nil?
-          attributes_key = attribs.key?(:attributes) ? :attributes : 'attributes'
-          if attribs.key?(attributes_key)
-            attribs[:attrs] = attribs[attributes_key]
-            attribs.delete(attributes_key)
-          end
-
-          # ugh. hack-ish. otherwise we have to modify code every time things change on cp side
-          attribs = attribs.reject do |k, _v|
-            !self.class.column_defaults.keys.member?(k.to_s) && (!respond_to?(:"#{k.to_s}=") rescue true)
-          end
-        end
-
-        super
-      end
-
       def support_level
         return _attr(:support_level)
       end

--- a/app/models/katello/product.rb
+++ b/app/models/katello/product.rb
@@ -79,27 +79,6 @@ module Katello
 
     before_create :assign_unique_label
 
-    def initialize(attrs = nil)
-      unless attrs.nil?
-        attrs = attrs.with_indifferent_access
-
-        #rename "id" to "cp_id" (activerecord and candlepin variable name conflict)
-        if attrs.key?(:id)
-          unless attrs.key?(:cp_id)
-            attrs[:cp_id] = attrs[:id]
-          end
-          attrs.delete(:id)
-        end
-
-        # ugh. hack-ish. otherwise we have to modify code every time things change on cp side
-        attrs = attrs.reject do |k, _v|
-          !self.class.column_defaults.keys.member?(k.to_s) && (!respond_to?(:"#{k.to_s}=") rescue true)
-        end
-      end
-
-      super
-    end
-
     def orphaned?
       self.pool_products.empty?
     end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -41,7 +41,7 @@ module Katello
         @p = Product.create!(
                                :label => "Zanzibar#{rand 10**6}",
                                :name => ProductTestData::PRODUCT_NAME,
-                               :id => ProductTestData::PRODUCT_ID,
+                               :cp_id => ProductTestData::PRODUCT_ID,
                                :provider => @provider,
                                :organization => @organization
         )


### PR DESCRIPTION
This was likely from years past when we would
initialize product objects straight from candlepin
json.  Current code does not do that.