### PR TITLE
Fixes #26242 - Working message on custom cron interval

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/sync-plan-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/sync-plan-details-info.controller.js
@@ -41,7 +41,12 @@ angular.module('Bastion.sync-plans').controller('SyncPlanDetailsInfoController',
                 $scope.$watch('syncPlan.interval', function (interval) {
                     if (interval !== $scope.syncPlanInterval) {
                         $scope.editInterval = true;
-                        $scope.editedInterval = (interval === "custom cron");
+                        $scope.editedInterval = false;
+                        $scope.workingText = translate('Working');
+                        if (interval === "custom cron") {
+                            $scope.editedInterval = true;
+                            $scope.workingText = translate('Please enter cron below');
+                        }
                     } else {
                         $scope.editedInterval = false;
                         $scope.editInterval = false;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/views/sync-plan-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/views/sync-plan-info.html
@@ -68,6 +68,7 @@
           on-save="save(syncPlan)"
           on-cancel="cancelCronEdit()"
           forced-working-mode="editedInterval"
+          forced-working-text="workingText"
           edit-trigger="editInterval">
       </dd>
 

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |gem|
 
   # UI
   gem.add_dependency "deface", '>= 1.0.2', '< 2.0.0'
-  gem.add_dependency "bastion", ">= 6.1.20", "< 7.0.0"
+  gem.add_dependency "bastion", ">= 6.1.22", "< 7.0.0"
 
   # Testing
   gem.add_development_dependency "factory_bot_rails", "~> 4.5"


### PR DESCRIPTION
Depends on https://github.com/Katello/bastion/pull/243
- Create a sync plan (Hourly)
- Go to edit page of sync plan and select custom cron as interval
- You will see the working spinner and the text "working "and the cron text field will become visible.
- The page waits for the user to enter cron logic and save
- We would want to change the text "working" to something more clear, like "Please enter cron below"