### PR TITLE
Fixes #26032- Repo certs propagated on save

### DIFF
--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -254,7 +254,8 @@ module Katello
 
     def pulp_update_needed?
       changeable_attributes = %w(url unprotected checksum_type docker_upstream_name download_policy mirror_on_sync verify_ssl_on_sync
-                                 upstream_username upstream_password ostree_upstream_sync_policy ostree_upstream_sync_depth ignore_global_proxy ignorable_content)
+                                 upstream_username upstream_password ostree_upstream_sync_policy ostree_upstream_sync_depth ignore_global_proxy ignorable_content
+                                 ssl_ca_cert_id ssl_client_cert_id ssl_client_key_id)
       changeable_attributes += %w(name container_repository_name docker_tags_whitelist) if docker?
       changeable_attributes += %w(deb_releases deb_components deb_architectures gpg_key_id) if deb?
       changeable_attributes.any? { |key| previous_changes.key?(key) }

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
@@ -41,7 +41,7 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
                     return false;
                 });
 
-                results.unshift({id: null});
+                results.unshift({id: null, name:''});
                 deferred.resolve(results);
             });
 
@@ -61,7 +61,7 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
                     return false;
                 });
 
-                results.unshift({id: null});
+                results.unshift({id: null, name:''});
                 deferred.resolve(results);
             });
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
@@ -41,7 +41,7 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
                     return false;
                 });
 
-                results.unshift({id: null, name:''});
+                results.unshift({id: null, name: ''});
                 deferred.resolve(results);
             });
 
@@ -61,7 +61,7 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
                     return false;
                 });
 
-                results.unshift({id: null, name:''});
+                results.unshift({id: null, name: ''});
                 deferred.resolve(results);
             });
 

--- a/engines/bastion_katello/test/products/details/repositories/details/repository-details-info.controller.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/details/repository-details-info.controller.test.js
@@ -55,7 +55,7 @@ describe('Controller: RepositoryDetailsInfoController', function() {
         expect(promise.then).toBeDefined();
         promise.then(function(contentCredentials) {
             expect(contentCredentials).toBeDefined();
-            expect(contentCredentials).toContain({id: null});
+            expect(contentCredentials).toContain({id: null, name: ''});
         });
 
         $scope.$apply();
@@ -67,7 +67,7 @@ describe('Controller: RepositoryDetailsInfoController', function() {
         expect(promise.then).toBeDefined();
         promise.then(function(contentCredentials) {
             expect(contentCredentials).toBeDefined();
-            expect(contentCredentials).toContain({id: null});
+            expect(contentCredentials).toContain({id: null, name: ''});
         });
 
         $scope.$apply();

--- a/test/models/root_repository_test.rb
+++ b/test/models/root_repository_test.rb
@@ -718,6 +718,26 @@ module Katello
       @ostree_root.save!
       assert @ostree_root.pulp_update_needed?
     end
+
+    def test_pulp_update_needed_with_ssl?
+      cert = GpgKey.find(katello_gpg_keys(:fedora_cert).id)
+      refute @fedora_root.pulp_update_needed?
+      @fedora_root.ssl_ca_cert_id = cert.id
+      @fedora_root.save!
+      assert @fedora_root.pulp_update_needed?
+
+      @fedora_root = @fedora_root.reload
+      refute @fedora_root.pulp_update_needed?
+      @fedora_root.ssl_client_cert_id = cert.id
+      @fedora_root.save!
+      assert @fedora_root.pulp_update_needed?
+
+      @fedora_root = @fedora_root.reload
+      refute @fedora_root.pulp_update_needed?
+      @fedora_root.ssl_client_key_id = cert.id
+      @fedora_root.save!
+      assert @fedora_root.pulp_update_needed?
+    end
   end
 
   class RootRepositoryAuditTest < RepositoryTestBase


### PR DESCRIPTION
This commit updates pulp when SSL Certs/Keys are changed in a
repository.