### PR TITLE
Fixes #26305 - Sync Plan enable field overrides

### DIFF
--- a/app/controllers/katello/api/v2/sync_plans_controller.rb
+++ b/app/controllers/katello/api/v2/sync_plans_controller.rb
@@ -47,12 +47,15 @@ module Katello
     param :organization_id, :number, :desc => N_("Filter sync plans by organization name or label"), :required => true
     param_group :sync_plan
     def create
+      if params[:sync_plan].key?(:enabled) || params.key?(:enabled)
+        enabled = params[:sync_plan][:enabled] || params[:enabled]
+      end
       unless sync_plan_params[:sync_date].to_time(:utc).is_a?(Time)
         fail _("Date format is incorrect.")
       end
-      @sync_plan = SyncPlan.new(sync_plan_params)
+      @sync_plan = SyncPlan.new(sync_plan_params.except(:enabled))
       @sync_plan.organization = @organization
-      @sync_plan.save_with_logic!
+      @sync_plan.save_with_logic!(enabled)
       respond_for_create(:resource => @sync_plan)
     end
 

--- a/app/models/katello/sync_plan.rb
+++ b/app/models/katello/sync_plan.rb
@@ -23,7 +23,6 @@ module Katello
     validates_lengths_from_database
     validates :name, :presence => true, :uniqueness => {:scope => :organization_id}
     validates :interval, :inclusion => {:in => TYPES}, :allow_blank => false
-    validates :enabled, :inclusion => [true, false]
     validate :validate_sync_date
     validate :product_enabled
     validate :custom_cron_interval_expression
@@ -34,7 +33,20 @@ module Katello
     scoped_search :on => :name, :complete_value => true
     scoped_search :on => :organization_id, :complete_value => true, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
     scoped_search :on => :interval, :complete_value => true
-    scoped_search :on => :enabled, :complete_value => true
+    scoped_search :on => :enabled, :complete_value => { :true => true, :false => false }, :ext_method => :search_enabled
+
+    def self.search_enabled(_key, operator, value)
+      value = ::Foreman::Cast.to_bool(value)
+      value = !value if operator == '<>'
+      active_logics = ForemanTasks::RecurringLogic.where(:state => "active")
+      active_logic_ids = active_logics.pluck(:id)
+      if active_logic_ids.empty?
+        {:conditions => "1=0"}
+      else
+        operator = value ? 'IN' : 'NOT IN'
+        {:conditions => "#{Katello::SyncPlan.table_name}.foreman_tasks_recurring_logic_id #{operator} (#{active_logic_ids.join(',')})"}
+      end
+    end
 
     def product_enabled
       products.each do |product|
@@ -46,25 +58,26 @@ module Katello
       errors.add :base, _("Custom cron expression only needs to be set for interval value of custom cron") if cron_status_mismatch?
     end
 
-    def save_with_logic!
+    def save_with_logic!(enabled = true)
       self.task_group ||= SyncPlanTaskGroup.create!
       self.cron_expression = '' if (self.cron_expression && !(self.interval.eql? CUSTOM_CRON))
       associate_recurring_logic
       self.save!
       start_recurring_logic
+      self.foreman_tasks_recurring_logic.enabled = enabled unless (enabled || enabled.nil?)
     end
 
     def update_attributes_with_logics!(params)
       transaction do
         params["cron_expression"] = '' if (params.key?("interval") && !params["interval"].eql?(CUSTOM_CRON) && self.interval.eql?(CUSTOM_CRON))
-        self.update_attributes!(params)
-        if rec_logic_changed?
+        self.update_attributes!(params.except(:enabled))
+        if (rec_logic_changed? || (params["enabled"] && !self.enabled? && self.foreman_tasks_recurring_logic.cancelled?))
           old_rec_logic = self.foreman_tasks_recurring_logic
           associate_recurring_logic
           old_rec_logic.cancel
           start_recurring_logic
         end
-        toggle_enabled if enabled_toggle?
+        toggle_enabled(params[:enabled]) if (params.key?(:enabled) && params[:enabled] != self.enabled?)
       end
     end
 
@@ -72,8 +85,8 @@ module Katello
       self.foreman_tasks_recurring_logic = add_recurring_logic_to_sync_plan(self.sync_date, self.interval, self.cron_expression)
     end
 
-    def toggle_enabled
-      self.foreman_tasks_recurring_logic.enabled = self.enabled
+    def toggle_enabled(value = false)
+      self.foreman_tasks_recurring_logic.enabled = value
     end
 
     def start_recurring_logic
@@ -84,6 +97,18 @@ module Katello
           self.foreman_tasks_recurring_logic.start_after(::Actions::Katello::SyncPlan::Run, self.sync_date, self)
         end
       end
+    end
+
+    def enabled?
+      self.foreman_tasks_recurring_logic && self.foreman_tasks_recurring_logic.state == 'active'
+    end
+
+    def enabled
+      enabled?
+    end
+
+    def enabled=(value)
+      self.foreman_tasks_recurring_logic.enabled = value
     end
 
     def cancel_recurring_logic
@@ -119,7 +144,7 @@ module Katello
     end
 
     def next_sync_date
-      return nil unless self.enabled
+      return nil unless self.enabled?
       self.foreman_tasks_recurring_logic&.tasks&.order(:start_at)&.last&.start_at
     end
 
