### PR TITLE
Fixes #25968 - Correct Repos with file urls

### DIFF
--- a/lib/katello/tasks/upgrades/3.8/clear_checksum_type.rake
+++ b/lib/katello/tasks/upgrades/3.8/clear_checksum_type.rake
@@ -8,6 +8,18 @@ namespace :katello do
         Katello::RootRepository.yum_type.find_each do |root_repo|
           root_repo.transaction do
             begin
+              if [::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND, ::Runcible::Models::YumImporter::DOWNLOAD_BACKGROUND].include?(root_repo.download_policy) && root_repo.url.present? && URI(root_repo.url).scheme == 'file'
+                root_repo.update_attribute(:download_policy, ::Runcible::Models::YumImporter::DOWNLOAD_IMMEDIATE)
+                root_repo.repositories.each do |repo|
+                  importer = repo.importers[0]
+                  config = {
+                    :download_policy => ::Runcible::Models::YumImporter::DOWNLOAD_IMMEDIATE
+                  }
+
+                  SmartProxy.pulp_master.pulp_api.resources.repository.update_importer(repo.pulp_id, importer[:id], config) if (importer && importer[:id])
+                end
+              end
+
               if root_repo.on_demand? && root_repo.url.present?
                 root_repo.update_attribute(:checksum_type, nil)
 


### PR DESCRIPTION
Move all roots with url of file schema to immediate download policy.

Q: How advisable is modifying an old migration file? I am guessing for users this has already run haven't had the issue causing error in this file meaning no such invalid repos existed in the first place.