### PR TITLE
 Fixes #26283 - hammer sync-plan update 

### DIFF
--- a/app/models/katello/sync_plan.rb
+++ b/app/models/katello/sync_plan.rb
@@ -56,12 +56,11 @@ module Katello
 
     def update_attributes_with_logics!(params)
       transaction do
-        params["cron_expression"] = '' unless params["interval"].eql? CUSTOM_CRON
+        params["cron_expression"] = '' if (params.key?("interval") && !params["interval"].eql?(CUSTOM_CRON) && self.interval.eql?(CUSTOM_CRON))
         self.update_attributes!(params)
         if rec_logic_changed?
           old_rec_logic = self.foreman_tasks_recurring_logic
           associate_recurring_logic
-          self.save!
           old_rec_logic.cancel
           start_recurring_logic
         end


### PR DESCRIPTION
Steps to Reproduce:
1. hammer sync-plan create  --name BugTest --sync-date "2019/02/01" --enabled 1  --interval "custom cron" --cron-expression "1 2 3 4 5" --organization-id 1 
2. hammer sync-plan info --name BugTest --organization-id 1

3. hammer sync-plan update --name BugTest --organization-id 1 --description Hello
Could not update the sync plan:
  Cron expression is not valid!

4. hammer sync-plan update --name BugTest --organization-id 1 --description Hello --cron-expression "1 2 3 4 5"
Could not update the sync plan:
  Cron expression is not valid!

Expected result: These are all valid operations and should succeed.