### PR TITLE
Fixes #25180 - Products index custom param fix

### DIFF
--- a/app/controllers/katello/api/v2/products_controller.rb
+++ b/app/controllers/katello/api/v2/products_controller.rb
@@ -33,7 +33,7 @@ module Katello
     param :organization_id, :number, :desc => N_("Filter products by organization"), :required => true
     param :subscription_id, :number, :desc => N_("Filter products by subscription")
     param :name, String, :desc => N_("Filter products by name")
-    param :enabled, :bool, :desc => N_("Filter products by enabled or disabled")
+    param :enabled, :bool, :desc => N_("Return enabled products only")
     param :custom, :bool, :desc => N_("Return custom products only")
     param :redhat_only, :bool, :desc => N_("Return Red Hat (non-custom) products only")
     param :include_available_content, :bool, :desc => N_("Whether to include available content attribute in results")
@@ -48,10 +48,10 @@ module Katello
 
     def index_relation
       query = Product.readable.where(:organization_id => @organization.id)
-      query = query.custom if params[:custom]
-      query = query.redhat if params[:redhat_only]
+      query = query.custom if Foreman::Cast.to_bool params[:custom]
+      query = query.redhat if Foreman::Cast.to_bool params[:redhat_only]
       query = query.where(:name => params[:name]) if params[:name]
-      query = query.enabled if params[:enabled]
+      query = query.enabled if Foreman::Cast.to_bool params[:enabled]
       query = query.where(:id => @activation_key.products) if @activation_key
 
       if params[:subscription_id]

--- a/app/controllers/katello/api/v2/products_controller.rb
+++ b/app/controllers/katello/api/v2/products_controller.rb
@@ -48,10 +48,10 @@ module Katello
 
     def index_relation
       query = Product.readable.where(:organization_id => @organization.id)
-      query = query.custom if Foreman::Cast.to_bool params[:custom]
-      query = query.redhat if Foreman::Cast.to_bool params[:redhat_only]
+      query = query.custom if ::Foreman::Cast.to_bool params[:custom]
+      query = query.redhat if ::Foreman::Cast.to_bool params[:redhat_only]
       query = query.where(:name => params[:name]) if params[:name]
-      query = query.enabled if Foreman::Cast.to_bool params[:enabled]
+      query = query.enabled if ::Foreman::Cast.to_bool params[:enabled]
       query = query.where(:id => @activation_key.products) if @activation_key
 
       if params[:subscription_id]

--- a/app/controllers/katello/api/v2/products_controller.rb
+++ b/app/controllers/katello/api/v2/products_controller.rb
@@ -34,7 +34,8 @@ module Katello
     param :subscription_id, :number, :desc => N_("Filter products by subscription")
     param :name, String, :desc => N_("Filter products by name")
     param :enabled, :bool, :desc => N_("Filter products by enabled or disabled")
-    param :custom, :bool, :desc => N_("Filter products by custom")
+    param :custom, :bool, :desc => N_("Return custom products only")
+    param :redhat_only, :bool, :desc => N_("Return Red Hat (non-custom) products only")
     param :include_available_content, :bool, :desc => N_("Whether to include available content attribute in results")
     param :sync_plan_id, :number, :desc => N_("Filter products by sync plan id")
     param :available_for, String, :desc => N_("Interpret specified object to return only Products that can be associated with specified object.  Only 'sync_plan' is supported."),
@@ -47,15 +48,8 @@ module Katello
 
     def index_relation
       query = Product.readable.where(:organization_id => @organization.id)
-
-      if params[:custom]
-        if Foreman::Cast.to_bool(params[:custom])
-          query = query.where(:provider_id => @organization.anonymous_provider.id)
-        else
-          query = query.where.not(:provider_id => @organization.anonymous_provider.id)
-        end
-      end
-
+      query = query.custom if params[:custom]
+      query = query.redhat if params[:redhat_only]
       query = query.where(:name => params[:name]) if params[:name]
       query = query.enabled if params[:enabled]
       query = query.where(:id => @activation_key.products) if @activation_key

--- a/app/controllers/katello/api/v2/products_controller.rb
+++ b/app/controllers/katello/api/v2/products_controller.rb
@@ -47,7 +47,15 @@ module Katello
 
     def index_relation
       query = Product.readable.where(:organization_id => @organization.id)
