### PR TITLE
Refs #25972 - use registry.redhat.io

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/container-registries.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/container-registries.service.js
@@ -11,7 +11,7 @@ angular.module('Bastion.products').service('ContainerRegistries',
     ['translate', function () {
 
         this.registries = {
-            'redhat': { name: 'Red Hat Registry', url: "https://registry.access.redhat.com" },
+            'redhat': { name: 'Red Hat Registry', url: "https://registry.redhat.io" },
             'dockerhub': { name: 'Docker Hub', url: "https://index.docker.io",
                                                 createUrl: "https://registry-1.docker.io" },
             'quay': { name: 'Quay', url: "https://quay.io" },

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
@@ -42,6 +42,7 @@
              class="form-control"
              ng-model="discovery.upstreamUsername"
              ng-disabled="discovery.working"
+             ng-required="discovery.registryType === 'redhat'"
              name="upstreamUsername"/>
     </div>
 
@@ -52,6 +53,7 @@
              class="form-control"
              ng-model="discovery.upstreamPassword"
              ng-disabled="discovery.working"
+             ng-required="discovery.registryType === 'redhat'"
              name="upstreamPassword"/>
     </div>
 

--- a/engines/bastion_katello/test/products/discovery/discovery.controller.test.js
+++ b/engines/bastion_katello/test/products/discovery/discovery.controller.test.js
@@ -135,7 +135,7 @@ describe('Controller: DiscoveryController', function() {
 
         $scope.discover();
 
-        expect(Organization.repoDiscover).toHaveBeenCalledWith({id: CurrentOrganization, url: 'https://registry.access.redhat.com', 'content_type': 'docker', upstream_username: undefined, upstream_password: undefined, search: 'search'},
+        expect(Organization.repoDiscover).toHaveBeenCalledWith({id: CurrentOrganization, url: 'https://registry.redhat.io', 'content_type': 'docker', upstream_username: undefined, upstream_password: undefined, search: 'search'},
                                                                jasmine.any(Function));
     });
 


### PR DESCRIPTION
Red Hat maintains three container registries:
registry.access.redhat.com, registry.redhat.io and
registry.connect.redhat.com. The plan is to eventually decommission
registry.access.redhat.com.

Use registry.redhat.io as default. registry.access.redhat.com can still
be used by selecting Custom and providing url manually.