### PR TITLE
Fixes #25867 - do not serialize all of repo types

### DIFF
--- a/app/services/katello/repository_type.rb
+++ b/app/services/katello/repository_type.rb
@@ -29,12 +29,12 @@ module Katello
       self.id.to_s <=> other.id.to_s
     end
 
-    def as_json(options = {})
-      ret = super(options)
-      ret[:name] = self.id.to_s
-      ret[:creatable] = @allow_creation_by_user
-      ret.delete("allow_creation_by_user")
-      ret
+    def as_json(_options = {})
+      {
+        :name => self.id.to_s,
+        :id => self.id,
+        :creatable => @allow_creation_by_user
+      }
     end
   end
 end


### PR DESCRIPTION
a previous change added attributes to the
repository type class which included class
references, appearing to sometimes cause
circular json serialization.