### PR TITLE
Fixes #26251 - Repo Discovery with uname/passwd

### DIFF
--- a/app/lib/katello/repo_discovery.rb
+++ b/app/lib/katello/repo_discovery.rb
@@ -59,7 +59,11 @@ module Katello
     end
 
     def http_crawl(resume_point)
-      Anemone.crawl(resume_point, @proxy) do |anemone|
+      resume_point_uri = URI(resume_point)
+      resume_point_uri.user = @upstream_username if @upstream_username
+      resume_point_uri.password = @upstream_password if @upstream_password
+
+      Anemone.crawl(resume_point_uri, @proxy) do |anemone|
         anemone.focus_crawl do |page|
           @crawled << page.url.path
 

--- a/app/lib/katello/repo_discovery.rb
+++ b/app/lib/katello/repo_discovery.rb
@@ -69,7 +69,10 @@ module Katello
 
           page.links.each do |link|
             if link.path.ends_with?('/repodata/')
-              @found << page.url.to_s
+              page_url = page.url.clone
+              page_url.user = nil
+              page_url.password = nil
+              @found << page_url.to_s
             else
               @to_follow << link.to_s if should_follow?(link.path)
             end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery-create.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery-create.controller.js
@@ -131,7 +131,7 @@ angular.module('Bastion.products').controller('DiscoveryCreateController',
         };
 
         $scope.getRepoPath = function (repo) {
-            return repo.repositoryUrl
+            return repo.repositoryUrl;
         };
 
         $scope.createRepoChoices.product['organization_id'] = CurrentOrganization;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery-create.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery-create.controller.js
@@ -35,13 +35,14 @@ angular.module('Bastion.products').controller('DiscoveryCreateController',
                 name: repo.name,
                 label: repo.label,
                 'content_type': repo.contentType,
-                url: repo.url + repo.path,
                 'product_id': $scope.createRepoChoices.existingProductId,
                 unprotected: $scope.createRepoChoices.unprotected,
                 'verify_ssl': $scope.createRepoChoices.verifySsl,
                 'upstream_username': $scope.createRepoChoices.upstreamUsername,
                 'upstream_password': $scope.createRepoChoices.upstreamPassword
             };
