### PR TITLE
Fixes #25906 - Adds Type to Subscriptions page

### DIFF
--- a/webpack/scenes/Subscriptions/SubscriptionConstants.js
+++ b/webpack/scenes/Subscriptions/SubscriptionConstants.js
@@ -78,6 +78,11 @@ export const SUBSCRIPTION_TABLE_COLUMNS = [
     value: false,
   },
   {
+    key: 'type',
+    label: __('Type'),
+    value: false,
+  },
+  {
     key: 'consumed',
     label: __('Consumed'),
     value: false,
@@ -97,4 +102,5 @@ export const SUBSCRIPTION_TABLE_DEFAULT_COLUMNS = [
   'end_date',
   'consumed',
   'quantity',
+  'type',
 ];

--- a/webpack/scenes/Subscriptions/__tests__/subscriptions.fixtures.js
+++ b/webpack/scenes/Subscriptions/__tests__/subscriptions.fixtures.js
@@ -419,6 +419,11 @@ export const tableColumns = [
     value: false,
   },
   {
+    key: 'type',
+    label: 'Type',
+    value: true,
+  },
+  {
     key: 'consumed',
     label: 'Consumed',
     value: true,
@@ -441,6 +446,7 @@ export const loadTableColumnsSuccessAction = [
         'end_date',
         'consumed',
         'quantity',
+        'type',
       ],
     },
   },


### PR DESCRIPTION
This commit adds the missing "Type" column to Content -> Subscriptions
page.