### PR TITLE
Fixes #26075 - RHEL8 on Sync Status Page

### DIFF
--- a/app/lib/katello/util/path_with_substitutions.rb
+++ b/app/lib/katello/util/path_with_substitutions.rb
@@ -15,7 +15,7 @@ module Katello
       end
 
       def split_path
-        @split ||= @path.split('/')
+        @split ||= path.split('/')
       end
 
       def substitutions_needed

--- a/app/lib/katello/util/path_with_substitutions.rb
+++ b/app/lib/katello/util/path_with_substitutions.rb
@@ -14,10 +14,14 @@ module Katello
         @resolved = []
       end
 
+      def split_path
+        @split ||= @path.split('/')
+      end
+
       def substitutions_needed
         # e.g. if content_url = "/content/dist/rhel/server/7/$releasever/$basearch/kickstart"
         #      return ['releasever', 'basearch']
-        path.split('/').map { |word| word.start_with?('$') ? word[1..-1] : nil }.compact
+        split_path.map { |word| word.start_with?('$') ? word[1..-1] : nil }.compact
       end
 
       def substitutable?
@@ -38,7 +42,7 @@ module Katello
 
       def unused_substitutions
         substitutions.keys.reject do |key|
-          path.include?("$#{key}")
+          path.include?("$#{key}") || split_path.include?(substitutions[key])
         end
       end
 

--- a/test/lib/util/path_with_substitutions_test.rb
+++ b/test/lib/util/path_with_substitutions_test.rb
@@ -6,6 +6,7 @@ module Katello
       def setup
         @el5_path = '/content/dist/rhel/server/5/$releasever/$basearch/os'
         @non_sub_path = '/content/dist/rhel/server/5/5Server/x86_64/os'
+        @el8_path = '/content/dist/rhel8/8/x86_64/appstream/kickstart'
         @releasever_list = ['5Server', '5.8']
         @arch_list = ['x86_64', 'i386']
         @cdn = Katello::Resources::CDN::CdnResource.new('http://someurl/')
@@ -51,6 +52,7 @@ module Katello
       def test_unused_substitutions
         assert_equal ['foo'], PathWithSubstitutions.new(@el5_path, 'foo' => 'bar').unused_substitutions
         assert_empty PathWithSubstitutions.new(@el5_path, 'basearch' => 'x86_64').unused_substitutions
+        assert_empty PathWithSubstitutions.new(@el8_path, 'basearch' => 'x86_64').unused_substitutions
       end
 
       def test_apply_substitutions

--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepository/RepositorySetRepository.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepository/RepositorySetRepository.js
@@ -16,13 +16,14 @@ class RepositorySetRepository extends Component {
 
     this.repoForAction = () => {
       const {
-        productId, contentId, arch, releasever, label,
+        productId, contentId, arch, displayArch, releasever, label,
       } = this.props;
 
+      const derivedArch = arch || displayArch;
       return {
+        arch: derivedArch,
         productId,
         contentId,
-        arch,
         releasever,
         label,
       };


### PR DESCRIPTION
RHEL8 includes arches inside of the URL path, not
passed in as substitutions to replace `$arch`.

We handle displaying the arch in the UI by parsing
the path to check for an arch if no arch is given.

That change can be seen
[here](https://github.com/Katello/katello/pull/7938/files)

The issue is that the derived arch isn't passed back
when enabling the repo. So you wind up with 'noarch'
for that repo. This can be seen on the sync status
page.

This change passes back the derived arch if no
substituted arch is found. This is then stored
when creating the repo, and can be seen on pages
like 'sync status'

The logic in creating the path with substitutions had
to be altered a bit as it will error if 'basearch' is
passed and there is no $basearch to replace in the path.

To review:
- enable a RHEL8 repo
- go to sync status page and make sure its listed under
the actual arch of the repo