### PR TITLE
Fixes #26304 - allow lce pattern with cvv version

### DIFF
--- a/app/lib/katello/validators/environment_docker_repositories_validator.rb
+++ b/app/lib/katello/validators/environment_docker_repositories_validator.rb
@@ -42,31 +42,13 @@ module Katello
       end
 
       def test_repository
-        Katello::Validators::EnvironmentDockerRepositoriesValidator::RepositoryOpenStruct.new(
-            name: "bad name!", label: "good_label", docker_upstream_name: "image/name", url: "https://registry.example.com",
-            organization: SafeOpenStruct.new(name: "bad name!", label: "good_label"),
-            product: SafeOpenStruct.new(name: "bad name!", label: "good_label"),
-            environment: SafeOpenStruct.new(name: "bad name!", label: "good_label"),
-            content_view_version: OpenStruct.new(content_view: ContentViewOpenStruct.new(name: "bad name!", label: "good_label", version: "1.2"))
+        Katello::Repository.new(
+          root: ::Katello::RootRepository.new(name: "bad name!", label: "good_label", docker_upstream_name: "image/name", url: "https://registry.example.com"),
+          product: ::Katello::Product.new(name: "bad name!", label: "good_label"),
+          environment: ::Katello::KTEnvironment.new(name: "bad name!", label: "good_label",
+                                                    organization: Organization.new(name: "bad name!", label: "good_label")),
+          content_view_version: ::Katello::ContentViewVersion.new(major: 1, minor: 20, content_view: Katello::ContentView.new(name: "bad name!", label: "good_label"))
         )
-      end
-
-      class RepositoryOpenStruct < OpenStruct
-        class Jail < ::Safemode::Jail
-          allow :name, :label, :version, :docker_upstream_name, :url
-        end
-      end
-
-      class ContentViewOpenStruct < OpenStruct
-        class Jail < ::Safemode::Jail
-          allow :name, :label, :version
-        end
-      end
-
-      class SafeOpenStruct < OpenStruct
-        class Jail < ::Safemode::Jail
-          allow :name, :label
-        end
       end
     end
   end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -687,7 +687,8 @@ module Katello
         allowed_methods = {}
         allowed_vars = {}
         scope_variables = {repository: repository, organization: repository.organization, product: repository.product,
-                           lifecycle_environment: repository.environment, content_view: repository.content_view_version.content_view}
+                           lifecycle_environment: repository.environment, content_view: repository.content_view_version.content_view,
+                           content_view_version: repository.content_view_version}
         box = Safemode::Box.new(repository, allowed_methods)
         erb = ERB.new(pattern)
         pattern = box.eval(erb.src, allowed_vars, scope_variables)

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-details.html
@@ -56,7 +56,7 @@ repository.label
 repository.docker_upstream_name
 content_view.label
 content_view.name
-content_view.version
+content_view_version.version
 product.name
 product.label
 lifecycle_environment.name

--- a/test/lib/validators/environment_docker_repositories_validator_test.rb
+++ b/test/lib/validators/environment_docker_repositories_validator_test.rb
@@ -45,6 +45,19 @@ module Katello
       assert_empty @hq_env_dev.errors[:registry_name_pattern]
     end
 
+    test "success static pattern for single repo with cvv version" do
+      hq_cvv_single_repo = create(:registry_content_view_version, :hq_cvv_single_repo,
+                                  content_view: @hq_cv_single_repo)
+      create(:registry_repository, :hq_repo_alpha,
+             environment: @hq_env_dev,
+             product: @hq_product,
+             content_view_version: hq_cvv_single_repo)
+
+      @hq_env_dev.registry_name_pattern = "content_view_version.version"
+      @validator.validate(@hq_env_dev)
+      assert_empty @hq_env_dev.errors[:registry_name_pattern]
+    end
+
     test "fails static pattern for multiple repos" do
       hq_cvv_multi_repo = create(:registry_content_view_version, :hq_cvv_multi_repo,
                                   content_view: @hq_cv_multi_repo)


### PR DESCRIPTION
the lifecycle environment docker registry pattern suggests that
content_view.version is a valid option, while it is not.  The user
should use content_view_version.version.  The validator seemed to be
using openstructs with duplicated jail definitions, so this was
changed to use unsaved models