### PR TITLE
Fixes #25937 - Set distributor_version to sat-6.5

### DIFF
--- a/app/models/katello/glue/provider.rb
+++ b/app/models/katello/glue/provider.rb
@@ -73,7 +73,7 @@ module Katello
         params[:capabilities] = Resources::Candlepin::CandlepinPing.ping['managerCapabilities'].inject([]) do |result, element|
           result << {'name' => element}
         end
-        params[:facts] = {:distributor_version => 'sat-6.3'}
+        params[:facts] = {:distributor_version => 'sat-6.5'}
         Resources::Candlepin::UpstreamConsumer.update("#{url}#{upstream['uuid']}", upstream['idCert']['cert'],
                                                       upstream['idCert']['key'], ca_file, params)
       end

--- a/test/models/provider_test.rb
+++ b/test/models/provider_test.rb
@@ -9,8 +9,8 @@ module Katello
 
       def setup
         @upstream_params = { 'apiUrl' => api_url, 'idCert' => { 'key' => '', 'cert' => ''}}
-        @expected_params = [expected_url, "", "", nil, { :capabilities => [], :facts => { :distributor_version => "sat-6.3" } }]
-        Resources::Candlepin::UpstreamConsumer.expects(:update).with(*@expected_params)
+        expected_params = [expected_url, "", "", nil, { :capabilities => [], :facts => { :distributor_version => "sat-6.5" } }]
+        Resources::Candlepin::UpstreamConsumer.expects(:update).with(*expected_params)
         Resources::Candlepin::CandlepinPing.stubs(:ping).returns('managerCapabilities' => [])
       end
 


### PR DESCRIPTION
Manifest refresh should

1) set the proper distributor version upstream
2) not undo (rollback) to an older version

This should probably be something in the installer and I'm open to approaching this in that way or a better way