### PR TITLE
Fixes #25918 - handle task rendering before task has started

### DIFF
--- a/app/lib/actions/pulp/abstract_async_task.rb
+++ b/app/lib/actions/pulp/abstract_async_task.rb
@@ -66,7 +66,7 @@ module Actions
       end
 
       def done?
-        external_task.all? { |task| task[:finish_time] || FINISHED_STATES.include?(task[:state]) }
+        external_task&.all? { |task| task[:finish_time] || FINISHED_STATES.include?(task[:state]) }
       end
 
       def external_task


### PR DESCRIPTION
There could be a race condition where the status of a
task is fetched, but the pulp task itself has not been
saved yet.