### PR TITLE
Fixes #26117 - Provide default syspurpose values

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
@@ -24,13 +24,16 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsController
         $scope.getHostStatusIcon = ContentHostsHelper.getHostStatusIcon;
         $scope.getHostPurposeStatusIcon = ContentHostsHelper.getHostPurposeStatusIcon;
 
-        $scope.organization = Organization.get({id: CurrentOrganization});
+        $scope.organization = Organization.get({id: CurrentOrganization}, function(org) {
+            $scope.purposeAddonsCount += org.system_purposes.addons.length;
+        });
 
         $scope.defaultUsages = ['Production', 'Development/Test', 'Disaster Recovery'];
         $scope.defaultRoles = ['Red Hat Enterprise Linux Server', 'Red Hat Enterprise Linux Workstation', 'Red Hat Enterprise Linux Compute Node'];
         $scope.defaultServiceLevels = ['Self-Support', 'Standard', 'Premium'];
 
         $scope.purposeAddonsList = [];
+        $scope.purposeAddonsCount = 0;
 
         $scope.panel = {
             error: false,
@@ -41,6 +44,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsController
             host.unregisterDelete = !host.hasSubscription() || deleteHostOnUnregister;
             host.deleteHostOnUnregister = deleteHostOnUnregister;
             $scope.panel.loading = false;
+            $scope.purposeAddonsCount += host.subscription_facet_attributes.purpose_addons.length;
         }, function (response) {
             $scope.panel.loading = false;
             ApiErrorHandler.handleGETRequestErrors(response, $scope);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
@@ -26,6 +26,10 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsController
 
         $scope.organization = Organization.get({id: CurrentOrganization});
 
+        $scope.defaultUsages = ['Production', 'Development/Test', 'Disaster Recovery'];
+        $scope.defaultRoles = ['Red Hat Enterprise Linux Server', 'Red Hat Enterprise Linux Workstation', 'Red Hat Enterprise Linux Compute Node'];
+        $scope.defaultServiceLevels = ['Self-Support', 'Standard', 'Premium'];
+
         $scope.purposeAddonsList = [];
 
         $scope.panel = {
@@ -136,7 +140,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsController
 
         $scope.serviceLevels = function () {
             return $scope.organization.$promise.then(function(org) {
-                return org.service_levels;
+                return _.union(org.service_levels, $scope.defaultServiceLevels);
             });
         };
 
@@ -147,7 +151,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsController
                 if (role && !_.includes(roles, role)) {
                     roles.push(role);
                 }
-                return roles;
+                return _.union(roles, $scope.defaultRoles);
             });
         };
 
@@ -158,7 +162,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsController
                 if (usage && !_.includes(usages, usage)) {
                     usages.push(usage);
                 }
-                return usages;
+                return _.union(usages, $scope.defaultUsages);
             });
         };
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -138,7 +138,7 @@
 
         <dt translate>Add ons</dt>
         <dd bst-edit-multiselect="host.subscription_facet_attributes.purpose_addons"
-            readonly="denied('edit_hosts', host)"
+            readonly="denied('edit_hosts', host) || (organization.system_purposes.addons.length + host.subscription_facet_attributes.purpose_addons.length === 0)"
             icon-class="getHostPurposeStatusIcon(host.purpose_addons_status)"
             icon-show="host.purpose_addons_status > 0"
             formatter="arrayToString"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -138,7 +138,7 @@
 
         <dt translate>Add ons</dt>
         <dd bst-edit-multiselect="host.subscription_facet_attributes.purpose_addons"
-            readonly="denied('edit_hosts', host) || (organization.system_purposes.addons.length + host.subscription_facet_attributes.purpose_addons.length === 0)"
+            readonly="denied('edit_hosts', host) || purposeAddonsCount === 0"
             icon-class="getHostPurposeStatusIcon(host.purpose_addons_status)"
             icon-show="host.purpose_addons_status > 0"
             formatter="arrayToString"

--- a/engines/bastion_katello/test/content-hosts/details/content-host-details.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-details.controller.test.js
@@ -25,7 +25,7 @@ describe('Controller: ContentHostDetailsController', function() {
 
         mockOrg = {
           id: '1',
-          service_levels: ['PREMIUM'],
+          service_levels: ['Premium'],
           system_purposes: {
             roles: ['custom-role'],
             usage: ['custom-usage'],
@@ -125,21 +125,23 @@ describe('Controller: ContentHostDetailsController', function() {
 
     it("provides a list of service levels", function() {
         $scope.serviceLevels().then(function(service_levels) {
-            expect(service_levels).toEqual(['PREMIUM']);
+            expect(service_levels.sort()).toEqual(['Self-Support', 'Standard', 'Premium'].sort());
         });
         $httpBackend.flush();
     });
 
     it("provides a list of system purpose roles", function() {
         $scope.purposeRoles().then(function(roles) {
-            expect(roles).toEqual(['custom-role', 'current-role']);
+            expect(roles.sort()).toEqual(['Red Hat Enterprise Linux Server', 'Red Hat Enterprise Linux Workstation',
+                'Red Hat Enterprise Linux Compute Node', 'custom-role', 'current-role'].sort());
         });
         $httpBackend.flush();
     });
 
     it("provides a list of system purpose usages", function() {
         $scope.purposeUsages().then(function(usages) {
-            expect(usages).toEqual(['custom-usage', 'current-usage']);
+            expect(usages.sort()).toEqual(['Production', 'Development/Test', 'Disaster Recovery',
+                'custom-usage', 'current-usage'].sort());
         });
         $httpBackend.flush();
     });

--- a/engines/bastion_katello/test/content-hosts/details/content-host-details.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-details.controller.test.js
@@ -119,7 +119,7 @@ describe('Controller: ContentHostDetailsController', function() {
     });
 
     it("attaches an organization to the scope", function() {
-        expect(Organization.get).toHaveBeenCalledWith({id: '1'});
+        expect(Organization.get).toHaveBeenCalledWith({id: '1'}, jasmine.any(Function));
         expect($scope.organization).toBeDefined();
     });
 

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |gem|
 
   # UI
   gem.add_dependency "deface", '>= 1.0.2', '< 2.0.0'
-  gem.add_dependency "bastion", ">= 6.1.13", "< 7.0.0"
+  gem.add_dependency "bastion", ">= 6.1.20", "< 7.0.0"
 
   # Testing
   gem.add_development_dependency "factory_bot_rails", "~> 4.5"


### PR DESCRIPTION
Be sure to `bundle update` when testing this to bring in the new bastion which has https://github.com/Katello/bastion/pull/242

Otherwise testing is pretty simple:

- create a content host in an org without a manifest
- view it in the web UI
- notice that there are now default options for SLA, Role, Usage
- Add-Ons should be disabled as there are no default values and there are none coming via manifest

To test that addons will become enabled:

- open rails console
```
facet = ::Host.find(:id).subscription_facet
facet.purpose_addons = ["Test Addon"]
facet.save
```

- reload the page and the Add Ons field will now be editable