### PR TITLE
Fixes #25884 - Speeds up Dashboard errata query

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -58,7 +58,7 @@ module Katello
       # which is calculated elsewhere.
 
       self.joins(:content_facets).
-        where("#{Katello::Host::ContentFacet.table_name}.host_id" => hosts.pluck(:id))
+        where("#{Katello::Host::ContentFacet.table_name}.host_id" => hosts.select(:id))
     end
 
     def self.applicable_to_hosts_dashboard(hosts)


### PR DESCRIPTION
This commit speeds up the dashboard errata query to handle 1000s of host
ids. Prior to this commit the sql run would look like
SELECT "katello_errata".* .... where ....
katello_content_facets"."host_id" IN (1000s of host ids)
to

SELECT "katello_errata".* .... where ....
katello_content_facets"."host_id" IN (<select id from  authorized hosts >)

This results in a 1000x speedup