### PR TITLE
Fixes #25934 - properly link sync plan to recur logic

### DIFF
--- a/app/models/katello/sync_plan.rb
+++ b/app/models/katello/sync_plan.rb
@@ -18,6 +18,7 @@ module Katello
     belongs_to :organization, :inverse_of => :sync_plans
     has_many :products, :class_name => "Katello::Product", :dependent => :nullify
     belongs_to :foreman_tasks_recurring_logic, :inverse_of => :sync_plan, :class_name => "ForemanTasks::RecurringLogic", :dependent => :destroy
+    belongs_to :task_group, :class_name => 'Katello::SyncPlanTaskGroup', :inverse_of => :sync_plan
 
     validates_lengths_from_database
     validates :name, :presence => true, :uniqueness => {:scope => :organization_id}
@@ -46,6 +47,7 @@ module Katello
     end
 
     def save_with_logic!
+      self.task_group ||= SyncPlanTaskGroup.create!
       self.cron_expression = '' if (self.cron_expression && !(self.interval.eql? CUSTOM_CRON))
       associate_recurring_logic
       self.save!

--- a/app/models/katello/sync_plan_task_group.rb
+++ b/app/models/katello/sync_plan_task_group.rb
@@ -1,0 +1,9 @@
+module Katello
+  class SyncPlanTaskGroup < ::ForemanTasks::TaskGroup
+    has_one :sync_plan, :foreign_key => :task_group_id, :dependent => :nullify, :inverse_of => :task_group, :class_name => "Katello::SyncPlan"
+
+    def resource_name
+      N_('Sync Plan')
+    end
+  end
+end

--- a/app/views/katello/sync_plan_task_groups/_sync_plan_task_groups.html.erb
+++ b/app/views/katello/sync_plan_task_groups/_sync_plan_task_groups.html.erb
@@ -1,0 +1,3 @@
+<%= _("Sync Plan: ") %>
+
+<%= link_to(task_groups.first.sync_plan.name, "/sync_plans/#{task_groups.first.sync_plan.id}") %>

--- a/db/migrate/20190129204844_add_sync_plan_task_group.rb
+++ b/db/migrate/20190129204844_add_sync_plan_task_group.rb
@@ -1,0 +1,19 @@
+class AddSyncPlanTaskGroup < ActiveRecord::Migration[5.2]
+  class FakeSyncPlan < Katello::Model
+    self.table_name = 'katello_sync_plans'
+  end
+
+  def up
+    add_column :katello_sync_plans, :task_group_id, :integer, :index => true
+    add_foreign_key :katello_sync_plans, :foreman_tasks_task_groups, :column => :task_group_id
+    FakeSyncPlan.all.each do |plan|
+      plan.task_group_id ||= Katello::SyncPlanTaskGroup.create!.id
+      plan.save!
+    end
+  end
+
+  def down
+    remove_column :katello_sync_plans, :task_group_id
+    ForemanTasks::TaskGroup.where(:type => "Katello::SyncPlanTaskGroup").delete_all
+  end
+end

--- a/test/actions/katello/sync_plan/run_test.rb
+++ b/test/actions/katello/sync_plan/run_test.rb
@@ -13,8 +13,17 @@ describe ::Actions::Katello::SyncPlan::Run do
 
   let(:action_class) { ::Actions::Katello::SyncPlan::Run }
   let(:action) { create_action action_class }
+  let(:uuid) { SecureRandom.uuid }
+  let(:task) do
+    OpenStruct.new(:id => uuid).tap do |o|
+      o.stubs(:add_missing_task_groups)
+      o.stubs(:task_groups).returns([])
+    end
+  end
 
   it 'plans' do
+    ForemanTasks::Task::DynflowTask.stubs(:where).returns(mock.tap { |m| m.stubs(:first! => task) })
+
     action.stubs(:action_subject).with(@sync_plan)
     plan_action(action, @sync_plan)
     syncable_products = @sync_plan.products.syncable


### PR DESCRIPTION
recurring logics need a custom task group in order to
properly render the correct links between the recurring
logic and the associated model