### PR TITLE
Fixes #26303 - RH Repos - Updating Satellite release

### DIFF
--- a/webpack/redux/actions/RedHatRepositories/helpers.js
+++ b/webpack/redux/actions/RedHatRepositories/helpers.js
@@ -19,15 +19,15 @@ const recommendedRepositoriesRHEL = [
 ];
 
 const recommendedRepositoriesSatTools = [
-  'rhel-7-server-satellite-tools-6.4-rpms',
-  'rhel-6-server-satellite-tools-6.4-rpms',
-  'rhel-5-server-els-satellite-tools-6.4-rpms',
+  'rhel-7-server-satellite-tools-6.5-rpms',
+  'rhel-6-server-satellite-tools-6.5-rpms',
+  'rhel-5-server-els-satellite-tools-6.5-rpms',
   'rhel-7-server-satellite-maintenance-6-rpms',
 ];
 
 const recommendedRepositoriesMisc = [
   'rhel-server-rhscl-7-rpms',
-  'rhel-7-server-satellite-capsule-6.4-rpms',
+  'rhel-7-server-satellite-capsule-6.5-rpms',
   'rhel-7-server-ansible-2.6-rpms',
 ];
 


### PR DESCRIPTION
Updating the Recommended Repositories on the Red Hat Repositories
page to the 'next' Satellite release.

The referenced issue also recommended removing the ELS/EUS
repositories; however, we are not removing those at this time.
If a user has access to them, there is no reason to omit
them.