### PR TITLE
Fixes #26095 - Provision distros with 3 digit vers

### DIFF
--- a/app/models/katello/concerns/redhat_extensions.rb
+++ b/app/models/katello/concerns/redhat_extensions.rb
@@ -72,8 +72,8 @@ module Katello
 
         if content_view && lifecycle_environment && host.os && host.architecture
           Katello::Repository.in_environment(lifecycle_environment).in_content_views([content_view]).
-              where(:distribution_version => host.os.release,
-                    :distribution_arch => host.architecture.name)
+              where(:distribution_arch => host.architecture.name).
+              where("#{Katello::Repository.table_name}.distribution_version like ?", "#{host.os.release}%")
         else
           []
         end

--- a/app/models/katello/concerns/redhat_extensions.rb
+++ b/app/models/katello/concerns/redhat_extensions.rb
@@ -73,7 +73,8 @@ module Katello
         if content_view && lifecycle_environment && host.os && host.architecture
           Katello::Repository.in_environment(lifecycle_environment).in_content_views([content_view]).
               where(:distribution_arch => host.architecture.name).
-              where("#{Katello::Repository.table_name}.distribution_version like ?", "#{host.os.release}%")
+              where("#{Katello::Repository.table_name}.distribution_version = :release or #{Katello::Repository.table_name}.distribution_version like :match",
+                      release: host.os.release, match:"#{host.os.release}.%")
         else
           []
         end

--- a/app/models/katello/concerns/redhat_extensions.rb
+++ b/app/models/katello/concerns/redhat_extensions.rb
@@ -74,7 +74,7 @@ module Katello
           Katello::Repository.in_environment(lifecycle_environment).in_content_views([content_view]).
               where(:distribution_arch => host.architecture.name).
               where("#{Katello::Repository.table_name}.distribution_version = :release or #{Katello::Repository.table_name}.distribution_version like :match",
-                      release: host.os.release, match:"#{host.os.release}.%")
+                      release: host.os.release, match: "#{host.os.release}.%")
         else
           []
         end

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -331,3 +331,16 @@ generic_file_dev:
   relative_path:        '/Default_Organization/dev/My_Files'
   environment_id:       <%= ActiveRecord::FixtureSet.identify(:dev) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_dev_view_version) %>
+
+three_digit_fedora_17_x86_64_distro:
+  root_id:              <%= ActiveRecord::FixtureSet.identify(:fedora_17_x86_64_root) %>
+  pulp_id:              Fedora_17
+  relative_path:        'ACME_Corporation/library/fedora_17_label'
+  environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
+  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
+  distribution_arch: "x86_64"
+  distribution_version: "2.1.2"
+  distribution_family: 'Red Hat Enterprise Linux'
+  distribution_variant: "TestVariant"
+  distribution_bootable: true
+  distribution_uuid: 'xyz123'

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -331,16 +331,3 @@ generic_file_dev:
   relative_path:        '/Default_Organization/dev/My_Files'
   environment_id:       <%= ActiveRecord::FixtureSet.identify(:dev) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_dev_view_version) %>
-
-three_digit_fedora_17_x86_64_distro:
-  root_id:              <%= ActiveRecord::FixtureSet.identify(:fedora_17_x86_64_root) %>
-  pulp_id:              Fedora_17
-  relative_path:        'ACME_Corporation/library/fedora_17_label'
-  environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
-  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
-  distribution_arch: "x86_64"
-  distribution_version: "2.1.2"
-  distribution_family: 'Red Hat Enterprise Linux'
-  distribution_variant: "TestVariant"
-  distribution_bootable: true
-  distribution_uuid: 'xyz123'

--- a/test/models/concerns/redhat_extensions_test.rb
+++ b/test/models/concerns/redhat_extensions_test.rb
@@ -60,22 +60,21 @@ module Katello
       # make sure it matches 3 digit distro versions correctly
       # If I asked for available distros for OS x.y , it should match x.y and x.y.z
       # but not x.yz
