### PR TITLE
Fixes #25900 - send whole correlation UUID

### DIFF
--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -41,7 +41,7 @@ module Katello
                      'content-type' => 'application/json'}
 
           request_id = ::Logging.mdc['request']
-          headers['X-Correlation-ID'] = request_id.split('-')[0] if request_id
+          headers['X-Correlation-ID'] = request_id if request_id
 
           headers.merge!(cp_oauth_header)
         end


### PR DESCRIPTION
Cheers, this enables easier search in Elasticsearch as Foreman core logs the whole UUID while CP is given only a portion of it.