@@ -159,10 +184,6 @@ module Katello
 
     def rec_logic_changed?
       saved_change_to_attribute?(:sync_date) || saved_change_to_attribute?(:interval) || saved_change_to_attribute?(:cron_expression)
-    end
-
-    def enabled_toggle?
-      saved_change_to_attribute?(:enabled)
     end
 
     def cron_status_mismatch?

--- a/lib/katello/tasks/upgrades/3.9/migrate_sync_plans.rake
+++ b/lib/katello/tasks/upgrades/3.9/migrate_sync_plans.rake
@@ -31,7 +31,7 @@ namespace :katello do
             sync_plan.save!
             if sync_plan.foreman_tasks_recurring_logic.state.nil?
               sync_plan.start_recurring_logic
-              sync_plan.foreman_tasks_recurring_logic.enabled = false unless sync_plan.enabled
+              sync_plan.foreman_tasks_recurring_logic.enabled = false unless sync_plan[:enabled]
             end
           end
           sync_plan.products.each do |product|

--- a/test/lib/tasks/migrate_sync_plan_test.rb
+++ b/test/lib/tasks/migrate_sync_plan_test.rb
@@ -19,7 +19,7 @@ module Katello
     end
 
     def test_disabled_sync_plan_migration
-      @plan.enabled = false
+      @plan[:enabled] = false
       @plan.save!
       assert_nil @plan.foreman_tasks_recurring_logic
       Rake.application.invoke_task('katello:upgrades:3.9:migrate_sync_plans')

--- a/test/models/sync_plan_test.rb
+++ b/test/models/sync_plan_test.rb
@@ -32,8 +32,9 @@ module Katello
     test_attributes :pid => 'df5837e7-3d0f-464a-bd67-86b423c16eb4'
     def test_create_enabled_disabled
       [false, true].each do |enabled|
-        sync_plan = SyncPlan.new(valid_attributes.merge(:enabled => enabled))
+        sync_plan = SyncPlan.new(valid_attributes.merge(:name => enabled))
         assert sync_plan.valid?, "Validation failed when creating with enabled = #{enabled}"
+        sync_plan.save_with_logic! enabled
         assert_equal enabled, sync_plan.enabled
       end
     end
@@ -93,8 +94,8 @@ module Katello
     end
 
     def test_recurring_logic_on_create
-      sync_plan = SyncPlan.new(valid_attributes.merge(:enabled => true))
-      sync_plan.save_with_logic!
+      sync_plan = SyncPlan.new(valid_attributes)
+      sync_plan.save_with_logic! true
       assert_not_equal sync_plan.foreman_tasks_recurring_logic, nil
       assert_equal sync_plan.foreman_tasks_recurring_logic.enabled?, sync_plan.enabled
     end
@@ -118,7 +119,7 @@ module Katello
     def test_invalid_cron_status
       @plan.cron_expression = "20 * * * *"
       refute @plan.valid?, "Custom cron expression only needs to be set for interval value of custom cron"
-      assert @plan.save_with_logic!
+      @plan.save_with_logic!
       assert_equal @plan.cron_expression, ''
     end
 
@@ -306,8 +307,8 @@ module Katello
     end
 
     def test_delete
-      sync_plan = SyncPlan.new(valid_attributes.merge(:enabled => true))
-      sync_plan.save_with_logic!
+      sync_plan = SyncPlan.new(valid_attributes)
+      sync_plan.save_with_logic! true
       p = SyncPlan.find_by_name('Sync plan')
       pid = p.id
       p.destroy
@@ -351,8 +352,8 @@ module Katello
     end
 
     def test_cancel_recurring_logic
-      sync_plan = SyncPlan.new(valid_attributes.merge(:enabled => true))
-      sync_plan.save_with_logic!
+      sync_plan = SyncPlan.new(valid_attributes)
+      sync_plan.save_with_logic! true
       p = SyncPlan.find_by_name('Sync plan')
       p.cancel_recurring_logic
       assert_equal "cancelled", p.foreman_tasks_recurring_logic.state


### PR DESCRIPTION
This is also related to : https://github.com/Katello/katello/pull/7995

We want this to be cherry-picked downstream while the other PR should be in the next release.

****
Today, a user can enable and disable a sync plan from the sync plan page/API and it will enable/disable the associated foreman tasks recurring logic.

This PR adds the ability to enable/disable the foreman task recurring logic directly and tie that change back to the sync plan and maintain consistency between the 2 states.
****
#### **Some use cases:**
1. Create a sync plan.
2. Open the associated recurring logic
3. Disable the recurring logic
4. Check the sync plan enabled status. This should now be false. (UI needs a refresh)
***
1. For the above use-case, go to the recurring logic you disabled. Enable it.
2. The sync plan should also be enabled now.
***
1. Cancel the above recurring logic
2. Sync plan should be in a disabled state.
3. Enable the sync plan, a new recurring logic should get created and associated to this sync plan.
_P.S: You will not be able to enable/disable a cancelled recurring logic._
***
1. Create a sync plan
2. Disable the sync plan and check state on recurring logic
3. Both should be disabled
4. Enable the sync plan.
5. Both should now be enabled.



