### PR TITLE
Fixes #25921 Sync Capsules before applying errata at incremental update

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -147,7 +147,7 @@ module Katello
       if params[:add_content] && params[:add_content].key?(:errata_ids) && params[:update_hosts] && any_environments
         hosts = calculate_hosts_for_incremental(params[:update_hosts], params[:propagate_to_composites])
       else
-        hosts = []
+        hosts = ::Host::Managed.none
       end
 
       validate_content(params[:add_content])

--- a/app/controllers/katello/concerns/api/v2/bulk_hosts_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/bulk_hosts_extensions.rb
@@ -8,7 +8,7 @@ module Katello
         organization = find_organization
         bulk_params[:included] ||= {}
         bulk_params[:excluded] ||= {}
-        @hosts = []
+        @hosts = ::Host::Managed.none
 
         unless bulk_params[:included][:ids].blank?
           @hosts = ::Host::Managed.authorized(permission).where(:id => bulk_params[:included][:ids])

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -56,6 +56,7 @@ module Katello
           :message => _("must be one of the following: %s") % DOWNLOAD_POLICIES.join(', ')
         }
         scope :with_content, -> { with_features(PULP_FEATURE, PULP_NODE_FEATURE) }
+        scope :non_default, -> { with_features(PULP_NODE_FEATURE) }
 
         def self.with_repo(repo)
           joins(:capsule_lifecycle_environments).


### PR DESCRIPTION
Identify smart proxies the Hosts are registered through, and invoke Capsule
synchronization of the updated content before applying errata to those Hosts.

This will make some of the automatically triggered Capsule synchronizations
redundant, but such no-op is harmless and preventing it could be error-prone.

Fixes: #25921

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>