-      query = query.where(:provider_id => @organization.anonymous_provider.id) if params[:custom]
+
+      if params[:custom]
+        if Foreman::Cast.to_bool(params[:custom])
+          query = query.where(:provider_id => @organization.anonymous_provider.id)
+        else
+          query = query.where.not(:provider_id => @organization.anonymous_provider.id)
+        end
+      end
+
       query = query.where(:name => params[:name]) if params[:name]
       query = query.enabled if params[:enabled]
       query = query.where(:id => @activation_key.products) if @activation_key

--- a/test/controllers/api/v2/products_controller_test.rb
+++ b/test/controllers/api/v2/products_controller_test.rb
@@ -69,14 +69,14 @@ module Katello
       get :index, params: { organization_id: @organization.id, custom: true }
       body = JSON.parse(response.body)
 
-      assert_equal 4, body['total']
+      assert_equal 5, body['total']
     end
 
     def test_index_no_custom_products
-      get :index, params: { organization_id: @organization.id, custom: false }
+      get :index, params: { organization_id: @organization.id, redhat_only: true }
       body = JSON.parse(response.body)
 
-      assert_equal 3, body['total']
+      assert_equal 2, body['total']
     end
 
     def test_create

--- a/test/controllers/api/v2/products_controller_test.rb
+++ b/test/controllers/api/v2/products_controller_test.rb
@@ -65,6 +65,20 @@ module Katello
       end
     end
 
+    def test_index_custom_products_only
+      get :index, params: { organization_id: @organization.id, custom: true }
+      body = JSON.parse(response.body)
+
+      assert_equal 4, body['total']
+    end
+
+    def test_index_no_custom_products
+      get :index, params: { organization_id: @organization.id, custom: false }
+      body = JSON.parse(response.body)
+
+      assert_equal 3, body['total']
+    end
+
     def test_create
       product_params = {
         :name => 'fedora product',

--- a/test/fixtures/models/katello_products.yml
+++ b/test/fixtures/models/katello_products.yml
@@ -19,7 +19,7 @@ puppet_product:
   description:  A product for puppet content
   cp_id:        puppet
   label:        puppet_product
-  provider_id:  <%= ActiveRecord::FixtureSet.identify(:puppet_labs) %>
+  provider_id:  <%= ActiveRecord::FixtureSet.identify(:anonymous) %>
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
 
 ostree_product:

--- a/test/fixtures/models/katello_providers.yml
+++ b/test/fixtures/models/katello_providers.yml
@@ -23,12 +23,6 @@ candlepin_redhat:
   provider_type: 'Red Hat'
   organization_id: <%= ActiveRecord::FixtureSet.identify(:organization2) %>
 
-puppet_labs:
-  name:           PuppetLabs
-  description:    Fie, fie, you counterfeit. You puppet, you!
-  provider_type:  Custom
-  organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
-
 redhat2:
   name: Red Hat Provider2
   description: Provider of all your red hat needs

--- a/webpack/scenes/RedHatRepositories/components/SearchBar.js
+++ b/webpack/scenes/RedHatRepositories/components/SearchBar.js
@@ -42,7 +42,7 @@ class SearchBar extends Component {
 
   componentDidMount() {
     // load all products until we use filtering and pagination
-    this.props.loadOrganizationProducts({ per_page: 1000 });
+    this.props.loadOrganizationProducts({ per_page: 1000, custom: false });
   }
 
   onSearch(query) {

--- a/webpack/scenes/RedHatRepositories/components/SearchBar.js
+++ b/webpack/scenes/RedHatRepositories/components/SearchBar.js
@@ -42,7 +42,7 @@ class SearchBar extends Component {
 
   componentDidMount() {
     // load all products until we use filtering and pagination
-    this.props.loadOrganizationProducts({ per_page: 1000, custom: false });
+    this.props.loadOrganizationProducts({ per_page: 1000, redhat_only: false });
   }
 
   onSearch(query) {


### PR DESCRIPTION
The custom param for the products controller wasn't working
before, this commit changes it to be cast as a bool. It also
adds the param to the Red hat repositories page product filter.

To test, you can fill an organizaiton with custom and RH products,
then use the API to ensure the `custom` param works.

Then, check the RH repos page 'filter by product' dropdown
no longer returns custom products