### PR TITLE
Fixes #26191 - Find existing system by UUID during registration

### DIFF
--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -255,7 +255,10 @@ module Katello
                    {:org_name => organization.name, :host_name => host_name }
         end
 
-        fail _("Could not associate this host to an existing profile since multiple were found. Please remove outdated content hosts.") if hosts.size > 1
+        if hosts.size > 1
+          hostnames = hosts.pluck(:name).sort
+          fail _("Multiple profiles found. Consider removing %s which match this host.") % hostnames.join(', ')
+        end
 
         hosts.first
       end

--- a/test/models/host/subscription_facet_test.rb
+++ b/test/models/host/subscription_facet_test.rb
@@ -248,7 +248,8 @@ module Katello
 
       # if we get two matches, raise an error
       error = assert_raises(RuntimeError) { Katello::Host::SubscriptionFacet.find_host(facts, org) }
-      assert_match(/since multiple were found/, error.message)
+      expected = "Multiple profiles found. Consider removing %s which match this host." % [host.name, host2.name].sort.join(', ')
+      assert_equal expected, error.message
 
       # if we get a single match uuid + hostname, return it
       host3 = FactoryBot.create(:host, organization: org)


### PR DESCRIPTION
The original report observed a '409 Conflict' error when registering the same (previously registered) client repeatedly with a script like this:

```
#!/usr/bin/env bash
# Run this as "h=<server hostname> ./register-systems.sh"
set -x

u=${u:-admin}
p=${p:-changeme}
h=${h:-$(hostname)}
o=${o:-Default_Organization}
e=${e:-Library}

for i in $(seq 1 2000); do
        echo $i
        subscription-manager clean
        hostnamectl set-hostname katello-client-$i.example.com
        subscription-manager register --username=$u --password=$p --environment="$e" --serverurl=http://$h --auto-attach --org="$o"
        res=$?
        echo $res
done
```

The reason for the error is because even though Katello sees the registration as net-new, Candlepin is able to find the existing host profile by the dmi.system.uuid fact which doesn't change across registrations. This was changed in Candlepin 2.5

When taking that (already existing) UUID from Candlepin and creating the consumer in Pulp the '409 Conflict' is raised since the consumer already exists there.

This change teaches Katello to look for existing system profiles based on `dmi.system.uuid` in addition to current hostname. It will break the above script in the sense that it won't create 2000 profiles any more - it'll unregister and re-register the system (in backend terms, not Katello proper). In order to create multiple profiles the `dmi.system.uuid` fact will need to be overridden on each registration

open questions:

- [ ] should we use the 'raise an error when multiple profiles are found' approach I used here, or something else?
- [ ] if we keep raising an error, how good is the messaging?
- [ ] currently the system in Katello will not get the updated hostname per the above script when a profile is reused. should I change it to take the new hostname?
