### PR TITLE
Fixes #26300 - alter default columns on subs page

### DIFF
--- a/webpack/scenes/Subscriptions/SubscriptionConstants.js
+++ b/webpack/scenes/Subscriptions/SubscriptionConstants.js
@@ -100,6 +100,7 @@ export const SUBSCRIPTION_TABLE_DEFAULT_COLUMNS = [
   'contract_number',
   'start_date',
   'end_date',
+  'virt_who',
   'consumed',
   'quantity',
   'type',

--- a/webpack/scenes/Subscriptions/__tests__/subscriptions.fixtures.js
+++ b/webpack/scenes/Subscriptions/__tests__/subscriptions.fixtures.js
@@ -416,7 +416,7 @@ export const tableColumns = [
   {
     key: 'virt_who',
     label: 'Requires Virt-Who',
-    value: false,
+    value: true,
   },
   {
     key: 'type',
@@ -444,6 +444,7 @@ export const loadTableColumnsSuccessAction = [
         'contract_number',
         'start_date',
         'end_date',
+        'virt_who',
         'consumed',
         'quantity',
         'type',


### PR DESCRIPTION
This commit adds the 'Requires Virt-Who' column to the list displayed by default on the Subscriptions page.

Similar changes were introduced in https://github.com/Katello/katello/pull/7885 for consumed and quantity fields.