### PR TITLE
Fixes #26275: add react helper to sync status page

### DIFF
--- a/app/controllers/katello/sync_management_controller.rb
+++ b/app/controllers/katello/sync_management_controller.rb
@@ -6,6 +6,7 @@ module Katello
     include SyncManagementHelper::RepoMethods
     helper Rails.application.routes.url_helpers
     helper ReactjsHelper
+    helper ReactAppHelper
     respond_to :html, :json
 
     def section_id


### PR DESCRIPTION
Add the new react app helper to the sync status page to avoid an
error.

https://projects.theforeman.org/issues/26275