### PR TITLE
Fixes #26049 - Docker tag whitelist error message

### DIFF
--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -184,7 +184,7 @@ module Katello
     def ensure_valid_docker_tags_whitelist
       return if docker_tags_whitelist.blank?
       if !docker?
-        errors.add(:docker_tags_whitelist, N_("White list can be only set for Container Image repositories."))
+        errors.add(:docker_tags_whitelist, N_("can be only set for Container Image repositories."))
       elsif !docker_tags_whitelist.is_a?(Array)
         errors.add(:docker_tags_whitelist, N_("Invalid value specified for Container Image repositories."))
       end


### PR DESCRIPTION
**To repro:**
1. hammer product create --name 'testprod' --organization-id 1
2. hammer repository create --product-id 1 --name test --content-type yum --docker-tags-whitelist 'one,two,three'

**Actual output:**
Could not create the repository:
Validation failed: Docker tags whitelist White list can be only set for Container Image repositories.

**Expected:**
Could not create the repository:
Validation failed: Docker tags whitelist can be only set for Container Image repositories.