### PR TITLE
Fixes #26345 - RH repos - Add kickstart repos to recommended list

### DIFF
--- a/webpack/redux/actions/RedHatRepositories/helpers.js
+++ b/webpack/redux/actions/RedHatRepositories/helpers.js
@@ -14,7 +14,9 @@ const recommendedRepositoriesRHEL = [
   'rhel-7-server-optional-rpms',
   'rhel-7-server-extras-rpms',
   'rhel-7-server-eus-rpms',
+  'rhel-7-server-kickstart',
   'rhel-6-server-rpms',
+  'rhel-6-server-kickstart',
   'rhel-5-server-els-rpms',
 ];
 


### PR DESCRIPTION
Small change to add the RHEL 6 & 7 kickstart repos to the RH Repositories 'Recommended' list.