### PR TITLE
Fixes #25907 - host permissions for package action

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-details.html
@@ -107,7 +107,7 @@
         </a>
         <ul uib-dropdown-menu>
           <li>
-            <a ui-sref="content-host.packages.actions" translate>
+            <a ui-sref="content-host.packages.actions" ng-hide="denied('edit_hosts')" translate>
               Actions
             </a>
           </li>


### PR DESCRIPTION
This commit hides the "Content Host -> Packages -> Actions" menu item if
the user does not have the appropriate edit_hosts permissions.