### PR TITLE
Fixes #25946 - Enabled repo search with label

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -81,6 +81,7 @@ module Katello
     param :library, :bool, :desc => N_("show repositories in Library and the default content view")
     param :content_type, RepositoryTypeManager.repository_types.keys, :desc => N_("limit to only repositories of this type")
     param :name, String, :desc => N_("name of the repository"), :required => false
+    param :label, String, :desc => N_("label of the repository"), :required => false
     param :description, String, :desc => N_("description of the repository")
     param :available_for, String, :desc => N_("interpret specified object to return only Repositories that can be associated with specified object.  Only 'content_view' & 'content_view_version' are supported."),
           :required => false
@@ -115,6 +116,7 @@ module Katello
       query = index_relation_product(query)
       query = query.with_type(params[:content_type]) if params[:content_type]
       query = query.where(:root_id => RootRepository.where(:name => params[:name])) if params[:name]
+      query = query.where(:root_id => RootRepository.where(:label => params[:label])) if params[:label]
       query = index_relation_content_unit(query)
       query = index_relation_content_view(query)
       query = index_relation_environment(query)

--- a/app/models/katello/content.rb
+++ b/app/models/katello/content.rb
@@ -12,6 +12,7 @@ module Katello
     scoped_search :on => :content_type, :complete_value => true
     scoped_search :on => :label, :complete_value => true
     scoped_search :relation => :products, :on => :name, :rename => :product_name, :complete_value => true
+    scoped_search :on => :label, :rename => :content_label, :complete_value => true
 
     after_save :update_repository_names, :if => :propagate_name_change?
 

--- a/app/models/katello/product_content.rb
+++ b/app/models/katello/product_content.rb
@@ -23,6 +23,7 @@ module Katello
     scoped_search :on => :label, :relation => :content
     scoped_search :on => :name, :relation => :product, :rename => :product_name
     scoped_search :on => :id, :relation => :product, :rename => :product_id, :only_explicit => true
+    scoped_search :on => :label, :relation => :content, :rename => :content_label
 
     def self.content_table_name
       Katello::Content.table_name

--- a/test/models/product_content_test.rb
+++ b/test/models/product_content_test.rb
@@ -84,5 +84,9 @@ module Katello
     def test_search_product_id
       assert_includes Katello::ProductContent.search_for("product_id = \"#{@product.id}\""), @product_content
     end
+
+    def test_search_content_label
+      assert_includes Katello::ProductContent.search_for("content_label = #{@content.label}"), @product_content
+    end
   end
 end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -312,6 +312,19 @@ module Katello
       refute_includes repos, @fedora_17_x86_64
       refute_includes repos, @puppet_forge
     end
+
+    def test_search_content_label
+      content_id = 'somecontent-123'
+      product = katello_products(:redhat)
+      content = FactoryBot.create(:katello_content, cp_content_id: content_id, :organization_id => product.organization_id)
+      FactoryBot.create(:katello_product_content, content: content, product: product)
+
+      repo = katello_repositories(:fedora_17_x86_64)
+      repo.root.update_attributes!(product: product, content_id: content_id)
+
+      repos = Repository.search_for("content_label=\"#{content.label}\"")
+      assert_includes repos, repo
+    end
   end
 
   class RepositoryInstanceTest < RepositoryTestBase

--- a/webpack/components/Search/index.js
+++ b/webpack/components/Search/index.js
@@ -33,13 +33,15 @@ class Search extends Component {
       params.params || {},
     ];
 
-    api.get(...autoCompleteParams).then(({ data }) => {
-      this.setState({
-        items: data.filter(({ error }) => !error).map(({ label }) => ({
-          text: label.trim(),
-        })),
+    if (autoCompleteParams[0] !== '') {
+      api.get(...autoCompleteParams).then(({ data }) => {
+        this.setState({
+          items: data.filter(({ error }) => !error).map(({ label }) => ({
+            text: label.trim(),
+          })),
+        });
       });
-    });
+    }
   }
 
   onSearch(search) {

--- a/webpack/scenes/RedHatRepositories/components/Search.js
+++ b/webpack/scenes/RedHatRepositories/components/Search.js
@@ -46,13 +46,16 @@ class RepositorySearch extends Component {
       organization_id: orgId(),
       search,
     };
-
+    let endpoint = '';
     if (this.state.searchList.key === 'enabled') {
       params.enabled = true;
+      endpoint = '/repositories/auto_complete_search';
+    } else if (this.state.searchList.key === 'available') {
+      endpoint = '/repository_sets/auto_complete_search';
     }
 
     return {
-      endpoint: '/repository_sets/auto_complete_search',
+      endpoint,
       params,
     };
   }


### PR DESCRIPTION
 1. On UI: Go to 'Content => Red Hat Repositories => Enable some repositories 
 _Note: Default filter type is = 'RPM'_

2. In Search bar, select => Enabled/Both => Click on 'Search'

You should see enabled repos matching criteria. Earlier was getting some error ~ _label is not a valid field to search._
