### PR TITLE
Fixes #25996 - fix available_repositories content_id lookup

### DIFF
--- a/app/controllers/katello/api/v2/repository_sets_controller.rb
+++ b/app/controllers/katello/api/v2/repository_sets_controller.rb
@@ -125,7 +125,7 @@ module Katello
         @product_content = @product.product_content_by_id(params[:id])
       else
         content = Katello::Content.find_by(:cp_content_id => params[:id], :organization_id => @organization[:id])
-        @product_content = Katello::ProductContent.find_by(:id => content[:id])
+        @product_content = Katello::ProductContent.find_by(:content_id => content.id)
       end
       fail HttpErrors::NotFound, _("Couldn't find repository set with id '%s'.") % params[:id] if @product_content.nil?
       @product = @product_content.product if @product.nil?

--- a/app/models/katello/glue/pulp/repos.rb
+++ b/app/models/katello/glue/pulp/repos.rb
@@ -34,10 +34,6 @@ module Katello
     end
 
     module InstanceMethods
-      def empty?
-        return self.repos(library).empty?
-      end
-
       def distributions(env)
         to_ret = []
         self.repos(env).each do |repo|

--- a/test/controllers/api/v2/repository_sets_controller_test.rb
+++ b/test/controllers/api/v2/repository_sets_controller_test.rb
@@ -103,6 +103,20 @@ module Katello
       assert_response :success
     end
 
+    def test_available_repositories_no_product
+      #reset the id of the product_content, as factorybot seems to use the same id as well as content_id
+      # not exposing the bug
+      @content.reload.product_contents.first.update_attributes(:id => Katello::ProductContent.maximum(:id) + 1000)
+      task = assert_sync_task ::Actions::Katello::RepositorySet::ScanCdn do |product, content_id|
+        product.must_equal @product
+        content_id.must_equal @content_id
+      end
+      task.expects(:output).at_least_once.returns(results: [])
+
+      get :available_repositories, params: {id: @content_id, organization_id: @product.organization_id }
+      assert_response :success
+    end
+
     def test_available_repo_sort
       task = assert_sync_task ::Actions::Katello::RepositorySet::ScanCdn
 


### PR DESCRIPTION
Two bugs were introduced into this controller previously:
1) product.present? is used, which relies on the empty? method
   however, this method had been overriden in repos.rb.  Nothing seemed
   to use it
2) a query mistake was using id of product_content instead of cp_content_id