### PR TITLE
Fixes #26028 - set foreign key for tasks sync plan explicitly

### DIFF
--- a/app/models/katello/concerns/recurring_logic_extensions.rb
+++ b/app/models/katello/concerns/recurring_logic_extensions.rb
@@ -4,7 +4,9 @@ module Katello
       extend ActiveSupport::Concern
 
       included do
-        has_one :sync_plan, :inverse_of => :foreman_tasks_recurring_logic, :class_name => "Katello::SyncPlan", :dependent => :destroy
+        has_one :sync_plan, :inverse_of => :foreman_tasks_recurring_logic,
+                :class_name => "Katello::SyncPlan", :dependent => :destroy,
+                :foreign_key => :foreman_tasks_recurring_logic_id
       end
     end
   end

--- a/test/models/sync_plan_test.rb
+++ b/test/models/sync_plan_test.rb
@@ -109,6 +109,12 @@ module Katello
       end
     end
 
+    def test_destroy
+      @plan.save_with_logic!
+      @plan.foreman_tasks_recurring_logic.destroy!
+      refute SyncPlan.find_by(id: @plan.id)
+    end
+
     def test_invalid_cron_status
       @plan.cron_expression = "20 * * * *"
       refute @plan.valid?, "Custom cron expression only needs to be set for interval value of custom cron"


### PR DESCRIPTION
Otherwise, destroying fails with `katello_sync_plans.recurring_logic_id
does not exist`

Interestingly enough, I was able to reproduce this in production only, while
everything worked fine in development. But I guess it's better safe than sorry, so we can be more explicity about this.