### PR TITLE
Fixes #25945 - Paginate content view repo page

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-deb-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-deb-repositories.controller.js
@@ -27,7 +27,7 @@
             'content_view_id': $scope.$stateParams.contentViewId,
             'available_for': 'content_view'
         },
-        'queryUnpaged', nutupaneParams);
+        'queryPaged', nutupaneParams);
         $scope.controllerName = 'katello_repositories';
 
         nutupane.load();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-docker-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-docker-repositories.controller.js
@@ -28,7 +28,7 @@ angular.module('Bastion.content-views').controller('ContentViewAvailableDockerRe
             'content_view_id': $scope.$stateParams.contentViewId,
             'available_for': 'content_view'
         },
-        'queryUnpaged', nutupaneParams);
+        'queryPaged', nutupaneParams);
         $scope.controllerName = 'katello_repositories';
 
         nutupane.masterOnly = true;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-file-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-file-repositories.controller.js
@@ -27,7 +27,7 @@
             'content_view_id': $scope.$stateParams.contentViewId,
             'available_for': 'content_view'
         },
-        'queryUnpaged', nutupaneParams);
+        'queryPaged', nutupaneParams);
         $scope.controllerName = 'katello_repositories';
 
         nutupane.load();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-ostree-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-ostree-repositories.controller.js
@@ -27,7 +27,7 @@ angular.module('Bastion.content-views').controller('ContentViewAvailableOstreeRe
             'content_view_id': $scope.$stateParams.contentViewId,
             'available_for': 'content_view'
         },
-        'queryUnpaged', nutupaneParams);
+        'queryPaged', nutupaneParams);
         $scope.controllerName = 'katello_repositories';
 
         nutupane.masterOnly = true;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-repositories.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-available-repositories.controller.js
@@ -30,7 +30,7 @@ angular.module('Bastion.content-views').controller('ContentViewAvailableReposito
             'content_view_id': $scope.$stateParams.contentViewId,
             'available_for': 'content_view'
         },
-        'queryUnpaged', nutupaneParams);
+        'queryPaged', nutupaneParams);
         $scope.controllerName = 'katello_repositories';
 
         nutupane.load();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-deb-repositories-list.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-deb-repositories-list.controller.js
@@ -25,7 +25,7 @@
             'content_view_id': $scope.$stateParams.contentViewId,
             'content_type': 'deb'
         },
-        'queryUnpaged', nutupaneParams);
+        'queryPaged', nutupaneParams);
         $scope.controllerName = 'katello_repositories';
 
         nutupane.load();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-docker-repositories-list.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-docker-repositories-list.controller.js
@@ -25,7 +25,7 @@
             'content_view_id': $scope.$stateParams.contentViewId,
             'content_type': 'docker'
         },
-        'queryUnpaged', nutupaneParams);
+        'queryPaged', nutupaneParams);
         $scope.controllerName = 'katello_repositories';
 
         nutupane.masterOnly = true;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-file-repositories-list.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-file-repositories-list.controller.js
@@ -25,7 +25,7 @@
             'content_view_id': $scope.$stateParams.contentViewId,
             'content_type': 'file'
         },
-        'queryUnpaged', nutupaneParams);
+        'queryPaged', nutupaneParams);
         $scope.controllerName = 'katello_repositories';
 
         nutupane.load();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-ostree-repositories-list.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-ostree-repositories-list.controller.js
@@ -25,7 +25,7 @@
             'content_view_id': $scope.$stateParams.contentViewId,
             'content_type': 'ostree'
         },
-        'queryUnpaged', nutupaneParams);
+        'queryPaged', nutupaneParams);
         $scope.controllerName = 'katello_repositories';
 
         nutupane.masterOnly = true;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-repositories-list.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-repositories-list.controller.js
@@ -27,7 +27,7 @@ angular.module('Bastion.content-views').controller('ContentViewRepositoriesListC
             'content_view_id': $scope.$stateParams.contentViewId,
             'content_type': 'yum'
         },
-        'queryUnpaged', nutupaneParams);
+        'queryPaged', nutupaneParams);
         $scope.controllerName = 'katello_repositories';
 
         nutupane.load();


### PR DESCRIPTION
#### To reproduce:
Go to Content View> Add repository (All types except puppet modules which has a different UI)
The results are not paginated, dumping all records on the page.
#### Expected:
With the change, the results are paginated
