### PR TITLE
Fixes #25972 - Better Docker Repo Discovery UI

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/container-registries.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/container-registries.service.js
@@ -1,0 +1,40 @@
+/**
+ * @ngdoc service
+ * @name  Bastion.product.service:ContainerRegistry
+ *
+ * @requires translate
+ *
+ * @description
+ *   Provides a list of container registries
+ */
+angular.module('Bastion.products').service('ContainerRegistries',
+    ['translate', function () {
+
+        this.registries = {
+            'redhat': { name: 'Red Hat Registry', url: "https://registry.access.redhat.com" },
+            'dockerhub': { name: 'Docker Hub', url: "https://index.docker.io",
+                                                createUrl: "https://registry-1.docker.io" },
+            'quay': { name: 'Quay', url: "https://quay.io" },
+            'custom': { name: 'Custom' }
+        };
+
+        this.urlFor = function (registryType, customUrl) {
+            if (registryType === "custom") {
+                return customUrl;
+            } else if (angular.isDefined(this.registries[registryType])) {
+                return this.registries[registryType].url;
+            }
+        };
+
+        this.createUrlFor = function (registryType, customUrl) {
+            if (registryType === "custom") {
+                return customUrl;
+            } else if (angular.isDefined(this.registries[registryType])) {
+                if (this.registries[registryType].createUrl) {
+                    return this.registries[registryType].createUrl;
+                }
+                return this.registries[registryType].url;
+            }
+        };
+    }]
+);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
@@ -7,7 +7,7 @@
               ng-options="contentType.id as contentType.name for contentType in contentTypes"/>
     </div>
 
-    <div bst-form-group ng-show="discovery.contentType === 'yum'"
+    <div bst-form-group ng-if="discovery.contentType === 'yum'"
          label="{{ 'URL to Discover' | translate }}">
       <input type="text" id="urlToDiscover"
              class="form-control"
@@ -18,15 +18,22 @@
              required/>
     </div>
 
-    <div bst-form-group ng-show="discovery.contentType === 'docker'"
-         label="{{ 'Registry to Discover' | translate }}">
-      <input type="text" id="registryToDiscover"
-             class="form-control"
-             ng-model="discovery.url"
-             ng-disabled="discovery.working"
-             placeholder="Example: registry.access.redhat.com or https://registry.access.redhat.com"
-             name="discoveryUrl"
-             required/>
+    <div bst-form-group label="{{ 'Registry to Discover' | translate }}"  ng-if="discovery.contentType === 'docker'">
+      <select required
+              id="registry_type"
+              name="registry_type"
+              ng-model="discovery.registryType"
+              ng-options="id as object.name for (id, object) in containerRegistries">
+      </select>
+
+      <input id="custom_registry_url"
+             name="custom_registry_url"
+             ng-model="discovery.customRegistryUrl"
+             placeholder="Example: <private registry url>"
+             ng-disabled="discovery.registryType !== 'custom'"/>
+      <h6 translate>
+        Choose one of the registry options to discover containers. To examine a private registry choose "Custom" and provide the url for the private registry.
+      </h6>
     </div>
 
     <div bst-form-group ng-show="discovery.contentType === 'docker'"
@@ -60,7 +67,6 @@
 
     <span class="input-group-btn">
       <button ng-show="!discovery.working && permitted('edit_products')"
-              ng-disabled="discoveryForm.discoveryUrl.$invalid"
               type="submit"
               class="btn btn-default">
         <span translate>Discover</span>

--- a/engines/bastion_katello/test/products/discovery/discovery.controller.test.js
+++ b/engines/bastion_katello/test/products/discovery/discovery.controller.test.js
@@ -116,7 +116,8 @@ describe('Controller: DiscoveryController', function() {
     });
 
     it('should initiate docker discovery', function() {
-        $scope.discovery.url = 'http://fake/';
+        $scope.discovery.registryType = 'custom';
+        $scope.discovery.customRegistryUrl = 'http://fake/';
         $scope.discovery.contentType = 'docker';
         spyOn(Organization, 'repoDiscover').and.callThrough();
 
@@ -126,8 +127,45 @@ describe('Controller: DiscoveryController', function() {
                                                                jasmine.any(Function));
     });
 
-    it('should initiate docker discovery with search', function() {
-        $scope.discovery.url = 'http://fake/';
+    it('should initiate docker discovery with search for rh registry', function() {
+        $scope.discovery.registryType = 'redhat';
+        $scope.discovery.contentType = 'docker';
+        $scope.discovery.search = 'search';
+        spyOn(Organization, 'repoDiscover').and.callThrough();
+
+        $scope.discover();
+
+        expect(Organization.repoDiscover).toHaveBeenCalledWith({id: CurrentOrganization, url: 'https://registry.access.redhat.com', 'content_type': 'docker', upstream_username: undefined, upstream_password: undefined, search: 'search'},
+                                                               jasmine.any(Function));
+    });
+
+    it('should initiate docker discovery for docker hub', function() {
+        $scope.discovery.registryType = 'dockerhub';
+        $scope.discovery.contentType = 'docker';
+        $scope.discovery.search = 'search';
+
+        spyOn(Organization, 'repoDiscover').and.callThrough();
+        $scope.discover();
+
+        expect(Organization.repoDiscover).toHaveBeenCalledWith({id: CurrentOrganization, url: 'https://index.docker.io', 'content_type': 'docker', upstream_username: undefined, upstream_password: undefined, search: 'search'},
+                                                               jasmine.any(Function));
+    });
+
+    it('should initiate docker discovery for quay', function() {
+        $scope.discovery.registryType = 'quay';
+        $scope.discovery.contentType = 'docker';
+        $scope.discovery.search = 'search';
+
+        spyOn(Organization, 'repoDiscover').and.callThrough();
+        $scope.discover();
+
+        expect(Organization.repoDiscover).toHaveBeenCalledWith({id: CurrentOrganization, url: 'https://quay.io', 'content_type': 'docker', upstream_username: undefined, upstream_password: undefined, search: 'search'},
+                                                               jasmine.any(Function));
+    });
+
+    it('should initiate docker discovery with search for custom', function() {
+        $scope.discovery.registryType = 'custom';
+        $scope.discovery.customRegistryUrl = 'http://fake/';
         $scope.discovery.contentType = 'docker';
         $scope.discovery.search = 'search';
         spyOn(Organization, 'repoDiscover').and.callThrough();


### PR DESCRIPTION
This commit tweaks the existing docker repo discovery workflow by
allowing the  user to search from one of
1) Docker Hub
2) RH Registry
3) Quay.io
4) Custom - Private Registries

When the user chooses Docker Hub, the javascript knows that it has to
search in index.docker.io while create the repo using
registry-1.docker.io

Basic issue that this commit resolves is that "docker search foo"
searches for foo in index.docker.io, but "docker pull foo" pulls it from
registry-1.docker.io. This causes issues when creating repos from
Discovery. This commit tries handle that situation with a better
workflow.