+
+            repoParams.url = $scope.getRepoPath(repo);
 
             if (repo.contentType === 'docker') {
                 repoParams.url = $scope.createRepoChoices.repositoryUrl;
@@ -127,6 +128,14 @@ angular.module('Bastion.products').controller('DiscoveryCreateController',
             repositoryUrl: DiscoveryRepositories.getRepositoryUrl(),
             upstreamUsername: DiscoveryRepositories.getUpstreamUsername(),
             upstreamPassword: DiscoveryRepositories.getUpstreamPassword()
+        };
+
+        $scope.getRepoPath = function (repo) {
+            var repoUrl = repo.url;
+            if (!repoUrl.endsWith('/')) {
+                repoUrl += '/';
+            }
+            return repoUrl + repo.path;
         };
 
         $scope.createRepoChoices.product['organization_id'] = CurrentOrganization;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery-create.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery-create.controller.js
@@ -131,11 +131,7 @@ angular.module('Bastion.products').controller('DiscoveryCreateController',
         };
 
         $scope.getRepoPath = function (repo) {
-            var repoUrl = repo.url;
-            if (repoUrl.endsWith('/') ) {
-                repoUrl = repoUrl.slice(0, -1);
-            }
-            return repoUrl + repo.path;
+            return repo.repositoryUrl
         };
 
         $scope.createRepoChoices.product['organization_id'] = CurrentOrganization;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery-create.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery-create.controller.js
@@ -132,8 +132,8 @@ angular.module('Bastion.products').controller('DiscoveryCreateController',
 
         $scope.getRepoPath = function (repo) {
             var repoUrl = repo.url;
-            if (!repoUrl.endsWith('/')) {
-                repoUrl += '/';
+            if (repoUrl.endsWith('/') ) {
+                repoUrl = repoUrl.slice(0, -1);
             }
             return repoUrl + repo.path;
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
@@ -109,7 +109,7 @@ angular.module('Bastion.products').controller('DiscoveryController',
             baseUrl = $scope.discovery.url;
 
             toRet = _.map(urls, function (url) {
-                var params;
+                var params, urlPath, baseUrlPath;
 
                 params = {
                     url: $scope.discovery.url,
@@ -118,7 +118,9 @@ angular.module('Bastion.products').controller('DiscoveryController',
                     repositoryUrl: url
                 };
                 if ($scope.discovery.contentType === 'yum') {
-                    params.path = new URL(url).pathname.replace(new URL(baseUrl).pathname, "/");
+                    urlPath = new URL(url).pathname
+                    baseUrlPath = new URL(baseUrl).pathname
+                    params.path = urlPath.replace(baseUrlPath, "/");
                     params.name = $scope.defaultName(params.path);
                 } else {
                     params.dockerUpstreamName = url;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
@@ -109,7 +109,7 @@ angular.module('Bastion.products').controller('DiscoveryController',
             baseUrl = $scope.discovery.url;
 
             toRet = _.map(urls, function (url) {
-                var params, urlPath, baseUrlPath;
+                var params, urlPath, baseUrlPath, replaceWith = '';
 
                 params = {
                     url: $scope.discovery.url,
@@ -120,7 +120,10 @@ angular.module('Bastion.products').controller('DiscoveryController',
                 if ($scope.discovery.contentType === 'yum') {
                     urlPath = new URL(url).pathname;
                     baseUrlPath = new URL(baseUrl).pathname;
-                    params.path = urlPath.replace(baseUrlPath, "/");
+                    if (baseUrlPath.endsWith("/")) {
+                        replaceWith = '/';
+                    }
+                    params.path = urlPath.replace(baseUrlPath, replaceWith);
                     params.name = $scope.defaultName(params.path);
                 } else {
                     params.dockerUpstreamName = url;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
@@ -106,7 +106,7 @@ angular.module('Bastion.products').controller('DiscoveryController',
 
         transformRows = function (urls) {
             var baseUrl, toRet;
-            baseUrl = $scope.discovery.url;
+            baseUrl = new URL($scope.discovery.url);
 
             toRet = _.map(urls, function (url) {
                 var params;
@@ -114,13 +114,11 @@ angular.module('Bastion.products').controller('DiscoveryController',
                 params = {
                     url: $scope.discovery.url,
                     label: '',
-                    contentType: $scope.discovery.contentType
+                    contentType: $scope.discovery.contentType,
+                    repositoryUrl: url,
                 };
                 if ($scope.discovery.contentType === 'yum') {
-                    if (baseUrl.endsWith('/')) {
-                        baseUrl = baseUrl.slice(0, -1);
-                    }
-                    params.path = url.replace(baseUrl, "");
+                    params.path = new URL(url).pathname.replace(baseUrl.pathname,"/");
                     params.name = $scope.defaultName(params.path);
                 } else {
                     params.dockerUpstreamName = url;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
@@ -106,7 +106,7 @@ angular.module('Bastion.products').controller('DiscoveryController',
 
         transformRows = function (urls) {
             var baseUrl, toRet;
-            baseUrl = new URL($scope.discovery.url);
+            baseUrl = $scope.discovery.url;
 
             toRet = _.map(urls, function (url) {
                 var params;
@@ -118,7 +118,7 @@ angular.module('Bastion.products').controller('DiscoveryController',
                     repositoryUrl: url,
                 };
                 if ($scope.discovery.contentType === 'yum') {
-                    params.path = new URL(url).pathname.replace(baseUrl.pathname,"/");
+                    params.path = new URL(url).pathname.replace(new URL(baseUrl).pathname,"/");
                     params.name = $scope.defaultName(params.path);
                 } else {
                     params.dockerUpstreamName = url;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
@@ -118,8 +118,8 @@ angular.module('Bastion.products').controller('DiscoveryController',
                     repositoryUrl: url
                 };
                 if ($scope.discovery.contentType === 'yum') {
-                    urlPath = new URL(url).pathname
-                    baseUrlPath = new URL(baseUrl).pathname
+                    urlPath = new URL(url).pathname;
+                    baseUrlPath = new URL(baseUrl).pathname;
                     params.path = urlPath.replace(baseUrlPath, "/");
                     params.name = $scope.defaultName(params.path);
                 } else {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
@@ -117,6 +117,9 @@ angular.module('Bastion.products').controller('DiscoveryController',
                     contentType: $scope.discovery.contentType
                 };
                 if ($scope.discovery.contentType === 'yum') {
+                    if (baseUrl[baseUrl.length - 1] !== '/') {
+                        baseUrl += '/';
+                    }
                     params.path = url.replace(baseUrl, "");
                     params.name = $scope.defaultName(params.path);
                 } else {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
@@ -115,10 +115,10 @@ angular.module('Bastion.products').controller('DiscoveryController',
                     url: $scope.discovery.url,
                     label: '',
                     contentType: $scope.discovery.contentType,
-                    repositoryUrl: url,
+                    repositoryUrl: url
                 };
                 if ($scope.discovery.contentType === 'yum') {
-                    params.path = new URL(url).pathname.replace(new URL(baseUrl).pathname,"/");
+                    params.path = new URL(url).pathname.replace(new URL(baseUrl).pathname, "/");
                     params.name = $scope.defaultName(params.path);
                 } else {
                     params.dockerUpstreamName = url;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery.controller.js
@@ -117,8 +117,8 @@ angular.module('Bastion.products').controller('DiscoveryController',
                     contentType: $scope.discovery.contentType
                 };
                 if ($scope.discovery.contentType === 'yum') {
-                    if (baseUrl[baseUrl.length - 1] !== '/') {
-                        baseUrl += '/';
+                    if (baseUrl.endsWith('/')) {
+                        baseUrl = baseUrl.slice(0, -1);
                     }
                     params.path = url.replace(baseUrl, "");
                     params.name = $scope.defaultName(params.path);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery-create.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery-create.html
@@ -73,8 +73,8 @@
       </label>
     </div>
 
-    <div bst-form-group ng-show="discovery.contentType === 'docker'"
-         label="{{ 'Registry username' | translate }}">
+    <div bst-form-group
+         label="{{ 'Username' | translate }}">
       <input id="registryUsername"
              type="text"
              class="form-control"
@@ -83,8 +83,8 @@
              name="upstreamUsername"/>
     </div>
 
-    <div bst-form-group ng-show="discovery.contentType === 'docker'"
-         label="{{ 'Registry Password' | translate }}">
+    <div bst-form-group
+         label="{{ 'Password' | translate }}">
       <input id="registryPassword"
              type="password"
              class="form-control"
@@ -162,7 +162,7 @@
             <span ng-show="creating() || repo.created">{{ repo.label }}</span>
           </td>
           <td bst-table-cell ng-show="discovery.contentType === 'yum'">
-            {{ repo.url + repo.path }}
+            {{ getRepoPath(repo) }}
           </td>
         </tr>
       </tbody>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
@@ -37,24 +37,24 @@
       </h6>
     </div>
 
-    <div bst-form-group ng-show="discovery.contentType === 'docker'"
-         label="{{ 'Registry Username' | translate }}">
+    <div bst-form-group
+         label="{{ 'Username' | translate }}">
       <input type="text" id="upstreamUsername"
              class="form-control"
              ng-model="discovery.upstreamUsername"
              ng-disabled="discovery.working"
-             ng-required="discovery.registryType === 'redhat'"
+             ng-required="discovery.contentType === 'docker' && discovery.registryType === 'redhat'"
              name="upstreamUsername"/>
     </div>
 
-    <div bst-form-group ng-show="discovery.contentType === 'docker'"
-         label="{{ 'Registry Password' | translate }}">
+    <div bst-form-group
+         label="{{ 'Password' | translate }}">
       <input id="upstreamPassword"
              type="password"
              class="form-control"
              ng-model="discovery.upstreamPassword"
              ng-disabled="discovery.working"
-             ng-required="discovery.registryType === 'redhat'"
+             ng-required="discovery.contentType === 'docker' && discovery.registryType === 'redhat'"
              name="upstreamPassword"/>
     </div>
 

--- a/engines/bastion_katello/test/products/discovery/discovery.controller.test.js
+++ b/engines/bastion_katello/test/products/discovery/discovery.controller.test.js
@@ -176,28 +176,13 @@ describe('Controller: DiscoveryController', function() {
                                                                jasmine.any(Function));
     });
 
-    it('should set discovery table upon completed discovery', function() {
-        $scope.discovery.url = 'http://fake/';
-        $scope.discovery.contentType = 'yum';
-        spyOn(Task, 'get');
-        $scope.discover();
-
-        expect(Task.get).not.toHaveBeenCalled();
-
-        Task.simulateBulkSearch(Organization.mockDiscoveryTask);
-
-        expect($scope.table.rows[0].path).toBe('foo');
-        expect($scope.table.rows[0].name).toBe('foo');
-    });
-
-    it('should set discovery table upon completed discovery', function() {
+    it('should set docker discovery table upon completed discovery', function() {
         $scope.discovery.url = 'http://fake/';
         $scope.discovery.contentType = 'docker';
         spyOn(Task, 'get');
         $scope.discover();
 
         expect(Task.get).not.toHaveBeenCalled();
-
         Task.simulateBulkSearch(Organization.mockDiscoveryTask);
 
         expect($scope.table.rows[0].path).toBe('http://fake/foo');
@@ -207,7 +192,7 @@ describe('Controller: DiscoveryController', function() {
 
     it('discovery should poll if task is pending', function() {
         $scope.discovery.url = 'http://fake/';
-        $scope.discovery.contentType = 'yum';
+        $scope.discovery.contentType = 'docker';
         $scope.discover();
         Organization.mockDiscoveryTask.state = 'running';
         spyOn(Task, 'unregisterSearch');
@@ -216,6 +201,7 @@ describe('Controller: DiscoveryController', function() {
     });
 
     it('discovery should stop polling if task is not pending', function() {
+        $scope.discovery.contentType = 'docker';
         $scope.discover();
         Organization.mockDiscoveryTask.state = 'finished';
         spyOn(Task, 'unregisterSearch');


### PR DESCRIPTION
This commit adds support to discovering yum repos with username and
password (assuming basic http authentication).