### PR TITLE
Fixes #26276 - remove react-bootstrap-tooltip-button

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "query-string": "^6.1.0",
     "react": "^16.4.0",
     "react-bootstrap": "^0.32.1",
-    "react-bootstrap-tooltip-button": "^1.0.6",
     "react-dom": "^16.4.0",
     "react-ellipsis-with-tooltip": "^1.0.7",
     "react-helmet": "^5.2.0",

--- a/webpack/__mocks__/react-bootstrap-tooltip-button.js
+++ b/webpack/__mocks__/react-bootstrap-tooltip-button.js
@@ -1,6 +1,0 @@
-import React from 'react';
-
-export const TooltipButton = () => () => (<button>Test Button</button>);
-
-export default TooltipButton;
-

--- a/webpack/move_to_pf/TooltipButton/TooltipButton.js
+++ b/webpack/move_to_pf/TooltipButton/TooltipButton.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, Tooltip, OverlayTrigger } from 'patternfly-react';
+import './TooltipButton.scss';
+
+const TooltipButton = ({
+  disabled, title, tooltipText, tooltipId, tooltipPlacement, renderedButton, ...props
+}) => {
+  if (!disabled) return renderedButton || (<Button {...props}>{title}</Button>);
+  return (
+    <OverlayTrigger
+      placement={tooltipPlacement}
+      delayHide={150}
+      overlay={<Tooltip id={tooltipId}>{tooltipText}</Tooltip>}
+    >
+      <div className="tooltip-button-helper">
+        {renderedButton || (<Button {...props} disabled>{title}</Button>)}
+      </div>
+    </OverlayTrigger>
+  );
+};
+
+TooltipButton.propTypes = {
+  disabled: PropTypes.bool,
+  title: PropTypes.string,
+  tooltipText: PropTypes.string,
+  tooltipId: PropTypes.string.isRequired,
+  tooltipPlacement: PropTypes.string,
+  renderedButton: PropTypes.node,
+};
+
+TooltipButton.defaultProps = {
+  disabled: false,
+  title: '',
+  tooltipPlacement: 'bottom',
+  tooltipText: '',
+  renderedButton: null,
+};
+
+export default TooltipButton;

