### PR TITLE
Refs #25972 - default value and class for Registry to Discover

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
@@ -30,6 +30,7 @@ angular.module('Bastion.products').controller('DiscoveryController',
         $scope.page = {loading: false};
 
         $scope.containerRegistries = ContainerRegistries.registries;
+        $scope.discovery.registryType = Object.keys($scope.containerRegistries)[0];
 
         $scope.contentTypes = [
             {id: "yum", name: "Yum Repositories"},

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
@@ -20,6 +20,7 @@
 
     <div bst-form-group label="{{ 'Registry to Discover' | translate }}"  ng-if="discovery.contentType === 'docker'">
       <select required
+              class="form-control"
               id="registry_type"
               name="registry_type"
               ng-model="discovery.registryType"


### PR DESCRIPTION
c490d55ed1012aac08e10dacc4e581d19125fbea introduced new `<select>`
'Registry to Discover'. There are two issues with it:

1. It uses default browser styling, making it stand out from other
elements on form.

2. It has no default value set. Empty string is used automatically
instead. As result, when user clicks it for the first time, there are 5
items available. After picking one, all subsequent click will display
only 4 items.

This commit fixes both of these issues.