-
-      repo_with_distro = katello_repositories(:three_digit_fedora_17_x86_64_distro)
+      @repo_with_distro.update_attributes!(:distribution_version => "2.3.4")
       version = @repo_with_distro.distribution_version.split('.')
-      os = ::Redhat.create_operating_system(@my_distro.name, version[0], version[1])
+      os = ::Redhat.create_operating_system("RedHat", version[0], version[1])
       host = ::Host.new(:architecture => architectures(:x86_64), :operatingsystem => os,
-                        :content_facet_attributes => {:lifecycle_environment_id => repo_with_distro.environment.id,
-                                                      :content_view_id => repo_with_distro.content_view.id})
+                        :content_facet_attributes => {:lifecycle_environment_id => @repo_with_distro.environment.id,
+                                                      :content_view_id => @repo_with_distro.content_view.id})
       repo_list = os.distribution_repositories(host)
-      assert_includes repo_list, repo_with_distro
+      assert_includes repo_list, @repo_with_distro
 
-      diff_os = ::Redhat.create_operating_system(@my_distro.name, version[0], "#{version[1]}0")
+      diff_os = ::Redhat.create_operating_system("RedHat", version[0], "#{version[1]}0")
       host = ::Host.new(:architecture => architectures(:x86_64), :operatingsystem => diff_os,
-                        :content_facet_attributes => {:lifecycle_environment_id => repo_with_distro.environment.id,
-                                                      :content_view_id => repo_with_distro.content_view.id})
+                        :content_facet_attributes => {:lifecycle_environment_id => @repo_with_distro.environment.id,
+                                                      :content_view_id => @repo_with_distro.content_view.id})
       repo_list = diff_os.distribution_repositories(host)
-      refute_includes repo_list, repo_with_distro
+      refute_includes repo_list, @repo_with_distro
     end
   end
 

--- a/test/models/concerns/redhat_extensions_test.rb
+++ b/test/models/concerns/redhat_extensions_test.rb
@@ -55,6 +55,28 @@ module Katello
       assert_includes repo_list, @repo_with_distro
       refute_includes repo_list, other_repo
     end
+
+    def test_distribution_repositories_fuzzy
+      # make sure it matches 3 digit distro versions correctly
+      # If I asked for available distros for OS x.y , it should match x.y and x.y.z
+      # but not x.yz
+
+      repo_with_distro = katello_repositories(:three_digit_fedora_17_x86_64_distro)
+      version = @repo_with_distro.distribution_version.split('.')
+      os = ::Redhat.create_operating_system(@my_distro.name, version[0], version[1])
+      host = ::Host.new(:architecture => architectures(:x86_64), :operatingsystem => os,
+                        :content_facet_attributes => {:lifecycle_environment_id => repo_with_distro.environment.id,
+                                                      :content_view_id => repo_with_distro.content_view.id})
+      repo_list = os.distribution_repositories(host)
+      assert_includes repo_list, repo_with_distro
+
+      diff_os = ::Redhat.create_operating_system(@my_distro.name, version[0], "#{version[1]}0")
+      host = ::Host.new(:architecture => architectures(:x86_64), :operatingsystem => diff_os,
+                        :content_facet_attributes => {:lifecycle_environment_id => repo_with_distro.environment.id,
+                                                      :content_view_id => repo_with_distro.content_view.id})
+      repo_list = diff_os.distribution_repositories(host)
+      refute_includes repo_list, repo_with_distro
+    end
   end
 
   class RedhatExtensionsMediaTest < ActiveSupport::TestCase


### PR DESCRIPTION
This commit handles the case where the treeinfo in a distribution has 3
or more digit versions like "8.0.0" during provisioning of a OS that has
2 digits like "8.0". This commit returns x.y.z as a possible bootable
version for any os that has "x.y or x.y.z"