--- a/webpack/move_to_pf/TooltipButton/TooltipButton.scss
+++ b/webpack/move_to_pf/TooltipButton/TooltipButton.scss
@@ -1,0 +1,36 @@
+.tooltip-button-helper {
+  display: inline-block;
+  vertical-align: top;
+  cursor: not-allowed;
+
+  button {
+    pointer-events: none;
+  }
+}
+.btn-group-vertical > .tooltip-button-helper,
+.btn-group > .tooltip-button-helper {
+  float: left;
+  position: relative;
+}
+.btn-toolbar .tooltip-button-helper {
+  float: left;
+}
+.btn-toolbar > .tooltip-button-helper {
+  margin-left: 5px;
+}
+.btn-group > .tooltip-button-helper:first-child:not(:last-child) > .btn:not(.dropdown-toggle) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.btn-group > .tooltip-button-helper:last-child:not(:first-child) > .btn,
+.btn-group > .tooltip-button-helper:not(:first-child) > .dropdown-toggle {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.btn-group .btn + .tooltip-button-helper,
+.btn-group .tooltip-button-helper + .btn,
+.btn-group .tooltip-button-helper + .tooltip-button-helper,
+.btn-group .tooltip-button-helper + .btn-group,
+.btn-group .btn-group + .tooltip-button-helper {
+  margin-left: -1px;
+}

--- a/webpack/move_to_pf/TooltipButton/TooltipButton.test.js
+++ b/webpack/move_to_pf/TooltipButton/TooltipButton.test.js
@@ -1,0 +1,37 @@
+import { testComponentSnapshotsWithFixtures } from '../test-utils/testHelpers';
+import TooltipButton from './TooltipButton';
+
+const createRequiredProps = () => ({
+  tooltipId: 'some-id',
+});
+
+const fixtures = {
+  'renders minimal TooltipButton': { ...createRequiredProps() },
+  'renders disabled TooltipButton': {
+    ...createRequiredProps(),
+    disabled: true,
+    title: 'some-title',
+    tooltipPlacement: 'top',
+    tooltipText: 'some-text',
+  },
+  'renders disabled TooltipButton with renderedButton': {
+    ...createRequiredProps(),
+    disabled: true,
+    renderedButton: 'some-render-button',
+    tooltipPlacement: 'top',
+    tooltipText: 'some-text',
+  },
+  'renders enabled TooltipButton': {
+    ...createRequiredProps(),
+    disabled: false,
+    title: 'some-title',
+  },
+  'renders enabled TooltipButton with renderedButton': {
+    ...createRequiredProps(),
+    disabled: false,
+    renderedButton: 'some-render-button',
+  },
+};
+
+describe('TooltipButton', () =>
+  testComponentSnapshotsWithFixtures(TooltipButton, fixtures));

--- a/webpack/move_to_pf/TooltipButton/__snapshots__/TooltipButton.test.js.snap
+++ b/webpack/move_to_pf/TooltipButton/__snapshots__/TooltipButton.test.js.snap
@@ -1,0 +1,91 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TooltipButton renders disabled TooltipButton 1`] = `
+<OverlayTrigger
+  defaultOverlayShown={false}
+  delayHide={150}
+  overlay={
+    <Tooltip
+      bsClass="tooltip"
+      id="some-id"
+      placement="right"
+    >
+      some-text
+    </Tooltip>
+  }
+  placement="top"
+  trigger={
+    Array [
+      "hover",
+      "focus",
+    ]
+  }
+>
+  <div
+    className="tooltip-button-helper"
+  >
+    <Button
+      active={false}
+      block={false}
+      bsClass="btn"
+      bsStyle="default"
+      disabled={true}
+    >
+      some-title
+    </Button>
+  </div>
+</OverlayTrigger>
+`;
+
+exports[`TooltipButton renders disabled TooltipButton with renderedButton 1`] = `
+<OverlayTrigger
+  defaultOverlayShown={false}
+  delayHide={150}
+  overlay={
+    <Tooltip
+      bsClass="tooltip"
+      id="some-id"
+      placement="right"
+    >
+      some-text
+    </Tooltip>
+  }
+  placement="top"
+  trigger={
+    Array [
+      "hover",
+      "focus",
+    ]
+  }
+>
+  <div
+    className="tooltip-button-helper"
+  >
+    some-render-button
+  </div>
+</OverlayTrigger>
+`;
+
+exports[`TooltipButton renders enabled TooltipButton 1`] = `
+<Button
+  active={false}
+  block={false}
+  bsClass="btn"
+  bsStyle="default"
+  disabled={false}
+>
+  some-title
+</Button>
+`;
+
+exports[`TooltipButton renders enabled TooltipButton with renderedButton 1`] = `"some-render-button"`;
+
+exports[`TooltipButton renders minimal TooltipButton 1`] = `
+<Button
+  active={false}
+  block={false}
+  bsClass="btn"
+  bsStyle="default"
+  disabled={false}
+/>
+`;

--- a/webpack/move_to_pf/TooltipButton/index.js
+++ b/webpack/move_to_pf/TooltipButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './TooltipButton';

--- a/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
+++ b/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Col, Tabs, Tab, Form, FormGroup, FormControl, ControlLabel } from 'react-bootstrap';
 import { Button, Icon, Modal, Spinner, OverlayTrigger, Tooltip, MessageDialog } from 'patternfly-react';
 import { isEqual } from 'lodash';
-import TooltipButton from 'react-bootstrap-tooltip-button';
+import TooltipButton from '../../../move_to_pf/TooltipButton';
 import { LoadingState } from '../../../move_to_pf/LoadingState';
 import { Table } from '../../../move_to_foreman/components/common/table';
 import { manifestExists } from '../SubscriptionHelpers';

--- a/webpack/scenes/Subscriptions/Manifest/__tests__/__snapshots__/ManageManifestModal.test.js.snap
+++ b/webpack/scenes/Subscriptions/Manifest/__tests__/__snapshots__/ManageManifestModal.test.js.snap
@@ -187,12 +187,14 @@ exports[`manage manifest modal should render 1`] = `
               <TooltipButton
                 disabled={true}
                 onClick={[Function]}
+                renderedButton={null}
                 title="Refresh"
                 tooltipId="refresh-manifest-button-tooltip"
                 tooltipPlacement="top"
                 tooltipText=""
               />
               <TooltipButton
+                disabled={false}
                 renderedButton={
                   <Button
                     active={false}
@@ -205,6 +207,7 @@ exports[`manage manifest modal should render 1`] = `
                     Delete
                   </Button>
                 }
+                title=""
                 tooltipId="delete-manifest-button-tooltip"
                 tooltipPlacement="top"
                 tooltipText="This is disabled because no manifest exists"

--- a/webpack/scenes/Subscriptions/components/SubscriptionsToolbar/SubscriptionsToolbar.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsToolbar/SubscriptionsToolbar.js
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Row, Col, Form, FormGroup, Button } from 'patternfly-react';
 import { LinkContainer } from 'react-router-bootstrap';
-import TooltipButton from 'react-bootstrap-tooltip-button';
 import { noop } from 'foremanReact/common/helpers';
 
 import Search from '../../../../components/Search/index';
+import TooltipButton from '../../../../move_to_pf/TooltipButton';
 import OptionTooltip from '../../../../move_to_pf/OptionTooltip';
 
 const SubscriptionsToolbar = ({

--- a/webpack/scenes/Subscriptions/components/SubscriptionsToolbar/__snapshots__/SubscriptionsToolbar.test.js.snap
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsToolbar/__snapshots__/SubscriptionsToolbar.test.js.snap
@@ -58,6 +58,7 @@ exports[`SubscriptionsToolbar renders SubscriptionsToolbar 1`] = `
             <TooltipButton
               bsStyle="primary"
               disabled={false}
+              renderedButton={null}
               title="Add Subscriptions"
               tooltipId="add-subscriptions-button-tooltip"
               tooltipPlacement="top"
@@ -85,6 +86,7 @@ exports[`SubscriptionsToolbar renders SubscriptionsToolbar 1`] = `
           <TooltipButton
             bsStyle="danger"
             disabled={false}
+            renderedButton={null}
             title="Delete"
             tooltipId="delete-subscriptions-button-tooltip"
             tooltipPlacement="top"
@@ -155,6 +157,7 @@ exports[`SubscriptionsToolbar renders SubscriptionsToolbar with disabled add but
             <TooltipButton
               bsStyle="primary"
               disabled={false}
+              renderedButton={null}
               title="Add Subscriptions"
               tooltipId="add-subscriptions-button-tooltip"
               tooltipPlacement="top"
@@ -182,6 +185,7 @@ exports[`SubscriptionsToolbar renders SubscriptionsToolbar with disabled add but
           <TooltipButton
             bsStyle="danger"
             disabled={false}
+            renderedButton={null}
             title="Delete"
             tooltipId="delete-subscriptions-button-tooltip"
             tooltipPlacement="top"
@@ -252,6 +256,7 @@ exports[`SubscriptionsToolbar renders SubscriptionsToolbar with disabled delete 
             <TooltipButton
               bsStyle="primary"
               disabled={false}
+              renderedButton={null}
               title="Add Subscriptions"
               tooltipId="add-subscriptions-button-tooltip"
               tooltipPlacement="top"
@@ -279,6 +284,7 @@ exports[`SubscriptionsToolbar renders SubscriptionsToolbar with disabled delete 
           <TooltipButton
             bsStyle="danger"
             disabled={true}
+            renderedButton={null}
             title="Delete"
             tooltipId="delete-subscriptions-button-tooltip"
             tooltipPlacement="top"
@@ -349,6 +355,7 @@ exports[`SubscriptionsToolbar renders SubscriptionsToolbar with disabled manifes
             <TooltipButton
               bsStyle="primary"
               disabled={true}
+              renderedButton={null}
               title="Add Subscriptions"
               tooltipId="add-subscriptions-button-tooltip"
               tooltipPlacement="top"
@@ -376,6 +383,7 @@ exports[`SubscriptionsToolbar renders SubscriptionsToolbar with disabled manifes
           <TooltipButton
             bsStyle="danger"
             disabled={true}
+            renderedButton={null}
             title="Delete"
             tooltipId="delete-subscriptions-button-tooltip"
             tooltipPlacement="top"
@@ -464,6 +472,7 @@ exports[`SubscriptionsToolbar renders SubscriptionsToolbar with table columns 1`
             <TooltipButton
               bsStyle="primary"
               disabled={false}
+              renderedButton={null}
               title="Add Subscriptions"
               tooltipId="add-subscriptions-button-tooltip"
               tooltipPlacement="top"
@@ -491,6 +500,7 @@ exports[`SubscriptionsToolbar renders SubscriptionsToolbar with table columns 1`
           <TooltipButton
             bsStyle="danger"
             disabled={false}
+            renderedButton={null}
             title="Delete"
             tooltipId="delete-subscriptions-button-tooltip"
             tooltipPlacement="top"


### PR DESCRIPTION
Bring the source code of `react-bootstrap-tooltip-button` locally.