### PR TITLE
Fixes #25920 - Recommend Sat-maintain repo

### DIFF
--- a/webpack/redux/actions/RedHatRepositories/helpers.js
+++ b/webpack/redux/actions/RedHatRepositories/helpers.js
@@ -20,6 +20,7 @@ const recommendedRepositoriesSatTools = [
   'rhel-7-server-satellite-tools-6.4-rpms',
   'rhel-6-server-satellite-tools-6.4-rpms',
   'rhel-5-server-els-satellite-tools-6.4-rpms',
+  'rhel-7-server-satellite-maintenance-6-rpms',
 ];
 
 const recommendedRepositoriesMisc = [


### PR DESCRIPTION
### To test  

1. Import a manifest with Sat-maintenance tools. (Satellite-all manifest)
2. Go to Repositories page and turn on recommended repositories.
3. You should see the product Red Hat Satellite Maintenance 6 (for RHEL 7 Server) (RPMs)