### PR TITLE
Fixes #25875 - Improve Beta and HTB repos filtering

### DIFF
--- a/webpack/redux/actions/RedHatRepositories/helpers.js
+++ b/webpack/redux/actions/RedHatRepositories/helpers.js
@@ -1,10 +1,10 @@
 const repoTypeSearchQueryMap = {
-  rpm: '(name !~ source rpm) and (name !~ debug rpm) and (content_type = yum) and (name !~ beta) and (product_name !~ beta)',
+  rpm: '(name !~ source rpm) and (name !~ debug rpm) and (content_type = yum) and (label !~ beta) and (label !~ htb) and (name !~ beta) and (product_name !~ beta)',
   sourceRpm: '(name ~ source rpm) and (content_type = yum)',
   debugRpm: '(name ~ debug rpm) and (content_type = yum)',
   kickstart: 'content_type = kickstart',
   ostree: 'content_type = ostree',
-  beta: 'name ~ beta',
+  beta: '(name ~ beta) or (label ~ beta) or (label ~ htb)',
 };
 
 const recommendedRepositoriesRHEL = [


### PR DESCRIPTION
This change ensures that Beta and HTB (high touch beta) repos are:

- filtered out of "RPM" filter correctly
- included in 'Beta" filter correctly

Mainly achieved by looking at the repo 'label' in addition to 'name'

To test, add a High Touch Beta SKU (see downstream bug) to a manifest and test the filters on Red Hat Repositories