### PR TITLE
Fixes #25917 - Check operating sys supports 'kickstart_repository'

### DIFF
--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -88,14 +88,19 @@ module Katello
       end
 
       def equivalent_kickstart_repository
-        return unless operatingsystem && kickstart_repository
+        return unless operatingsystem &&
+                      kickstart_repository &&
+                      operatingsystem.class.method_defined?(:kickstart_repos)
         ks_repos = operatingsystem.kickstart_repos(self)
         ks_repos.find { |repo| repo[:name] == kickstart_repository.label }
       end
 
       def matching_kickstart_repository?
         return true unless operatingsystem
-        operatingsystem.kickstart_repos(self).any? { |repo| repo[:id] == kickstart_repository_id }
+
+        if operatingsystem.class.method_defined? :kickstart_repos
+          return operatingsystem.kickstart_repos(self).any? { |repo| repo[:id] == kickstart_repository_id }
+        end
       end
 
       private

--- a/test/models/concerns/hostgroup_extensions_test.rb
+++ b/test/models/concerns/hostgroup_extensions_test.rb
@@ -92,6 +92,9 @@ module Katello
       @distro = katello_repositories(:fedora_17_x86_64)
       @dev_distro = katello_repositories(:fedora_17_x86_64_acme_dev)
       @os = ::Redhat.create_operating_system('RedHat', '17', '0')
+      @no_family_os = FactoryBot.create(:operatingsystem,
+                                        major: 1,
+                                        name: 'no_family_os')
       @arch = architectures(:x86_64)
       @distro_cv = @distro.content_view
       @distro_env = @distro.environment
@@ -183,6 +186,14 @@ module Katello
 
       assert hg.save
       assert_equal hg.kickstart_repository_id, @dev_distro.id
+    end
+
+    def test_create_hostgroup_no_family_os
+      hg = Hostgroup.new(
+        name: 'kickstart_repo',
+        operatingsystem: @no_family_os)
+
+      assert_valid hg
     end
   end
 end


### PR DESCRIPTION
before calling. Operating systems with no family won't have the
'kickstart_repository' method since this is a method for RedHat
class operating systems.

I'm not sure if this bug is a symptom of larger issues around
operating systems, but it does fix the issue and I've added a test
that reproduces the issue.