### PR TITLE
Fixes #25955 - Expose route for system purpose compliance

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -485,7 +485,7 @@ module Katello
            "rhsm_proxy_consumer_entitlements_path", "rhsm_proxy_consumer_entitlements_post_path",
            "rhsm_proxy_consumer_entitlements_delete_path", "rhsm_proxy_consumer_entitlements_pool_delete_path",
            "rhsm_proxy_consumer_certificates_put_path", "rhsm_proxy_consumer_dryrun_path",
-           "rhsm_proxy_consumer_owners_path", "rhsm_proxy_consumer_compliance_path"
+           "rhsm_proxy_consumer_owners_path", "rhsm_proxy_consumer_compliance_path", "rhsm_proxy_consumer_purpose_compliance_path"
         User.consumer? && current_user.uuid == params[:id]
       when "rhsm_proxy_consumer_certificates_delete_path"
         User.consumer? && current_user.uuid == params[:consumer_id]

--- a/config/routes/api/rhsm.rb
+++ b/config/routes/api/rhsm.rb
@@ -29,6 +29,7 @@ Katello::Engine.routes.draw do
       match '/consumers/:id/certificates' => 'candlepin_proxies#put', :via => :put, :as => :proxy_consumer_certificates_put_path
       match '/consumers/:id/release' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_releases_path
       match '/consumers/:id/compliance' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_compliance_path
+      match '/consumers/:id/purpose_compliance' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_purpose_compliance_path
       match '/consumers/:id/certificates/serials' => 'candlepin_proxies#serials', :via => :get, :as => :proxy_certificate_serials_path
       match '/consumers/:id/entitlements' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_entitlements_path
       match '/consumers/:id/entitlements' => 'candlepin_proxies#post', :via => :post, :as => :proxy_consumer_entitlements_post_path

--- a/test/routing/candlepin_proxies_test.rb
+++ b/test/routing/candlepin_proxies_test.rb
@@ -8,7 +8,11 @@ module Katello
     end
 
     def test_user_resource_proxies
-      {:controller => @proxies_controller, :action => "list_owners", :login => "1"}.must_recognize(:method => "get", :path => "/rhsm/users/1/owners")
+      {controller: @proxies_controller, action: 'list_owners', login: '1'}.must_recognize(method: :get, path: '/rhsm/users/1/owners')
+    end
+
+    def test_consumer_purpose_compliance
+      {controller: @proxies_controller, action: 'get', id: '1'}.must_recognize(method: :get, path: '/rhsm/consumers/1/purpose_compliance')
     end
   end
 end


### PR DESCRIPTION
to reproduce problem:

- register a content host to your server and run `subscription-manager status`
- observe that System Purpose Status is Unknown and there is a RoutingError in the server log for /rhsm/consumers/:id/purpose_compliance

with the patch:
- clear the  subman cache (rm -rf /var/lib/rhsm/cache/*)
- run `subscription-manager status`
- status should not be Unknown  and no RoutingError in the server logs