### PR TITLE
Fixes #25034 - No Duplicate repos on LCE UI

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/content.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/content.service.js
@@ -76,7 +76,7 @@
 
             params = params || {};
             params = angular.extend(params, getContentType(currentState()).params);
-            nutupane = new Nutupane($injector.get(getContentType(currentState()).resource), params, 'queryPaged');
+            nutupane = new Nutupane($injector.get(getContentType(currentState()).resource), params, 'queryPaged', { 'disableAutoLoad': true });
 
             return nutupane;
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/content.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/content.service.js
@@ -67,6 +67,21 @@
             }
         ];
 
+        this.getNoRowsMessage = function () {
+            var contentType = this.getCurrentContentType();
+            return translate('There are no %(contentType)s that match the criteria.  ')
+                        .replace('%(contentType)s', contentType.display);
+        };
+
+        this.getZeroResultsMessage = function () {
+            return translate('Your search returned zero %(contentType)s that match the criteria.')
+                        .replace('%(contentType)s', this.getCurrentContentType().display);
+        };
+
+        this.getCurrentContentType = function () {
+            return getContentType(currentState());
+        };
+
         this.getRepositoryType = function () {
             return getContentType(currentState()).repositoryType;
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/environment-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/environment-content.controller.js
@@ -13,7 +13,9 @@
 
         function fetchContentViews(environmentId) {
             ContentView.queryUnpaged({'environment_id': environmentId}, function (data) {
-                $scope.contentViews = [$scope.contentView].concat(data.results);
+                $scope.contentViews = data.results;
+                $scope.contentView = $scope.contentViews[0];
+                $scope.contentViewSelected($scope.contentView)
             });
         }
 
@@ -74,16 +76,11 @@
         $scope.nutupane = nutupane;
         $scope.table = nutupane.table;
 
-        $scope.contentView = {id: 'all', name: translate('All Content Views')};
-
         allRepositories = {id: 'all', name: translate('All Repositories')};
         $scope.repository = allRepositories;
 
         fetchContentViews($scope.$stateParams.environmentId);
 
-        if (ContentService.getRepositoryType()) {
-            fetchRepositories();
-        }
 
         $scope.contentViewSelected = function (contentView) {
             var params = nutupane.getParams();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/environment-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/environment-content.controller.js
@@ -86,7 +86,7 @@
             var params = nutupane.getParams();
             if (contentView.id === '') {
                 $scope.repository = allRepositories;
-                $scope.repositories.splice(0, $scope.repositories.length);
+                $scope.repositories = [];
                 params['repository_id'] = null;
                 params['content_view_id'] = null;
                 nutupane.table.rows = [];

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/environment-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/environment-content.controller.js
@@ -81,6 +81,25 @@
 
         fetchContentViews($scope.$stateParams.environmentId);
 
+        $scope.getNoRowsMessage = function () {
+            var messages = [ContentService.getNoRowsMessage()];
+            if ($scope.contentView.id === '') {
+                messages.push($scope.getNoContentViewMessage());
+            }
+            return messages.join(" ");
+        };
+
+        $scope.getNoContentViewMessage = function () {
+            return translate('Please make sure a Content View is selected.');
+        };
+
+        $scope.getZeroResultsMessage = function () {
+            var messages = [ContentService.getZeroResultsMessage()];
+            if ($scope.contentView.id === '') {
+                messages.push($scope.getNoContentViewMessage());
+            }
+            return messages.join(" ");
+        };
 
         $scope.contentViewSelected = function (contentView) {
             var params = nutupane.getParams();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-docker.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-docker.html
@@ -4,13 +4,8 @@
     <select class="form-control" ng-model="repository" ng-change="repositorySelected(repository)" ng-options="repository.name for (id, repository) in repositories"></select>
   </div>
 
-  <span data-block="no-rows-message" translate>
-    There are no Container Image Tags that match the criteria.
-  </span>
-
-  <span data-block="no-search-results-message" translate>
-    Your search returned zero Container Image Tags.
-  </span>
+  <span data-block="no-rows-message" ng-bind="getNoRowsMessage()"></span>
+  <span data-block="no-search-results-message" ng-bind="getZeroResultsMessage()"></span>
 
   <table data-block="table" class="table table-striped table-bordered">
     <thead>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-errata.html
@@ -4,13 +4,8 @@
     <select class="form-control" ng-model="repository" ng-change="repositorySelected(repository)" ng-options="repository.name for (id, repository) in repositories"></select>
   </div>
 
-  <span data-block="no-rows-message" translate>
-    There are no Errata that match the criteria.
-  </span>
-
-  <span data-block="no-search-results-message" translate>
-    Your search returned zero Errata.
-  </span>
+  <span data-block="no-rows-message" ng-bind="getNoRowsMessage()"></span>
+  <span data-block="no-search-results-message" ng-bind="getZeroResultsMessage()"></span>
 
   <table data-block="table" class="table table-striped table-bordered">
     <thead>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-module-streams.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-module-streams.html
@@ -4,13 +4,8 @@
     <select class="form-control" ng-model="repository" ng-change="repositorySelected(repository)" ng-options="repository.name for (id, repository) in repositories"></select>
   </div>
 
-  <span data-block="no-rows-message" translate>
-    There are no module streams that match the criteria.
-  </span>
-
-  <span data-block="no-search-results-message" translate>
-    Your search returned zero module streams.
-  </span>
+  <span data-block="no-rows-message" ng-bind="getNoRowsMessage()"></span>
+  <span data-block="no-search-results-message" ng-bind="getZeroResultsMessage()"></span>
 
   <table data-block="table" class="table table-striped table-bordered">
     <thead>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-ostree.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-ostree.html
@@ -4,13 +4,8 @@
     <select class="form-control" ng-model="repository" ng-change="repositorySelected(repository)" ng-options="repository.name for (id, repository) in repositories"></select>
   </div>
 
-  <span data-block="no-rows-message" translate>
-    There are no OSTree Branches that match the criteria.
-  </span>
-
-  <span data-block="no-search-results-message" translate>
-    Your search returned zero OSTree Branches.
-  </span>
+  <span data-block="no-rows-message" ng-bind="getNoRowsMessage()"></span>
+  <span data-block="no-search-results-message" ng-bind="getZeroResultsMessage()"></span>
 
   <table data-block="table" class="table table-striped table-bordered">
     <thead>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-packages.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-packages.html
@@ -4,13 +4,8 @@
     <select class="form-control" ng-model="repository" ng-change="repositorySelected(repository)" ng-options="repository.name for (id, repository) in repositories"></select>
   </div>
 
-  <span data-block="no-rows-message" translate>
-    There are no Packages that match the criteria.
-  </span>
-
-  <span data-block="no-search-results-message" translate>
-    Your search returned zero Packages.
-  </span>
+  <span data-block="no-rows-message" ng-bind="getNoRowsMessage()"></span>
+  <span data-block="no-search-results-message" ng-bind="getZeroResultsMessage()"></span>
 
   <table data-block="table" class="table table-striped table-bordered">
     <thead>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-puppet-modules.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-puppet-modules.html
@@ -3,6 +3,9 @@
     <select class="form-control" ng-model="contentView" ng-change="contentViewSelected(contentView)" ng-options="contentView.name for (id, contentView) in contentViews"></select>
   </div>
 
+  <span data-block="no-rows-message" ng-bind="getNoRowsMessage()"></span>
+  <span data-block="no-search-results-message" ng-bind="getZeroResultsMessage()"></span>
+
   <table data-block="table" class="table table-striped table-bordered">
     <thead>
       <tr bst-table-head>
@@ -11,15 +14,6 @@
         <th bst-table-column translate>Version</th>
       </tr>
     </thead>
-
-    <span data-block="no-rows-message" translate>
-      There are no Puppet Modules that match the criteria.
-    </span>
-
-    <span data-block="no-search-results-message" translate>
-      Your search returned zero Puppet Modules.
-    </span>
-
     <tbody>
       <tr bst-table-row ng-repeat="puppetModule in table.rows">
         <td bst-table-cell>{{ puppetModule.name }}</td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-repositories.html
@@ -3,6 +3,9 @@
     <select class="form-control" ng-model="contentView" ng-change="contentViewSelected(contentView)" ng-options="contentView.name for (id, contentView) in contentViews"></select>
   </span>
 
+  <span data-block="no-rows-message" ng-bind="getNoRowsMessage()"></span>
+  <span data-block="no-search-results-message" ng-bind="getZeroResultsMessage()"></span>
+
   <table data-block="table" class="table table-striped table-bordered">
     <thead>
       <tr bst-table-head>
@@ -11,14 +14,6 @@
         <th bst-table-column translate>Content View</th>
       </tr>
     </thead>
-
-    <span data-block="no-rows-message" translate>
-      There are no Yum Repositories that match the criteria.
-    </span>
-
-    <span data-block="no-search-results-message" translate>
-      Your search returned zero Repositories.
-    </span>
 
     <tbody>
       <tr bst-table-row ng-repeat="repository in table.rows">

--- a/engines/bastion_katello/test/environments/details/environment-content.controller.test.js
+++ b/engines/bastion_katello/test/environments/details/environment-content.controller.test.js
@@ -73,7 +73,7 @@ describe('Controller: EnvironmentContentController', function() {
     });
 
     it("sets the content_view_id to undefined when all content views set", function () {
-        $scope.contentViewSelected({id: 'all'});
+        $scope.contentViewSelected({id: ''});
 
         expect($scope.nutupane.getParams()['content_view_version_id']).toBe(undefined);
     });


### PR DESCRIPTION
Click on a Lifecycle Env Details page. Notice that there is a "All
Content View" selction option and duplicate repository names displayed
in the "repositories"  section. The duplication is because the same
repository is in multiple content views.
This commmit tries to address this issue by removing the "All Content
Views" option which is probably never used. Instead it auto selects the
first available content view and displays repositories belonging to
that.