### PR TITLE
Fixes #26030 - Add only_explicit search to errata packages

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -31,8 +31,8 @@ module Katello
     scoped_search :on => :reboot_suggested, :complete_value => true
     scoped_search :relation => :cves, :on => :cve_id, :rename => :cve
     scoped_search :relation => :bugzillas, :on => :bug_id, :rename => :bug
-    scoped_search :relation => :packages, :on => :nvrea, :rename => :package, :complete_value => true
-    scoped_search :relation => :packages, :on => :name, :rename => :package_name, :complete_value => true
+    scoped_search :relation => :packages, :on => :nvrea, :rename => :package, :complete_value => true, :only_explicit => true
+    scoped_search :relation => :packages, :on => :name, :rename => :package_name, :complete_value => true, :only_explicit => true
 
     before_save lambda { |erratum| erratum.title = erratum.title.truncate(255) unless erratum.title.blank? }
 


### PR DESCRIPTION
This speeds up errata search by specifying the package searches
to only happen on explicit search (package=foo rather than foo)

You can reproduce the slow query by running a search with no specified key, i.e. `erratum list --page 1 --per-page 200 --search 1`

I tried analyzing the SQL to see if there are any improvements to be made by adding indexes, but I couldn't see any performance gain from adding indexes on the `erratum_id` field in the associated tables. Here are explain plans from [master](https://explain.depesz.com/s/848K) and [this PR](https://explain.depesz.com/s/jngH) if you would like to look for further improvements.

I used this benchmark file to get an idea of what kind of improvement we would see:
```ruby
require 'benchmark'

#$stdout = File.new('/tmp/errata_benchmark.log', 'w')
#$stdout.sync = true

PER_PAGE=500
REPEAT=10
Benchmark.bm do |bm|
  bm.report('errata') do
    REPEAT.times do
      `BUNDLE_GEMFILE=~/hammer-cli-foreman/Gemfile bundle exec hammer erratum list --page 1 --per-page #{PER_PAGE} --search "1"`
    end
  end
end
```

On master the script completed in around 7 and a half minutes
```
[vagrant@centos7-hammer-devel ~]$ ~/errata_benchmark.rb 
       user     system      total        real
errata  0.000000   0.000000  13.380000 (453.625497)
```

In this PR, it took a little over a minute
```
[vagrant@centos7-hammer-devel ~]$ ./errata_benchmark.rb 
       user     system      total        real
errata  0.010000   0.000000  13.330000 ( 85.444504)
```

If we add `only_explicit` to the bugzilla and CVE fields, that number goes down to 14 seconds, so that is an option, but I don't know how often users would like to search for CVE and bugzilla numbers without using a search key

This change seems like the most benefit with little value lost, but I'm open to more solutions!