### PR TITLE
Fixes #26223 - Copies modular rpms on cv publish

### DIFF
--- a/app/controllers/katello/api/v2/packages_controller.rb
+++ b/app/controllers/katello/api/v2/packages_controller.rb
@@ -21,8 +21,8 @@ module Katello
       rpms = Rpm.in_repositories(@repositories)
       col = "#{Rpm.table_name}.arch"
       rpms = rpms.where("#{col} ILIKE ?", "%#{params[:term]}%").select(col).group(col).order(col).limit(page_size)
-      rpms = rpms.modular if Foreman::Cast.to_bool(params[:modular_only])
-      rpms = rpms.non_modular if Foreman::Cast.to_bool(params[:non_modular_only])
+      rpms = rpms.modular if ::Foreman::Cast.to_bool(params[:modular_only])
+      rpms = rpms.non_modular if ::Foreman::Cast.to_bool(params[:non_modular_only])
       render :json => rpms.pluck(col)
     end
 

--- a/app/controllers/katello/api/v2/packages_controller.rb
+++ b/app/controllers/katello/api/v2/packages_controller.rb
@@ -11,8 +11,8 @@ module Katello
       rpms = Rpm.in_repositories(@repositories)
       col = "#{Rpm.table_name}.name"
       rpms = rpms.where("#{Rpm.table_name}.name ILIKE ?", "#{params[:term]}%").select(col).group(col).order(col).limit(page_size)
-      rpms = rpms.modular if Foreman::Cast.to_bool(params[:modular_only])
-      rpms = rpms.non_modular if Foreman::Cast.to_bool(params[:non_modular_only])
+      rpms = rpms.modular if ::Foreman::Cast.to_bool(params[:modular_only])
+      rpms = rpms.non_modular if ::Foreman::Cast.to_bool(params[:non_modular_only])
       render :json => rpms.pluck(col)
     end
 

--- a/app/controllers/katello/api/v2/packages_controller.rb
+++ b/app/controllers/katello/api/v2/packages_controller.rb
@@ -11,6 +11,8 @@ module Katello
       rpms = Rpm.in_repositories(@repositories)
       col = "#{Rpm.table_name}.name"
       rpms = rpms.where("#{Rpm.table_name}.name ILIKE ?", "#{params[:term]}%").select(col).group(col).order(col).limit(page_size)
+      rpms = rpms.modular if Foreman::Cast.to_bool(params[:modular_only])
+      rpms = rpms.non_modular if Foreman::Cast.to_bool(params[:non_modular_only])
       render :json => rpms.pluck(col)
     end
 
@@ -19,6 +21,8 @@ module Katello
       rpms = Rpm.in_repositories(@repositories)
       col = "#{Rpm.table_name}.arch"
       rpms = rpms.where("#{col} ILIKE ?", "%#{params[:term]}%").select(col).group(col).order(col).limit(page_size)
+      rpms = rpms.modular if Foreman::Cast.to_bool(params[:modular_only])
+      rpms = rpms.non_modular if Foreman::Cast.to_bool(params[:non_modular_only])
       render :json => rpms.pluck(col)
     end
 

--- a/app/models/katello/content_view_package_filter.rb
+++ b/app/models/katello/content_view_package_filter.rb
@@ -32,7 +32,7 @@ module Katello
 
     def query_rpms(repo, rule)
       query_name = rule.name.tr("*", "%")
-      query = Rpm.in_repositories(repo).where("#{Rpm.table_name}.name ilike ?", query_name)
+      query = Rpm.in_repositories(repo).non_modular.where("#{Rpm.table_name}.name ilike ?", query_name)
       if rule.architecture
         query_arch = rule.architecture.tr("*", "%")
         query = query.where("#{Rpm.table_name}.arch ilike ?", query_arch)

--- a/app/services/katello/pulp/repository/yum.rb
+++ b/app/services/katello/pulp/repository/yum.rb
@@ -84,6 +84,10 @@ module Katello
                                                                           filters: {unit: rpm_remove_clauses})
           end
 
+          # always copy modular rpms
+          modular_includes = {filters: {unit: { 'filename' => { '$in' => repo.rpms.modular.pluck(:filename) } }}}
+          smart_proxy.pulp_api.extensions.rpm.copy(repo.pulp_id, destination_repo.pulp_id, modular_includes)
+
           [:srpm, :errata, :package_group, :yum_repo_metadata_file, :distribution, :module, :module_default].each do |type|
             tasks << smart_proxy.pulp_api.extensions.send(type).copy(repo.pulp_id, destination_repo.pulp_id)
           end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/package-filter.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/package-filter.controller.js
@@ -141,7 +141,7 @@ angular.module('Bastion.content-views').controller('PackageFilterController',
             var repositoryIds = $scope.contentView['repository_ids'],
                 promise;
 
-            promise = Package.autocompleteName({'repoids[]': repositoryIds, term: term, non_modular_only : true}).$promise;
+            promise = Package.autocompleteName({'repoids[]': repositoryIds, term: term, 'non_modular_only': true}).$promise;
 
             return promise.then(function (data) {
                 return data.results;
@@ -152,7 +152,7 @@ angular.module('Bastion.content-views').controller('PackageFilterController',
             var repositoryIds = $scope.contentView['repository_ids'],
                 promise;
 
-            promise = Package.autocompleteArch({'repoids[]': repositoryIds, term: term, non_modular_only : true}).$promise;
+            promise = Package.autocompleteArch({'repoids[]': repositoryIds, term: term, 'non_modular_only': true}).$promise;
 
             return promise.then(function (data) {
                 return data.results;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/package-filter.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/package-filter.controller.js
@@ -141,7 +141,7 @@ angular.module('Bastion.content-views').controller('PackageFilterController',
             var repositoryIds = $scope.contentView['repository_ids'],
                 promise;
 
-            promise = Package.autocompleteName({'repoids[]': repositoryIds, term: term}).$promise;
+            promise = Package.autocompleteName({'repoids[]': repositoryIds, term: term, non_modular_only : true}).$promise;
 
             return promise.then(function (data) {
                 return data.results;
@@ -152,7 +152,7 @@ angular.module('Bastion.content-views').controller('PackageFilterController',
             var repositoryIds = $scope.contentView['repository_ids'],
                 promise;
 
-            promise = Package.autocompleteArch({'repoids[]': repositoryIds, term: term}).$promise;
+            promise = Package.autocompleteArch({'repoids[]': repositoryIds, term: term, non_modular_only : true}).$promise;
 
             return promise.then(function (data) {
                 return data.results;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filter-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filter-details.html
@@ -4,8 +4,8 @@
   <h3>{{ filter.name }}</h3>
   <small translate>Type: {{ filter.inclusion | filterType }} {{ filter.type | filterContentType }}</small>
   <br/>
-  <i class="fa fa-warning inline-icon" ng-if="filter.type === 'rpm' || filter.type === 'errata'" translate>
-RPMs belonging to Module Streams will not be affected by filters. These RPMs will automatically be included in a Content View Version along with the associated Module Streams.</i>
+  <i class="fa fa-warning inline-icon" ng-if="filter.type === 'rpm' || filter.type === 'errata'">&nbsp;<span translate>
+RPMs belonging to Module Streams will not be affected by filters. These RPMs will automatically be included in a Content View Version along with the associated Module Streams.</span></i>
 </header>
 
 <div ui-view></div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filter-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filter-details.html
@@ -3,6 +3,7 @@
 <header class="details-header">
   <h3>{{ filter.name }}</h3>
   <small translate>Type: {{ filter.inclusion | filterType }} {{ filter.type | filterContentType }}</small>
+  <div class="help-block" ng-if="filter.type === 'rpm' || filter.type === 'errata'" translate>RPMs belonging to modules will not get filtered.</div>
 </header>
 
 <div ui-view></div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filter-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filter-details.html
@@ -4,7 +4,8 @@
   <h3>{{ filter.name }}</h3>
   <small translate>Type: {{ filter.inclusion | filterType }} {{ filter.type | filterContentType }}</small>
   <br/>
-  <i class="fa fa-warning inline-icon" ng-if="filter.type === 'rpm' || filter.type === 'errata'" translate>RPMs belonging to Module Streams will not be affected by filters. These RPMs will automatically get included in a Content View Version along with the associated Module Streams.</i>
+  <i class="fa fa-warning inline-icon" ng-if="filter.type === 'rpm' || filter.type === 'errata'" translate>
+RPMs belonging to Module Streams will not be affected by filters. These RPMs will automatically be included in a Content View Version along with the associated Module Streams.</i>
 </header>
 
 <div ui-view></div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filter-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filter-details.html
@@ -3,7 +3,8 @@
 <header class="details-header">
   <h3>{{ filter.name }}</h3>
   <small translate>Type: {{ filter.inclusion | filterType }} {{ filter.type | filterContentType }}</small>
-  <div class="help-block" ng-if="filter.type === 'rpm' || filter.type === 'errata'" translate>RPMs belonging to modules will not get filtered.</div>
+  <br/>
+  <i class="fa fa-warning inline-icon" ng-if="filter.type === 'rpm' || filter.type === 'errata'" translate>RPMs belonging to Module Streams will not be affected by filters. These RPMs will automatically get included in a Content View Version along with the associated Module Streams.</i>
 </header>
 
 <div ui-view></div>

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/create.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/create.yml
@@ -2266,294 +2266,6 @@ http_interactions:
     http_version: 
   recorded_at: Tue, 19 Mar 2019 17:58:15 GMT
 - request:
-    method: delete
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:56 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '474'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
-        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
-        OiByZXBvc2l0b3J5PXB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvcHVscC11dWlkLXJoZWxf
-        Nl94ODZfNjQvIiwgImh0dHBfc3RhdHVzIjogNDA0LCAiZXJyb3IiOiB7ImNv
-        ZGUiOiAiUExQMDAwOSIsICJkYXRhIjogeyJyZXNvdXJjZXMiOiB7InJlcG9z
-        aXRvcnkiOiAicHVscC11dWlkLXJoZWxfNl94ODZfNjQifX0sICJkZXNjcmlw
-        dGlvbiI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PXB1bHAt
-        dXVpZC1yaGVsXzZfeDg2XzY0IiwgInN1Yl9lcnJvcnMiOiBbXX0sICJ0cmFj
-        ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogInB1
-        bHAtdXVpZC1yaGVsXzZfeDg2XzY0In19
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:56 GMT
-- request:
-    method: delete
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:56 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '404'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
-        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
-        OiByZXBvc2l0b3J5PUZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
-        djIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8iLCAiaHR0cF9zdGF0dXMiOiA0
-        MDQsICJlcnJvciI6IHsiY29kZSI6ICJQTFAwMDA5IiwgImRhdGEiOiB7InJl
-        c291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0sICJkZXNj
-        cmlwdGlvbiI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PUZl
-        ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
-        bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:56 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6InB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwiZGlzcGxheV9uYW1l
-        IjoiUkhFTCA2IHg4Nl82NCIsImltcG9ydGVyX3R5cGVfaWQiOiJ5dW1faW1w
-        b3J0ZXIiLCJpbXBvcnRlcl9jb25maWciOnsiZG93bmxvYWRfcG9saWN5Ijoi
-        b25fZGVtYW5kIiwicmVtb3ZlX21pc3NpbmciOnRydWUsImZlZWQiOiJodHRw
-        czovL2Nkbi5yZWRoYXQuY29tL2Zvby9iYXIiLCJ0eXBlX3NraXBfbGlzdCI6
-        WyJycG0iXSwicHJveHlfaG9zdCI6bnVsbCwiYmFzaWNfYXV0aF91c2VybmFt
-        ZSI6bnVsbCwiYmFzaWNfYXV0aF9wYXNzd29yZCI6bnVsbCwic3NsX3ZhbGlk
-        YXRpb24iOnRydWUsInNzbF9jbGllbnRfY2VydCI6InJlcG9fY2VydCIsInNz
-        bF9jbGllbnRfa2V5IjoicmVwb19rZXkiLCJzc2xfY2FfY2VydCI6ImNhX2Nl
-        cnQifSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRpc3Ry
-        aWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0cmli
-        dXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwiOiJB
-        Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvcmhlbF82X2xhYmVsIiwiaHR0cCI6
-        ZmFsc2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRydWUsImNoZWNrc3Vt
-        X3R5cGUiOm51bGx9LCJhdXRvX3B1Ymxpc2giOnRydWUsImRpc3RyaWJ1dG9y
-        X2lkIjoicHVscC11dWlkLXJoZWxfNl94ODZfNjQifSx7ImRpc3RyaWJ1dG9y
-        X3R5cGVfaWQiOiJ5dW1fY2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRv
-        cl9jb25maWciOnsiZGVzdGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJwdWxw
-        LXV1aWQtcmhlbF82X3g4Nl82NCJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJk
-        aXN0cmlidXRvcl9pZCI6InB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0X2Nsb25l
-        In0seyJkaXN0cmlidXRvcl90eXBlX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9y
-        IiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7Imh0dHAiOmZhbHNlLCJodHRwcyI6
-        ZmFsc2UsInJlbGF0aXZlX3VybCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFy
-        eS9yaGVsXzZfbGFiZWwifSwiYXV0b19wdWJsaXNoIjpmYWxzZSwiZGlzdHJp
-        YnV0b3JfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3IifV19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1113'
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:56 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '345'
-      Location:
-      - "/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/"
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA2IHg4
-        Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQi
-        OiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwg
-        Imxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3Vu
-        dHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNWM5
-        MTMxZGNkYjI4NGUwOTQzOTU3MDMxIn0sICJpZCI6ICJwdWxwLXV1aWQtcmhl
-        bF82X3g4Nl82NCIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
-        aWVzL3B1bHAtdXVpZC1yaGVsXzZfeDg2XzY0LyJ9
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:56 GMT
-- request:
-    method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:56 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"eb24e5f07005f53049379b40a4142add-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2598'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA2IHg4
-        Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMiOiBb
-        eyJyZXBvX2lkIjogInB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgImxhc3Rf
-        dXBkYXRlZCI6ICIyMDE5LTAzLTE5VDE4OjE1OjU2WiIsICJfaHJlZiI6ICIv
-        cHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL3B1bHAtdXVpZC1yaGVsXzZfeDg2
-        XzY0L2Rpc3RyaWJ1dG9ycy9wdWxwLXV1aWQtcmhlbF82X3g4Nl82NF9jbG9u
-        ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
-        aCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9jbG9uZV9k
-        aXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hw
-        YWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7
-        IiRvaWQiOiAiNWM5MTMxZGNkYjI4NGUwOTQzOTU3MDM0In0sICJjb25maWci
-        OiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogInB1bHAtdXVpZC1y
-        aGVsXzZfeDg2XzY0In0sICJpZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82
-        NF9jbG9uZSJ9LCB7InJlcG9faWQiOiAicHVscC11dWlkLXJoZWxfNl94ODZf
-        NjQiLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDMtMTlUMTg6MTU6NTZaIiwg
-        Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvcHVscC11dWlk
-        LXJoZWxfNl94ODZfNjQvZGlzdHJpYnV0b3JzL3B1bHAtdXVpZC1yaGVsXzZf
-        eDg2XzY0LyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9w
-        dWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Rp
-        c3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IHRydWUsICJzY3JhdGNocGFk
-        Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVjOTEzMWRjZGIyODRlMDk0Mzk1NzAzMyJ9LCAiY29uZmlnIjog
-        eyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6IGZhbHNlLCAiaHR0cHMiOiB0
-        cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29ycG9yYXRpb24vbGlicmFy
-        eS9yaGVsXzZfbGFiZWwifSwgImlkIjogInB1bHAtdXVpZC1yaGVsXzZfeDg2
-        XzY0In0sIHsicmVwb19pZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCIs
-        ICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wMy0xOVQxODoxNTo1NloiLCAiX2hy
-        ZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9wdWxwLXV1aWQtcmhl
-        bF82X3g4Nl82NC9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3RyaWJ1dG9yLyIs
-        ICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjog
-        bnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1
-        dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9
-        LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6
-        ICI1YzkxMzFkY2RiMjg0ZTA5NDM5NTcwMzUifSwgImNvbmZpZyI6IHsiaHR0
-        cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29ycG9yYXRpb24v
-        bGlicmFyeS9yaGVsXzZfbGFiZWwiLCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6
-        ICJleHBvcnRfZGlzdHJpYnV0b3IifV0sICJsYXN0X3VuaXRfYWRkZWQiOiBu
-        dWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwgImxh
-        c3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3VudHMi
-        OiB7fSwgIl9ucyI6ICJyZXBvcyIsICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lk
-        IjogInB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgImxhc3RfdXBkYXRlZCI6
-        ICIyMDE5LTAzLTE5VDE4OjE1OjU2WiIsICJfaHJlZiI6ICIvcHVscC9hcGkv
-        djIvcmVwb3NpdG9yaWVzL3B1bHAtdXVpZC1yaGVsXzZfeDg2XzY0L2ltcG9y
-        dGVycy95dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIs
-        ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJsYXN0X292
-        ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjogbnVsbCwgInNjcmF0
-        Y2hwYWQiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOTEzMWRjZGIyODRl
-        MDk0Mzk1NzAzMiJ9LCAiY29uZmlnIjogeyJmZWVkIjogImh0dHBzOi8vY2Ru
-        LnJlZGhhdC5jb20vZm9vL2JhciIsICJzc2xfY2FfY2VydCI6ICJjYV9jZXJ0
-        IiwgInNzbF9jbGllbnRfY2VydCI6ICJyZXBvX2NlcnQiLCAicmVtb3ZlX21p
-        c3NpbmciOiB0cnVlLCAic3NsX3ZhbGlkYXRpb24iOiB0cnVlLCAic3NsX2Ns
-        aWVudF9rZXkiOiAicmVwb19rZXkiLCAiZG93bmxvYWRfcG9saWN5IjogIm9u
-        X2RlbWFuZCIsICJ0eXBlX3NraXBfbGlzdCI6IFsicnBtIl19LCAiaWQiOiAi
-        eXVtX2ltcG9ydGVyIn1dLCAibG9jYWxseV9zdG9yZWRfdW5pdHMiOiAwLCAi
-        X2lkIjogeyIkb2lkIjogIjVjOTEzMWRjZGIyODRlMDk0Mzk1NzAzMSJ9LCAi
-        dG90YWxfcmVwb3NpdG9yeV91bml0cyI6IDAsICJpZCI6ICJwdWxwLXV1aWQt
-        cmhlbF82X3g4Nl82NCIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3Np
-        dG9yaWVzL3B1bHAtdXVpZC1yaGVsXzZfeDg2XzY0LyJ9
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:56 GMT
-- request:
-    method: delete
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:56 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzUwN2M5ODRhLTA1NjUtNGFmNS1iMzk3LTczOGIyZGU4NzQ4NS8iLCAi
-        dGFza19pZCI6ICI1MDdjOTg0YS0wNTY1LTRhZjUtYjM5Ny03MzhiMmRlODc0
-        ODUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:56 GMT
-- request:
     method: get
     uri: https://theta.partello.example.com/pulp/api/v2/tasks/507c984a-0565-4af5-b397-738b2de87485/
     body:
@@ -2711,4 +2423,448 @@ http_interactions:
         NWM5MTMxZGNmNzQ3ZTYzYzhjMGU3YmExIn0=
     http_version: 
   recorded_at: Tue, 19 Mar 2019 18:15:56 GMT
+- request:
+    method: delete
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:53 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '474'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
+        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
+        OiByZXBvc2l0b3J5PXB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgIl9ocmVm
+        IjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvcHVscC11dWlkLXJoZWxf
+        Nl94ODZfNjQvIiwgImh0dHBfc3RhdHVzIjogNDA0LCAiZXJyb3IiOiB7ImNv
+        ZGUiOiAiUExQMDAwOSIsICJkYXRhIjogeyJyZXNvdXJjZXMiOiB7InJlcG9z
+        aXRvcnkiOiAicHVscC11dWlkLXJoZWxfNl94ODZfNjQifX0sICJkZXNjcmlw
+        dGlvbiI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PXB1bHAt
+        dXVpZC1yaGVsXzZfeDg2XzY0IiwgInN1Yl9lcnJvcnMiOiBbXX0sICJ0cmFj
+        ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogInB1
+        bHAtdXVpZC1yaGVsXzZfeDg2XzY0In19
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:53 GMT
+- request:
+    method: delete
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:53 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '404'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
+        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
+        OiByZXBvc2l0b3J5PUZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
+        djIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8iLCAiaHR0cF9zdGF0dXMiOiA0
+        MDQsICJlcnJvciI6IHsiY29kZSI6ICJQTFAwMDA5IiwgImRhdGEiOiB7InJl
+        c291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0sICJkZXNj
+        cmlwdGlvbiI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PUZl
+        ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
+        bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:53 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6InB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwiZGlzcGxheV9uYW1l
+        IjoiUkhFTCA2IHg4Nl82NCIsImltcG9ydGVyX3R5cGVfaWQiOiJ5dW1faW1w
+        b3J0ZXIiLCJpbXBvcnRlcl9jb25maWciOnsiZG93bmxvYWRfcG9saWN5Ijoi
+        b25fZGVtYW5kIiwicmVtb3ZlX21pc3NpbmciOnRydWUsImZlZWQiOiJodHRw
+        czovL2Nkbi5yZWRoYXQuY29tL2Zvby9iYXIiLCJ0eXBlX3NraXBfbGlzdCI6
+        WyJycG0iXSwicHJveHlfaG9zdCI6bnVsbCwiYmFzaWNfYXV0aF91c2VybmFt
+        ZSI6bnVsbCwiYmFzaWNfYXV0aF9wYXNzd29yZCI6bnVsbCwic3NsX3ZhbGlk
+        YXRpb24iOnRydWUsInNzbF9jbGllbnRfY2VydCI6InJlcG9fY2VydCIsInNz
+        bF9jbGllbnRfa2V5IjoicmVwb19rZXkiLCJzc2xfY2FfY2VydCI6ImNhX2Nl
+        cnQifSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRpc3Ry
+        aWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0cmli
+        dXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwiOiJB
+        Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvcmhlbF82X2xhYmVsIiwiaHR0cCI6
+        ZmFsc2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRydWUsImNoZWNrc3Vt
+        X3R5cGUiOm51bGx9LCJhdXRvX3B1Ymxpc2giOnRydWUsImRpc3RyaWJ1dG9y
+        X2lkIjoicHVscC11dWlkLXJoZWxfNl94ODZfNjQifSx7ImRpc3RyaWJ1dG9y
+        X3R5cGVfaWQiOiJ5dW1fY2xvbmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRv
+        cl9jb25maWciOnsiZGVzdGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiJwdWxw
+        LXV1aWQtcmhlbF82X3g4Nl82NCJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJk
+        aXN0cmlidXRvcl9pZCI6InB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0X2Nsb25l
+        In0seyJkaXN0cmlidXRvcl90eXBlX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9y
+        IiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7Imh0dHAiOmZhbHNlLCJodHRwcyI6
+        ZmFsc2UsInJlbGF0aXZlX3VybCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFy
+        eS9yaGVsXzZfbGFiZWwifSwiYXV0b19wdWJsaXNoIjpmYWxzZSwiZGlzdHJp
+        YnV0b3JfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3IifV19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1113'
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:53 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '345'
+      Location:
+      - "/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA2IHg4
+        Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQi
+        OiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwg
+        Imxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3Vu
+        dHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNWM5
+        YmMyMTFkYjI4NGU1OWJmMTI1OTMxIn0sICJpZCI6ICJwdWxwLXV1aWQtcmhl
+        bF82X3g4Nl82NCIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
+        aWVzL3B1bHAtdXVpZC1yaGVsXzZfeDg2XzY0LyJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:53 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:53 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"8342dc63be1fcbd2553f15a0220b58aa-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2598'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA2IHg4
+        Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMiOiBb
+        eyJyZXBvX2lkIjogInB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgImxhc3Rf
+        dXBkYXRlZCI6ICIyMDE5LTAzLTI3VDE4OjMzOjUzWiIsICJfaHJlZiI6ICIv
+        cHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL3B1bHAtdXVpZC1yaGVsXzZfeDg2
+        XzY0L2Rpc3RyaWJ1dG9ycy9wdWxwLXV1aWQtcmhlbF82X3g4Nl82NF9jbG9u
+        ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
+        aCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9jbG9uZV9k
+        aXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hw
+        YWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7
+        IiRvaWQiOiAiNWM5YmMyMTFkYjI4NGU1OWJmMTI1OTM0In0sICJjb25maWci
+        OiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogInB1bHAtdXVpZC1y
+        aGVsXzZfeDg2XzY0In0sICJpZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82
+        NF9jbG9uZSJ9LCB7InJlcG9faWQiOiAicHVscC11dWlkLXJoZWxfNl94ODZf
+        NjQiLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDMtMjdUMTg6MzM6NTNaIiwg
+        Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvcHVscC11dWlk
+        LXJoZWxfNl94ODZfNjQvZGlzdHJpYnV0b3JzL3B1bHAtdXVpZC1yaGVsXzZf
+        eDg2XzY0LyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9w
+        dWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Rp
+        c3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IHRydWUsICJzY3JhdGNocGFk
+        Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
+        b2lkIjogIjVjOWJjMjExZGIyODRlNTliZjEyNTkzMyJ9LCAiY29uZmlnIjog
+        eyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6IGZhbHNlLCAiaHR0cHMiOiB0
+        cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29ycG9yYXRpb24vbGlicmFy
+        eS9yaGVsXzZfbGFiZWwifSwgImlkIjogInB1bHAtdXVpZC1yaGVsXzZfeDg2
+        XzY0In0sIHsicmVwb19pZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCIs
+        ICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wMy0yN1QxODozMzo1M1oiLCAiX2hy
+        ZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9wdWxwLXV1aWQtcmhl
+        bF82X3g4Nl82NC9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3RyaWJ1dG9yLyIs
+        ICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjog
+        bnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1
+        dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9
+        LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzliYzIxMWRiMjg0ZTU5YmYxMjU5MzUifSwgImNvbmZpZyI6IHsiaHR0
+        cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29ycG9yYXRpb24v
+        bGlicmFyeS9yaGVsXzZfbGFiZWwiLCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6
+        ICJleHBvcnRfZGlzdHJpYnV0b3IifV0sICJsYXN0X3VuaXRfYWRkZWQiOiBu
+        dWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwgImxh
+        c3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3VudHMi
+        OiB7fSwgIl9ucyI6ICJyZXBvcyIsICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lk
+        IjogInB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgImxhc3RfdXBkYXRlZCI6
+        ICIyMDE5LTAzLTI3VDE4OjMzOjUzWiIsICJfaHJlZiI6ICIvcHVscC9hcGkv
+        djIvcmVwb3NpdG9yaWVzL3B1bHAtdXVpZC1yaGVsXzZfeDg2XzY0L2ltcG9y
+        dGVycy95dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIs
+        ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJsYXN0X292
+        ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjogbnVsbCwgInNjcmF0
+        Y2hwYWQiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjExZGIyODRl
+        NTliZjEyNTkzMiJ9LCAiY29uZmlnIjogeyJmZWVkIjogImh0dHBzOi8vY2Ru
+        LnJlZGhhdC5jb20vZm9vL2JhciIsICJzc2xfY2FfY2VydCI6ICJjYV9jZXJ0
+        IiwgInNzbF9jbGllbnRfY2VydCI6ICJyZXBvX2NlcnQiLCAicmVtb3ZlX21p
+        c3NpbmciOiB0cnVlLCAic3NsX3ZhbGlkYXRpb24iOiB0cnVlLCAic3NsX2Ns
+        aWVudF9rZXkiOiAicmVwb19rZXkiLCAiZG93bmxvYWRfcG9saWN5IjogIm9u
+        X2RlbWFuZCIsICJ0eXBlX3NraXBfbGlzdCI6IFsicnBtIl19LCAiaWQiOiAi
+        eXVtX2ltcG9ydGVyIn1dLCAibG9jYWxseV9zdG9yZWRfdW5pdHMiOiAwLCAi
+        X2lkIjogeyIkb2lkIjogIjVjOWJjMjExZGIyODRlNTliZjEyNTkzMSJ9LCAi
+        dG90YWxfcmVwb3NpdG9yeV91bml0cyI6IDAsICJpZCI6ICJwdWxwLXV1aWQt
+        cmhlbF82X3g4Nl82NCIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3Np
+        dG9yaWVzL3B1bHAtdXVpZC1yaGVsXzZfeDg2XzY0LyJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:53 GMT
+- request:
+    method: delete
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:53 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzZkNzU1MzdlLTQyMjItNGM5YS05YzI4LTMwN2NjYWFjNDAxMC8iLCAi
+        dGFza19pZCI6ICI2ZDc1NTM3ZS00MjIyLTRjOWEtOWMyOC0zMDdjY2FhYzQw
+        MTAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:53 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/6d75537e-4222-4c9a-9c28-307ccaac4010/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:53 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"5134eaa847df0457483cd940b08c0fec-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '556'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82ZDc1NTM3ZS00MjIyLTRjOWEtOWMyOC0zMDdjY2FhYzQw
+        MTAvIiwgInRhc2tfaWQiOiAiNmQ3NTUzN2UtNDIyMi00YzlhLTljMjgtMzA3
+        Y2NhYWM0MDEwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpwdWxwLXV1
+        aWQtcmhlbF82X3g4Nl82NCIsICJwdWxwOmFjdGlvbjpkZWxldGUiXSwgImZp
+        bmlzaF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFy
+        dF90aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rh
+        c2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIiIs
+        ICJzdGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJl
+        c3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
+        NWM5YmMyMTFmYjZlOTViNDliZmNjZTNmIn0sICJpZCI6ICI1YzliYzIxMWZi
+        NmU5NWI0OWJmY2NlM2YifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:53 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/6d75537e-4222-4c9a-9c28-307ccaac4010/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:53 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"4400af0be519a55d181e0377aac1f43d-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '682'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82ZDc1NTM3ZS00MjIyLTRjOWEtOWMyOC0zMDdjY2FhYzQw
+        MTAvIiwgInRhc2tfaWQiOiAiNmQ3NTUzN2UtNDIyMi00YzlhLTljMjgtMzA3
+        Y2NhYWM0MDEwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpwdWxwLXV1
+        aWQtcmhlbF82X3g4Nl82NCIsICJwdWxwOmFjdGlvbjpkZWxldGUiXSwgImZp
+        bmlzaF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFy
+        dF90aW1lIjogIjIwMTktMDMtMjdUMTg6MzM6NTNaIiwgInRyYWNlYmFjayI6
+        IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQi
+        OiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQHRo
+        ZXRhLnBhcnRlbGxvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5u
+        aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0wQHRoZXRhLnBhcnRlbGxvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM5YmMyMTFm
+        YjZlOTViNDliZmNjZTNmIn0sICJpZCI6ICI1YzliYzIxMWZiNmU5NWI0OWJm
+        Y2NlM2YifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:53 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/6d75537e-4222-4c9a-9c28-307ccaac4010/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:53 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"3c0bffdc1f0abaaf064c402ce121ed74-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '701'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82ZDc1NTM3ZS00MjIyLTRjOWEtOWMyOC0zMDdjY2FhYzQw
+        MTAvIiwgInRhc2tfaWQiOiAiNmQ3NTUzN2UtNDIyMi00YzlhLTljMjgtMzA3
+        Y2NhYWM0MDEwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpwdWxwLXV1
+        aWQtcmhlbF82X3g4Nl82NCIsICJwdWxwOmFjdGlvbjpkZWxldGUiXSwgImZp
+        bmlzaF90aW1lIjogIjIwMTktMDMtMjdUMTg6MzM6NTNaIiwgIl9ucyI6ICJ0
+        YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTktMDMtMjdUMTg6MzM6
+        NTNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10s
+        ICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0wQHRoZXRhLnBhcnRlbGxvLmV4YW1wbGUuY29tLmRx
+        MiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
+        eyIkb2lkIjogIjVjOWJjMjExZmI2ZTk1YjQ5YmZjY2UzZiJ9LCAiaWQiOiAi
+        NWM5YmMyMTFmYjZlOTViNDliZmNjZTNmIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:53 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/create_custom.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/create_custom.yml
@@ -2097,288 +2097,6 @@ http_interactions:
     http_version: 
   recorded_at: Tue, 19 Mar 2019 17:58:16 GMT
 - request:
-    method: delete
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:52 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '474'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
-        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
-        OiByZXBvc2l0b3J5PXB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvcHVscC11dWlkLXJoZWxf
-        Nl94ODZfNjQvIiwgImh0dHBfc3RhdHVzIjogNDA0LCAiZXJyb3IiOiB7ImNv
-        ZGUiOiAiUExQMDAwOSIsICJkYXRhIjogeyJyZXNvdXJjZXMiOiB7InJlcG9z
-        aXRvcnkiOiAicHVscC11dWlkLXJoZWxfNl94ODZfNjQifX0sICJkZXNjcmlw
-        dGlvbiI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PXB1bHAt
-        dXVpZC1yaGVsXzZfeDg2XzY0IiwgInN1Yl9lcnJvcnMiOiBbXX0sICJ0cmFj
-        ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogInB1
-        bHAtdXVpZC1yaGVsXzZfeDg2XzY0In19
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:52 GMT
-- request:
-    method: delete
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:52 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '404'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
-        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
-        OiByZXBvc2l0b3J5PUZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
-        djIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8iLCAiaHR0cF9zdGF0dXMiOiA0
-        MDQsICJlcnJvciI6IHsiY29kZSI6ICJQTFAwMDA5IiwgImRhdGEiOiB7InJl
-        c291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0sICJkZXNj
-        cmlwdGlvbiI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PUZl
-        ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
-        bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:52 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImRvd25sb2FkX3BvbGljeSI6Im9uX2RlbWFuZCIs
-        InJlbW92ZV9taXNzaW5nIjp0cnVlLCJmZWVkIjoiaHR0cDovL215cmVwby5j
-        b20iLCJ0eXBlX3NraXBfbGlzdCI6WyJkcnBtIl0sInByb3h5X2hvc3QiOm51
-        bGwsImJhc2ljX2F1dGhfdXNlcm5hbWUiOiJyb290IiwiYmFzaWNfYXV0aF9w
-        YXNzd29yZCI6InJlZGhhdCIsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJzc2xf
-        Y2xpZW50X2NlcnQiOm51bGwsInNzbF9jbGllbnRfa2V5IjpudWxsLCJzc2xf
-        Y2FfY2VydCI6bnVsbH0sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJycG0tcmVw
-        byJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5
-        dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsicmVsYXRp
-        dmVfdXJsIjoiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5L2ZlZG9yYV8xN19s
-        YWJlbCIsImh0dHAiOmZhbHNlLCJodHRwcyI6dHJ1ZSwicHJvdGVjdGVkIjp0
-        cnVlLCJjaGVja3N1bV90eXBlIjpudWxsfSwiYXV0b19wdWJsaXNoIjp0cnVl
-        LCJkaXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xNyJ9LHsiZGlzdHJpYnV0b3Jf
-        dHlwZV9pZCI6Inl1bV9jbG9uZV9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9y
-        X2NvbmZpZyI6eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6IkZlZG9y
-        YV8xNyJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRvcl9pZCI6
-        IkZlZG9yYV8xN19jbG9uZSJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ImV4
-        cG9ydF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJodHRw
-        IjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxhdGl2ZV91cmwiOiJBQ01FX0Nv
-        cnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIn0sImF1dG9fcHVi
-        bGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1
-        dG9yIn1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1042'
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:52 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '320'
-      Location:
-      - "/pulp/api/v2/repositories/Fedora_17/"
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWM5MTMxZDhkYjI4NGUwOTQxZGEwYjIzIn0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:52 GMT
-- request:
-    method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:52 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"3fd90319960dd6ce433dea4a021597f2-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2360'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
-        OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
-        MjAxOS0wMy0xOVQxODoxNTo1MloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
-        L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
-        aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
-        c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
-        cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
-        cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWM5MTMxZDhkYjI4NGUwOTQxZGEwYjI3In0sICJj
-        b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
-        X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
-        IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
-        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDMt
-        MTlUMTg6MTU6NTJaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
-        b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
-        IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
-        OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
-        dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
-        Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVjOTEzMWQ4ZGIyODRlMDk0MWRhMGIyNiJ9LCAiY29uZmlnIjog
-        eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
-        ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9LCB7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTAzLTE5VDE4OjE1OjUyWiIs
-        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
-        Ny9kaXN0cmlidXRvcnMvRmVkb3JhXzE3LyIsICJsYXN0X292ZXJyaWRlX2Nv
-        bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
-        X3R5cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6
-        IHRydWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmli
-        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVjOTEzMWQ4ZGIyODRlMDk0MWRh
-        MGIyNSJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
-        IGZhbHNlLCAiaHR0cHMiOiB0cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVf
-        Q29ycG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwifSwgImlkIjog
-        IkZlZG9yYV8xNyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3Rl
-        cyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3Jl
-        bW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25z
-        IjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTAzLTE5VDE4OjE1OjUyWiIs
-        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
-        Ny9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBv
-        cnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
-        bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGws
-        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzkxMzFk
-        OGRiMjg0ZTA5NDFkYTBiMjQifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
-        Oi8vbXlyZXBvLmNvbSIsICJ0eXBlX3NraXBfbGlzdCI6IFsiZHJwbSJdLCAi
-        YmFzaWNfYXV0aF9wYXNzd29yZCI6ICIqKioqKiIsICJyZW1vdmVfbWlzc2lu
-        ZyI6IHRydWUsICJzc2xfdmFsaWRhdGlvbiI6IHRydWUsICJkb3dubG9hZF9w
-        b2xpY3kiOiAib25fZGVtYW5kIiwgImJhc2ljX2F1dGhfdXNlcm5hbWUiOiAi
-        cm9vdCJ9LCAiaWQiOiAieXVtX2ltcG9ydGVyIn1dLCAibG9jYWxseV9zdG9y
-        ZWRfdW5pdHMiOiAwLCAiX2lkIjogeyIkb2lkIjogIjVjOTEzMWQ4ZGIyODRl
-        MDk0MWRhMGIyMyJ9LCAidG90YWxfcmVwb3NpdG9yeV91bml0cyI6IDAsICJp
-        ZCI6ICJGZWRvcmFfMTciLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9z
-        aXRvcmllcy9GZWRvcmFfMTcvIn0=
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:52 GMT
-- request:
-    method: delete
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:52 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzk1ZDMxM2Y3LTdlNDUtNGZmNC1iYmFkLWQ0NWY0MjdjYjNkMC8iLCAi
-        dGFza19pZCI6ICI5NWQzMTNmNy03ZTQ1LTRmZjQtYmJhZC1kNDVmNDI3Y2Iz
-        ZDAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:52 GMT
-- request:
     method: get
     uri: https://theta.partello.example.com/pulp/api/v2/tasks/95d313f7-7e45-4ff4-bbad-d45f427cb3d0/
     body:
@@ -2533,4 +2251,493 @@ http_interactions:
         M2M4YzBlNzlkOSJ9
     http_version: 
   recorded_at: Tue, 19 Mar 2019 18:15:52 GMT
+- request:
+    method: delete
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:51 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '474'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
+        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
+        OiByZXBvc2l0b3J5PXB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgIl9ocmVm
+        IjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvcHVscC11dWlkLXJoZWxf
+        Nl94ODZfNjQvIiwgImh0dHBfc3RhdHVzIjogNDA0LCAiZXJyb3IiOiB7ImNv
+        ZGUiOiAiUExQMDAwOSIsICJkYXRhIjogeyJyZXNvdXJjZXMiOiB7InJlcG9z
+        aXRvcnkiOiAicHVscC11dWlkLXJoZWxfNl94ODZfNjQifX0sICJkZXNjcmlw
+        dGlvbiI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PXB1bHAt
+        dXVpZC1yaGVsXzZfeDg2XzY0IiwgInN1Yl9lcnJvcnMiOiBbXX0sICJ0cmFj
+        ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogInB1
+        bHAtdXVpZC1yaGVsXzZfeDg2XzY0In19
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:51 GMT
+- request:
+    method: delete
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:51 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '404'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
+        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
+        OiByZXBvc2l0b3J5PUZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
+        djIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8iLCAiaHR0cF9zdGF0dXMiOiA0
+        MDQsICJlcnJvciI6IHsiY29kZSI6ICJQTFAwMDA5IiwgImRhdGEiOiB7InJl
+        c291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0sICJkZXNj
+        cmlwdGlvbiI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PUZl
+        ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
+        bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:51 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
+        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
+        b3J0ZXJfY29uZmlnIjp7ImRvd25sb2FkX3BvbGljeSI6Im9uX2RlbWFuZCIs
+        InJlbW92ZV9taXNzaW5nIjp0cnVlLCJmZWVkIjoiaHR0cDovL215cmVwby5j
+        b20iLCJ0eXBlX3NraXBfbGlzdCI6WyJkcnBtIl0sInByb3h5X2hvc3QiOm51
+        bGwsImJhc2ljX2F1dGhfdXNlcm5hbWUiOiJyb290IiwiYmFzaWNfYXV0aF9w
+        YXNzd29yZCI6InJlZGhhdCIsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJzc2xf
+        Y2xpZW50X2NlcnQiOm51bGwsInNzbF9jbGllbnRfa2V5IjpudWxsLCJzc2xf
+        Y2FfY2VydCI6bnVsbH0sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJycG0tcmVw
+        byJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5
+        dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsicmVsYXRp
+        dmVfdXJsIjoiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5L2ZlZG9yYV8xN19s
+        YWJlbCIsImh0dHAiOmZhbHNlLCJodHRwcyI6dHJ1ZSwicHJvdGVjdGVkIjp0
+        cnVlLCJjaGVja3N1bV90eXBlIjpudWxsfSwiYXV0b19wdWJsaXNoIjp0cnVl
+        LCJkaXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xNyJ9LHsiZGlzdHJpYnV0b3Jf
+        dHlwZV9pZCI6Inl1bV9jbG9uZV9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9y
+        X2NvbmZpZyI6eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6IkZlZG9y
+        YV8xNyJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRvcl9pZCI6
+        IkZlZG9yYV8xN19jbG9uZSJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ImV4
+        cG9ydF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJodHRw
+        IjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxhdGl2ZV91cmwiOiJBQ01FX0Nv
+        cnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIn0sImF1dG9fcHVi
+        bGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3RyaWJ1
+        dG9yIn1dfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1042'
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:51 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '320'
+      Location:
+      - "/pulp/api/v2/repositories/Fedora_17/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
+        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWM5YmMyMGZkYjI4NGU1OWJlOTZiYWNlIn0sICJpZCI6ICJGZWRvcmFfMTci
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
+        MTcvIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:51 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:51 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"32261191c1bf07001fcc7d3d1867f61c-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2360'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
+        OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
+        MjAxOS0wMy0yN1QxODozMzo1MVoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
+        aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
+        c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
+        cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
+        cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
+        aWQiOiB7IiRvaWQiOiAiNWM5YmMyMGZkYjI4NGU1OWJlOTZiYWQyIn0sICJj
+        b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
+        X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
+        IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
+        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDMt
+        MjdUMTg6MzM6NTFaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
+        IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
+        OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
+        dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
+        Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
+        b2lkIjogIjVjOWJjMjBmZGIyODRlNTliZTk2YmFkMSJ9LCAiY29uZmlnIjog
+        eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
+        ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9LCB7InJlcG9faWQiOiAiRmVkb3Jh
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTAzLTI3VDE4OjMzOjUxWiIs
+        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
+        Ny9kaXN0cmlidXRvcnMvRmVkb3JhXzE3LyIsICJsYXN0X292ZXJyaWRlX2Nv
+        bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
+        X3R5cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6
+        IHRydWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmli
+        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjBmZGIyODRlNTliZTk2
+        YmFkMCJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
+        IGZhbHNlLCAiaHR0cHMiOiB0cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVf
+        Q29ycG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwifSwgImlkIjog
+        IkZlZG9yYV8xNyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3Rl
+        cyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3Jl
+        bW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25z
+        IjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiRmVkb3Jh
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTAzLTI3VDE4OjMzOjUxWiIs
+        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
+        Ny9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBv
+        cnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
+        bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGws
+        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIw
+        ZmRiMjg0ZTU5YmU5NmJhY2YifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
+        Oi8vbXlyZXBvLmNvbSIsICJ0eXBlX3NraXBfbGlzdCI6IFsiZHJwbSJdLCAi
+        YmFzaWNfYXV0aF9wYXNzd29yZCI6ICIqKioqKiIsICJyZW1vdmVfbWlzc2lu
+        ZyI6IHRydWUsICJzc2xfdmFsaWRhdGlvbiI6IHRydWUsICJkb3dubG9hZF9w
+        b2xpY3kiOiAib25fZGVtYW5kIiwgImJhc2ljX2F1dGhfdXNlcm5hbWUiOiAi
+        cm9vdCJ9LCAiaWQiOiAieXVtX2ltcG9ydGVyIn1dLCAibG9jYWxseV9zdG9y
+        ZWRfdW5pdHMiOiAwLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjBmZGIyODRl
+        NTliZTk2YmFjZSJ9LCAidG90YWxfcmVwb3NpdG9yeV91bml0cyI6IDAsICJp
+        ZCI6ICJGZWRvcmFfMTciLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9z
+        aXRvcmllcy9GZWRvcmFfMTcvIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:51 GMT
+- request:
+    method: delete
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:51 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzJlMjUyZmE4LTVjNzYtNDM1MC1hYzM1LTRkZmJmYmNiNzNlMy8iLCAi
+        dGFza19pZCI6ICIyZTI1MmZhOC01Yzc2LTQzNTAtYWMzNS00ZGZiZmJjYjcz
+        ZTMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:51 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/2e252fa8-5c76-4350-ac35-4dfbfbcb73e3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:51 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"b5aa07b1e44de34a6ea663855b3c68f4-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '542'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yZTI1MmZhOC01Yzc2LTQzNTAtYWMzNS00ZGZiZmJjYjcz
+        ZTMvIiwgInRhc2tfaWQiOiAiMmUyNTJmYTgtNWM3Ni00MzUwLWFjMzUtNGRm
+        YmZiY2I3M2UzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICIiLCAic3RhdGUiOiAid2Fp
+        dGluZyIsICJ3b3JrZXJfbmFtZSI6IG51bGwsICJyZXN1bHQiOiBudWxsLCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjBmZmI2ZTk1
+        YjQ5YmZjY2RiMSJ9LCAiaWQiOiAiNWM5YmMyMGZmYjZlOTViNDliZmNjZGIx
+        In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:51 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/2e252fa8-5c76-4350-ac35-4dfbfbcb73e3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:51 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"1e105ea770d24604f3bdb9978b3ec81e-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '668'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yZTI1MmZhOC01Yzc2LTQzNTAtYWMzNS00ZGZiZmJjYjcz
+        ZTMvIiwgInRhc2tfaWQiOiAiMmUyNTJmYTgtNWM3Ni00MzUwLWFjMzUtNGRm
+        YmZiY2I3M2UzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5
+        LTAzLTI3VDE4OjMzOjUxWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5l
+        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0
+        ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjBmZmI2ZTk1YjQ5YmZjY2Ri
+        MSJ9LCAiaWQiOiAiNWM5YmMyMGZmYjZlOTViNDliZmNjZGIxIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:51 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/2e252fa8-5c76-4350-ac35-4dfbfbcb73e3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:52 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"1e105ea770d24604f3bdb9978b3ec81e-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '668'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yZTI1MmZhOC01Yzc2LTQzNTAtYWMzNS00ZGZiZmJjYjcz
+        ZTMvIiwgInRhc2tfaWQiOiAiMmUyNTJmYTgtNWM3Ni00MzUwLWFjMzUtNGRm
+        YmZiY2I3M2UzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5
+        LTAzLTI3VDE4OjMzOjUxWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5l
+        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0
+        ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjBmZmI2ZTk1YjQ5YmZjY2Ri
+        MSJ9LCAiaWQiOiAiNWM5YmMyMGZmYjZlOTViNDliZmNjZGIxIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:52 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/2e252fa8-5c76-4350-ac35-4dfbfbcb73e3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:52 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"d4667d4e06747d7618db6aebf6d43034-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '687'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8yZTI1MmZhOC01Yzc2LTQzNTAtYWMzNS00ZGZiZmJjYjcz
+        ZTMvIiwgInRhc2tfaWQiOiAiMmUyNTJmYTgtNWM3Ni00MzUwLWFjMzUtNGRm
+        YmZiY2I3M2UzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE5LTAzLTI3VDE4OjMzOjUyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjUxWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Yzli
+        YzIwZmZiNmU5NWI0OWJmY2NkYjEifSwgImlkIjogIjVjOWJjMjBmZmI2ZTk1
+        YjQ5YmZjY2RiMSJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:52 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/refresh.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/refresh.yml
@@ -1492,285 +1492,6 @@ http_interactions:
     http_version: 
   recorded_at: Tue, 19 Mar 2019 17:58:14 GMT
 - request:
-    method: delete
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:54 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '474'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
-        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
-        OiByZXBvc2l0b3J5PXB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvcHVscC11dWlkLXJoZWxf
-        Nl94ODZfNjQvIiwgImh0dHBfc3RhdHVzIjogNDA0LCAiZXJyb3IiOiB7ImNv
-        ZGUiOiAiUExQMDAwOSIsICJkYXRhIjogeyJyZXNvdXJjZXMiOiB7InJlcG9z
-        aXRvcnkiOiAicHVscC11dWlkLXJoZWxfNl94ODZfNjQifX0sICJkZXNjcmlw
-        dGlvbiI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PXB1bHAt
-        dXVpZC1yaGVsXzZfeDg2XzY0IiwgInN1Yl9lcnJvcnMiOiBbXX0sICJ0cmFj
-        ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogInB1
-        bHAtdXVpZC1yaGVsXzZfeDg2XzY0In19
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:54 GMT
-- request:
-    method: delete
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:54 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '404'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
-        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
-        OiByZXBvc2l0b3J5PUZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
-        djIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8iLCAiaHR0cF9zdGF0dXMiOiA0
-        MDQsICJlcnJvciI6IHsiY29kZSI6ICJQTFAwMDA5IiwgImRhdGEiOiB7InJl
-        c291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0sICJkZXNj
-        cmlwdGlvbiI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PUZl
-        ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
-        bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:54 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImRvd25sb2FkX3BvbGljeSI6Im9uX2RlbWFuZCIs
-        InJlbW92ZV9taXNzaW5nIjp0cnVlLCJmZWVkIjoiaHR0cDovL215cmVwby5j
-        b20iLCJ0eXBlX3NraXBfbGlzdCI6bnVsbCwicHJveHlfaG9zdCI6bnVsbCwi
-        YmFzaWNfYXV0aF91c2VybmFtZSI6bnVsbCwiYmFzaWNfYXV0aF9wYXNzd29y
-        ZCI6bnVsbCwic3NsX3ZhbGlkYXRpb24iOnRydWUsInNzbF9jbGllbnRfY2Vy
-        dCI6bnVsbCwic3NsX2NsaWVudF9rZXkiOm51bGwsInNzbF9jYV9jZXJ0Ijpu
-        dWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRpc3Ry
-        aWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0cmli
-        dXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwiOiJB
-        Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwiaHR0
-        cCI6ZmFsc2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRydWUsImNoZWNr
-        c3VtX3R5cGUiOm51bGx9LCJhdXRvX3B1Ymxpc2giOnRydWUsImRpc3RyaWJ1
-        dG9yX2lkIjoiRmVkb3JhXzE3In0seyJkaXN0cmlidXRvcl90eXBlX2lkIjoi
-        eXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7
-        ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3In0sImF1
-        dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3
-        X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBlX2lkIjoiZXhwb3J0X2Rpc3Ry
-        aWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7Imh0dHAiOmZhbHNlLCJo
-        dHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6IkFDTUVfQ29ycG9yYXRpb24v
-        bGlicmFyeS9mZWRvcmFfMTdfbGFiZWwifSwiYXV0b19wdWJsaXNoIjpmYWxz
-        ZSwiZGlzdHJpYnV0b3JfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3IifV19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1032'
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:54 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '320'
-      Location:
-      - "/pulp/api/v2/repositories/Fedora_17/"
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWM5MTMxZGFkYjI4NGUwOTQzOTU3MDJjIn0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:54 GMT
-- request:
-    method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:54 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"954159ddaf63a23b1425cc77499b6c67-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2269'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
-        OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
-        MjAxOS0wMy0xOVQxODoxNTo1NFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
-        L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
-        aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
-        c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
-        cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
-        cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWM5MTMxZGFkYjI4NGUwOTQzOTU3MDMwIn0sICJj
-        b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
-        X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
-        IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
-        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDMt
-        MTlUMTg6MTU6NTRaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
-        b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
-        IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
-        OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
-        dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
-        Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVjOTEzMWRhZGIyODRlMDk0Mzk1NzAyZiJ9LCAiY29uZmlnIjog
-        eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
-        ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9LCB7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTAzLTE5VDE4OjE1OjU0WiIs
-        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
-        Ny9kaXN0cmlidXRvcnMvRmVkb3JhXzE3LyIsICJsYXN0X292ZXJyaWRlX2Nv
-        bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
-        X3R5cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6
-        IHRydWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmli
-        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVjOTEzMWRhZGIyODRlMDk0Mzk1
-        NzAyZSJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
-        IGZhbHNlLCAiaHR0cHMiOiB0cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVf
-        Q29ycG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwifSwgImlkIjog
-        IkZlZG9yYV8xNyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3Rl
-        cyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3Jl
-        bW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25z
-        IjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTAzLTE5VDE4OjE1OjU0WiIs
-        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
-        Ny9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBv
-        cnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
-        bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGws
-        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzkxMzFk
-        YWRiMjg0ZTA5NDM5NTcwMmQifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
-        Oi8vbXlyZXBvLmNvbSIsICJzc2xfdmFsaWRhdGlvbiI6IHRydWUsICJyZW1v
-        dmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9wb2xpY3kiOiAib25fZGVt
-        YW5kIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0sICJsb2NhbGx5X3N0b3Jl
-        ZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQiOiAiNWM5MTMxZGFkYjI4NGUw
-        OTQzOTU3MDJjIn0sICJ0b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMCwgImlk
-        IjogIkZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3Np
-        dG9yaWVzL0ZlZG9yYV8xNy8ifQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:54 GMT
-- request:
-    method: delete
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17//distributors/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:54 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2Y1MTU5YmM1LWY5ZTctNDY1NC1hNDM1LTU1YWZmYmM4OThiMC8iLCAi
-        dGFza19pZCI6ICJmNTE1OWJjNS1mOWU3LTQ2NTQtYTQzNS01NWFmZmJjODk4
-        YjAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:54 GMT
-- request:
     method: get
     uri: https://theta.partello.example.com/pulp/api/v2/tasks/f5159bc5-f9e7-4654-a435-55affbc898b0/
     body:
@@ -1875,509 +1596,6 @@ http_interactions:
         aWQiOiAiNWM5MTMxZGFmNzQ3ZTYzYzhjMGU3YTU0In0=
     http_version: 
   recorded_at: Tue, 19 Mar 2019 18:15:54 GMT
-- request:
-    method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:54 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"2ea8bbbc75b16fa7d29bc7991ad4c115-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1786'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
-        OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
-        MjAxOS0wMy0xOVQxODoxNTo1NFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
-        L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
-        aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
-        c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
-        cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
-        cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWM5MTMxZGFkYjI4NGUwOTQzOTU3MDMwIn0sICJj
-        b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
-        X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
-        IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
-        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDMt
-        MTlUMTg6MTU6NTRaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
-        b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
-        IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
-        OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
-        dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
-        Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVjOTEzMWRhZGIyODRlMDk0Mzk1NzAyZiJ9LCAiY29uZmlnIjog
-        eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
-        ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6
-        IG51bGwsICJub3RlcyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAi
-        bGFzdF91bml0X3JlbW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50
-        cyI6IHt9LCAiX25zIjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9f
-        aWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTAzLTE5
-        VDE4OjE1OjU0WiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
-        aWVzL0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMi
-        OiAicmVwb19pbXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
-        aW1wb3J0ZXIiLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rf
-        c3luYyI6IG51bGwsICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1YzkxMzFkYWRiMjg0ZTA5NDM5NTcwMmQifSwgImNvbmZpZyI6IHsi
-        ZmVlZCI6ICJodHRwOi8vbXlyZXBvLmNvbSIsICJzc2xfdmFsaWRhdGlvbiI6
-        IHRydWUsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9wb2xp
-        Y3kiOiAib25fZGVtYW5kIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0sICJs
-        b2NhbGx5X3N0b3JlZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQiOiAiNWM5
-        MTMxZGFkYjI4NGUwOTQzOTU3MDJjIn0sICJ0b3RhbF9yZXBvc2l0b3J5X3Vu
-        aXRzIjogMCwgImlkIjogIkZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8ifQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:54 GMT
-- request:
-    method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:54 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"2ea8bbbc75b16fa7d29bc7991ad4c115-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1786'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
-        OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
-        MjAxOS0wMy0xOVQxODoxNTo1NFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
-        L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
-        aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
-        c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
-        cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
-        cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWM5MTMxZGFkYjI4NGUwOTQzOTU3MDMwIn0sICJj
-        b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
-        X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
-        IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
-        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDMt
-        MTlUMTg6MTU6NTRaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
-        b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
-        IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
-        OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
-        dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
-        Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVjOTEzMWRhZGIyODRlMDk0Mzk1NzAyZiJ9LCAiY29uZmlnIjog
-        eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
-        ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6
-        IG51bGwsICJub3RlcyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAi
-        bGFzdF91bml0X3JlbW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50
-        cyI6IHt9LCAiX25zIjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9f
-        aWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTAzLTE5
-        VDE4OjE1OjU0WiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
-        aWVzL0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMi
-        OiAicmVwb19pbXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
-        aW1wb3J0ZXIiLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rf
-        c3luYyI6IG51bGwsICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1YzkxMzFkYWRiMjg0ZTA5NDM5NTcwMmQifSwgImNvbmZpZyI6IHsi
-        ZmVlZCI6ICJodHRwOi8vbXlyZXBvLmNvbSIsICJzc2xfdmFsaWRhdGlvbiI6
-        IHRydWUsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9wb2xp
-        Y3kiOiAib25fZGVtYW5kIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0sICJs
-        b2NhbGx5X3N0b3JlZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQiOiAiNWM5
-        MTMxZGFkYjI4NGUwOTQzOTU3MDJjIn0sICJ0b3RhbF9yZXBvc2l0b3J5X3Vu
-        aXRzIjogMCwgImlkIjogIkZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8ifQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:54 GMT
-- request:
-    method: put
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer//
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpbXBvcnRlcl9jb25maWciOnsic3NsX2NsaWVudF9jZXJ0IjpudWxsLCJz
-        c2xfY2xpZW50X2tleSI6bnVsbCwic3NsX2NhX2NlcnQiOm51bGx9fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '85'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:54 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2VlODQzZjQwLWNlY2ItNGJlYy1hNTUwLTk3ZWY2YmJjY2RiNC8iLCAi
-        dGFza19pZCI6ICJlZTg0M2Y0MC1jZWNiLTRiZWMtYTU1MC05N2VmNmJiY2Nk
-        YjQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:54 GMT
-- request:
-    method: put
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer//
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpbXBvcnRlcl9jb25maWciOnsiZG93bmxvYWRfcG9saWN5Ijoib25fZGVt
-        YW5kIiwicmVtb3ZlX21pc3NpbmciOnRydWUsImZlZWQiOiJodHRwOi8vbXly
-        ZXBvLmNvbSIsInR5cGVfc2tpcF9saXN0IjpudWxsLCJwcm94eV9ob3N0Ijpu
-        dWxsLCJiYXNpY19hdXRoX3VzZXJuYW1lIjpudWxsLCJiYXNpY19hdXRoX3Bh
-        c3N3b3JkIjpudWxsLCJzc2xfdmFsaWRhdGlvbiI6dHJ1ZSwic3NsX2NsaWVu
-        dF9jZXJ0IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3NsX2NhX2Nl
-        cnQiOm51bGx9fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '280'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:54 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzkzYTk2ZDBmLWU2NzYtNDI0NC1hZDg0LWZhODAzY2VhZTJlYi8iLCAi
-        dGFza19pZCI6ICI5M2E5NmQwZi1lNjc2LTQyNDQtYWQ4NC1mYTgwM2NlYWUy
-        ZWIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:54 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/distributors/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJkaXN0cmlidXRvcl90eXBlX2lkIjoieXVtX2Rpc3RyaWJ1dG9yIiwiZGlz
-        dHJpYnV0b3JfY29uZmlnIjp7InJlbGF0aXZlX3VybCI6IkFDTUVfQ29ycG9y
-        YXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwiLCJodHRwIjpmYWxzZSwi
-        aHR0cHMiOnRydWUsInByb3RlY3RlZCI6dHJ1ZSwiY2hlY2tzdW1fdHlwZSI6
-        bnVsbH0sImRpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3IiwiYXV0b19wdWJs
-        aXNoIjp0cnVlfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '235'
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:54 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '481'
-      Location:
-      - "/pulp/api/v2/repositories/Fedora_17/distributors/Fedora_17/"
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAiMjAx
-        OS0wMy0xOVQxODoxNTo1NFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Jl
-        cG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL0ZlZG9yYV8xNy8i
-        LCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlzaCI6
-        IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRv
-        ciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAi
-        X25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1
-        YzkxMzFkYWRiMjg0ZTA5NDJhOTU0MDMifSwgImNvbmZpZyI6IHsicHJvdGVj
-        dGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJB
-        Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0
-        dHBzIjogdHJ1ZX0sICJpZCI6ICJGZWRvcmFfMTcifQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:54 GMT
-- request:
-    method: put
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/distributors/Fedora_17_clone//
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJkaXN0cmlidXRvcl9jb25maWciOnsiZGVzdGluYXRpb25fZGlzdHJpYnV0
-        b3JfaWQiOiJGZWRvcmFfMTcifX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '65'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:54 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzhmNDBmYjNkLTUwMWYtNDQ2MC1hYWY2LWU4MWIyYWFjMjU3NC8iLCAi
-        dGFza19pZCI6ICI4ZjQwZmIzZC01MDFmLTQ0NjAtYWFmNi1lODFiMmFhYzI1
-        NzQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:54 GMT
-- request:
-    method: put
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/distributors/export_distributor//
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBzIjpm
-        YWxzZSwicmVsYXRpdmVfdXJsIjoiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5
-        L2ZlZG9yYV8xN19sYWJlbCJ9fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '109'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:54 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2FkNThiMWUwLWU0NDQtNDIwZS04Nzc3LThlM2JkYTBmOTNiZS8iLCAi
-        dGFza19pZCI6ICJhZDU4YjFlMC1lNDQ0LTQyMGUtODc3Ny04ZTNiZGEwZjkz
-        YmUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:54 GMT
-- request:
-    method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:55 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"f2dd6c3daf423e94911a3fd5fd13980e-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2269'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
-        OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
-        MjAxOS0wMy0xOVQxODoxNTo1NFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
-        L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
-        aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
-        c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
-        cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
-        cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWM5MTMxZGFkYjI4NGUwOTQzOTU3MDMwIn0sICJj
-        b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
-        X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
-        IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
-        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDMt
-        MTlUMTg6MTU6NTVaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
-        b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
-        IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
-        OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
-        dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
-        Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVjOTEzMWRhZGIyODRlMDk0Mzk1NzAyZiJ9LCAiY29uZmlnIjog
-        eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
-        ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9LCB7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTAzLTE5VDE4OjE1OjU0WiIs
-        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
-        Ny9kaXN0cmlidXRvcnMvRmVkb3JhXzE3LyIsICJsYXN0X292ZXJyaWRlX2Nv
-        bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
-        X3R5cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6
-        IHRydWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmli
-        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVjOTEzMWRhZGIyODRlMDk0MmE5
-        NTQwMyJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
-        IGZhbHNlLCAiaHR0cHMiOiB0cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVf
-        Q29ycG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwifSwgImlkIjog
-        IkZlZG9yYV8xNyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3Rl
-        cyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3Jl
-        bW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25z
-        IjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTAzLTE5VDE4OjE1OjU0WiIs
-        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
-        Ny9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBv
-        cnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
-        bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGws
-        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzkxMzFk
-        YWRiMjg0ZTA5NDM5NTcwMmQifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
-        Oi8vbXlyZXBvLmNvbSIsICJzc2xfdmFsaWRhdGlvbiI6IHRydWUsICJyZW1v
-        dmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9wb2xpY3kiOiAib25fZGVt
-        YW5kIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0sICJsb2NhbGx5X3N0b3Jl
-        ZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQiOiAiNWM5MTMxZGFkYjI4NGUw
-        OTQzOTU3MDJjIn0sICJ0b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMCwgImlk
-        IjogIkZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3Np
-        dG9yaWVzL0ZlZG9yYV8xNy8ifQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:55 GMT
-- request:
-    method: delete
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:55 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzliNDhkMjI2LWY0OTEtNDgyZi04NzU0LWQ4YTAzNzI4OTllOS8iLCAi
-        dGFza19pZCI6ICI5YjQ4ZDIyNi1mNDkxLTQ4MmYtODc1NC1kOGEwMzcyODk5
-        ZTkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:55 GMT
 - request:
     method: get
     uri: https://theta.partello.example.com/pulp/api/v2/tasks/9b48d226-f491-482f-8754-d8a0372899e9/
@@ -2533,4 +1751,1046 @@ http_interactions:
         M2M4YzBlN2IxYyJ9
     http_version: 
   recorded_at: Tue, 19 Mar 2019 18:15:55 GMT
+- request:
+    method: delete
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:54 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '474'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
+        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
+        OiByZXBvc2l0b3J5PXB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgIl9ocmVm
+        IjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvcHVscC11dWlkLXJoZWxf
+        Nl94ODZfNjQvIiwgImh0dHBfc3RhdHVzIjogNDA0LCAiZXJyb3IiOiB7ImNv
+        ZGUiOiAiUExQMDAwOSIsICJkYXRhIjogeyJyZXNvdXJjZXMiOiB7InJlcG9z
+        aXRvcnkiOiAicHVscC11dWlkLXJoZWxfNl94ODZfNjQifX0sICJkZXNjcmlw
+        dGlvbiI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PXB1bHAt
+        dXVpZC1yaGVsXzZfeDg2XzY0IiwgInN1Yl9lcnJvcnMiOiBbXX0sICJ0cmFj
+        ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogInB1
+        bHAtdXVpZC1yaGVsXzZfeDg2XzY0In19
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:54 GMT
+- request:
+    method: delete
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:54 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '404'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
+        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
+        OiByZXBvc2l0b3J5PUZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
+        djIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8iLCAiaHR0cF9zdGF0dXMiOiA0
+        MDQsICJlcnJvciI6IHsiY29kZSI6ICJQTFAwMDA5IiwgImRhdGEiOiB7InJl
+        c291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0sICJkZXNj
+        cmlwdGlvbiI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PUZl
+        ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
+        bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:54 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
+        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
+        b3J0ZXJfY29uZmlnIjp7ImRvd25sb2FkX3BvbGljeSI6Im9uX2RlbWFuZCIs
+        InJlbW92ZV9taXNzaW5nIjp0cnVlLCJmZWVkIjoiaHR0cDovL215cmVwby5j
+        b20iLCJ0eXBlX3NraXBfbGlzdCI6bnVsbCwicHJveHlfaG9zdCI6bnVsbCwi
+        YmFzaWNfYXV0aF91c2VybmFtZSI6bnVsbCwiYmFzaWNfYXV0aF9wYXNzd29y
+        ZCI6bnVsbCwic3NsX3ZhbGlkYXRpb24iOnRydWUsInNzbF9jbGllbnRfY2Vy
+        dCI6bnVsbCwic3NsX2NsaWVudF9rZXkiOm51bGwsInNzbF9jYV9jZXJ0Ijpu
+        dWxsfSwibm90ZXMiOnsiX3JlcG8tdHlwZSI6InJwbS1yZXBvIn0sImRpc3Ry
+        aWJ1dG9ycyI6W3siZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9kaXN0cmli
+        dXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJyZWxhdGl2ZV91cmwiOiJB
+        Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwiaHR0
+        cCI6ZmFsc2UsImh0dHBzIjp0cnVlLCJwcm90ZWN0ZWQiOnRydWUsImNoZWNr
+        c3VtX3R5cGUiOm51bGx9LCJhdXRvX3B1Ymxpc2giOnRydWUsImRpc3RyaWJ1
+        dG9yX2lkIjoiRmVkb3JhXzE3In0seyJkaXN0cmlidXRvcl90eXBlX2lkIjoi
+        eXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7
+        ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3In0sImF1
+        dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3
+        X2Nsb25lIn0seyJkaXN0cmlidXRvcl90eXBlX2lkIjoiZXhwb3J0X2Rpc3Ry
+        aWJ1dG9yIiwiZGlzdHJpYnV0b3JfY29uZmlnIjp7Imh0dHAiOmZhbHNlLCJo
+        dHRwcyI6ZmFsc2UsInJlbGF0aXZlX3VybCI6IkFDTUVfQ29ycG9yYXRpb24v
+        bGlicmFyeS9mZWRvcmFfMTdfbGFiZWwifSwiYXV0b19wdWJsaXNoIjpmYWxz
+        ZSwiZGlzdHJpYnV0b3JfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3IifV19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1032'
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:54 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '320'
+      Location:
+      - "/pulp/api/v2/repositories/Fedora_17/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
+        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWM5YmMyMTJkYjI4NGU1OWJmMTI1OTM2In0sICJpZCI6ICJGZWRvcmFfMTci
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
+        MTcvIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:54 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:54 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"2441215f353ff0b11f98dcedc7f64560-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2269'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
+        OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
+        MjAxOS0wMy0yN1QxODozMzo1NFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
+        aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
+        c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
+        cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
+        cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
+        aWQiOiB7IiRvaWQiOiAiNWM5YmMyMTJkYjI4NGU1OWJmMTI1OTNhIn0sICJj
+        b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
+        X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
+        IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
+        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDMt
+        MjdUMTg6MzM6NTRaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
+        IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
+        OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
+        dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
+        Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
+        b2lkIjogIjVjOWJjMjEyZGIyODRlNTliZjEyNTkzOSJ9LCAiY29uZmlnIjog
+        eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
+        ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9LCB7InJlcG9faWQiOiAiRmVkb3Jh
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTAzLTI3VDE4OjMzOjU0WiIs
+        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
+        Ny9kaXN0cmlidXRvcnMvRmVkb3JhXzE3LyIsICJsYXN0X292ZXJyaWRlX2Nv
+        bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
+        X3R5cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6
+        IHRydWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmli
+        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjEyZGIyODRlNTliZjEy
+        NTkzOCJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
+        IGZhbHNlLCAiaHR0cHMiOiB0cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVf
+        Q29ycG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwifSwgImlkIjog
+        IkZlZG9yYV8xNyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3Rl
+        cyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3Jl
+        bW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25z
+        IjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiRmVkb3Jh
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTAzLTI3VDE4OjMzOjU0WiIs
+        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
+        Ny9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBv
+        cnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
+        bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGws
+        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIx
+        MmRiMjg0ZTU5YmYxMjU5MzcifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
+        Oi8vbXlyZXBvLmNvbSIsICJzc2xfdmFsaWRhdGlvbiI6IHRydWUsICJyZW1v
+        dmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9wb2xpY3kiOiAib25fZGVt
+        YW5kIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0sICJsb2NhbGx5X3N0b3Jl
+        ZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQiOiAiNWM5YmMyMTJkYjI4NGU1
+        OWJmMTI1OTM2In0sICJ0b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMCwgImlk
+        IjogIkZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3Np
+        dG9yaWVzL0ZlZG9yYV8xNy8ifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:54 GMT
+- request:
+    method: delete
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17//distributors/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:54 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzk4YWVmZTllLWQ3YjItNGYzMy1iYmM3LTliNGQ3NTIzNDI3NC8iLCAi
+        dGFza19pZCI6ICI5OGFlZmU5ZS1kN2IyLTRmMzMtYmJjNy05YjRkNzUyMzQy
+        NzQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:54 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/98aefe9e-d7b2-4f33-bbc7-9b4d75234274/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:54 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"7b162b0fbfafee619daa65e75b5aecd5-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '607'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGlzdHJpYnV0b3JfZGVsZXRlIiwgIl9ocmVm
+        IjogIi9wdWxwL2FwaS92Mi90YXNrcy85OGFlZmU5ZS1kN2IyLTRmMzMtYmJj
+        Ny05YjRkNzUyMzQyNzQvIiwgInRhc2tfaWQiOiAiOThhZWZlOWUtZDdiMi00
+        ZjMzLWJiYzctOWI0ZDc1MjM0Mjc0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
+        dG9yeTpGZWRvcmFfMTciLCAicHVscDpyZXBvc2l0b3J5X2Rpc3RyaWJ1dG9y
+        OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpyZW1vdmVfZGlzdHJpYnV0b3Ii
+        XSwgImZpbmlzaF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVl
+        IjogIiIsICJzdGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVs
+        bCwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRv
+        aWQiOiAiNWM5YmMyMTJmYjZlOTViNDliZmNjZWJkIn0sICJpZCI6ICI1Yzli
+        YzIxMmZiNmU5NWI0OWJmY2NlYmQifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:54 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/98aefe9e-d7b2-4f33-bbc7-9b4d75234274/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:54 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"40551d777db674d1eb26ff3a35d9257c-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '752'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGlzdHJpYnV0b3JfZGVsZXRlIiwgIl9ocmVm
+        IjogIi9wdWxwL2FwaS92Mi90YXNrcy85OGFlZmU5ZS1kN2IyLTRmMzMtYmJj
+        Ny05YjRkNzUyMzQyNzQvIiwgInRhc2tfaWQiOiAiOThhZWZlOWUtZDdiMi00
+        ZjMzLWJiYzctOWI0ZDc1MjM0Mjc0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
+        dG9yeTpGZWRvcmFfMTciLCAicHVscDpyZXBvc2l0b3J5X2Rpc3RyaWJ1dG9y
+        OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpyZW1vdmVfZGlzdHJpYnV0b3Ii
+        XSwgImZpbmlzaF90aW1lIjogIjIwMTktMDMtMjdUMTg6MzM6NTRaIiwgIl9u
+        cyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTktMDMtMjdU
+        MTg6MzM6NTRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2Vy
+        dmVkX3Jlc291cmNlX3dvcmtlci0wQHRoZXRhLnBhcnRlbGxvLmV4YW1wbGUu
+        Y29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5l
+        eGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVjOWJjMjEyZmI2ZTk1YjQ5YmZjY2ViZCJ9LCAi
+        aWQiOiAiNWM5YmMyMTJmYjZlOTViNDliZmNjZWJkIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:54 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:55 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"e2ac2b4d669a643f05c24cb814e0b928-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1786'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
+        OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
+        MjAxOS0wMy0yN1QxODozMzo1NFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
+        aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
+        c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
+        cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
+        cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
+        aWQiOiB7IiRvaWQiOiAiNWM5YmMyMTJkYjI4NGU1OWJmMTI1OTNhIn0sICJj
+        b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
+        X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
+        IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
+        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDMt
+        MjdUMTg6MzM6NTRaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
+        IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
+        OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
+        dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
+        Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
+        b2lkIjogIjVjOWJjMjEyZGIyODRlNTliZjEyNTkzOSJ9LCAiY29uZmlnIjog
+        eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
+        ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6
+        IG51bGwsICJub3RlcyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAi
+        bGFzdF91bml0X3JlbW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50
+        cyI6IHt9LCAiX25zIjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9f
+        aWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTAzLTI3
+        VDE4OjMzOjU0WiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
+        aWVzL0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMi
+        OiAicmVwb19pbXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
+        aW1wb3J0ZXIiLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rf
+        c3luYyI6IG51bGwsICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1YzliYzIxMmRiMjg0ZTU5YmYxMjU5MzcifSwgImNvbmZpZyI6IHsi
+        ZmVlZCI6ICJodHRwOi8vbXlyZXBvLmNvbSIsICJzc2xfdmFsaWRhdGlvbiI6
+        IHRydWUsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9wb2xp
+        Y3kiOiAib25fZGVtYW5kIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0sICJs
+        b2NhbGx5X3N0b3JlZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQiOiAiNWM5
+        YmMyMTJkYjI4NGU1OWJmMTI1OTM2In0sICJ0b3RhbF9yZXBvc2l0b3J5X3Vu
+        aXRzIjogMCwgImlkIjogIkZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8ifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:55 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:55 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"e2ac2b4d669a643f05c24cb814e0b928-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1786'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
+        OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
+        MjAxOS0wMy0yN1QxODozMzo1NFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
+        aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
+        c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
+        cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
+        cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
+        aWQiOiB7IiRvaWQiOiAiNWM5YmMyMTJkYjI4NGU1OWJmMTI1OTNhIn0sICJj
+        b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
+        X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
+        IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
+        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDMt
+        MjdUMTg6MzM6NTRaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
+        IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
+        OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
+        dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
+        Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
+        b2lkIjogIjVjOWJjMjEyZGIyODRlNTliZjEyNTkzOSJ9LCAiY29uZmlnIjog
+        eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
+        ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6
+        IG51bGwsICJub3RlcyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAi
+        bGFzdF91bml0X3JlbW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50
+        cyI6IHt9LCAiX25zIjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9f
+        aWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTAzLTI3
+        VDE4OjMzOjU0WiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
+        aWVzL0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMi
+        OiAicmVwb19pbXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
+        aW1wb3J0ZXIiLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rf
+        c3luYyI6IG51bGwsICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1YzliYzIxMmRiMjg0ZTU5YmYxMjU5MzcifSwgImNvbmZpZyI6IHsi
+        ZmVlZCI6ICJodHRwOi8vbXlyZXBvLmNvbSIsICJzc2xfdmFsaWRhdGlvbiI6
+        IHRydWUsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9wb2xp
+        Y3kiOiAib25fZGVtYW5kIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0sICJs
+        b2NhbGx5X3N0b3JlZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQiOiAiNWM5
+        YmMyMTJkYjI4NGU1OWJmMTI1OTM2In0sICJ0b3RhbF9yZXBvc2l0b3J5X3Vu
+        aXRzIjogMCwgImlkIjogIkZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8ifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:55 GMT
+- request:
+    method: put
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer//
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpbXBvcnRlcl9jb25maWciOnsic3NsX2NsaWVudF9jZXJ0IjpudWxsLCJz
+        c2xfY2xpZW50X2tleSI6bnVsbCwic3NsX2NhX2NlcnQiOm51bGx9fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '85'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:55 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzA2ZDEwNTIyLTM1YTktNGNjMy04YTYyLTg5NjQ2YzExNzA0OS8iLCAi
+        dGFza19pZCI6ICIwNmQxMDUyMi0zNWE5LTRjYzMtOGE2Mi04OTY0NmMxMTcw
+        NDkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:55 GMT
+- request:
+    method: put
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer//
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpbXBvcnRlcl9jb25maWciOnsiZG93bmxvYWRfcG9saWN5Ijoib25fZGVt
+        YW5kIiwicmVtb3ZlX21pc3NpbmciOnRydWUsImZlZWQiOiJodHRwOi8vbXly
+        ZXBvLmNvbSIsInR5cGVfc2tpcF9saXN0IjpudWxsLCJwcm94eV9ob3N0Ijpu
+        dWxsLCJiYXNpY19hdXRoX3VzZXJuYW1lIjpudWxsLCJiYXNpY19hdXRoX3Bh
+        c3N3b3JkIjpudWxsLCJzc2xfdmFsaWRhdGlvbiI6dHJ1ZSwic3NsX2NsaWVu
+        dF9jZXJ0IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3NsX2NhX2Nl
+        cnQiOm51bGx9fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '280'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:55 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzYxNmIxYjNjLTc5MGItNDRiYy04ODllLTlhYzM5NzBkMjUzYi8iLCAi
+        dGFza19pZCI6ICI2MTZiMWIzYy03OTBiLTQ0YmMtODg5ZS05YWMzOTcwZDI1
+        M2IifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:55 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/distributors/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJkaXN0cmlidXRvcl90eXBlX2lkIjoieXVtX2Rpc3RyaWJ1dG9yIiwiZGlz
+        dHJpYnV0b3JfY29uZmlnIjp7InJlbGF0aXZlX3VybCI6IkFDTUVfQ29ycG9y
+        YXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwiLCJodHRwIjpmYWxzZSwi
+        aHR0cHMiOnRydWUsInByb3RlY3RlZCI6dHJ1ZSwiY2hlY2tzdW1fdHlwZSI6
+        bnVsbH0sImRpc3RyaWJ1dG9yX2lkIjoiRmVkb3JhXzE3IiwiYXV0b19wdWJs
+        aXNoIjp0cnVlfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '235'
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:55 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '481'
+      Location:
+      - "/pulp/api/v2/repositories/Fedora_17/distributors/Fedora_17/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAiMjAx
+        OS0wMy0yN1QxODozMzo1NVoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Jl
+        cG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL0ZlZG9yYV8xNy8i
+        LCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlzaCI6
+        IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRv
+        ciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAi
+        X25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1
+        YzliYzIxM2RiMjg0ZTU5YmYxMjU5M2IifSwgImNvbmZpZyI6IHsicHJvdGVj
+        dGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJB
+        Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0
+        dHBzIjogdHJ1ZX0sICJpZCI6ICJGZWRvcmFfMTcifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:55 GMT
+- request:
+    method: put
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/distributors/Fedora_17_clone//
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJkaXN0cmlidXRvcl9jb25maWciOnsiZGVzdGluYXRpb25fZGlzdHJpYnV0
+        b3JfaWQiOiJGZWRvcmFfMTcifX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '65'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:55 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzNlODY0NmQzLTkyMzktNGU5MS04ZGVmLTdiMWMxNTFlYTY4My8iLCAi
+        dGFza19pZCI6ICIzZTg2NDZkMy05MjM5LTRlOTEtOGRlZi03YjFjMTUxZWE2
+        ODMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:55 GMT
+- request:
+    method: put
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/distributors/export_distributor//
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBzIjpm
+        YWxzZSwicmVsYXRpdmVfdXJsIjoiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5
+        L2ZlZG9yYV8xN19sYWJlbCJ9fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '109'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:55 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2U5YTYyYTVlLWQ0OWYtNDcxYi05YjU5LWU4ZTViMWJiNjUzZC8iLCAi
+        dGFza19pZCI6ICJlOWE2MmE1ZS1kNDlmLTQ3MWItOWI1OS1lOGU1YjFiYjY1
+        M2QifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:55 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:55 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"b5fa653276abe1ab23f2661009b796a2-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2269'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
+        OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
+        MjAxOS0wMy0yN1QxODozMzo1NFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
+        aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
+        c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
+        cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
+        cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
+        aWQiOiB7IiRvaWQiOiAiNWM5YmMyMTJkYjI4NGU1OWJmMTI1OTNhIn0sICJj
+        b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
+        X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
+        IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
+        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDMt
+        MjdUMTg6MzM6NTRaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
+        IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
+        OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
+        dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
+        Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
+        b2lkIjogIjVjOWJjMjEyZGIyODRlNTliZjEyNTkzOSJ9LCAiY29uZmlnIjog
+        eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
+        ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9LCB7InJlcG9faWQiOiAiRmVkb3Jh
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTAzLTI3VDE4OjMzOjU1WiIs
+        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
+        Ny9kaXN0cmlidXRvcnMvRmVkb3JhXzE3LyIsICJsYXN0X292ZXJyaWRlX2Nv
+        bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
+        X3R5cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6
+        IHRydWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmli
+        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjEzZGIyODRlNTliZjEy
+        NTkzYiJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
+        IGZhbHNlLCAiaHR0cHMiOiB0cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVf
+        Q29ycG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwifSwgImlkIjog
+        IkZlZG9yYV8xNyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3Rl
+        cyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3Jl
+        bW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25z
+        IjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiRmVkb3Jh
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTAzLTI3VDE4OjMzOjU1WiIs
+        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
+        Ny9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBv
+        cnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
+        bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGws
+        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIx
+        MmRiMjg0ZTU5YmYxMjU5MzcifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
+        Oi8vbXlyZXBvLmNvbSIsICJzc2xfdmFsaWRhdGlvbiI6IHRydWUsICJyZW1v
+        dmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9wb2xpY3kiOiAib25fZGVt
+        YW5kIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0sICJsb2NhbGx5X3N0b3Jl
+        ZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQiOiAiNWM5YmMyMTJkYjI4NGU1
+        OWJmMTI1OTM2In0sICJ0b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMCwgImlk
+        IjogIkZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3Np
+        dG9yaWVzL0ZlZG9yYV8xNy8ifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:55 GMT
+- request:
+    method: delete
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:55 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzk5NTI0NGJiLTc5ZmEtNGIxOS1hNzRhLTUwNzdmZGU4YjRlYi8iLCAi
+        dGFza19pZCI6ICI5OTUyNDRiYi03OWZhLTRiMTktYTc0YS01MDc3ZmRlOGI0
+        ZWIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:55 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/995244bb-79fa-4b19-a74a-5077fde8b4eb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:55 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"b5c8627078cb7f86138df291e477dfa9-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '542'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85OTUyNDRiYi03OWZhLTRiMTktYTc0YS01MDc3ZmRlOGI0
+        ZWIvIiwgInRhc2tfaWQiOiAiOTk1MjQ0YmItNzlmYS00YjE5LWE3NGEtNTA3
+        N2ZkZThiNGViIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICIiLCAic3RhdGUiOiAid2Fp
+        dGluZyIsICJ3b3JrZXJfbmFtZSI6IG51bGwsICJyZXN1bHQiOiBudWxsLCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjEzZmI2ZTk1
+        YjQ5YmZjY2Y5MSJ9LCAiaWQiOiAiNWM5YmMyMTNmYjZlOTViNDliZmNjZjkx
+        In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:55 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/995244bb-79fa-4b19-a74a-5077fde8b4eb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:55 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"0b987758d44b91eb48ced33f2b22651d-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '668'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85OTUyNDRiYi03OWZhLTRiMTktYTc0YS01MDc3ZmRlOGI0
+        ZWIvIiwgInRhc2tfaWQiOiAiOTk1MjQ0YmItNzlmYS00YjE5LWE3NGEtNTA3
+        N2ZkZThiNGViIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5
+        LTAzLTI3VDE4OjMzOjU1WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5l
+        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0
+        ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjEzZmI2ZTk1YjQ5YmZjY2Y5
+        MSJ9LCAiaWQiOiAiNWM5YmMyMTNmYjZlOTViNDliZmNjZjkxIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:55 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/995244bb-79fa-4b19-a74a-5077fde8b4eb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:55 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"5a83829d939508264022a617fbf54d09-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '687'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85OTUyNDRiYi03OWZhLTRiMTktYTc0YS01MDc3ZmRlOGI0
+        ZWIvIiwgInRhc2tfaWQiOiAiOTk1MjQ0YmItNzlmYS00YjE5LWE3NGEtNTA3
+        N2ZkZThiNGViIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE5LTAzLTI3VDE4OjMzOjU1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU1WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Yzli
+        YzIxM2ZiNmU5NWI0OWJmY2NmOTEifSwgImlkIjogIjVjOWJjMjEzZmI2ZTk1
+        YjQ5YmZjY2Y5MSJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:55 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/copy_no_filters.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/copy_no_filters.yml
@@ -24493,98 +24493,6 @@ http_interactions:
   recorded_at: Tue, 19 Mar 2019 17:58:07 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 17:58:08 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"c9a3bf34ffc1628b45c93da1d73d5184-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2474'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJzY3JhdGNocGFkIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiJ9LCAi
-        ZGlzcGxheV9uYW1lIjogIkZlZG9yYSAxNyB4ODZfNjQiLCAiZGVzY3JpcHRp
-        b24iOiBudWxsLCAiZGlzdHJpYnV0b3JzIjogW3sicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDMtMTlUMTc6NTg6MDNa
-        IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvRmVkb3Jh
-        XzE3L2Rpc3RyaWJ1dG9ycy9leHBvcnRfZGlzdHJpYnV0b3IvIiwgImxhc3Rf
-        b3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAi
-        ZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJleHBvcnRfZGlzdHJpYnV0b3IiLCAi
-        YXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFkIjoge30sICJfbnMi
-        OiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVjOTEy
-        ZGFiZGIyODRlMDk0Mzk1NzAwNiJ9LCAiY29uZmlnIjogeyJodHRwIjogZmFs
-        c2UsICJyZWxhdGl2ZV91cmwiOiAiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5
-        L2ZlZG9yYV8xN19sYWJlbCIsICJodHRwcyI6IGZhbHNlfSwgImlkIjogImV4
-        cG9ydF9kaXN0cmlidXRvciJ9LCB7InJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        Imxhc3RfdXBkYXRlZCI6ICIyMDE5LTAzLTE5VDE3OjU4OjAzWiIsICJfaHJl
-        ZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy9kaXN0
-        cmlidXRvcnMvRmVkb3JhXzE3X2Nsb25lLyIsICJsYXN0X292ZXJyaWRlX2Nv
-        bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
-        X3R5cGVfaWQiOiAieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVi
-        bGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9f
-        ZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1YzkxMmRhYmRiMjg0
-        ZTA5NDM5NTcwMDUifSwgImNvbmZpZyI6IHsiZGVzdGluYXRpb25fZGlzdHJp
-        YnV0b3JfaWQiOiAiRmVkb3JhXzE3In0sICJpZCI6ICJGZWRvcmFfMTdfY2xv
-        bmUifSwgeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQi
-        OiAiMjAxOS0wMy0xOVQxNzo1ODowM1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
-        L3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL0ZlZG9y
-        YV8xNy8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVi
-        bGlzaCI6ICIyMDE5LTAzLTE5VDE3OjU4OjAzWiIsICJkaXN0cmlidXRvcl90
-        eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0
-        cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0
-        b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1YzkxMmRhYmRiMjg0ZTA5NDM5NTcw
-        MDQifSwgImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBm
-        YWxzZSwgImh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0Nv
-        cnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIn0sICJpZCI6ICJG
-        ZWRvcmFfMTcifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAxOS0wMy0xOVQx
-        Nzo1ODowM1oiLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7InBhY2thZ2VfZ3JvdXAiOiAyLCAiZGlzdHJpYnV0aW9uIjog
-        MSwgInBhY2thZ2VfY2F0ZWdvcnkiOiAxLCAicnBtIjogOCwgImVycmF0dW0i
-        OiAzfSwgIl9ucyI6ICJyZXBvcyIsICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lk
-        IjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wMy0xOVQx
-        Nzo1ODowM1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
-        cy9GZWRvcmFfMTcvaW1wb3J0ZXJzL3l1bV9pbXBvcnRlci8iLCAiX25zIjog
-        InJlcG9faW1wb3J0ZXJzIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2lt
-        cG9ydGVyIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3N5
-        bmMiOiAiMjAxOS0wMy0xOVQxNzo1ODowM1oiLCAic2NyYXRjaHBhZCI6IHsi
-        cmVwb21kX3JldmlzaW9uIjogMTMyMTg5MzgwMH0sICJfaWQiOiB7IiRvaWQi
-        OiAiNWM5MTJkYWJkYjI4NGUwOTQzOTU3MDAzIn0sICJjb25maWciOiB7ImZl
-        ZWQiOiAiZmlsZTovLy92YXIvd3d3L3Rlc3RfcmVwb3Mvem9vIiwgInNzbF92
-        YWxpZGF0aW9uIjogdHJ1ZSwgInJlbW92ZV9taXNzaW5nIjogdHJ1ZSwgImRv
-        d25sb2FkX3BvbGljeSI6ICJvbl9kZW1hbmQifSwgImlkIjogInl1bV9pbXBv
-        cnRlciJ9XSwgImxvY2FsbHlfc3RvcmVkX3VuaXRzIjogMTQsICJfaWQiOiB7
-        IiRvaWQiOiAiNWM5MTJkYWJkYjI4NGUwOTQzOTU3MDAyIn0sICJ0b3RhbF9y
-        ZXBvc2l0b3J5X3VuaXRzIjogMTUsICJpZCI6ICJGZWRvcmFfMTciLCAiX2hy
-        ZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvIn0=
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 17:58:08 GMT
-- request:
-    method: get
     uri: https://theta.partello.example.com/pulp/api/v2/tasks/154a058b-4d1f-4f39-9fe7-6f6266de0a70/
     body:
       encoding: US-ASCII
@@ -24897,158 +24805,6 @@ http_interactions:
         OGMwZTUzN2IifQ==
     http_version: 
   recorded_at: Tue, 19 Mar 2019 17:58:08 GMT
-- request:
-    method: delete
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:30 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '404'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
-        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
-        OiByZXBvc2l0b3J5PUZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
-        djIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8iLCAiaHR0cF9zdGF0dXMiOiA0
-        MDQsICJlcnJvciI6IHsiY29kZSI6ICJQTFAwMDA5IiwgImRhdGEiOiB7InJl
-        c291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0sICJkZXNj
-        cmlwdGlvbiI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PUZl
-        ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
-        bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:30 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImRvd25sb2FkX3BvbGljeSI6Im9uX2RlbWFuZCIs
-        InJlbW92ZV9taXNzaW5nIjp0cnVlLCJmZWVkIjoiZmlsZTovLy92YXIvd3d3
-        L3Rlc3RfcmVwb3Mvem9vIiwidHlwZV9za2lwX2xpc3QiOm51bGwsInByb3h5
-        X2hvc3QiOm51bGwsImJhc2ljX2F1dGhfdXNlcm5hbWUiOm51bGwsImJhc2lj
-        X2F1dGhfcGFzc3dvcmQiOm51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJz
-        c2xfY2xpZW50X2NlcnQiOm51bGwsInNzbF9jbGllbnRfa2V5IjpudWxsLCJz
-        c2xfY2FfY2VydCI6bnVsbH0sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJycG0t
-        cmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQi
-        OiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsicmVs
-        YXRpdmVfdXJsIjoiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5L2ZlZG9yYV8x
-        N19sYWJlbCIsImh0dHAiOmZhbHNlLCJodHRwcyI6dHJ1ZSwicHJvdGVjdGVk
-        Ijp0cnVlLCJjaGVja3N1bV90eXBlIjpudWxsfSwiYXV0b19wdWJsaXNoIjp0
-        cnVlLCJkaXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xNyJ9LHsiZGlzdHJpYnV0
-        b3JfdHlwZV9pZCI6Inl1bV9jbG9uZV9kaXN0cmlidXRvciIsImRpc3RyaWJ1
-        dG9yX2NvbmZpZyI6eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6IkZl
-        ZG9yYV8xNyJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRvcl9p
-        ZCI6IkZlZG9yYV8xN19jbG9uZSJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9pZCI6
-        ImV4cG9ydF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJo
-        dHRwIjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxhdGl2ZV91cmwiOiJBQ01F
-        X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIn0sImF1dG9f
-        cHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3Ry
-        aWJ1dG9yIn1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1045'
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:30 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '320'
-      Location:
-      - "/pulp/api/v2/repositories/Fedora_17/"
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWM5MTMxYzJkYjI4NGUwOTQzOTU3MDBlIn0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:30 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
-        Ijp0cnVlfX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '53'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:30 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2NiYmMxY2Y3LTBlNWUtNGVmYS1hYTg5LTVkZDRkOGUyNWVhYy8iLCAi
-        dGFza19pZCI6ICJjYmJjMWNmNy0wZTVlLTRlZmEtYWE4OS01ZGQ0ZDhlMjVl
-        YWMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:30 GMT
 - request:
     method: get
     uri: https://theta.partello.example.com/pulp/api/v2/tasks/cbbc1cf7-0e5e-4efa-aa89-5dd4d8e25eac/
@@ -27110,400 +26866,6 @@ http_interactions:
     http_version: 
   recorded_at: Tue, 19 Mar 2019 18:15:30 GMT
 - request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IjNfdmlldzEiLCJkaXNwbGF5X25hbWUiOiJGZWRvcmEgMTcgeDg2
-        XzY0IiwiaW1wb3J0ZXJfdHlwZV9pZCI6Inl1bV9pbXBvcnRlciIsImltcG9y
-        dGVyX2NvbmZpZyI6e30sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJycG0tcmVw
-        byJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5
-        dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsicmVsYXRp
-        dmVfdXJsIjoiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5L0xpYnJhcnlWaWV3
-        L2ZlZG9yYV8xN19sYWJlbCIsImh0dHAiOmZhbHNlLCJodHRwcyI6dHJ1ZSwi
-        cHJvdGVjdGVkIjp0cnVlLCJjaGVja3N1bV90eXBlIjpudWxsfSwiYXV0b19w
-        dWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9pZCI6IjNfdmlldzEifSx7ImRp
-        c3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1fY2xvbmVfZGlzdHJpYnV0b3IiLCJk
-        aXN0cmlidXRvcl9jb25maWciOnsiZGVzdGluYXRpb25fZGlzdHJpYnV0b3Jf
-        aWQiOiIzX3ZpZXcxIn0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
-        dG9yX2lkIjoiM192aWV3MV9jbG9uZSJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9p
-        ZCI6ImV4cG9ydF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6
-        eyJodHRwIjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxhdGl2ZV91cmwiOiJB
-        Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvTGlicmFyeVZpZXcvZmVkb3JhXzE3
-        X2xhYmVsIn0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lk
-        IjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '790'
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:30 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '316'
-      Location:
-      - "/pulp/api/v2/repositories/3_view1/"
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWM5MTMxYzJkYjI4NGUwOTQxZGEwYjE2In0sICJpZCI6ICIzX3ZpZXcxIiwg
-        Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS8i
-        fQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:30 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbInJwbSJdLCJmaWx0ZXJzIjp7fSwiZmllbGRzIjp7InVuaXQi
-        OlsibmFtZSIsImVwb2NoIiwidmVyc2lvbiIsInJlbGVhc2UiLCJhcmNoIiwi
-        Y2hlY2tzdW10eXBlIiwiY2hlY2tzdW0iXX19fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '163'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:30 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzcwNDQ0Y2UzLTM2YmQtNGUzMS04YTE4LTg0MjE5YTQ4NzhjNS8iLCAi
-        dGFza19pZCI6ICI3MDQ0NGNlMy0zNmJkLTRlMzEtOGExOC04NDIxOWE0ODc4
-        YzUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:30 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbInNycG0iXSwiZmlsdGVycyI6e319fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '76'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:30 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2MwMzdjNTRhLTkzZmMtNGExOS1hODkwLTQ0MzIzMjU5MjJlOC8iLCAi
-        dGFza19pZCI6ICJjMDM3YzU0YS05M2ZjLTRhMTktYTg5MC00NDMyMzI1OTIy
-        ZTgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:30 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbImVycmF0dW0iXSwiZmlsdGVycyI6e319fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '79'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:30 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2E2MGEyYjY4LWVmNmUtNGNhZS1iMjFhLTE4NTFmNjIwZTVhOC8iLCAi
-        dGFza19pZCI6ICJhNjBhMmI2OC1lZjZlLTRjYWUtYjIxYS0xODUxZjYyMGU1
-        YTgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:30 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbInBhY2thZ2VfZ3JvdXAiXSwiZmlsdGVycyI6e319fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '85'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:30 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzRlODZkYWU0LWMyYWYtNGJmYy05NTFmLTNhNTgwOTM2OTZhZi8iLCAi
-        dGFza19pZCI6ICI0ZTg2ZGFlNC1jMmFmLTRiZmMtOTUxZi0zYTU4MDkzNjk2
-        YWYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:30 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiXSwiZmlsdGVycyI6
-        e319fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '94'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:30 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzYxZGM1OGQ2LTQxMTQtNDUzNi04NjdkLTM2NDhhOTFlZjlmNS8iLCAi
-        dGFza19pZCI6ICI2MWRjNThkNi00MTE0LTQ1MzYtODY3ZC0zNjQ4YTkxZWY5
-        ZjUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:30 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbImRpc3RyaWJ1dGlvbiJdLCJmaWx0ZXJzIjp7fX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '84'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:31 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzQ5NWZhZDkwLTUxOGItNDFiMi04MmM1LWM2NjA0ZGEwYjQ2NC8iLCAi
-        dGFza19pZCI6ICI0OTVmYWQ5MC01MThiLTQxYjItODJjNS1jNjYwNGRhMGI0
-        NjQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:31 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbIm1vZHVsZW1kIl0sImZpbHRlcnMiOnt9fX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '80'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:31 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2NkY2Y1Nzk5LTJmNzEtNDNiYi04ZTZjLTU3ZTIyNTY5MTlhZi8iLCAi
-        dGFza19pZCI6ICJjZGNmNTc5OS0yZjcxLTQzYmItOGU2Yy01N2UyMjU2OTE5
-        YWYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:31 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbIm1vZHVsZW1kX2RlZmF1bHRzIl0sImZpbHRlcnMiOnt9fX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '89'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:31 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzcyNGNlNzU2LWNhMjctNGM2NS1iOWQ0LTMzOGRmZmYxODNkNS8iLCAi
-        dGFza19pZCI6ICI3MjRjZTc1Ni1jYTI3LTRjNjUtYjlkNC0zMzhkZmZmMTgz
-        ZDUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:31 GMT
-- request:
     method: get
     uri: https://theta.partello.example.com/pulp/api/v2/tasks/70444ce3-36bd-4e31-8a18-84219a4878c5/
     body:
@@ -28594,130 +27956,6 @@ http_interactions:
   recorded_at: Tue, 19 Mar 2019 18:15:35 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:35 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"ddc38c87d955cb2aff18eb85f90ffa5c-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2237'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
-        OiBbeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MTktMDMtMTlUMTg6MTU6MzBaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
-        ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3Ry
-        aWJ1dG9yLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9w
-        dWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0
-        X2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRj
-        aHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6
-        IHsiJG9pZCI6ICI1YzkxMzFjMmRiMjg0ZTA5NDFkYTBiMWEifSwgImNvbmZp
-        ZyI6IHsiaHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29y
-        cG9yYXRpb24vbGlicmFyeS9MaWJyYXJ5Vmlldy9mZWRvcmFfMTdfbGFiZWwi
-        LCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6ICJleHBvcnRfZGlzdHJpYnV0b3Ii
-        fSwgeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MTktMDMtMTlUMTg6MTU6MzBaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
-        ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvM192aWV3MV9jbG9u
-        ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
-        aCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9jbG9uZV9k
-        aXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hw
-        YWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7
-        IiRvaWQiOiAiNWM5MTMxYzJkYjI4NGUwOTQxZGEwYjE5In0sICJjb25maWci
-        OiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogIjNfdmlldzEifSwg
-        ImlkIjogIjNfdmlldzFfY2xvbmUifSwgeyJyZXBvX2lkIjogIjNfdmlldzEi
-        LCAibGFzdF91cGRhdGVkIjogIjIwMTktMDMtMTlUMTg6MTU6MzBaIiwgIl9o
-        cmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0
-        cmlidXRvcnMvM192aWV3MS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7
-        fSwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lk
-        IjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAi
-        c2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwg
-        Il9pZCI6IHsiJG9pZCI6ICI1YzkxMzFjMmRiMjg0ZTA5NDFkYTBiMTgifSwg
-        ImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwg
-        Imh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0NvcnBvcmF0
-        aW9uL2xpYnJhcnkvTGlicmFyeVZpZXcvZmVkb3JhXzE3X2xhYmVsIn0sICJp
-        ZCI6ICIzX3ZpZXcxIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIwMTktMDMt
-        MTlUMTg6MTU6MzFaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
-        ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
-        aXRfY291bnRzIjogeyJwYWNrYWdlX2dyb3VwIjogMiwgImRpc3RyaWJ1dGlv
-        biI6IDEsICJycG0iOiA4LCAiZXJyYXR1bSI6IDN9LCAiX25zIjogInJlcG9z
-        IiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiM192aWV3MSIsICJsYXN0
-        X3VwZGF0ZWQiOiAiMjAxOS0wMy0xOVQxODoxNTozMFoiLCAiX2hyZWYiOiAi
-        L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy8zX3ZpZXcxL2ltcG9ydGVycy95
-        dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJsYXN0X292ZXJyaWRl
-        X2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjogbnVsbCwgInNjcmF0Y2hwYWQi
-        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOTEzMWMyZGIyODRlMDk0MWRh
-        MGIxNyJ9LCAiY29uZmlnIjoge30sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0s
-        ICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDEzLCAiX2lkIjogeyIkb2lkIjog
-        IjVjOTEzMWMyZGIyODRlMDk0MWRhMGIxNiJ9LCAidG90YWxfcmVwb3NpdG9y
-        eV91bml0cyI6IDE0LCAiaWQiOiAiM192aWV3MSIsICJfaHJlZiI6ICIvcHVs
-        cC9hcGkvdjIvcmVwb3NpdG9yaWVzLzNfdmlldzEvIn0=
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:35 GMT
-- request:
-    method: delete
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:35 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzYxNGRlNmIyLWQ1MjItNGQ1MC04YjVjLWNlNWE1MTZiNTJiMS8iLCAi
-        dGFza19pZCI6ICI2MTRkZTZiMi1kNTIyLTRkNTAtOGI1Yy1jZTVhNTE2YjUy
-        YjEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:35 GMT
-- request:
-    method: get
     uri: https://theta.partello.example.com/pulp/api/v2/tasks/614de6b2-d522-4d50-8b5c-ce5a516b52b1/
     body:
       encoding: US-ASCII
@@ -28871,43 +28109,6 @@ http_interactions:
         IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Yzkx
         MzFjN2Y3NDdlNjNjOGMwZTZlYjIifSwgImlkIjogIjVjOTEzMWM3Zjc0N2U2
         M2M4YzBlNmViMiJ9
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:35 GMT
-- request:
-    method: delete
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:35 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzg3NmYyYTdiLTBlNmEtNDEwOS1hMWZlLWE5ZjEyODJjZGNmMS8iLCAi
-        dGFza19pZCI6ICI4NzZmMmE3Yi0wZTZhLTQxMDktYTFmZS1hOWYxMjgyY2Rj
-        ZjEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
   recorded_at: Tue, 19 Mar 2019 18:15:35 GMT
 - request:
@@ -29067,4 +28268,4180 @@ http_interactions:
         OGMwZTZmMDAifQ==
     http_version: 
   recorded_at: Tue, 19 Mar 2019 18:15:36 GMT
+- request:
+    method: delete
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:12 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '404'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
+        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
+        OiByZXBvc2l0b3J5PUZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
+        djIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8iLCAiaHR0cF9zdGF0dXMiOiA0
+        MDQsICJlcnJvciI6IHsiY29kZSI6ICJQTFAwMDA5IiwgImRhdGEiOiB7InJl
+        c291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0sICJkZXNj
+        cmlwdGlvbiI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PUZl
+        ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
+        bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:12 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
+        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
+        b3J0ZXJfY29uZmlnIjp7ImRvd25sb2FkX3BvbGljeSI6Im9uX2RlbWFuZCIs
+        InJlbW92ZV9taXNzaW5nIjp0cnVlLCJmZWVkIjoiZmlsZTovLy92YXIvd3d3
+        L3Rlc3RfcmVwb3Mvem9vIiwidHlwZV9za2lwX2xpc3QiOm51bGwsInByb3h5
+        X2hvc3QiOm51bGwsImJhc2ljX2F1dGhfdXNlcm5hbWUiOm51bGwsImJhc2lj
+        X2F1dGhfcGFzc3dvcmQiOm51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJz
+        c2xfY2xpZW50X2NlcnQiOm51bGwsInNzbF9jbGllbnRfa2V5IjpudWxsLCJz
+        c2xfY2FfY2VydCI6bnVsbH0sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJycG0t
+        cmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQi
+        OiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsicmVs
+        YXRpdmVfdXJsIjoiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5L2ZlZG9yYV8x
+        N19sYWJlbCIsImh0dHAiOmZhbHNlLCJodHRwcyI6dHJ1ZSwicHJvdGVjdGVk
+        Ijp0cnVlLCJjaGVja3N1bV90eXBlIjpudWxsfSwiYXV0b19wdWJsaXNoIjp0
+        cnVlLCJkaXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xNyJ9LHsiZGlzdHJpYnV0
+        b3JfdHlwZV9pZCI6Inl1bV9jbG9uZV9kaXN0cmlidXRvciIsImRpc3RyaWJ1
+        dG9yX2NvbmZpZyI6eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6IkZl
+        ZG9yYV8xNyJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRvcl9p
+        ZCI6IkZlZG9yYV8xN19jbG9uZSJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9pZCI6
+        ImV4cG9ydF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJo
+        dHRwIjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxhdGl2ZV91cmwiOiJBQ01F
+        X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIn0sImF1dG9f
+        cHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3Ry
+        aWJ1dG9yIn1dfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1045'
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:12 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '320'
+      Location:
+      - "/pulp/api/v2/repositories/Fedora_17/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
+        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWM5YmMyMjRkYjI4NGU1OWJmMTI1OTQ3In0sICJpZCI6ICJGZWRvcmFfMTci
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
+        MTcvIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:12 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
+        Ijp0cnVlfX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '53'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:12 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzE0ZTlhY2JhLTVhOGItNDdkYi1hOTYzLTdlOGY2MmJmNzkxMS8iLCAi
+        dGFza19pZCI6ICIxNGU5YWNiYS01YThiLTQ3ZGItYTk2My03ZThmNjJiZjc5
+        MTEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:12 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14e9acba-5a8b-47db-a963-7e8f62bf7911/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:12 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"9e77c3ac0c0ed21a3fa0144508274332-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '540'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xNGU5YWNiYS01YThiLTQ3ZGItYTk2My03ZThmNjJiZjc5
+        MTEvIiwgInRhc2tfaWQiOiAiMTRlOWFjYmEtNWE4Yi00N2RiLWE5NjMtN2U4
+        ZjYyYmY3OTExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiIiwgInN0YXRlIjogIndhaXRp
+        bmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIyNGZiNmU5NWI0
+        OWJmY2RhYTEifSwgImlkIjogIjVjOWJjMjI0ZmI2ZTk1YjQ5YmZjZGFhMSJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:12 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14e9acba-5a8b-47db-a963-7e8f62bf7911/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:12 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"a711d87cf1495d3436d8757dcb8fa092-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1175'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xNGU5YWNiYS01YThiLTQ3ZGItYTk2My03ZThmNjJiZjc5
+        MTEvIiwgInRhc2tfaWQiOiAiMTRlOWFjYmEtNWE4Yi00N2RiLWE5NjMtN2U4
+        ZjYyYmY3OTExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDoxMloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiTk9UX1NU
+        QVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJJTl9QUk9HUkVTUyJ9
+        fX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0
+        YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjI0ZmI2
+        ZTk1YjQ5YmZjZGFhMSJ9LCAiaWQiOiAiNWM5YmMyMjRmYjZlOTViNDliZmNk
+        YWExIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:12 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14e9acba-5a8b-47db-a963-7e8f62bf7911/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:12 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"359fe505062e458b201f8443394c8698-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xNGU5YWNiYS01YThiLTQ3ZGItYTk2My03ZThmNjJiZjc5
+        MTEvIiwgInRhc2tfaWQiOiAiMTRlOWFjYmEtNWE4Yi00N2RiLWE5NjMtN2U4
+        ZjYyYmY3OTExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDoxMloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
+        Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiTk9UX1NU
+        QVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5w
+        YXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0
+        aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjI0ZmI2ZTk1
+        YjQ5YmZjZGFhMSJ9LCAiaWQiOiAiNWM5YmMyMjRmYjZlOTViNDliZmNkYWEx
+        In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:12 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14e9acba-5a8b-47db-a963-7e8f62bf7911/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:12 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"359fe505062e458b201f8443394c8698-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xNGU5YWNiYS01YThiLTQ3ZGItYTk2My03ZThmNjJiZjc5
+        MTEvIiwgInRhc2tfaWQiOiAiMTRlOWFjYmEtNWE4Yi00N2RiLWE5NjMtN2U4
+        ZjYyYmY3OTExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDoxMloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
+        Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiTk9UX1NU
+        QVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5w
+        YXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0
+        aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjI0ZmI2ZTk1
+        YjQ5YmZjZGFhMSJ9LCAiaWQiOiAiNWM5YmMyMjRmYjZlOTViNDliZmNkYWEx
+        In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:12 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14e9acba-5a8b-47db-a963-7e8f62bf7911/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:12 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"359fe505062e458b201f8443394c8698-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xNGU5YWNiYS01YThiLTQ3ZGItYTk2My03ZThmNjJiZjc5
+        MTEvIiwgInRhc2tfaWQiOiAiMTRlOWFjYmEtNWE4Yi00N2RiLWE5NjMtN2U4
+        ZjYyYmY3OTExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDoxMloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
+        Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiTk9UX1NU
+        QVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5w
+        YXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0
+        aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjI0ZmI2ZTk1
+        YjQ5YmZjZGFhMSJ9LCAiaWQiOiAiNWM5YmMyMjRmYjZlOTViNDliZmNkYWEx
+        In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:12 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14e9acba-5a8b-47db-a963-7e8f62bf7911/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:12 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"359fe505062e458b201f8443394c8698-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xNGU5YWNiYS01YThiLTQ3ZGItYTk2My03ZThmNjJiZjc5
+        MTEvIiwgInRhc2tfaWQiOiAiMTRlOWFjYmEtNWE4Yi00N2RiLWE5NjMtN2U4
+        ZjYyYmY3OTExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDoxMloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
+        Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiTk9UX1NU
+        QVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5w
+        YXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0
+        aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjI0ZmI2ZTk1
+        YjQ5YmZjZGFhMSJ9LCAiaWQiOiAiNWM5YmMyMjRmYjZlOTViNDliZmNkYWEx
+        In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:12 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14e9acba-5a8b-47db-a963-7e8f62bf7911/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:12 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"fdbcad7555c50a0298360b3b74397fc9-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1169'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xNGU5YWNiYS01YThiLTQ3ZGItYTk2My03ZThmNjJiZjc5
+        MTEvIiwgInRhc2tfaWQiOiAiMTRlOWFjYmEtNWE4Yi00N2RiLWE5NjMtN2U4
+        ZjYyYmY3OTExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDoxMloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        Tk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        Tk9UX1NUQVJURUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiTk9UX1NUQVJU
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJx
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0
+        ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0
+        YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjI0ZmI2ZTk1YjQ5
+        YmZjZGFhMSJ9LCAiaWQiOiAiNWM5YmMyMjRmYjZlOTViNDliZmNkYWExIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:12 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14e9acba-5a8b-47db-a963-7e8f62bf7911/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:12 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"662a3e88ea7073e5d414d475fccbac6f-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1163'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xNGU5YWNiYS01YThiLTQ3ZGItYTk2My03ZThmNjJiZjc5
+        MTEvIiwgInRhc2tfaWQiOiAiMTRlOWFjYmEtNWE4Yi00N2RiLWE5NjMtN2U4
+        ZjYyYmY3OTExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDoxMloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        Tk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiSU5fUFJPR1JFU1MifSwg
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5l
+        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0
+        ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjI0ZmI2ZTk1YjQ5YmZjZGFh
+        MSJ9LCAiaWQiOiAiNWM5YmMyMjRmYjZlOTViNDliZmNkYWExIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:12 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14e9acba-5a8b-47db-a963-7e8f62bf7911/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:12 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"662a3e88ea7073e5d414d475fccbac6f-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1163'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xNGU5YWNiYS01YThiLTQ3ZGItYTk2My03ZThmNjJiZjc5
+        MTEvIiwgInRhc2tfaWQiOiAiMTRlOWFjYmEtNWE4Yi00N2RiLWE5NjMtN2U4
+        ZjYyYmY3OTExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDoxMloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        Tk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiSU5fUFJPR1JFU1MifSwg
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5l
+        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0
+        ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjI0ZmI2ZTk1YjQ5YmZjZGFh
+        MSJ9LCAiaWQiOiAiNWM5YmMyMjRmYjZlOTViNDliZmNkYWExIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:12 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14e9acba-5a8b-47db-a963-7e8f62bf7911/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:12 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"78e25435f7f89b489bb67cacd69f262e-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1157'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xNGU5YWNiYS01YThiLTQ3ZGItYTk2My03ZThmNjJiZjc5
+        MTEvIiwgInRhc2tfaWQiOiAiMTRlOWFjYmEtNWE4Yi00N2RiLWE5NjMtN2U4
+        ZjYyYmY3OTExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDoxMloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiSU5f
+        UFJPR1JFU1MifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5l
+        eGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVjOWJjMjI0ZmI2ZTk1YjQ5YmZjZGFhMSJ9LCAi
+        aWQiOiAiNWM5YmMyMjRmYjZlOTViNDliZmNkYWExIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:12 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14e9acba-5a8b-47db-a963-7e8f62bf7911/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:12 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"06a22d403a7bd874b34f074def61524f-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1154'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xNGU5YWNiYS01YThiLTQ3ZGItYTk2My03ZThmNjJiZjc5
+        MTEvIiwgInRhc2tfaWQiOiAiMTRlOWFjYmEtNWE4Yi00N2RiLWE5NjMtN2U4
+        ZjYyYmY3OTExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDoxMloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRl
+        bXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNlcnZl
+        ZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNv
+        bS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFt
+        cGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjVjOWJjMjI0ZmI2ZTk1YjQ5YmZjZGFhMSJ9LCAiaWQi
+        OiAiNWM5YmMyMjRmYjZlOTViNDliZmNkYWExIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:12 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14e9acba-5a8b-47db-a963-7e8f62bf7911/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:12 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"7456dcfd02b4fb0f578086809d741a84-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2403'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xNGU5YWNiYS01YThiLTQ3ZGItYTk2My03ZThmNjJiZjc5
+        MTEvIiwgInRhc2tfaWQiOiAiMTRlOWFjYmEtNWE4Yi00N2RiLWE5NjMtN2U4
+        ZjYyYmY3OTExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        OS0wMy0yN1QxODozNDoxMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozNDoxMloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMTljNzgzNzgtMDc0Ny00OTE5LTlhYTUtOTE3ZDQxOGJj
+        Y2VkLyIsICJ0YXNrX2lkIjogIjE5Yzc4Mzc4LTA3NDctNDkxOS05YWE1LTkx
+        N2Q0MThiY2NlZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjog
+        bnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzdGFydGVkIjogIjIwMTktMDMtMjdUMTg6MzQ6MTJaIiwgIl9ucyI6
+        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wMy0y
+        N1QxODozNDoxMloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJtb2R1
+        bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWM5
+        YmMyMjRkYjI4NGU0YWUyMjExOWVkIiwgImRldGFpbHMiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzaXplX3Rv
+        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
+        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
+        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzliYzIyNGZiNmU5NWI0OWJmY2RhYTEifSwgImlkIjogIjVjOWJjMjI0
+        ZmI2ZTk1YjQ5YmZjZGFhMSJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:12 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/19c78378-0747-4919-9aa5-917d418bcced/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:12 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"20807dc936ee876ed2a81604b5e992cc-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '675'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8xOWM3ODM3OC0wNzQ3LTQ5MTktOWFhNS05MTdk
+        NDE4YmNjZWQvIiwgInRhc2tfaWQiOiAiMTljNzgzNzgtMDc0Ny00OTE5LTlh
+        YTUtOTE3ZDQxOGJjY2VkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxOS0wMy0yN1QxODozNDoxMloiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFy
+        dGVsbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAi
+        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhl
+        dGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIyNGZiNmU5NWI0
+        OWJmY2RjMTIifSwgImlkIjogIjVjOWJjMjI0ZmI2ZTk1YjQ5YmZjZGMxMiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:12 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14e9acba-5a8b-47db-a963-7e8f62bf7911/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:12 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"7456dcfd02b4fb0f578086809d741a84-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2403'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xNGU5YWNiYS01YThiLTQ3ZGItYTk2My03ZThmNjJiZjc5
+        MTEvIiwgInRhc2tfaWQiOiAiMTRlOWFjYmEtNWE4Yi00N2RiLWE5NjMtN2U4
+        ZjYyYmY3OTExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        OS0wMy0yN1QxODozNDoxMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozNDoxMloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMTljNzgzNzgtMDc0Ny00OTE5LTlhYTUtOTE3ZDQxOGJj
+        Y2VkLyIsICJ0YXNrX2lkIjogIjE5Yzc4Mzc4LTA3NDctNDkxOS05YWE1LTkx
+        N2Q0MThiY2NlZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjog
+        bnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzdGFydGVkIjogIjIwMTktMDMtMjdUMTg6MzQ6MTJaIiwgIl9ucyI6
+        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wMy0y
+        N1QxODozNDoxMloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJtb2R1
+        bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWM5
+        YmMyMjRkYjI4NGU0YWUyMjExOWVkIiwgImRldGFpbHMiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzaXplX3Rv
+        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
+        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
+        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzliYzIyNGZiNmU5NWI0OWJmY2RhYTEifSwgImlkIjogIjVjOWJjMjI0
+        ZmI2ZTk1YjQ5YmZjZGFhMSJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:12 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/19c78378-0747-4919-9aa5-917d418bcced/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:12 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"afa7902125d178ec60534fcfd1afee20-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4288'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8xOWM3ODM3OC0wNzQ3LTQ5MTktOWFhNS05MTdk
+        NDE4YmNjZWQvIiwgInRhc2tfaWQiOiAiMTljNzgzNzgtMDc0Ny00OTE5LTlh
+        YTUtOTE3ZDQxOGJjY2VkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxOS0wMy0yN1QxODozNDoxMloiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzZjY2
+        ZjQwOC1lM2FkLTQ1MjgtOGIyMy04ODlkNjNiODRmMGEiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmJiNjNmZDUtODU3
+        ZS00ZmExLWI4OTUtY2ZlZjhhMTE5YzVjIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiMjNlYmQ0M2YtNjBkMC00MjYxLWI0YzgtMDYzZjNhZmFhZmUwIiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
+        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE3NGFkMjE2LTBjYmIt
+        NDY0NS05YmM4LTczNDZjMzZlZWJjOSIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICIwY2FkMWE3Yy01ZjkyLTQ3OTgtYjkzYi1kYjMzY2NkNTkzNzki
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxlcyIsICJzdGVwX3R5cGUi
+        OiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
+        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzOWRlZjBhOC01NzVh
+        LTQ4NTAtYTg3My03ZWQzNzQ4MGY4N2MiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiOWY1OGZhZDItZmY3Ni00ZTYzLWI3YTUtY2Q3MzM0ODk2
+        NDU2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVw
+        X3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODQwMWZj
+        ZTItYjZjNS00NmI4LTg3NTgtODJhNzMxYmZmMGFmIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJD
+        bG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNsb3NlX3Jl
+        cG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2Q3YWQwYWQtOTNi
+        MC00NDUyLWFiM2ItODkwZGNhYmJmZjM1IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
+        aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3Fs
+        aXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjk1ZWM5ZTY4LTUxYTAtNGIwNC05
+        MmIxLTZhNTc5OGZiNTA0YSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJl
+        cG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImJiY2E5MmRhLTU3OWUtNGE0Ny04NjJjLWZh
+        M2Y4NWM2MmY4OCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVz
+        IiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJlMjNjNjk5Yy01OTc4LTQzMTYtYTg5Zi0zYmMxZTQ1OTRjY2IiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6
+        ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNWY3
+        Y2E1Zi0xMmY2LTRiZDctODJlOC02MTQ3MDJhNGVmODYiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
+        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjMyM2E3
+        YTZiLWE3Y2EtNGZjOC05N2IwLTk1ZmU2MGQ0ODA5ZiIsICJudW1fcHJvY2Vz
+        c2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0wQHRoZXRhLnBhcnRlbGxvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6
+        ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0wQHRoZXRhLnBhcnRlbGxvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM5
+        YmMyMjRmYjZlOTViNDliZmNkYzEyIn0sICJpZCI6ICI1YzliYzIyNGZiNmU5
+        NWI0OWJmY2RjMTIifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14e9acba-5a8b-47db-a963-7e8f62bf7911/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"7456dcfd02b4fb0f578086809d741a84-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2403'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xNGU5YWNiYS01YThiLTQ3ZGItYTk2My03ZThmNjJiZjc5
+        MTEvIiwgInRhc2tfaWQiOiAiMTRlOWFjYmEtNWE4Yi00N2RiLWE5NjMtN2U4
+        ZjYyYmY3OTExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        OS0wMy0yN1QxODozNDoxMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozNDoxMloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMTljNzgzNzgtMDc0Ny00OTE5LTlhYTUtOTE3ZDQxOGJj
+        Y2VkLyIsICJ0YXNrX2lkIjogIjE5Yzc4Mzc4LTA3NDctNDkxOS05YWE1LTkx
+        N2Q0MThiY2NlZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjog
+        bnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzdGFydGVkIjogIjIwMTktMDMtMjdUMTg6MzQ6MTJaIiwgIl9ucyI6
+        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wMy0y
+        N1QxODozNDoxMloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJtb2R1
+        bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWM5
+        YmMyMjRkYjI4NGU0YWUyMjExOWVkIiwgImRldGFpbHMiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzaXplX3Rv
+        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
+        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
+        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzliYzIyNGZiNmU5NWI0OWJmY2RhYTEifSwgImlkIjogIjVjOWJjMjI0
+        ZmI2ZTk1YjQ5YmZjZGFhMSJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/19c78378-0747-4919-9aa5-917d418bcced/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"87639524f70cc083704ee28078251f17-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4288'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8xOWM3ODM3OC0wNzQ3LTQ5MTktOWFhNS05MTdk
+        NDE4YmNjZWQvIiwgInRhc2tfaWQiOiAiMTljNzgzNzgtMDc0Ny00OTE5LTlh
+        YTUtOTE3ZDQxOGJjY2VkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxOS0wMy0yN1QxODozNDoxMloiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzZjY2
+        ZjQwOC1lM2FkLTQ1MjgtOGIyMy04ODlkNjNiODRmMGEiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmJiNjNmZDUtODU3
+        ZS00ZmExLWI4OTUtY2ZlZjhhMTE5YzVjIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDcsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiMjNlYmQ0M2YtNjBkMC00MjYxLWI0YzgtMDYzZjNhZmFhZmUwIiwg
+        Im51bV9wcm9jZXNzZWQiOiA3fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
+        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE3NGFkMjE2LTBjYmIt
+        NDY0NS05YmM4LTczNDZjMzZlZWJjOSIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICIwY2FkMWE3Yy01ZjkyLTQ3OTgtYjkzYi1kYjMzY2NkNTkzNzki
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxlcyIsICJzdGVwX3R5cGUi
+        OiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
+        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzOWRlZjBhOC01NzVh
+        LTQ4NTAtYTg3My03ZWQzNzQ4MGY4N2MiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiOWY1OGZhZDItZmY3Ni00ZTYzLWI3YTUtY2Q3MzM0ODk2
+        NDU2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVw
+        X3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODQwMWZj
+        ZTItYjZjNS00NmI4LTg3NTgtODJhNzMxYmZmMGFmIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJD
+        bG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNsb3NlX3Jl
+        cG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2Q3YWQwYWQtOTNi
+        MC00NDUyLWFiM2ItODkwZGNhYmJmZjM1IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
+        aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3Fs
+        aXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjk1ZWM5ZTY4LTUxYTAtNGIwNC05
+        MmIxLTZhNTc5OGZiNTA0YSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJl
+        cG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImJiY2E5MmRhLTU3OWUtNGE0Ny04NjJjLWZh
+        M2Y4NWM2MmY4OCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVz
+        IiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJlMjNjNjk5Yy01OTc4LTQzMTYtYTg5Zi0zYmMxZTQ1OTRjY2IiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6
+        ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNWY3
+        Y2E1Zi0xMmY2LTRiZDctODJlOC02MTQ3MDJhNGVmODYiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
+        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjMyM2E3
+        YTZiLWE3Y2EtNGZjOC05N2IwLTk1ZmU2MGQ0ODA5ZiIsICJudW1fcHJvY2Vz
+        c2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0wQHRoZXRhLnBhcnRlbGxvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6
+        ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0wQHRoZXRhLnBhcnRlbGxvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM5
+        YmMyMjRmYjZlOTViNDliZmNkYzEyIn0sICJpZCI6ICI1YzliYzIyNGZiNmU5
+        NWI0OWJmY2RjMTIifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14e9acba-5a8b-47db-a963-7e8f62bf7911/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"7456dcfd02b4fb0f578086809d741a84-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2403'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xNGU5YWNiYS01YThiLTQ3ZGItYTk2My03ZThmNjJiZjc5
+        MTEvIiwgInRhc2tfaWQiOiAiMTRlOWFjYmEtNWE4Yi00N2RiLWE5NjMtN2U4
+        ZjYyYmY3OTExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        OS0wMy0yN1QxODozNDoxMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozNDoxMloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMTljNzgzNzgtMDc0Ny00OTE5LTlhYTUtOTE3ZDQxOGJj
+        Y2VkLyIsICJ0YXNrX2lkIjogIjE5Yzc4Mzc4LTA3NDctNDkxOS05YWE1LTkx
+        N2Q0MThiY2NlZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjog
+        bnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzdGFydGVkIjogIjIwMTktMDMtMjdUMTg6MzQ6MTJaIiwgIl9ucyI6
+        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wMy0y
+        N1QxODozNDoxMloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJtb2R1
+        bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWM5
+        YmMyMjRkYjI4NGU0YWUyMjExOWVkIiwgImRldGFpbHMiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzaXplX3Rv
+        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
+        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
+        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzliYzIyNGZiNmU5NWI0OWJmY2RhYTEifSwgImlkIjogIjVjOWJjMjI0
+        ZmI2ZTk1YjQ5YmZjZGFhMSJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/19c78378-0747-4919-9aa5-917d418bcced/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"238f1d0ac3cc95c4da084ef2afe68303-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4274'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8xOWM3ODM3OC0wNzQ3LTQ5MTktOWFhNS05MTdk
+        NDE4YmNjZWQvIiwgInRhc2tfaWQiOiAiMTljNzgzNzgtMDc0Ny00OTE5LTlh
+        YTUtOTE3ZDQxOGJjY2VkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxOS0wMy0yN1QxODozNDoxMloiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzZjY2
+        ZjQwOC1lM2FkLTQ1MjgtOGIyMy04ODlkNjNiODRmMGEiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmJiNjNmZDUtODU3
+        ZS00ZmExLWI4OTUtY2ZlZjhhMTE5YzVjIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiMjNlYmQ0M2YtNjBkMC00MjYxLWI0YzgtMDYzZjNhZmFhZmUwIiwgIm51
+        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
+        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTc0YWQyMTYtMGNiYi00NjQ1LTli
+        YzgtNzM0NmMzNmVlYmM5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
+        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBj
+        YWQxYTdjLTVmOTItNDc5OC1iOTNiLWRiMzNjY2Q1OTM3OSIsICJudW1fcHJv
+        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1bGVz
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiMzlkZWYwYTgtNTc1YS00ODUwLWE4NzMtN2Vk
+        Mzc0ODBmODdjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUi
+        LCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0
+        YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjlm
+        NThmYWQyLWZmNzYtNGU2My1iN2E1LWNkNzMzNDg5NjQ1NiIsICJudW1fcHJv
+        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFk
+        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjg0MDFmY2UyLWI2YzUtNDZiOC04
+        NzU4LTgyYTczMWJmZjBhZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjNkN2FkMGFkLTkzYjAtNDQ1Mi1hYjNiLTg5
+        MGRjYWJiZmYzNSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI5NWVjOWU2OC01MWEwLTRiMDQtOTJiMS02YTU3OThmYjUw
+        NGEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVw
+        X3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJiYmNhOTJkYS01NzllLTRhNDctODYyYy1mYTNmODVjNjJmODgiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUi
+        OiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTIzYzY5OWMtNTk3
+        OC00MzE2LWE4OWYtM2JjMWU0NTk0Y2NiIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJl
+        Y3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDVmN2NhNWYtMTJmNi00YmQ3
+        LTgyZTgtNjE0NzAyYTRlZjg2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3Rp
+        bmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRh
+        ZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzMjNhN2E2Yi1hN2NhLTRmYzgt
+        OTdiMC05NWZlNjBkNDgwOWYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJx
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0
+        ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0
+        YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjI0ZmI2ZTk1YjQ5
+        YmZjZGMxMiJ9LCAiaWQiOiAiNWM5YmMyMjRmYjZlOTViNDliZmNkYzEyIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14e9acba-5a8b-47db-a963-7e8f62bf7911/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"7456dcfd02b4fb0f578086809d741a84-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2403'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xNGU5YWNiYS01YThiLTQ3ZGItYTk2My03ZThmNjJiZjc5
+        MTEvIiwgInRhc2tfaWQiOiAiMTRlOWFjYmEtNWE4Yi00N2RiLWE5NjMtN2U4
+        ZjYyYmY3OTExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        OS0wMy0yN1QxODozNDoxMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozNDoxMloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMTljNzgzNzgtMDc0Ny00OTE5LTlhYTUtOTE3ZDQxOGJj
+        Y2VkLyIsICJ0YXNrX2lkIjogIjE5Yzc4Mzc4LTA3NDctNDkxOS05YWE1LTkx
+        N2Q0MThiY2NlZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjog
+        bnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzdGFydGVkIjogIjIwMTktMDMtMjdUMTg6MzQ6MTJaIiwgIl9ucyI6
+        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wMy0y
+        N1QxODozNDoxMloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJtb2R1
+        bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWM5
+        YmMyMjRkYjI4NGU0YWUyMjExOWVkIiwgImRldGFpbHMiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzaXplX3Rv
+        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
+        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
+        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzliYzIyNGZiNmU5NWI0OWJmY2RhYTEifSwgImlkIjogIjVjOWJjMjI0
+        ZmI2ZTk1YjQ5YmZjZGFhMSJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/19c78378-0747-4919-9aa5-917d418bcced/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"4e55aab2b430ac1730a1db4a9ab04b5b-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4251'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8xOWM3ODM3OC0wNzQ3LTQ5MTktOWFhNS05MTdk
+        NDE4YmNjZWQvIiwgInRhc2tfaWQiOiAiMTljNzgzNzgtMDc0Ny00OTE5LTlh
+        YTUtOTE3ZDQxOGJjY2VkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxOS0wMy0yN1QxODozNDoxMloiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzZjY2
+        ZjQwOC1lM2FkLTQ1MjgtOGIyMy04ODlkNjNiODRmMGEiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmJiNjNmZDUtODU3
+        ZS00ZmExLWI4OTUtY2ZlZjhhMTE5YzVjIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiMjNlYmQ0M2YtNjBkMC00MjYxLWI0YzgtMDYzZjNhZmFhZmUwIiwgIm51
+        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
+        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTc0YWQyMTYtMGNiYi00NjQ1LTli
+        YzgtNzM0NmMzNmVlYmM5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
+        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBj
+        YWQxYTdjLTVmOTItNDc5OC1iOTNiLWRiMzNjY2Q1OTM3OSIsICJudW1fcHJv
+        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1bGVz
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiMzlkZWYwYTgtNTc1YS00ODUwLWE4NzMtN2Vk
+        Mzc0ODBmODdjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUi
+        LCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjlmNThm
+        YWQyLWZmNzYtNGU2My1iN2E1LWNkNzMzNDg5NjQ1NiIsICJudW1fcHJvY2Vz
+        c2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        UHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjg0MDFmY2UyLWI2YzUtNDZiOC04NzU4LTgy
+        YTczMWJmZjBhZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
+        IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjNkN2FkMGFkLTkzYjAtNDQ1Mi1hYjNiLTg5MGRjYWJiZmYz
+        NSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
+        ZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjk1
+        ZWM5ZTY4LTUxYTAtNGIwNC05MmIxLTZhNTc5OGZiNTA0YSIsICJudW1fcHJv
+        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
+        OiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1v
+        dmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJiY2E5MmRhLTU3
+        OWUtNGE0Ny04NjJjLWZhM2Y4NWM2MmY4OCIsICJudW1fcHJvY2Vzc2VkIjog
+        MX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
+        dGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImUyM2M2OTljLTU5NzgtNDMxNi1hODlmLTNiYzFlNDU5
+        NGNjYiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAi
+        c3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImQ1ZjdjYTVmLTEyZjYtNGJkNy04MmU4LTYxNDcwMmE0ZWY4NiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6
+        ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAx
+        LCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiMzIzYTdhNmItYTdjYS00ZmM4LTk3YjAtOTVmZTYwZDQ4MDlmIiwgIm51
+        bV9wcm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEyIiwg
+        InN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1YzliYzIyNGZiNmU5NWI0OWJmY2RjMTIifSwgImlkIjogIjVjOWJj
+        MjI0ZmI2ZTk1YjQ5YmZjZGMxMiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14e9acba-5a8b-47db-a963-7e8f62bf7911/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"7456dcfd02b4fb0f578086809d741a84-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2403'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xNGU5YWNiYS01YThiLTQ3ZGItYTk2My03ZThmNjJiZjc5
+        MTEvIiwgInRhc2tfaWQiOiAiMTRlOWFjYmEtNWE4Yi00N2RiLWE5NjMtN2U4
+        ZjYyYmY3OTExIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        OS0wMy0yN1QxODozNDoxMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozNDoxMloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMTljNzgzNzgtMDc0Ny00OTE5LTlhYTUtOTE3ZDQxOGJj
+        Y2VkLyIsICJ0YXNrX2lkIjogIjE5Yzc4Mzc4LTA3NDctNDkxOS05YWE1LTkx
+        N2Q0MThiY2NlZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjog
+        bnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzdGFydGVkIjogIjIwMTktMDMtMjdUMTg6MzQ6MTJaIiwgIl9ucyI6
+        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wMy0y
+        N1QxODozNDoxMloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJtb2R1
+        bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWM5
+        YmMyMjRkYjI4NGU0YWUyMjExOWVkIiwgImRldGFpbHMiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzaXplX3Rv
+        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
+        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
+        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzliYzIyNGZiNmU5NWI0OWJmY2RhYTEifSwgImlkIjogIjVjOWJjMjI0
+        ZmI2ZTk1YjQ5YmZjZGFhMSJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/19c78378-0747-4919-9aa5-917d418bcced/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"9e4e853f674fbaf5de6606ce7dc03887-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '8518'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8xOWM3ODM3OC0wNzQ3LTQ5MTktOWFhNS05MTdk
+        NDE4YmNjZWQvIiwgInRhc2tfaWQiOiAiMTljNzgzNzgtMDc0Ny00OTE5LTlh
+        YTUtOTE3ZDQxOGJjY2VkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxOS0wMy0yN1QxODozNDoxM1oiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozNDoxMloiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIzZjY2ZjQwOC1lM2FkLTQ1MjgtOGIyMy04ODlkNjNi
+        ODRmMGEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiMmJiNjNmZDUtODU3ZS00ZmExLWI4OTUtY2ZlZjhhMTE5YzVjIiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMjNlYmQ0M2YtNjBkMC00MjYxLWI0Yzgt
+        MDYzZjNhZmFhZmUwIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTc0
+        YWQyMTYtMGNiYi00NjQ1LTliYzgtNzM0NmMzNmVlYmM5IiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjBjYWQxYTdjLTVmOTItNDc5OC1iOTNiLWRiMzNj
+        Y2Q1OTM3OSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0
+        ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzlkZWYwYTgt
+        NTc1YS00ODUwLWE4NzMtN2VkMzc0ODBmODdjIiwgIm51bV9wcm9jZXNzZWQi
+        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJs
+        aXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0
+        ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjlmNThmYWQyLWZmNzYtNGU2My1iN2E1LWNkNzMzNDg5
+        NjQ1NiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3Rl
+        cF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjg0MDFmY2Uy
+        LWI2YzUtNDZiOC04NzU4LTgyYTczMWJmZjBhZiIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xv
+        c2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNkN2FkMGFkLTkzYjAtNDQ1
+        Mi1hYjNiLTg5MGRjYWJiZmYzNSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBz
+        cWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjk1ZWM5ZTY4LTUxYTAtNGIwNC05MmIxLTZhNTc5
+        OGZiNTA0YSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwg
+        InN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogImJiY2E5MmRhLTU3OWUtNGE0Ny04NjJjLWZhM2Y4NWM2MmY4OCIs
+        ICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
+        Y3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlw
+        ZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
+        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUyM2M2OTljLTU5Nzgt
+        NDMxNi1hODlmLTNiYzFlNDU5NGNjYiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
+        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImQ1ZjdjYTVmLTEyZjYtNGJkNy04MmU4
+        LTYxNDcwMmE0ZWY4NiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
+        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiMzIzYTdhNmItYTdjYS00ZmM4LTk3YjAtOTVm
+        ZTYwZDQ4MDlmIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhh
+        bXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9u
+        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQHRoZXRhLnBhcnRl
+        bGxvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
+        c3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3
+        IiwgInN0YXJ0ZWQiOiAiMjAxOS0wMy0yN1QxODozNDoxMloiLCAiX25zIjog
+        InJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTAz
+        LTI3VDE4OjM0OjEzWiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0
+        b3JfdHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6IHsi
+        Z2VuZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQiLCAicnBtcyI6ICJGSU5JU0hF
+        RCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAi
+        cmVtb3ZlX29sZF9yZXBvZGF0YSI6ICJGSU5JU0hFRCIsICJtb2R1bGVzIjog
+        IlNLSVBQRUQiLCAiY2xvc2VfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIs
+        ICJkcnBtcyI6ICJTS0lQUEVEIiwgImNvbXBzIjogIkZJTklTSEVEIiwgImRp
+        c3RyaWJ1dGlvbiI6ICJGSU5JU0hFRCIsICJyZXBvdmlldyI6ICJTS0lQUEVE
+        IiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6
+        ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3Jf
+        bWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTci
+        LCAiaWQiOiAiNWM5YmMyMjVkYjI4NGU0YWUyMjExOWVlIiwgImRldGFpbHMi
+        OiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFs
+        aXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6
+        ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNmNjZmNDA4LWUz
+        YWQtNDUyOC04YjIzLTg4OWQ2M2I4NGYwYSIsICJudW1fcHJvY2Vzc2VkIjog
+        MX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3Ry
+        aWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyYmI2M2ZkNS04NTdlLTRmYTEt
+        Yjg5NS1jZmVmOGExMTljNWMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBN
+        cyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyM2Vi
+        ZDQzZi02MGQwLTQyNjEtYjRjOC0wNjNmM2FmYWFmZTAiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJhNzRhZDIxNi0wY2JiLTQ2NDUtOWJjOC03MzQ2
+        YzM2ZWViYzkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGNhZDFhN2Mt
+        NWY5Mi00Nzk4LWI5M2ItZGIzM2NjZDU5Mzc5IiwgIm51bV9wcm9jZXNzZWQi
+        OiAzfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
+        aXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIzOWRlZjBhOC01NzVhLTQ4NTAtYTg3My03ZWQzNzQ4MGY4
+        N2MiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVw
+        X3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOWY1OGZhZDItZmY3
+        Ni00ZTYzLWI3YTUtY2Q3MzM0ODk2NDU2IiwgIm51bV9wcm9jZXNzZWQiOiAz
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiODQwMWZjZTItYjZjNS00NmI4LTg3NTgtODJhNzMxYmZm
+        MGFmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEs
+        ICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3Rl
+        cF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiM2Q3YWQwYWQtOTNiMC00NDUyLWFiM2ItODkwZGNhYmJmZjM1IiwgIm51
+        bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUi
+        OiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTVlYzllNjgt
+        NTFhMC00YjA0LTkyYjEtNmE1Nzk4ZmI1MDRhIiwgIm51bV9wcm9jZXNzZWQi
+        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1v
+        dmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRf
+        cmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYmJjYTkyZGEtNTc5ZS00YTQ3
+        LTg2MmMtZmEzZjg1YzYyZjg4IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhU
+        TUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3Rv
+        dGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiZTIzYzY5OWMtNTk3OC00MzE2LWE4OWYtM2JjMWU0NTk0Y2NiIiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5
+        cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDVm
+        N2NhNWYtMTJmNi00YmQ3LTgyZTgtNjE0NzAyYTRlZjg2IiwgIm51bV9wcm9j
+        ZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
+        ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRp
+        YWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzMjNhN2E2
+        Yi1hN2NhLTRmYzgtOTdiMC05NWZlNjBkNDgwOWYiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDF9XX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM5
+        YmMyMjRmYjZlOTViNDliZmNkYzEyIn0sICJpZCI6ICI1YzliYzIyNGZiNmU5
+        NWI0OWJmY2RjMTIifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjNfdmlldzEiLCJkaXNwbGF5X25hbWUiOiJGZWRvcmEgMTcgeDg2
+        XzY0IiwiaW1wb3J0ZXJfdHlwZV9pZCI6Inl1bV9pbXBvcnRlciIsImltcG9y
+        dGVyX2NvbmZpZyI6e30sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJycG0tcmVw
+        byJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5
+        dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsicmVsYXRp
+        dmVfdXJsIjoiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5L0xpYnJhcnlWaWV3
+        L2ZlZG9yYV8xN19sYWJlbCIsImh0dHAiOmZhbHNlLCJodHRwcyI6dHJ1ZSwi
+        cHJvdGVjdGVkIjp0cnVlLCJjaGVja3N1bV90eXBlIjpudWxsfSwiYXV0b19w
+        dWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9pZCI6IjNfdmlldzEifSx7ImRp
+        c3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1fY2xvbmVfZGlzdHJpYnV0b3IiLCJk
+        aXN0cmlidXRvcl9jb25maWciOnsiZGVzdGluYXRpb25fZGlzdHJpYnV0b3Jf
+        aWQiOiIzX3ZpZXcxIn0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
+        dG9yX2lkIjoiM192aWV3MV9jbG9uZSJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9p
+        ZCI6ImV4cG9ydF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6
+        eyJodHRwIjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxhdGl2ZV91cmwiOiJB
+        Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvTGlicmFyeVZpZXcvZmVkb3JhXzE3
+        X2xhYmVsIn0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lk
+        IjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '790'
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '316'
+      Location:
+      - "/pulp/api/v2/repositories/3_view1/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
+        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWM5YmMyMjVkYjI4NGU1OWJlOTZiYWU0In0sICJpZCI6ICIzX3ZpZXcxIiwg
+        Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS8i
+        fQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInJwbSJdLCJmaWx0ZXJzIjp7fSwiZmllbGRzIjp7InVuaXQi
+        OlsibmFtZSIsImVwb2NoIiwidmVyc2lvbiIsInJlbGVhc2UiLCJhcmNoIiwi
+        Y2hlY2tzdW10eXBlIiwiY2hlY2tzdW0iXX19fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '163'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzdiZTdjN2Y4LWJjMmYtNDJiYi05YzhhLWRiMjg3YzI3NGFhYS8iLCAi
+        dGFza19pZCI6ICI3YmU3YzdmOC1iYzJmLTQyYmItOWM4YS1kYjI4N2MyNzRh
+        YWEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInJwbSJdLCJmaWx0ZXJzIjp7InVuaXQiOnsiZmlsZW5hbWUi
+        OnsiJGluIjpbIm1vZC05OS0xMDgucnBtIl19fX19fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '121'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzRmMGQyZmJiLWFmMDktNGUyNi1iNWQwLWIxZjUwOGQwNjE0ZS8iLCAi
+        dGFza19pZCI6ICI0ZjBkMmZiYi1hZjA5LTRlMjYtYjVkMC1iMWY1MDhkMDYx
+        NGUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInNycG0iXSwiZmlsdGVycyI6e319fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '76'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzVhYmVmYTdhLTE5YjctNDBlZS05Y2JiLTZhNDdlZjhkMjA4ZC8iLCAi
+        dGFza19pZCI6ICI1YWJlZmE3YS0xOWI3LTQwZWUtOWNiYi02YTQ3ZWY4ZDIw
+        OGQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbImVycmF0dW0iXSwiZmlsdGVycyI6e319fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '79'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzk0MWYzODVhLWRiMzQtNGViNS04MmY4LTBmOWUwZjUyZjE3ZS8iLCAi
+        dGFza19pZCI6ICI5NDFmMzg1YS1kYjM0LTRlYjUtODJmOC0wZjllMGY1MmYx
+        N2UifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInBhY2thZ2VfZ3JvdXAiXSwiZmlsdGVycyI6e319fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '85'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2JjMDgwMjdkLWMyZGEtNDlkNC04MDI1LWM3MDI5ZWE0ZjY2Zi8iLCAi
+        dGFza19pZCI6ICJiYzA4MDI3ZC1jMmRhLTQ5ZDQtODAyNS1jNzAyOWVhNGY2
+        NmYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiXSwiZmlsdGVycyI6
+        e319fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '94'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2ZiMzA0NTFiLTgwYzctNDU2YS1iMjI0LTY5M2Y4ODUzOWU4MC8iLCAi
+        dGFza19pZCI6ICJmYjMwNDUxYi04MGM3LTQ1NmEtYjIyNC02OTNmODg1Mzll
+        ODAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbImRpc3RyaWJ1dGlvbiJdLCJmaWx0ZXJzIjp7fX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '84'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2ZiODM1MTVkLThmYzYtNGFmOS1hNGJlLTBkNzgzY2FkYWRlYy8iLCAi
+        dGFza19pZCI6ICJmYjgzNTE1ZC04ZmM2LTRhZjktYTRiZS0wZDc4M2NhZGFk
+        ZWMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbIm1vZHVsZW1kIl0sImZpbHRlcnMiOnt9fX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '80'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2ExZmUyMGJlLTU0ODAtNGZlMi1hZGZlLWRjMzQyYmM3ZTAwMC8iLCAi
+        dGFza19pZCI6ICJhMWZlMjBiZS01NDgwLTRmZTItYWRmZS1kYzM0MmJjN2Uw
+        MDAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbIm1vZHVsZW1kX2RlZmF1bHRzIl0sImZpbHRlcnMiOnt9fX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '89'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzliOGQ4ZmVlLTg3MjYtNGJlZS04MjVmLWExMmE5ZDVmNWNhMC8iLCAi
+        dGFza19pZCI6ICI5YjhkOGZlZS04NzI2LTRiZWUtODI1Zi1hMTJhOWQ1ZjVj
+        YTAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/7be7c7f8-bc2f-42bb-9c8a-db287c274aaa/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"8076ec5bccabc93235dbf4fcea3ac2b9-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2780'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy83YmU3Yzdm
+        OC1iYzJmLTQyYmItOWM4YS1kYjI4N2MyNzRhYWEvIiwgInRhc2tfaWQiOiAi
+        N2JlN2M3ZjgtYmMyZi00MmJiLTljOGEtZGIyODdjMjc0YWFhIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEzWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEz
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sic2lnbmlu
+        Z19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAibGlvbiIsICJj
+        aGVja3N1bSI6ICIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNk
+        ZDdhODk4MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0IiwgImVwb2NoIjogIjAi
+        LCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6
+        ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9p
+        ZCI6ICJycG0ifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6
+        IHsibmFtZSI6ICJjaGVldGFoIiwgImNoZWNrc3VtIjogIjQyMmQwYmFhMGNk
+        OWQ3NzEzYWU3OTZlODg2YTIzZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1
+        ZmIzNjhkYWUiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJy
+        ZWxlYXNlIjogIjAuOCIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5
+        cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdf
+        a2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogImVsZXBoYW50Iiwg
+        ImNoZWNrc3VtIjogIjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0
+        NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJhcmNo
+        IjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBl
+        X2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5
+        IjogeyJuYW1lIjogIm1vbmtleSIsICJjaGVja3N1bSI6ICIwZThmYTUwZDAx
+        MjhmYmFiYzdjY2M1NjMyZTNmYTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0
+        ZGU4NTAxZGIxIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAi
+        cmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10
+        eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJzaWduaW5n
+        X2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJwZW5ndWluIiwg
+        ImNoZWNrc3VtIjogIjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5
+        ZDNlNWFkMmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJhcmNo
+        IjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBl
+        X2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5
+        IjogeyJuYW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6ICI2ZThkNmRjMDU3
+        ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2
+        MjFhNDYxZGZkIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAi
+        cmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10
+        eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJzaWduaW5n
+        X2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJnaXJhZmZlIiwg
+        ImNoZWNrc3VtIjogImYyNWQ2N2QxZDlkYTA0ZjEyZTU3Y2EzMjMyNDdiNDM4
+        OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQiLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJhcmNo
+        IjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBl
+        X2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5
+        IjogeyJuYW1lIjogInNxdWlycmVsIiwgImNoZWNrc3VtIjogIjI1MTc2OGJk
+        ZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFj
+        MGFlODc4YTE3ZDIiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIs
+        ICJyZWxlYXNlIjogIjAuOCIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1
+        bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9XSwgInVuaXRz
+        X2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW119LCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjI1ZmI2ZTk1YjQ5YmZjZGQxMSJ9
+        LCAiaWQiOiAiNWM5YmMyMjVmYjZlOTViNDliZmNkZDExIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/5abefa7a-19b7-40ee-9cbb-6a47ef8d208d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"6323e6c293cd22f5e338c59584ba7376-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '801'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81YWJlZmE3
+        YS0xOWI3LTQwZWUtOWNiYi02YTQ3ZWY4ZDIwOGQvIiwgInRhc2tfaWQiOiAi
+        NWFiZWZhN2EtMTliNy00MGVlLTljYmItNmE0N2VmOGQyMDhkIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEzWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEz
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW10sICJ1bml0
+        c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIyNWZiNmU5NWI0OWJmY2RkNDMi
+        fSwgImlkIjogIjVjOWJjMjI1ZmI2ZTk1YjQ5YmZjZGQ0MyJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/941f385a-db34-4eb5-82f8-0f9e0f52f17e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"e8259467efc914910a0c7e860e3d4a31-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '985'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy85NDFmMzg1
+        YS1kYjM0LTRlYjUtODJmOC0wZjllMGY1MmYxN2UvIiwgInRhc2tfaWQiOiAi
+        OTQxZjM4NWEtZGIzNC00ZWI1LTgyZjgtMGY5ZTBmNTJmMTdlIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEzWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEz
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sidW5pdF9r
+        ZXkiOiB7ImlkIjogIlJIRUEtMjAxMDowMDAyIn0sICJ0eXBlX2lkIjogImVy
+        cmF0dW0ifSwgeyJ1bml0X2tleSI6IHsiaWQiOiAiUkhTQS0yMDEwOjA4NTgi
+        fSwgInR5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6
+        ICJSSEVBLTIwMTA6MDAwMSJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn1dLCAi
+        dW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM5YmMyMjVmYjZlOTViNDliZmNk
+        ZDcyIn0sICJpZCI6ICI1YzliYzIyNWZiNmU5NWI0OWJmY2RkNzIifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/bc08027d-c2da-49d4-8025-c7029ea4f66f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"b0a0e8388d3bcb4629529907548b91cf-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1125'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9iYzA4MDI3
+        ZC1jMmRhLTQ5ZDQtODAyNS1jNzAyOWVhNGY2NmYvIiwgInRhc2tfaWQiOiAi
+        YmMwODAyN2QtYzJkYS00OWQ0LTgwMjUtYzcwMjllYTRmNjZmIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEzWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEz
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sidW5pdF9r
+        ZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIsICJpZCI6ICJiaXJkIn0sICJ0
+        eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAifSwgeyJ1bml0X2tleSI6IHsicmVw
+        b19pZCI6ICIzX3ZpZXcxIiwgImlkIjogIm1hbW1hbCJ9LCAidHlwZV9pZCI6
+        ICJwYWNrYWdlX2dyb3VwIn1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9m
+        aWx0ZXIiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRvcmFfMTci
+        LCAiaWQiOiAiYmlyZCJ9LCAidHlwZV9pZCI6ICJwYWNrYWdlX2dyb3VwIn0s
+        IHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImlkIjog
+        Im1hbW1hbCJ9LCAidHlwZV9pZCI6ICJwYWNrYWdlX2dyb3VwIn1dfSwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIyNWZiNmU5NWI0
+        OWJmY2RkOGYifSwgImlkIjogIjVjOWJjMjI1ZmI2ZTk1YjQ5YmZjZGQ4ZiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/fb30451b-80c7-456a-b224-693f88539e80/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"7cb1c53e926e2f78416113c08fb523a7-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '725'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9mYjMwNDUx
+        Yi04MGM3LTQ1NmEtYjIyNC02OTNmODg1MzllODAvIiwgInRhc2tfaWQiOiAi
+        ZmIzMDQ1MWItODBjNy00NTZhLWIyMjQtNjkzZjg4NTM5ZTgwIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6IG51bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRf
+        dGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEzWiIsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijog
+        e30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0
+        YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjI1ZmI2
+        ZTk1YjQ5YmZjZGRhZCJ9LCAiaWQiOiAiNWM5YmMyMjVmYjZlOTViNDliZmNk
+        ZGFkIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/fb83515d-8fc6-4af9-a4be-0d783cadadec/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"91c14e1d77e8e2fb83ecb99af81a400d-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '707'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9mYjgzNTE1
+        ZC04ZmM2LTRhZjktYTRiZS0wZDc4M2NhZGFkZWMvIiwgInRhc2tfaWQiOiAi
+        ZmI4MzUxNWQtOGZjNi00YWY5LWE0YmUtMGQ3ODNjYWRhZGVjIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6IG51bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRf
+        dGltZSI6IG51bGwsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNr
+        cyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5l
+        eGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVjOWJjMjI1ZmI2ZTk1YjQ5YmZjZGRjNCJ9LCAi
+        aWQiOiAiNWM5YmMyMjVmYjZlOTViNDliZmNkZGM0In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/a1fe20be-5480-4fe2-adfe-dc342bc7e000/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"e6348f010cd4b3f29e17abf05dfb6690-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '707'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9hMWZlMjBi
+        ZS01NDgwLTRmZTItYWRmZS1kYzM0MmJjN2UwMDAvIiwgInRhc2tfaWQiOiAi
+        YTFmZTIwYmUtNTQ4MC00ZmUyLWFkZmUtZGMzNDJiYzdlMDAwIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6IG51bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRf
+        dGltZSI6IG51bGwsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNr
+        cyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5l
+        eGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVjOWJjMjI1ZmI2ZTk1YjQ5YmZjZGRkYSJ9LCAi
+        aWQiOiAiNWM5YmMyMjVmYjZlOTViNDliZmNkZGRhIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/9b8d8fee-8726-4bee-825f-a12a9d5f5ca0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"04dcb5ba9e5c1f7d5d734d09cd9e3df4-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '707'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy85YjhkOGZl
+        ZS04NzI2LTRiZWUtODI1Zi1hMTJhOWQ1ZjVjYTAvIiwgInRhc2tfaWQiOiAi
+        OWI4ZDhmZWUtODcyNi00YmVlLTgyNWYtYTEyYTlkNWY1Y2EwIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6IG51bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRf
+        dGltZSI6IG51bGwsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNr
+        cyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5l
+        eGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVjOWJjMjI1ZmI2ZTk1YjQ5YmZjZGRmYiJ9LCAi
+        aWQiOiAiNWM5YmMyMjVmYjZlOTViNDliZmNkZGZiIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/7be7c7f8-bc2f-42bb-9c8a-db287c274aaa/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:13 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"8076ec5bccabc93235dbf4fcea3ac2b9-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2780'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy83YmU3Yzdm
+        OC1iYzJmLTQyYmItOWM4YS1kYjI4N2MyNzRhYWEvIiwgInRhc2tfaWQiOiAi
+        N2JlN2M3ZjgtYmMyZi00MmJiLTljOGEtZGIyODdjMjc0YWFhIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEzWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEz
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sic2lnbmlu
+        Z19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAibGlvbiIsICJj
+        aGVja3N1bSI6ICIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNk
+        ZDdhODk4MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0IiwgImVwb2NoIjogIjAi
+        LCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6
+        ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9p
+        ZCI6ICJycG0ifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6
+        IHsibmFtZSI6ICJjaGVldGFoIiwgImNoZWNrc3VtIjogIjQyMmQwYmFhMGNk
+        OWQ3NzEzYWU3OTZlODg2YTIzZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1
+        ZmIzNjhkYWUiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJy
+        ZWxlYXNlIjogIjAuOCIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5
+        cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdf
+        a2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogImVsZXBoYW50Iiwg
+        ImNoZWNrc3VtIjogIjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0
+        NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJhcmNo
+        IjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBl
+        X2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5
+        IjogeyJuYW1lIjogIm1vbmtleSIsICJjaGVja3N1bSI6ICIwZThmYTUwZDAx
+        MjhmYmFiYzdjY2M1NjMyZTNmYTI1ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0
+        ZGU4NTAxZGIxIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAi
+        cmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10
+        eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJzaWduaW5n
+        X2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJwZW5ndWluIiwg
+        ImNoZWNrc3VtIjogIjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5
+        ZDNlNWFkMmU1ODU2NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJhcmNo
+        IjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBl
+        X2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5
+        IjogeyJuYW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6ICI2ZThkNmRjMDU3
+        ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2
+        MjFhNDYxZGZkIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAi
+        cmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10
+        eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJzaWduaW5n
+        X2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJnaXJhZmZlIiwg
+        ImNoZWNrc3VtIjogImYyNWQ2N2QxZDlkYTA0ZjEyZTU3Y2EzMjMyNDdiNDM4
+        OTFhYzQ2NTMzZTM1NWI4MmRlNmQxOTIyMDA5ZjlmMTQiLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJhcmNo
+        IjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBl
+        X2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5
+        IjogeyJuYW1lIjogInNxdWlycmVsIiwgImNoZWNrc3VtIjogIjI1MTc2OGJk
+        ZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFj
+        MGFlODc4YTE3ZDIiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIs
+        ICJyZWxlYXNlIjogIjAuOCIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1
+        bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9XSwgInVuaXRz
+        X2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW119LCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjI1ZmI2ZTk1YjQ5YmZjZGQxMSJ9
+        LCAiaWQiOiAiNWM5YmMyMjVmYjZlOTViNDliZmNkZDExIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:13 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/5abefa7a-19b7-40ee-9cbb-6a47ef8d208d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:14 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"6323e6c293cd22f5e338c59584ba7376-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '801'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81YWJlZmE3
+        YS0xOWI3LTQwZWUtOWNiYi02YTQ3ZWY4ZDIwOGQvIiwgInRhc2tfaWQiOiAi
+        NWFiZWZhN2EtMTliNy00MGVlLTljYmItNmE0N2VmOGQyMDhkIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEzWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEz
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW10sICJ1bml0
+        c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIyNWZiNmU5NWI0OWJmY2RkNDMi
+        fSwgImlkIjogIjVjOWJjMjI1ZmI2ZTk1YjQ5YmZjZGQ0MyJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:14 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/941f385a-db34-4eb5-82f8-0f9e0f52f17e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:14 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"e8259467efc914910a0c7e860e3d4a31-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '985'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy85NDFmMzg1
+        YS1kYjM0LTRlYjUtODJmOC0wZjllMGY1MmYxN2UvIiwgInRhc2tfaWQiOiAi
+        OTQxZjM4NWEtZGIzNC00ZWI1LTgyZjgtMGY5ZTBmNTJmMTdlIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEzWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEz
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sidW5pdF9r
+        ZXkiOiB7ImlkIjogIlJIRUEtMjAxMDowMDAyIn0sICJ0eXBlX2lkIjogImVy
+        cmF0dW0ifSwgeyJ1bml0X2tleSI6IHsiaWQiOiAiUkhTQS0yMDEwOjA4NTgi
+        fSwgInR5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6
+        ICJSSEVBLTIwMTA6MDAwMSJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn1dLCAi
+        dW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM5YmMyMjVmYjZlOTViNDliZmNk
+        ZDcyIn0sICJpZCI6ICI1YzliYzIyNWZiNmU5NWI0OWJmY2RkNzIifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:14 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/bc08027d-c2da-49d4-8025-c7029ea4f66f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:15 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"b0a0e8388d3bcb4629529907548b91cf-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1125'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9iYzA4MDI3
+        ZC1jMmRhLTQ5ZDQtODAyNS1jNzAyOWVhNGY2NmYvIiwgInRhc2tfaWQiOiAi
+        YmMwODAyN2QtYzJkYS00OWQ0LTgwMjUtYzcwMjllYTRmNjZmIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEzWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEz
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sidW5pdF9r
+        ZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIsICJpZCI6ICJiaXJkIn0sICJ0
+        eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAifSwgeyJ1bml0X2tleSI6IHsicmVw
+        b19pZCI6ICIzX3ZpZXcxIiwgImlkIjogIm1hbW1hbCJ9LCAidHlwZV9pZCI6
+        ICJwYWNrYWdlX2dyb3VwIn1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9m
+        aWx0ZXIiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRvcmFfMTci
+        LCAiaWQiOiAiYmlyZCJ9LCAidHlwZV9pZCI6ICJwYWNrYWdlX2dyb3VwIn0s
+        IHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImlkIjog
+        Im1hbW1hbCJ9LCAidHlwZV9pZCI6ICJwYWNrYWdlX2dyb3VwIn1dfSwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIyNWZiNmU5NWI0
+        OWJmY2RkOGYifSwgImlkIjogIjVjOWJjMjI1ZmI2ZTk1YjQ5YmZjZGQ4ZiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:15 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/fb30451b-80c7-456a-b224-693f88539e80/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:15 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"9f6e576cc3851a71def2279c4fb786d6-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '801'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9mYjMwNDUx
+        Yi04MGM3LTQ1NmEtYjIyNC02OTNmODg1MzllODAvIiwgInRhc2tfaWQiOiAi
+        ZmIzMDQ1MWItODBjNy00NTZhLWIyMjQtNjkzZjg4NTM5ZTgwIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEzWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEz
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW10sICJ1bml0
+        c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIyNWZiNmU5NWI0OWJmY2RkYWQi
+        fSwgImlkIjogIjVjOWJjMjI1ZmI2ZTk1YjQ5YmZjZGRhZCJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:15 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/fb83515d-8fc6-4af9-a4be-0d783cadadec/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:16 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"219c25e14e43fb6254c77ce53526ba3e-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '974'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9mYjgzNTE1
+        ZC04ZmM2LTRhZjktYTRiZS0wZDc4M2NhZGFkZWMvIiwgInRhc2tfaWQiOiAi
+        ZmI4MzUxNWQtOGZjNi00YWY5LWE0YmUtMGQ3ODNjYWRhZGVjIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEzWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEz
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sidW5pdF9r
+        ZXkiOiB7InZhcmlhbnQiOiAiVGVzdFZhcmlhbnQiLCAidmVyc2lvbiI6ICIx
+        NiIsICJhcmNoIjogIng4Nl82NCIsICJpZCI6ICJrcy1UZXN0IEZhbWlseS1U
+        ZXN0VmFyaWFudC0xNi14ODZfNjQiLCAiZmFtaWx5IjogIlRlc3QgRmFtaWx5
+        In0sICJ0eXBlX2lkIjogImRpc3RyaWJ1dGlvbiJ9XSwgInVuaXRzX2ZhaWxl
+        ZF9zaWduYXR1cmVfZmlsdGVyIjogW119LCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjVjOWJjMjI1ZmI2ZTk1YjQ5YmZjZGRjNCJ9LCAiaWQi
+        OiAiNWM5YmMyMjVmYjZlOTViNDliZmNkZGM0In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:16 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/a1fe20be-5480-4fe2-adfe-dc342bc7e000/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:17 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"ca0dc2d6dcb6ce7548828a898efc3de8-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '801'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9hMWZlMjBi
+        ZS01NDgwLTRmZTItYWRmZS1kYzM0MmJjN2UwMDAvIiwgInRhc2tfaWQiOiAi
+        YTFmZTIwYmUtNTQ4MC00ZmUyLWFkZmUtZGMzNDJiYzdlMDAwIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEzWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEz
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW10sICJ1bml0
+        c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIyNWZiNmU5NWI0OWJmY2RkZGEi
+        fSwgImlkIjogIjVjOWJjMjI1ZmI2ZTk1YjQ5YmZjZGRkYSJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:17 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/9b8d8fee-8726-4bee-825f-a12a9d5f5ca0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:17 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"fb7f9005aa8c45ef6a364e26dd077603-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '801'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy85YjhkOGZl
+        ZS04NzI2LTRiZWUtODI1Zi1hMTJhOWQ1ZjVjYTAvIiwgInRhc2tfaWQiOiAi
+        OWI4ZDhmZWUtODcyNi00YmVlLTgyNWYtYTEyYTlkNWY1Y2EwIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEzWiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEz
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW10sICJ1bml0
+        c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIyNWZiNmU5NWI0OWJmY2RkZmIi
+        fSwgImlkIjogIjVjOWJjMjI1ZmI2ZTk1YjQ5YmZjZGRmYiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:17 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:18 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"cd317a34041f40e89b5e4208d3b98488-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2474'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiJ9LCAi
+        ZGlzcGxheV9uYW1lIjogIkZlZG9yYSAxNyB4ODZfNjQiLCAiZGVzY3JpcHRp
+        b24iOiBudWxsLCAiZGlzdHJpYnV0b3JzIjogW3sicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDMtMjdUMTg6MzQ6MTJa
+        IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvRmVkb3Jh
+        XzE3L2Rpc3RyaWJ1dG9ycy9leHBvcnRfZGlzdHJpYnV0b3IvIiwgImxhc3Rf
+        b3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAi
+        ZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJleHBvcnRfZGlzdHJpYnV0b3IiLCAi
+        YXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFkIjoge30sICJfbnMi
+        OiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVjOWJj
+        MjI0ZGIyODRlNTliZjEyNTk0YiJ9LCAiY29uZmlnIjogeyJodHRwIjogZmFs
+        c2UsICJyZWxhdGl2ZV91cmwiOiAiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5
+        L2ZlZG9yYV8xN19sYWJlbCIsICJodHRwcyI6IGZhbHNlfSwgImlkIjogImV4
+        cG9ydF9kaXN0cmlidXRvciJ9LCB7InJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
+        Imxhc3RfdXBkYXRlZCI6ICIyMDE5LTAzLTI3VDE4OjM0OjEyWiIsICJfaHJl
+        ZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy9kaXN0
+        cmlidXRvcnMvRmVkb3JhXzE3X2Nsb25lLyIsICJsYXN0X292ZXJyaWRlX2Nv
+        bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
+        X3R5cGVfaWQiOiAieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVi
+        bGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9f
+        ZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIyNGRiMjg0
+        ZTU5YmYxMjU5NGEifSwgImNvbmZpZyI6IHsiZGVzdGluYXRpb25fZGlzdHJp
+        YnV0b3JfaWQiOiAiRmVkb3JhXzE3In0sICJpZCI6ICJGZWRvcmFfMTdfY2xv
+        bmUifSwgeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQi
+        OiAiMjAxOS0wMy0yN1QxODozNDoxMloiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
+        L3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL0ZlZG9y
+        YV8xNy8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVi
+        bGlzaCI6ICIyMDE5LTAzLTI3VDE4OjM0OjEzWiIsICJkaXN0cmlidXRvcl90
+        eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0
+        cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0
+        b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIyNGRiMjg0ZTU5YmYxMjU5
+        NDkifSwgImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBm
+        YWxzZSwgImh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0Nv
+        cnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIn0sICJpZCI6ICJG
+        ZWRvcmFfMTcifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAxOS0wMy0yN1Qx
+        ODozNDoxMloiLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7InBhY2thZ2VfZ3JvdXAiOiAyLCAiZGlzdHJpYnV0aW9uIjog
+        MSwgInBhY2thZ2VfY2F0ZWdvcnkiOiAxLCAicnBtIjogOCwgImVycmF0dW0i
+        OiAzfSwgIl9ucyI6ICJyZXBvcyIsICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lk
+        IjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wMy0yN1Qx
+        ODozNDoxMloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
+        cy9GZWRvcmFfMTcvaW1wb3J0ZXJzL3l1bV9pbXBvcnRlci8iLCAiX25zIjog
+        InJlcG9faW1wb3J0ZXJzIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2lt
+        cG9ydGVyIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3N5
+        bmMiOiAiMjAxOS0wMy0yN1QxODozNDoxMloiLCAic2NyYXRjaHBhZCI6IHsi
+        cmVwb21kX3JldmlzaW9uIjogMTMyMTg5MzgwMH0sICJfaWQiOiB7IiRvaWQi
+        OiAiNWM5YmMyMjRkYjI4NGU1OWJmMTI1OTQ4In0sICJjb25maWciOiB7ImZl
+        ZWQiOiAiZmlsZTovLy92YXIvd3d3L3Rlc3RfcmVwb3Mvem9vIiwgInNzbF92
+        YWxpZGF0aW9uIjogdHJ1ZSwgInJlbW92ZV9taXNzaW5nIjogdHJ1ZSwgImRv
+        d25sb2FkX3BvbGljeSI6ICJvbl9kZW1hbmQifSwgImlkIjogInl1bV9pbXBv
+        cnRlciJ9XSwgImxvY2FsbHlfc3RvcmVkX3VuaXRzIjogMTQsICJfaWQiOiB7
+        IiRvaWQiOiAiNWM5YmMyMjRkYjI4NGU1OWJmMTI1OTQ3In0sICJ0b3RhbF9y
+        ZXBvc2l0b3J5X3VuaXRzIjogMTUsICJpZCI6ICJGZWRvcmFfMTciLCAiX2hy
+        ZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:18 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:18 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"411024f66a8eb26c9fc81f34a2200385-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2237'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
+        OiBbeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
+        MTktMDMtMjdUMTg6MzQ6MTNaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3Ry
+        aWJ1dG9yLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9w
+        dWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0
+        X2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRj
+        aHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6
+        IHsiJG9pZCI6ICI1YzliYzIyNWRiMjg0ZTU5YmU5NmJhZTgifSwgImNvbmZp
+        ZyI6IHsiaHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29y
+        cG9yYXRpb24vbGlicmFyeS9MaWJyYXJ5Vmlldy9mZWRvcmFfMTdfbGFiZWwi
+        LCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6ICJleHBvcnRfZGlzdHJpYnV0b3Ii
+        fSwgeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
+        MTktMDMtMjdUMTg6MzQ6MTNaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvM192aWV3MV9jbG9u
+        ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
+        aCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9jbG9uZV9k
+        aXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hw
+        YWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7
+        IiRvaWQiOiAiNWM5YmMyMjVkYjI4NGU1OWJlOTZiYWU3In0sICJjb25maWci
+        OiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogIjNfdmlldzEifSwg
+        ImlkIjogIjNfdmlldzFfY2xvbmUifSwgeyJyZXBvX2lkIjogIjNfdmlldzEi
+        LCAibGFzdF91cGRhdGVkIjogIjIwMTktMDMtMjdUMTg6MzQ6MTNaIiwgIl9o
+        cmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0
+        cmlidXRvcnMvM192aWV3MS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7
+        fSwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lk
+        IjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAi
+        c2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwg
+        Il9pZCI6IHsiJG9pZCI6ICI1YzliYzIyNWRiMjg0ZTU5YmU5NmJhZTYifSwg
+        ImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwg
+        Imh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0NvcnBvcmF0
+        aW9uL2xpYnJhcnkvTGlicmFyeVZpZXcvZmVkb3JhXzE3X2xhYmVsIn0sICJp
+        ZCI6ICIzX3ZpZXcxIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIwMTktMDMt
+        MjdUMTg6MzQ6MTNaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
+        ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
+        aXRfY291bnRzIjogeyJwYWNrYWdlX2dyb3VwIjogMiwgImRpc3RyaWJ1dGlv
+        biI6IDEsICJycG0iOiA4LCAiZXJyYXR1bSI6IDN9LCAiX25zIjogInJlcG9z
+        IiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiM192aWV3MSIsICJsYXN0
+        X3VwZGF0ZWQiOiAiMjAxOS0wMy0yN1QxODozNDoxM1oiLCAiX2hyZWYiOiAi
+        L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy8zX3ZpZXcxL2ltcG9ydGVycy95
+        dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIsICJpbXBv
+        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJsYXN0X292ZXJyaWRl
+        X2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjogbnVsbCwgInNjcmF0Y2hwYWQi
+        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjI1ZGIyODRlNTliZTk2
+        YmFlNSJ9LCAiY29uZmlnIjoge30sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0s
+        ICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDEzLCAiX2lkIjogeyIkb2lkIjog
+        IjVjOWJjMjI1ZGIyODRlNTliZTk2YmFlNCJ9LCAidG90YWxfcmVwb3NpdG9y
+        eV91bml0cyI6IDE0LCAiaWQiOiAiM192aWV3MSIsICJfaHJlZiI6ICIvcHVs
+        cC9hcGkvdjIvcmVwb3NpdG9yaWVzLzNfdmlldzEvIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:18 GMT
+- request:
+    method: delete
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:18 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzViMDY1MjkwLWI2ZGQtNGRhZC05YjM4LTM0ZDBkMzAwYThiNS8iLCAi
+        dGFza19pZCI6ICI1YjA2NTI5MC1iNmRkLTRkYWQtOWIzOC0zNGQwZDMwMGE4
+        YjUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:18 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/5b065290-b6dd-4dad-9b38-34d0d300a8b5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:18 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"1a8af91697419dfe1f19021ac86ac120-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '542'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81YjA2NTI5MC1iNmRkLTRkYWQtOWIzOC0zNGQwZDMwMGE4
+        YjUvIiwgInRhc2tfaWQiOiAiNWIwNjUyOTAtYjZkZC00ZGFkLTliMzgtMzRk
+        MGQzMDBhOGI1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICIiLCAic3RhdGUiOiAid2Fp
+        dGluZyIsICJ3b3JrZXJfbmFtZSI6IG51bGwsICJyZXN1bHQiOiBudWxsLCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjJhZmI2ZTk1
+        YjQ5YmZjZGYzNiJ9LCAiaWQiOiAiNWM5YmMyMmFmYjZlOTViNDliZmNkZjM2
+        In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:18 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/5b065290-b6dd-4dad-9b38-34d0d300a8b5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:18 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"cb1ed4aa18794e50fbe4b8409060f044-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '668'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81YjA2NTI5MC1iNmRkLTRkYWQtOWIzOC0zNGQwZDMwMGE4
+        YjUvIiwgInRhc2tfaWQiOiAiNWIwNjUyOTAtYjZkZC00ZGFkLTliMzgtMzRk
+        MGQzMDBhOGI1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5
+        LTAzLTI3VDE4OjM0OjE4WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5l
+        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0
+        ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjJhZmI2ZTk1YjQ5YmZjZGYz
+        NiJ9LCAiaWQiOiAiNWM5YmMyMmFmYjZlOTViNDliZmNkZjM2In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:18 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/5b065290-b6dd-4dad-9b38-34d0d300a8b5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:18 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"cbb7f6a4282a2568e0e430bafa6d9e87-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '687'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy81YjA2NTI5MC1iNmRkLTRkYWQtOWIzOC0zNGQwZDMwMGE4
+        YjUvIiwgInRhc2tfaWQiOiAiNWIwNjUyOTAtYjZkZC00ZGFkLTliMzgtMzRk
+        MGQzMDBhOGI1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE5LTAzLTI3VDE4OjM0OjE4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjE4WiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Yzli
+        YzIyYWZiNmU5NWI0OWJmY2RmMzYifSwgImlkIjogIjVjOWJjMjJhZmI2ZTk1
+        YjQ5YmZjZGYzNiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:18 GMT
+- request:
+    method: delete
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:18 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2UwYmUxYTNlLWQ5NWQtNDFkYS1hYjA1LTEzYmM2MzVlOTQ5ZC8iLCAi
+        dGFza19pZCI6ICJlMGJlMWEzZS1kOTVkLTQxZGEtYWIwNS0xM2JjNjM1ZTk0
+        OWQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:18 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/e0be1a3e-d95d-41da-ab05-13bc635e949d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:18 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"09d544c11bc96b4e875f7a2ff0cef30a-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '540'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9lMGJlMWEzZS1kOTVkLTQxZGEtYWIwNS0xM2JjNjM1ZTk0
+        OWQvIiwgInRhc2tfaWQiOiAiZTBiZTFhM2UtZDk1ZC00MWRhLWFiMDUtMTNi
+        YzYzNWU5NDlkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
+        IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiIiwgInN0YXRlIjogIndhaXRp
+        bmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIyYWZiNmU5NWI0
+        OWJmY2RmODQifSwgImlkIjogIjVjOWJjMjJhZmI2ZTk1YjQ5YmZjZGY4NCJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:18 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/e0be1a3e-d95d-41da-ab05-13bc635e949d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:18 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"5d50f78d21781f68646c3ab0bb633b22-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '666'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9lMGJlMWEzZS1kOTVkLTQxZGEtYWIwNS0xM2JjNjM1ZTk0
+        OWQvIiwgInRhc2tfaWQiOiAiZTBiZTFhM2UtZDk1ZC00MWRhLWFiMDUtMTNi
+        YzYzNWU5NDlkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
+        IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDoxOFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhh
+        bXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVs
+        bG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIyYWZiNmU5NWI0OWJmY2RmODQi
+        fSwgImlkIjogIjVjOWJjMjJhZmI2ZTk1YjQ5YmZjZGY4NCJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:18 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/e0be1a3e-d95d-41da-ab05-13bc635e949d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:18 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"f37c6615bb60c670d50115a97ace7364-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '685'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9lMGJlMWEzZS1kOTVkLTQxZGEtYWIwNS0xM2JjNjM1ZTk0
+        OWQvIiwgInRhc2tfaWQiOiAiZTBiZTFhM2UtZDk1ZC00MWRhLWFiMDUtMTNi
+        YzYzNWU5NDlkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
+        IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        OS0wMy0yN1QxODozNDoxOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozNDoxOFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9y
+        dCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
+        dGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZp
+        bmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0wQHRoZXRhLnBhcnRlbGxvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
+        IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM5YmMy
+        MmFmYjZlOTViNDliZmNkZjg0In0sICJpZCI6ICI1YzliYzIyYWZiNmU5NWI0
+        OWJmY2RmODQifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:18 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/copy_rpm_filenames.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/copy_rpm_filenames.yml
@@ -20535,158 +20535,6 @@ http_interactions:
     http_version: 
   recorded_at: Tue, 19 Mar 2019 17:58:01 GMT
 - request:
-    method: delete
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:37 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '404'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
-        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
-        OiByZXBvc2l0b3J5PUZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
-        djIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8iLCAiaHR0cF9zdGF0dXMiOiA0
-        MDQsICJlcnJvciI6IHsiY29kZSI6ICJQTFAwMDA5IiwgImRhdGEiOiB7InJl
-        c291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0sICJkZXNj
-        cmlwdGlvbiI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PUZl
-        ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
-        bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:37 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImRvd25sb2FkX3BvbGljeSI6Im9uX2RlbWFuZCIs
-        InJlbW92ZV9taXNzaW5nIjp0cnVlLCJmZWVkIjoiZmlsZTovLy92YXIvd3d3
-        L3Rlc3RfcmVwb3Mvem9vIiwidHlwZV9za2lwX2xpc3QiOm51bGwsInByb3h5
-        X2hvc3QiOm51bGwsImJhc2ljX2F1dGhfdXNlcm5hbWUiOm51bGwsImJhc2lj
-        X2F1dGhfcGFzc3dvcmQiOm51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJz
-        c2xfY2xpZW50X2NlcnQiOm51bGwsInNzbF9jbGllbnRfa2V5IjpudWxsLCJz
-        c2xfY2FfY2VydCI6bnVsbH0sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJycG0t
-        cmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQi
-        OiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsicmVs
-        YXRpdmVfdXJsIjoiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5L2ZlZG9yYV8x
-        N19sYWJlbCIsImh0dHAiOmZhbHNlLCJodHRwcyI6dHJ1ZSwicHJvdGVjdGVk
-        Ijp0cnVlLCJjaGVja3N1bV90eXBlIjpudWxsfSwiYXV0b19wdWJsaXNoIjp0
-        cnVlLCJkaXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xNyJ9LHsiZGlzdHJpYnV0
-        b3JfdHlwZV9pZCI6Inl1bV9jbG9uZV9kaXN0cmlidXRvciIsImRpc3RyaWJ1
-        dG9yX2NvbmZpZyI6eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6IkZl
-        ZG9yYV8xNyJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRvcl9p
-        ZCI6IkZlZG9yYV8xN19jbG9uZSJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9pZCI6
-        ImV4cG9ydF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJo
-        dHRwIjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxhdGl2ZV91cmwiOiJBQ01F
-        X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIn0sImF1dG9f
-        cHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3Ry
-        aWJ1dG9yIn1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1045'
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:37 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '320'
-      Location:
-      - "/pulp/api/v2/repositories/Fedora_17/"
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWM5MTMxYzlkYjI4NGUwOTQzOTU3MDE1In0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:37 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
-        Ijp0cnVlfX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '53'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:37 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2Q0M2RjZDE1LTcxNDMtNDEyMi1hYTg3LTY2N2IwYzE2OTFmYy8iLCAi
-        dGFza19pZCI6ICJkNDNkY2QxNS03MTQzLTQxMjItYWE4Ny02NjdiMGMxNjkx
-        ZmMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:37 GMT
-- request:
     method: get
     uri: https://theta.partello.example.com/pulp/api/v2/tasks/d43dcd15-7143-4122-aa87-667b0c1691fc/
     body:
@@ -22587,401 +22435,6 @@ http_interactions:
     http_version: 
   recorded_at: Tue, 19 Mar 2019 18:15:38 GMT
 - request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IjNfdmlldzEiLCJkaXNwbGF5X25hbWUiOiJGZWRvcmEgMTcgeDg2
-        XzY0IiwiaW1wb3J0ZXJfdHlwZV9pZCI6Inl1bV9pbXBvcnRlciIsImltcG9y
-        dGVyX2NvbmZpZyI6e30sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJycG0tcmVw
-        byJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5
-        dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsicmVsYXRp
-        dmVfdXJsIjoiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5L0xpYnJhcnlWaWV3
-        L2ZlZG9yYV8xN19sYWJlbCIsImh0dHAiOmZhbHNlLCJodHRwcyI6dHJ1ZSwi
-        cHJvdGVjdGVkIjp0cnVlLCJjaGVja3N1bV90eXBlIjpudWxsfSwiYXV0b19w
-        dWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9pZCI6IjNfdmlldzEifSx7ImRp
-        c3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1fY2xvbmVfZGlzdHJpYnV0b3IiLCJk
-        aXN0cmlidXRvcl9jb25maWciOnsiZGVzdGluYXRpb25fZGlzdHJpYnV0b3Jf
-        aWQiOiIzX3ZpZXcxIn0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
-        dG9yX2lkIjoiM192aWV3MV9jbG9uZSJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9p
-        ZCI6ImV4cG9ydF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6
-        eyJodHRwIjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxhdGl2ZV91cmwiOiJB
-        Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvTGlicmFyeVZpZXcvZmVkb3JhXzE3
-        X2xhYmVsIn0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lk
-        IjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '790'
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:38 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '316'
-      Location:
-      - "/pulp/api/v2/repositories/3_view1/"
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWM5MTMxY2FkYjI4NGUwOTQzOTU3MDFhIn0sICJpZCI6ICIzX3ZpZXcxIiwg
-        Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS8i
-        fQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:38 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbInJwbSJdLCJmaWx0ZXJzIjp7InVuaXQiOnsiZmlsZW5hbWUi
-        OnsiJGluIjpbIndhbHJ1cy0wLjMtMC44Lm5vYXJjaC5ycG0iXX19fSwiZmll
-        bGRzIjp7InVuaXQiOlsibmFtZSIsImVwb2NoIiwidmVyc2lvbiIsInJlbGVh
-        c2UiLCJhcmNoIiwiY2hlY2tzdW10eXBlIiwiY2hlY2tzdW0iXX19fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '220'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:38 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzk5NzRlZjFlLTQzOTQtNGRlNy1iMWVlLWE4OTEzMWI5ZDYxMi8iLCAi
-        dGFza19pZCI6ICI5OTc0ZWYxZS00Mzk0LTRkZTctYjFlZS1hODkxMzFiOWQ2
-        MTIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:38 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbInNycG0iXSwiZmlsdGVycyI6e319fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '76'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:38 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzk3YjJlMjNkLTUzYTYtNGYyZi1hZWZjLTM4NzJhMDBiZmNhOS8iLCAi
-        dGFza19pZCI6ICI5N2IyZTIzZC01M2E2LTRmMmYtYWVmYy0zODcyYTAwYmZj
-        YTkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:38 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbImVycmF0dW0iXSwiZmlsdGVycyI6e319fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '79'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:38 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2Y3YzMzMTE5LWI4OWQtNDFiNS04OWRhLTkwMWZjOWNlZGMxZS8iLCAi
-        dGFza19pZCI6ICJmN2MzMzExOS1iODlkLTQxYjUtODlkYS05MDFmYzljZWRj
-        MWUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:38 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbInBhY2thZ2VfZ3JvdXAiXSwiZmlsdGVycyI6e319fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '85'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:38 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2NjOGYwZTg3LTkxN2QtNDBmYS04ZTNjLTc1ZmM5OTc1NTkyNy8iLCAi
-        dGFza19pZCI6ICJjYzhmMGU4Ny05MTdkLTQwZmEtOGUzYy03NWZjOTk3NTU5
-        MjcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:38 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiXSwiZmlsdGVycyI6
-        e319fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '94'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:38 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzkyNzYwZDQ5LTI0Y2QtNGJmNi05MTRhLWRmYjEyZmE2YzVhMS8iLCAi
-        dGFza19pZCI6ICI5Mjc2MGQ0OS0yNGNkLTRiZjYtOTE0YS1kZmIxMmZhNmM1
-        YTEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:38 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbImRpc3RyaWJ1dGlvbiJdLCJmaWx0ZXJzIjp7fX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '84'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:38 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2E2MmNlNjBmLTI3ZDktNGI1Mi04ZmIwLTViN2I1YTdkOGUyMy8iLCAi
-        dGFza19pZCI6ICJhNjJjZTYwZi0yN2Q5LTRiNTItOGZiMC01YjdiNWE3ZDhl
-        MjMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:38 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbIm1vZHVsZW1kIl0sImZpbHRlcnMiOnt9fX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '80'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:38 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzYwMDBjNGVhLTU1NzAtNDNkNy04MzQ2LWE4NDM4NTFlNTJkZC8iLCAi
-        dGFza19pZCI6ICI2MDAwYzRlYS01NTcwLTQzZDctODM0Ni1hODQzODUxZTUy
-        ZGQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:38 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbIm1vZHVsZW1kX2RlZmF1bHRzIl0sImZpbHRlcnMiOnt9fX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '89'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:38 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2JkYTUwMzBlLTFmYjYtNDQ2MC1iM2JhLWUzNTg5MGUxZDA5OC8iLCAi
-        dGFza19pZCI6ICJiZGE1MDMwZS0xZmI2LTQ0NjAtYjNiYS1lMzU4OTBlMWQw
-        OTgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:38 GMT
-- request:
     method: get
     uri: https://theta.partello.example.com/pulp/api/v2/tasks/9974ef1e-4394-4de7-b1ee-a89131b9d612/
     body:
@@ -23903,130 +23356,6 @@ http_interactions:
   recorded_at: Tue, 19 Mar 2019 18:15:42 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:42 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"fe8ec6d1d1f21dd208c0ed4c5fa7b6ea-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2235'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
-        OiBbeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MTktMDMtMTlUMTg6MTU6MzhaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
-        ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3Ry
-        aWJ1dG9yLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9w
-        dWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0
-        X2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRj
-        aHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6
-        IHsiJG9pZCI6ICI1YzkxMzFjYWRiMjg0ZTA5NDM5NTcwMWUifSwgImNvbmZp
-        ZyI6IHsiaHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29y
-        cG9yYXRpb24vbGlicmFyeS9MaWJyYXJ5Vmlldy9mZWRvcmFfMTdfbGFiZWwi
-        LCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6ICJleHBvcnRfZGlzdHJpYnV0b3Ii
-        fSwgeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MTktMDMtMTlUMTg6MTU6MzhaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
-        ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvM192aWV3MV9jbG9u
-        ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
-        aCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9jbG9uZV9k
-        aXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hw
-        YWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7
-        IiRvaWQiOiAiNWM5MTMxY2FkYjI4NGUwOTQzOTU3MDFkIn0sICJjb25maWci
-        OiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogIjNfdmlldzEifSwg
-        ImlkIjogIjNfdmlldzFfY2xvbmUifSwgeyJyZXBvX2lkIjogIjNfdmlldzEi
-        LCAibGFzdF91cGRhdGVkIjogIjIwMTktMDMtMTlUMTg6MTU6MzhaIiwgIl9o
-        cmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0
-        cmlidXRvcnMvM192aWV3MS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7
-        fSwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lk
-        IjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAi
-        c2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwg
-        Il9pZCI6IHsiJG9pZCI6ICI1YzkxMzFjYWRiMjg0ZTA5NDM5NTcwMWMifSwg
-        ImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwg
-        Imh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0NvcnBvcmF0
-        aW9uL2xpYnJhcnkvTGlicmFyeVZpZXcvZmVkb3JhXzE3X2xhYmVsIn0sICJp
-        ZCI6ICIzX3ZpZXcxIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIwMTktMDMt
-        MTlUMTg6MTU6MzhaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
-        ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
-        aXRfY291bnRzIjogeyJwYWNrYWdlX2dyb3VwIjogMiwgImRpc3RyaWJ1dGlv
-        biI6IDEsICJycG0iOiAxLCAiZXJyYXR1bSI6IDN9LCAiX25zIjogInJlcG9z
-        IiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiM192aWV3MSIsICJsYXN0
-        X3VwZGF0ZWQiOiAiMjAxOS0wMy0xOVQxODoxNTozOFoiLCAiX2hyZWYiOiAi
-        L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy8zX3ZpZXcxL2ltcG9ydGVycy95
-        dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJsYXN0X292ZXJyaWRl
-        X2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjogbnVsbCwgInNjcmF0Y2hwYWQi
-        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOTEzMWNhZGIyODRlMDk0Mzk1
-        NzAxYiJ9LCAiY29uZmlnIjoge30sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0s
-        ICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDYsICJfaWQiOiB7IiRvaWQiOiAi
-        NWM5MTMxY2FkYjI4NGUwOTQzOTU3MDFhIn0sICJ0b3RhbF9yZXBvc2l0b3J5
-        X3VuaXRzIjogNywgImlkIjogIjNfdmlldzEiLCAiX2hyZWYiOiAiL3B1bHAv
-        YXBpL3YyL3JlcG9zaXRvcmllcy8zX3ZpZXcxLyJ9
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:42 GMT
-- request:
-    method: delete
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:43 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzVjN2M2YzYwLWI5MGEtNDBhOS05YWVjLWZlYjQ4MGU2NGI4NC8iLCAi
-        dGFza19pZCI6ICI1YzdjNmM2MC1iOTBhLTQwYTktOWFlYy1mZWI0ODBlNjRi
-        ODQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:43 GMT
-- request:
-    method: get
     uri: https://theta.partello.example.com/pulp/api/v2/tasks/5c7c6c60-b90a-40a9-9aec-feb480e64b84/
     body:
       encoding: US-ASCII
@@ -24183,43 +23512,6 @@ http_interactions:
     http_version: 
   recorded_at: Tue, 19 Mar 2019 18:15:43 GMT
 - request:
-    method: delete
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:43 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2ZjYzg2MGFhLWRkZWMtNGQ0My05NGI0LWQ4OGIwMWJlYmI1Zi8iLCAi
-        dGFza19pZCI6ICJmY2M4NjBhYS1kZGVjLTRkNDMtOTRiNC1kODhiMDFiZWJi
-        NWYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:43 GMT
-- request:
     method: get
     uri: https://theta.partello.example.com/pulp/api/v2/tasks/fcc860aa-ddec-4d43-94b4-d88b01bebb5f/
     body:
@@ -24373,4 +23665,4047 @@ http_interactions:
         OGMwZTc0MDEifQ==
     http_version: 
   recorded_at: Tue, 19 Mar 2019 18:15:43 GMT
+- request:
+    method: delete
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:56 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '404'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
+        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
+        OiByZXBvc2l0b3J5PUZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
+        djIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8iLCAiaHR0cF9zdGF0dXMiOiA0
+        MDQsICJlcnJvciI6IHsiY29kZSI6ICJQTFAwMDA5IiwgImRhdGEiOiB7InJl
+        c291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0sICJkZXNj
+        cmlwdGlvbiI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PUZl
+        ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
+        bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:56 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
+        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
+        b3J0ZXJfY29uZmlnIjp7ImRvd25sb2FkX3BvbGljeSI6Im9uX2RlbWFuZCIs
+        InJlbW92ZV9taXNzaW5nIjp0cnVlLCJmZWVkIjoiZmlsZTovLy92YXIvd3d3
+        L3Rlc3RfcmVwb3Mvem9vIiwidHlwZV9za2lwX2xpc3QiOm51bGwsInByb3h5
+        X2hvc3QiOm51bGwsImJhc2ljX2F1dGhfdXNlcm5hbWUiOm51bGwsImJhc2lj
+        X2F1dGhfcGFzc3dvcmQiOm51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJz
+        c2xfY2xpZW50X2NlcnQiOm51bGwsInNzbF9jbGllbnRfa2V5IjpudWxsLCJz
+        c2xfY2FfY2VydCI6bnVsbH0sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJycG0t
+        cmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQi
+        OiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsicmVs
+        YXRpdmVfdXJsIjoiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5L2ZlZG9yYV8x
+        N19sYWJlbCIsImh0dHAiOmZhbHNlLCJodHRwcyI6dHJ1ZSwicHJvdGVjdGVk
+        Ijp0cnVlLCJjaGVja3N1bV90eXBlIjpudWxsfSwiYXV0b19wdWJsaXNoIjp0
+        cnVlLCJkaXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xNyJ9LHsiZGlzdHJpYnV0
+        b3JfdHlwZV9pZCI6Inl1bV9jbG9uZV9kaXN0cmlidXRvciIsImRpc3RyaWJ1
+        dG9yX2NvbmZpZyI6eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6IkZl
+        ZG9yYV8xNyJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRvcl9p
+        ZCI6IkZlZG9yYV8xN19jbG9uZSJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9pZCI6
+        ImV4cG9ydF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJo
+        dHRwIjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxhdGl2ZV91cmwiOiJBQ01F
+        X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIn0sImF1dG9f
+        cHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3Ry
+        aWJ1dG9yIn1dfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1045'
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:56 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '320'
+      Location:
+      - "/pulp/api/v2/repositories/Fedora_17/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
+        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWM5YmMyMTRkYjI4NGU1OWJlOTZiYWQzIn0sICJpZCI6ICJGZWRvcmFfMTci
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
+        MTcvIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:56 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
+        Ijp0cnVlfX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '53'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:56 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2QzMDZmOGEzLTBhOGEtNGQ3Ny1iNTIzLTdiNDYyYzNmODA1NC8iLCAi
+        dGFza19pZCI6ICJkMzA2ZjhhMy0wYThhLTRkNzctYjUyMy03YjQ2MmMzZjgw
+        NTQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:56 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d306f8a3-0a8a-4d77-b523-7b462c3f8054/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:56 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"0b0d21a63d35b88fa81544c87c8ba8e2-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '666'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMzA2ZjhhMy0wYThhLTRkNzctYjUyMy03YjQ2MmMzZjgw
+        NTQvIiwgInRhc2tfaWQiOiAiZDMwNmY4YTMtMGE4YS00ZDc3LWI1MjMtN2I0
+        NjJjM2Y4MDU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozMzo1NloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhh
+        bXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVs
+        bG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIxNGZiNmU5NWI0OWJmY2QwMDYi
+        fSwgImlkIjogIjVjOWJjMjE0ZmI2ZTk1YjQ5YmZjZDAwNiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:56 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d306f8a3-0a8a-4d77-b523-7b462c3f8054/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:56 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"d90a3861ad4cdcd1780d56d3aeff0177-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1175'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMzA2ZjhhMy0wYThhLTRkNzctYjUyMy03YjQ2MmMzZjgw
+        NTQvIiwgInRhc2tfaWQiOiAiZDMwNmY4YTMtMGE4YS00ZDc3LWI1MjMtN2I0
+        NjJjM2Y4MDU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozMzo1NloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiTk9UX1NU
+        QVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJJTl9QUk9HUkVTUyJ9
+        fX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0
+        YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjE0ZmI2
+        ZTk1YjQ5YmZjZDAwNiJ9LCAiaWQiOiAiNWM5YmMyMTRmYjZlOTViNDliZmNk
+        MDA2In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:56 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d306f8a3-0a8a-4d77-b523-7b462c3f8054/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:56 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"628ddad454fbf1d35902707472f51fc6-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMzA2ZjhhMy0wYThhLTRkNzctYjUyMy03YjQ2MmMzZjgw
+        NTQvIiwgInRhc2tfaWQiOiAiZDMwNmY4YTMtMGE4YS00ZDc3LWI1MjMtN2I0
+        NjJjM2Y4MDU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozMzo1NloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
+        Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiTk9UX1NU
+        QVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5w
+        YXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0
+        aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjE0ZmI2ZTk1
+        YjQ5YmZjZDAwNiJ9LCAiaWQiOiAiNWM5YmMyMTRmYjZlOTViNDliZmNkMDA2
+        In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:56 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d306f8a3-0a8a-4d77-b523-7b462c3f8054/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:56 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"628ddad454fbf1d35902707472f51fc6-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMzA2ZjhhMy0wYThhLTRkNzctYjUyMy03YjQ2MmMzZjgw
+        NTQvIiwgInRhc2tfaWQiOiAiZDMwNmY4YTMtMGE4YS00ZDc3LWI1MjMtN2I0
+        NjJjM2Y4MDU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozMzo1NloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
+        Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiTk9UX1NU
+        QVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5w
+        YXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0
+        aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjE0ZmI2ZTk1
+        YjQ5YmZjZDAwNiJ9LCAiaWQiOiAiNWM5YmMyMTRmYjZlOTViNDliZmNkMDA2
+        In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:56 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d306f8a3-0a8a-4d77-b523-7b462c3f8054/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:56 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"628ddad454fbf1d35902707472f51fc6-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMzA2ZjhhMy0wYThhLTRkNzctYjUyMy03YjQ2MmMzZjgw
+        NTQvIiwgInRhc2tfaWQiOiAiZDMwNmY4YTMtMGE4YS00ZDc3LWI1MjMtN2I0
+        NjJjM2Y4MDU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozMzo1NloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
+        Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiTk9UX1NU
+        QVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5w
+        YXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0
+        aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjE0ZmI2ZTk1
+        YjQ5YmZjZDAwNiJ9LCAiaWQiOiAiNWM5YmMyMTRmYjZlOTViNDliZmNkMDA2
+        In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:56 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d306f8a3-0a8a-4d77-b523-7b462c3f8054/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:56 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"628ddad454fbf1d35902707472f51fc6-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMzA2ZjhhMy0wYThhLTRkNzctYjUyMy03YjQ2MmMzZjgw
+        NTQvIiwgInRhc2tfaWQiOiAiZDMwNmY4YTMtMGE4YS00ZDc3LWI1MjMtN2I0
+        NjJjM2Y4MDU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozMzo1NloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
+        Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiTk9UX1NU
+        QVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5w
+        YXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0
+        aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjE0ZmI2ZTk1
+        YjQ5YmZjZDAwNiJ9LCAiaWQiOiAiNWM5YmMyMTRmYjZlOTViNDliZmNkMDA2
+        In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:56 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d306f8a3-0a8a-4d77-b523-7b462c3f8054/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:56 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"6446f0e06ec93ee0d2255e7f5bbb9e6f-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1169'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMzA2ZjhhMy0wYThhLTRkNzctYjUyMy03YjQ2MmMzZjgw
+        NTQvIiwgInRhc2tfaWQiOiAiZDMwNmY4YTMtMGE4YS00ZDc3LWI1MjMtN2I0
+        NjJjM2Y4MDU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozMzo1NloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        Tk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        Tk9UX1NUQVJURUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiTk9UX1NUQVJU
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJx
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0
+        ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0
+        YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjE0ZmI2ZTk1YjQ5
+        YmZjZDAwNiJ9LCAiaWQiOiAiNWM5YmMyMTRmYjZlOTViNDliZmNkMDA2In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:56 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d306f8a3-0a8a-4d77-b523-7b462c3f8054/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:56 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"04bbfe538ac7c3f66b1018a384a654c8-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1163'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMzA2ZjhhMy0wYThhLTRkNzctYjUyMy03YjQ2MmMzZjgw
+        NTQvIiwgInRhc2tfaWQiOiAiZDMwNmY4YTMtMGE4YS00ZDc3LWI1MjMtN2I0
+        NjJjM2Y4MDU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozMzo1NloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        Tk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiSU5fUFJPR1JFU1MifSwg
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5l
+        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0
+        ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjE0ZmI2ZTk1YjQ5YmZjZDAw
+        NiJ9LCAiaWQiOiAiNWM5YmMyMTRmYjZlOTViNDliZmNkMDA2In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:56 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d306f8a3-0a8a-4d77-b523-7b462c3f8054/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:56 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"41d77e276a5deef0ab0f9b38eacf5596-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1160'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMzA2ZjhhMy0wYThhLTRkNzctYjUyMy03YjQ2MmMzZjgw
+        NTQvIiwgInRhc2tfaWQiOiAiZDMwNmY4YTMtMGE4YS00ZDc3LWI1MjMtN2I0
+        NjJjM2Y4MDU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozMzo1NloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJJ
+        Tl9QUk9HUkVTUyJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        Tk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFt
+        cGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxs
+        by5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjE0ZmI2ZTk1YjQ5YmZjZDAwNiJ9
+        LCAiaWQiOiAiNWM5YmMyMTRmYjZlOTViNDliZmNkMDA2In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:56 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d306f8a3-0a8a-4d77-b523-7b462c3f8054/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:56 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"73df1cffe449167bde3121583e517f45-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1154'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMzA2ZjhhMy0wYThhLTRkNzctYjUyMy03YjQ2MmMzZjgw
+        NTQvIiwgInRhc2tfaWQiOiAiZDMwNmY4YTMtMGE4YS00ZDc3LWI1MjMtN2I0
+        NjJjM2Y4MDU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozMzo1NloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRl
+        bXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNlcnZl
+        ZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNv
+        bS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFt
+        cGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjVjOWJjMjE0ZmI2ZTk1YjQ5YmZjZDAwNiJ9LCAiaWQi
+        OiAiNWM5YmMyMTRmYjZlOTViNDliZmNkMDA2In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:56 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d306f8a3-0a8a-4d77-b523-7b462c3f8054/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:56 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"54119cef6a7cf48d417ded4968dc5dbb-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2403'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMzA2ZjhhMy0wYThhLTRkNzctYjUyMy03YjQ2MmMzZjgw
+        NTQvIiwgInRhc2tfaWQiOiAiZDMwNmY4YTMtMGE4YS00ZDc3LWI1MjMtN2I0
+        NjJjM2Y4MDU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        OS0wMy0yN1QxODozMzo1NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozMzo1NloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMTRjY2EyY2QtN2NjZS00NzFlLWJmZjQtOGZmOGVkMWE3
+        MmU3LyIsICJ0YXNrX2lkIjogIjE0Y2NhMmNkLTdjY2UtNDcxZS1iZmY0LThm
+        ZjhlZDFhNzJlNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjog
+        bnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzdGFydGVkIjogIjIwMTktMDMtMjdUMTg6MzM6NTZaIiwgIl9ucyI6
+        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wMy0y
+        N1QxODozMzo1NloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJtb2R1
+        bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWM5
+        YmMyMTRkYjI4NGU0YWUyMjExOWFmIiwgImRldGFpbHMiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzaXplX3Rv
+        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
+        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
+        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzliYzIxNGZiNmU5NWI0OWJmY2QwMDYifSwgImlkIjogIjVjOWJjMjE0
+        ZmI2ZTk1YjQ5YmZjZDAwNiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:56 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14cca2cd-7cce-471e-bff4-8ff8ed1a72e7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:56 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"5236a2598ae68ad1540ec59aae4e9959-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4294'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8xNGNjYTJjZC03Y2NlLTQ3MWUtYmZmNC04ZmY4
+        ZWQxYTcyZTcvIiwgInRhc2tfaWQiOiAiMTRjY2EyY2QtN2NjZS00NzFlLWJm
+        ZjQtOGZmOGVkMWE3MmU3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxOS0wMy0yN1QxODozMzo1NloiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4
+        Y2NiMzc2NC04OTQ4LTQ2MDMtOGVjYS00NzExMWExZmYyNWMiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlw
+        ZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNmI3ZWYw
+        NTAtNGFmNi00YjMwLTliMzMtNTUwOWUwNDk4YTJhIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiYTQxMDI3ZGYtNzlhZC00YzM3LWJmMjUtODMyZDdlZTgz
+        ZDZjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3Rl
+        cF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY4MGM4Y2Fm
+        LWU0YjMtNDZhMy1iOTA4LTE5NzQwNDcwMjM3ZiIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVt
+        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJhMGQ0NWM1Ny0xNWQ3LTRmYmQtOTRlOS1mOGExNDYw
+        YzE4MGEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxlcyIsICJzdGVw
+        X3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxYTJhNzZi
+        ZS0yODI2LTRkNzYtYWE4MC0yYmYzMjBmMGVjODciLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29tcHMiLCAi
+        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiZWExN2Y0YzAtMjVmZS00YjRhLWEyODUtNjRj
+        NGIwYTY3MjhiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIs
+        ICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        NzYwMDNlOTYtMWIzOC00ZDgzLWI1NjUtN2E2ODMyMGU5YjNhIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNs
+        b3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDAyMTg5
+        Y2UtZjUxZi00ZTFjLWE3NTQtZDEwNmQzODYxYjFkIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJH
+        ZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJh
+        dGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjMwNmQ3ODI5LThhMTIt
+        NDgyZC1iZGRhLWJjOWZjYTRmNjY5ZSIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcg
+        b2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9k
+        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjZlYjIzODEzLTdkMzYtNDkxYy1h
+        ZjMyLTIyZGY2YTcxZTA2OSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1M
+        IGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICIzYjI0NGFlNy1jMTMxLTRiYjktYjdlNi02MmVjNzBjNWVhZGQi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBf
+        dHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJhZWI2NTZhOC1lYzdhLTQ0YTUtYjI3YS0zOGRjNzIxYmIyZjciLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAi
+        aW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        ImI2NmQ1YmUwLWRjYWEtNDVlNS05OGQzLTQ5NGRiMTk2ZmM5NyIsICJudW1f
+        cHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0wQHRoZXRhLnBhcnRlbGxvLmV4YW1wbGUuY29tLmRxMiIsICJz
+        dGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0wQHRoZXRhLnBhcnRlbGxvLmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNWM5YmMyMTRmYjZlOTViNDliZmNkMTc3In0sICJpZCI6ICI1YzliYzIx
+        NGZiNmU5NWI0OWJmY2QxNzcifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:56 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d306f8a3-0a8a-4d77-b523-7b462c3f8054/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"54119cef6a7cf48d417ded4968dc5dbb-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2403'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMzA2ZjhhMy0wYThhLTRkNzctYjUyMy03YjQ2MmMzZjgw
+        NTQvIiwgInRhc2tfaWQiOiAiZDMwNmY4YTMtMGE4YS00ZDc3LWI1MjMtN2I0
+        NjJjM2Y4MDU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        OS0wMy0yN1QxODozMzo1NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozMzo1NloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMTRjY2EyY2QtN2NjZS00NzFlLWJmZjQtOGZmOGVkMWE3
+        MmU3LyIsICJ0YXNrX2lkIjogIjE0Y2NhMmNkLTdjY2UtNDcxZS1iZmY0LThm
+        ZjhlZDFhNzJlNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjog
+        bnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzdGFydGVkIjogIjIwMTktMDMtMjdUMTg6MzM6NTZaIiwgIl9ucyI6
+        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wMy0y
+        N1QxODozMzo1NloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJtb2R1
+        bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWM5
+        YmMyMTRkYjI4NGU0YWUyMjExOWFmIiwgImRldGFpbHMiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzaXplX3Rv
+        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
+        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
+        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzliYzIxNGZiNmU5NWI0OWJmY2QwMDYifSwgImlkIjogIjVjOWJjMjE0
+        ZmI2ZTk1YjQ5YmZjZDAwNiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14cca2cd-7cce-471e-bff4-8ff8ed1a72e7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"baca22f0a6411f76b0342589ff8351f8-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4288'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8xNGNjYTJjZC03Y2NlLTQ3MWUtYmZmNC04ZmY4
+        ZWQxYTcyZTcvIiwgInRhc2tfaWQiOiAiMTRjY2EyY2QtN2NjZS00NzFlLWJm
+        ZjQtOGZmOGVkMWE3MmU3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxOS0wMy0yN1QxODozMzo1NloiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4Y2Ni
+        Mzc2NC04OTQ4LTQ2MDMtOGVjYS00NzExMWExZmYyNWMiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNmI3ZWYwNTAtNGFm
+        Ni00YjMwLTliMzMtNTUwOWUwNDk4YTJhIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiYTQxMDI3ZGYtNzlhZC00YzM3LWJmMjUtODMyZDdlZTgzZDZjIiwg
+        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
+        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY4MGM4Y2FmLWU0YjMt
+        NDZhMy1iOTA4LTE5NzQwNDcwMjM3ZiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJhMGQ0NWM1Ny0xNWQ3LTRmYmQtOTRlOS1mOGExNDYwYzE4MGEi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxlcyIsICJzdGVwX3R5cGUi
+        OiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
+        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxYTJhNzZiZS0yODI2
+        LTRkNzYtYWE4MC0yYmYzMjBmMGVjODciLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiZWExN2Y0YzAtMjVmZS00YjRhLWEyODUtNjRjNGIwYTY3
+        MjhiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVw
+        X3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzYwMDNl
+        OTYtMWIzOC00ZDgzLWI1NjUtN2E2ODMyMGU5YjNhIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJD
+        bG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNsb3NlX3Jl
+        cG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDAyMTg5Y2UtZjUx
+        Zi00ZTFjLWE3NTQtZDEwNmQzODYxYjFkIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
+        aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3Fs
+        aXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjMwNmQ3ODI5LThhMTItNDgyZC1i
+        ZGRhLWJjOWZjYTRmNjY5ZSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJl
+        cG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjZlYjIzODEzLTdkMzYtNDkxYy1hZjMyLTIy
+        ZGY2YTcxZTA2OSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVz
+        IiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICIzYjI0NGFlNy1jMTMxLTRiYjktYjdlNi02MmVjNzBjNWVhZGQiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6
+        ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZWI2
+        NTZhOC1lYzdhLTQ0YTUtYjI3YS0zOGRjNzIxYmIyZjciLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
+        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI2NmQ1
+        YmUwLWRjYWEtNDVlNS05OGQzLTQ5NGRiMTk2ZmM5NyIsICJudW1fcHJvY2Vz
+        c2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0wQHRoZXRhLnBhcnRlbGxvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6
+        ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0wQHRoZXRhLnBhcnRlbGxvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM5
+        YmMyMTRmYjZlOTViNDliZmNkMTc3In0sICJpZCI6ICI1YzliYzIxNGZiNmU5
+        NWI0OWJmY2QxNzcifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d306f8a3-0a8a-4d77-b523-7b462c3f8054/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"54119cef6a7cf48d417ded4968dc5dbb-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2403'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMzA2ZjhhMy0wYThhLTRkNzctYjUyMy03YjQ2MmMzZjgw
+        NTQvIiwgInRhc2tfaWQiOiAiZDMwNmY4YTMtMGE4YS00ZDc3LWI1MjMtN2I0
+        NjJjM2Y4MDU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        OS0wMy0yN1QxODozMzo1NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozMzo1NloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMTRjY2EyY2QtN2NjZS00NzFlLWJmZjQtOGZmOGVkMWE3
+        MmU3LyIsICJ0YXNrX2lkIjogIjE0Y2NhMmNkLTdjY2UtNDcxZS1iZmY0LThm
+        ZjhlZDFhNzJlNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjog
+        bnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzdGFydGVkIjogIjIwMTktMDMtMjdUMTg6MzM6NTZaIiwgIl9ucyI6
+        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wMy0y
+        N1QxODozMzo1NloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJtb2R1
+        bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWM5
+        YmMyMTRkYjI4NGU0YWUyMjExOWFmIiwgImRldGFpbHMiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzaXplX3Rv
+        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
+        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
+        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzliYzIxNGZiNmU5NWI0OWJmY2QwMDYifSwgImlkIjogIjVjOWJjMjE0
+        ZmI2ZTk1YjQ5YmZjZDAwNiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14cca2cd-7cce-471e-bff4-8ff8ed1a72e7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"cc0afd4b740dc5a0073fc06cd8e4be19-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4281'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8xNGNjYTJjZC03Y2NlLTQ3MWUtYmZmNC04ZmY4
+        ZWQxYTcyZTcvIiwgInRhc2tfaWQiOiAiMTRjY2EyY2QtN2NjZS00NzFlLWJm
+        ZjQtOGZmOGVkMWE3MmU3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxOS0wMy0yN1QxODozMzo1NloiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4Y2Ni
+        Mzc2NC04OTQ4LTQ2MDMtOGVjYS00NzExMWExZmYyNWMiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNmI3ZWYwNTAtNGFm
+        Ni00YjMwLTliMzMtNTUwOWUwNDk4YTJhIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiYTQxMDI3ZGYtNzlhZC00YzM3LWJmMjUtODMyZDdlZTgzZDZjIiwgIm51
+        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
+        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjgwYzhjYWYtZTRiMy00NmEzLWI5
+        MDgtMTk3NDA0NzAyMzdmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
+        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
+        InN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        ImEwZDQ1YzU3LTE1ZDctNGZiZC05NGU5LWY4YTE0NjBjMTgwYSIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1
+        bGVzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjFhMmE3NmJlLTI4MjYtNGQ3Ni1h
+        YTgwLTJiZjMyMGYwZWM4NyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21w
+        cyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJlYTE3ZjRjMC0yNWZlLTRiNGEtYTI4NS02NGM0YjBhNjcyOGIiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6
+        ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
+        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3NjAwM2U5Ni0xYjM4
+        LTRkODMtYjU2NS03YTY4MzIwZTliM2EiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkNsb3Npbmcg
+        cmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRh
+        ZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkMDIxODljZS1mNTFmLTRlMWMt
+        YTc1NC1kMTA2ZDM4NjFiMWQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3Fs
+        aXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAi
+        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiMzA2ZDc4MjktOGExMi00ODJkLWJkZGEtYmM5
+        ZmNhNGY2NjllIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVwb2RhdGEi
+        LCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiNmViMjM4MTMtN2QzNi00OTFjLWFmMzItMjJkZjZhNzFl
+        MDY5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAic3Rl
+        cF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNiMjQ0
+        YWU3LWMxMzEtNGJiOS1iN2U2LTYyZWM3MGM1ZWFkZCIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        UHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxp
+        c2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
+        VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFlYjY1NmE4LWVj
+        N2EtNDRhNS1iMjdhLTM4ZGM3MjFiYjJmNyIsICJudW1fcHJvY2Vzc2VkIjog
+        MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiV3JpdGlu
+        ZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3Jl
+        cG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjY2ZDViZTAtZGNh
+        YS00NWU1LTk4ZDMtNDk0ZGIxOTZmYzk3IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhl
+        dGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5p
+        bmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVs
+        bCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIxNGZi
+        NmU5NWI0OWJmY2QxNzcifSwgImlkIjogIjVjOWJjMjE0ZmI2ZTk1YjQ5YmZj
+        ZDE3NyJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d306f8a3-0a8a-4d77-b523-7b462c3f8054/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"54119cef6a7cf48d417ded4968dc5dbb-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2403'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMzA2ZjhhMy0wYThhLTRkNzctYjUyMy03YjQ2MmMzZjgw
+        NTQvIiwgInRhc2tfaWQiOiAiZDMwNmY4YTMtMGE4YS00ZDc3LWI1MjMtN2I0
+        NjJjM2Y4MDU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        OS0wMy0yN1QxODozMzo1NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozMzo1NloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMTRjY2EyY2QtN2NjZS00NzFlLWJmZjQtOGZmOGVkMWE3
+        MmU3LyIsICJ0YXNrX2lkIjogIjE0Y2NhMmNkLTdjY2UtNDcxZS1iZmY0LThm
+        ZjhlZDFhNzJlNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjog
+        bnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzdGFydGVkIjogIjIwMTktMDMtMjdUMTg6MzM6NTZaIiwgIl9ucyI6
+        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wMy0y
+        N1QxODozMzo1NloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJtb2R1
+        bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWM5
+        YmMyMTRkYjI4NGU0YWUyMjExOWFmIiwgImRldGFpbHMiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzaXplX3Rv
+        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
+        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
+        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzliYzIxNGZiNmU5NWI0OWJmY2QwMDYifSwgImlkIjogIjVjOWJjMjE0
+        ZmI2ZTk1YjQ5YmZjZDAwNiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14cca2cd-7cce-471e-bff4-8ff8ed1a72e7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"4ab6571cb7343b95f20b4cfc48dce8c7-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4271'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8xNGNjYTJjZC03Y2NlLTQ3MWUtYmZmNC04ZmY4
+        ZWQxYTcyZTcvIiwgInRhc2tfaWQiOiAiMTRjY2EyY2QtN2NjZS00NzFlLWJm
+        ZjQtOGZmOGVkMWE3MmU3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxOS0wMy0yN1QxODozMzo1NloiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4Y2Ni
+        Mzc2NC04OTQ4LTQ2MDMtOGVjYS00NzExMWExZmYyNWMiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNmI3ZWYwNTAtNGFm
+        Ni00YjMwLTliMzMtNTUwOWUwNDk4YTJhIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiYTQxMDI3ZGYtNzlhZC00YzM3LWJmMjUtODMyZDdlZTgzZDZjIiwgIm51
+        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
+        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjgwYzhjYWYtZTRiMy00NmEzLWI5
+        MDgtMTk3NDA0NzAyMzdmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
+        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImEw
+        ZDQ1YzU3LTE1ZDctNGZiZC05NGU5LWY4YTE0NjBjMTgwYSIsICJudW1fcHJv
+        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1bGVz
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiMWEyYTc2YmUtMjgyNi00ZDc2LWFhODAtMmJm
+        MzIwZjBlYzg3IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUi
+        LCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVhMTdm
+        NGMwLTI1ZmUtNGI0YS1hMjg1LTY0YzRiMGE2NzI4YiIsICJudW1fcHJvY2Vz
+        c2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        UHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIklOX1BST0dSRVNTIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjc2MDAzZTk2LTFiMzgtNGQ4My1iNTY1
+        LTdhNjgzMjBlOWIzYSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFk
+        YXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImQwMjE4OWNlLWY1MWYtNGUxYy1hNzU0LWQxMDZk
+        Mzg2MWIxZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
+        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICIzMDZkNzgyOS04YTEyLTQ4MmQtYmRkYS1iYzlmY2E0ZjY2OWUi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5
+        cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICI2ZWIyMzgxMy03ZDM2LTQ5MWMtYWYzMi0yMmRmNmE3MWUwNjkiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
+        cmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
+        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2IyNDRhZTctYzEzMS00
+        YmI5LWI3ZTYtNjJlYzcwYzVlYWRkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
+        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
+        IGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rv
+        cnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWViNjU2YTgtZWM3YS00NGE1LWIy
+        N2EtMzhkYzcyMWJiMmY3IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3Rpbmdz
+        IEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0
+        YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNjZkNWJlMC1kY2FhLTQ1ZTUtOThk
+        My00OTRkYjE5NmZjOTciLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxs
+        by5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5w
+        YXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3Ii
+        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjE0ZmI2ZTk1YjQ5YmZj
+        ZDE3NyJ9LCAiaWQiOiAiNWM5YmMyMTRmYjZlOTViNDliZmNkMTc3In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d306f8a3-0a8a-4d77-b523-7b462c3f8054/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"54119cef6a7cf48d417ded4968dc5dbb-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2403'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMzA2ZjhhMy0wYThhLTRkNzctYjUyMy03YjQ2MmMzZjgw
+        NTQvIiwgInRhc2tfaWQiOiAiZDMwNmY4YTMtMGE4YS00ZDc3LWI1MjMtN2I0
+        NjJjM2Y4MDU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        OS0wMy0yN1QxODozMzo1NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozMzo1NloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMTRjY2EyY2QtN2NjZS00NzFlLWJmZjQtOGZmOGVkMWE3
+        MmU3LyIsICJ0YXNrX2lkIjogIjE0Y2NhMmNkLTdjY2UtNDcxZS1iZmY0LThm
+        ZjhlZDFhNzJlNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjog
+        bnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzdGFydGVkIjogIjIwMTktMDMtMjdUMTg6MzM6NTZaIiwgIl9ucyI6
+        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wMy0y
+        N1QxODozMzo1NloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJtb2R1
+        bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWM5
+        YmMyMTRkYjI4NGU0YWUyMjExOWFmIiwgImRldGFpbHMiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzaXplX3Rv
+        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
+        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
+        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzliYzIxNGZiNmU5NWI0OWJmY2QwMDYifSwgImlkIjogIjVjOWJjMjE0
+        ZmI2ZTk1YjQ5YmZjZDAwNiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14cca2cd-7cce-471e-bff4-8ff8ed1a72e7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"35cf92007fd8b4725f9bbc46c9517edb-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4248'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8xNGNjYTJjZC03Y2NlLTQ3MWUtYmZmNC04ZmY4
+        ZWQxYTcyZTcvIiwgInRhc2tfaWQiOiAiMTRjY2EyY2QtN2NjZS00NzFlLWJm
+        ZjQtOGZmOGVkMWE3MmU3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxOS0wMy0yN1QxODozMzo1NloiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4Y2Ni
+        Mzc2NC04OTQ4LTQ2MDMtOGVjYS00NzExMWExZmYyNWMiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNmI3ZWYwNTAtNGFm
+        Ni00YjMwLTliMzMtNTUwOWUwNDk4YTJhIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiYTQxMDI3ZGYtNzlhZC00YzM3LWJmMjUtODMyZDdlZTgzZDZjIiwgIm51
+        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
+        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjgwYzhjYWYtZTRiMy00NmEzLWI5
+        MDgtMTk3NDA0NzAyMzdmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
+        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImEw
+        ZDQ1YzU3LTE1ZDctNGZiZC05NGU5LWY4YTE0NjBjMTgwYSIsICJudW1fcHJv
+        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1bGVz
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiMWEyYTc2YmUtMjgyNi00ZDc2LWFhODAtMmJm
+        MzIwZjBlYzg3IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUi
+        LCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVhMTdm
+        NGMwLTI1ZmUtNGI0YS1hMjg1LTY0YzRiMGE2NzI4YiIsICJudW1fcHJvY2Vz
+        c2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        UHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjc2MDAzZTk2LTFiMzgtNGQ4My1iNTY1LTdh
+        NjgzMjBlOWIzYSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
+        IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImQwMjE4OWNlLWY1MWYtNGUxYy1hNzU0LWQxMDZkMzg2MWIx
+        ZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
+        ZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjMw
+        NmQ3ODI5LThhMTItNDgyZC1iZGRhLWJjOWZjYTRmNjY5ZSIsICJudW1fcHJv
+        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
+        OiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1v
+        dmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjZlYjIzODEzLTdk
+        MzYtNDkxYy1hZjMyLTIyZGY2YTcxZTA2OSIsICJudW1fcHJvY2Vzc2VkIjog
+        MX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
+        dGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjNiMjQ0YWU3LWMxMzEtNGJiOS1iN2U2LTYyZWM3MGM1
+        ZWFkZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAi
+        c3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImFlYjY1NmE4LWVjN2EtNDRhNS1iMjdhLTM4ZGM3MjFiYjJmNyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6
+        ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAx
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        YjY2ZDViZTAtZGNhYS00NWU1LTk4ZDMtNDk0ZGIxOTZmYzk3IiwgIm51bV9w
+        cm9jZXNzZWQiOiAxfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0
+        YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzliYzIxNGZiNmU5NWI0OWJmY2QxNzcifSwgImlkIjogIjVjOWJjMjE0
+        ZmI2ZTk1YjQ5YmZjZDE3NyJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d306f8a3-0a8a-4d77-b523-7b462c3f8054/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"54119cef6a7cf48d417ded4968dc5dbb-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2403'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMzA2ZjhhMy0wYThhLTRkNzctYjUyMy03YjQ2MmMzZjgw
+        NTQvIiwgInRhc2tfaWQiOiAiZDMwNmY4YTMtMGE4YS00ZDc3LWI1MjMtN2I0
+        NjJjM2Y4MDU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        OS0wMy0yN1QxODozMzo1NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozMzo1NloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvMTRjY2EyY2QtN2NjZS00NzFlLWJmZjQtOGZmOGVkMWE3
+        MmU3LyIsICJ0YXNrX2lkIjogIjE0Y2NhMmNkLTdjY2UtNDcxZS1iZmY0LThm
+        ZjhlZDFhNzJlNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjog
+        bnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzdGFydGVkIjogIjIwMTktMDMtMjdUMTg6MzM6NTZaIiwgIl9ucyI6
+        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wMy0y
+        N1QxODozMzo1NloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJtb2R1
+        bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWM5
+        YmMyMTRkYjI4NGU0YWUyMjExOWFmIiwgImRldGFpbHMiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzaXplX3Rv
+        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
+        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
+        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzliYzIxNGZiNmU5NWI0OWJmY2QwMDYifSwgImlkIjogIjVjOWJjMjE0
+        ZmI2ZTk1YjQ5YmZjZDAwNiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/14cca2cd-7cce-471e-bff4-8ff8ed1a72e7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"a1c3c5996f78e25dc29c1788adbfbeb8-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '8518'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8xNGNjYTJjZC03Y2NlLTQ3MWUtYmZmNC04ZmY4
+        ZWQxYTcyZTcvIiwgInRhc2tfaWQiOiAiMTRjY2EyY2QtN2NjZS00NzFlLWJm
+        ZjQtOGZmOGVkMWE3MmU3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxOS0wMy0yN1QxODozMzo1N1oiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozMzo1NloiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICI4Y2NiMzc2NC04OTQ4LTQ2MDMtOGVjYS00NzExMWEx
+        ZmYyNWMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiNmI3ZWYwNTAtNGFmNi00YjMwLTliMzMtNTUwOWUwNDk4YTJhIiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiYTQxMDI3ZGYtNzlhZC00YzM3LWJmMjUt
+        ODMyZDdlZTgzZDZjIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjgw
+        YzhjYWYtZTRiMy00NmEzLWI5MDgtMTk3NDA0NzAyMzdmIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImEwZDQ1YzU3LTE1ZDctNGZiZC05NGU5LWY4YTE0
+        NjBjMTgwYSIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0
+        ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMWEyYTc2YmUt
+        MjgyNi00ZDc2LWFhODAtMmJmMzIwZjBlYzg3IiwgIm51bV9wcm9jZXNzZWQi
+        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJs
+        aXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0
+        ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImVhMTdmNGMwLTI1ZmUtNGI0YS1hMjg1LTY0YzRiMGE2
+        NzI4YiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3Rl
+        cF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc2MDAzZTk2
+        LTFiMzgtNGQ4My1iNTY1LTdhNjgzMjBlOWIzYSIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xv
+        c2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQwMjE4OWNlLWY1MWYtNGUx
+        Yy1hNzU0LWQxMDZkMzg2MWIxZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBz
+        cWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjMwNmQ3ODI5LThhMTItNDgyZC1iZGRhLWJjOWZj
+        YTRmNjY5ZSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwg
+        InN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjZlYjIzODEzLTdkMzYtNDkxYy1hZjMyLTIyZGY2YTcxZTA2OSIs
+        ICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
+        Y3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlw
+        ZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
+        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNiMjQ0YWU3LWMxMzEt
+        NGJiOS1iN2U2LTYyZWM3MGM1ZWFkZCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
+        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImFlYjY1NmE4LWVjN2EtNDRhNS1iMjdh
+        LTM4ZGM3MjFiYjJmNyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
+        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiYjY2ZDViZTAtZGNhYS00NWU1LTk4ZDMtNDk0
+        ZGIxOTZmYzk3IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhh
+        bXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9u
+        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQHRoZXRhLnBhcnRl
+        bGxvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
+        c3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3
+        IiwgInN0YXJ0ZWQiOiAiMjAxOS0wMy0yN1QxODozMzo1NloiLCAiX25zIjog
+        InJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTAz
+        LTI3VDE4OjMzOjU3WiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0
+        b3JfdHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6IHsi
+        Z2VuZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQiLCAicnBtcyI6ICJGSU5JU0hF
+        RCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAi
+        cmVtb3ZlX29sZF9yZXBvZGF0YSI6ICJGSU5JU0hFRCIsICJtb2R1bGVzIjog
+        IlNLSVBQRUQiLCAiY2xvc2VfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIs
+        ICJkcnBtcyI6ICJTS0lQUEVEIiwgImNvbXBzIjogIkZJTklTSEVEIiwgImRp
+        c3RyaWJ1dGlvbiI6ICJGSU5JU0hFRCIsICJyZXBvdmlldyI6ICJTS0lQUEVE
+        IiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6
+        ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3Jf
+        bWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTci
+        LCAiaWQiOiAiNWM5YmMyMTVkYjI4NGU0YWUyMjExOWIwIiwgImRldGFpbHMi
+        OiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFs
+        aXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6
+        ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjhjY2IzNzY0LTg5
+        NDgtNDYwMy04ZWNhLTQ3MTExYTFmZjI1YyIsICJudW1fcHJvY2Vzc2VkIjog
+        MX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3Ry
+        aWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2YjdlZjA1MC00YWY2LTRiMzAt
+        OWIzMy01NTA5ZTA0OThhMmEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBN
+        cyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNDEw
+        MjdkZi03OWFkLTRjMzctYmYyNS04MzJkN2VlODNkNmMiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJmODBjOGNhZi1lNGIzLTQ2YTMtYjkwOC0xOTc0
+        MDQ3MDIzN2YiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTBkNDVjNTct
+        MTVkNy00ZmJkLTk0ZTktZjhhMTQ2MGMxODBhIiwgIm51bV9wcm9jZXNzZWQi
+        OiAzfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
+        aXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIxYTJhNzZiZS0yODI2LTRkNzYtYWE4MC0yYmYzMjBmMGVj
+        ODciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVw
+        X3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWExN2Y0YzAtMjVm
+        ZS00YjRhLWEyODUtNjRjNGIwYTY3MjhiIiwgIm51bV9wcm9jZXNzZWQiOiAz
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiNzYwMDNlOTYtMWIzOC00ZDgzLWI1NjUtN2E2ODMyMGU5
+        YjNhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEs
+        ICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3Rl
+        cF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiZDAyMTg5Y2UtZjUxZi00ZTFjLWE3NTQtZDEwNmQzODYxYjFkIiwgIm51
+        bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUi
+        OiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzA2ZDc4Mjkt
+        OGExMi00ODJkLWJkZGEtYmM5ZmNhNGY2NjllIiwgIm51bV9wcm9jZXNzZWQi
+        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1v
+        dmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRf
+        cmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNmViMjM4MTMtN2QzNi00OTFj
+        LWFmMzItMjJkZjZhNzFlMDY5IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhU
+        TUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3Rv
+        dGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiM2IyNDRhZTctYzEzMS00YmI5LWI3ZTYtNjJlYzcwYzVlYWRkIiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5
+        cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWVi
+        NjU2YTgtZWM3YS00NGE1LWIyN2EtMzhkYzcyMWJiMmY3IiwgIm51bV9wcm9j
+        ZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
+        ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRp
+        YWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNjZkNWJl
+        MC1kY2FhLTQ1ZTUtOThkMy00OTRkYjE5NmZjOTciLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDF9XX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM5
+        YmMyMTRmYjZlOTViNDliZmNkMTc3In0sICJpZCI6ICI1YzliYzIxNGZiNmU5
+        NWI0OWJmY2QxNzcifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjNfdmlldzEiLCJkaXNwbGF5X25hbWUiOiJGZWRvcmEgMTcgeDg2
+        XzY0IiwiaW1wb3J0ZXJfdHlwZV9pZCI6Inl1bV9pbXBvcnRlciIsImltcG9y
+        dGVyX2NvbmZpZyI6e30sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJycG0tcmVw
+        byJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5
+        dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsicmVsYXRp
+        dmVfdXJsIjoiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5L0xpYnJhcnlWaWV3
+        L2ZlZG9yYV8xN19sYWJlbCIsImh0dHAiOmZhbHNlLCJodHRwcyI6dHJ1ZSwi
+        cHJvdGVjdGVkIjp0cnVlLCJjaGVja3N1bV90eXBlIjpudWxsfSwiYXV0b19w
+        dWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9pZCI6IjNfdmlldzEifSx7ImRp
+        c3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1fY2xvbmVfZGlzdHJpYnV0b3IiLCJk
+        aXN0cmlidXRvcl9jb25maWciOnsiZGVzdGluYXRpb25fZGlzdHJpYnV0b3Jf
+        aWQiOiIzX3ZpZXcxIn0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
+        dG9yX2lkIjoiM192aWV3MV9jbG9uZSJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9p
+        ZCI6ImV4cG9ydF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6
+        eyJodHRwIjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxhdGl2ZV91cmwiOiJB
+        Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvTGlicmFyeVZpZXcvZmVkb3JhXzE3
+        X2xhYmVsIn0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lk
+        IjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '790'
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '316'
+      Location:
+      - "/pulp/api/v2/repositories/3_view1/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
+        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWM5YmMyMTVkYjI4NGU1OWJmMTI1OTNjIn0sICJpZCI6ICIzX3ZpZXcxIiwg
+        Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS8i
+        fQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInJwbSJdLCJmaWx0ZXJzIjp7InVuaXQiOnsiZmlsZW5hbWUi
+        OnsiJGluIjpbIndhbHJ1cy0wLjMtMC44Lm5vYXJjaC5ycG0iXX19fSwiZmll
+        bGRzIjp7InVuaXQiOlsibmFtZSIsImVwb2NoIiwidmVyc2lvbiIsInJlbGVh
+        c2UiLCJhcmNoIiwiY2hlY2tzdW10eXBlIiwiY2hlY2tzdW0iXX19fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '220'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzRjODMzNWQxLWRmYmItNDlhOS05NTMyLTRhODJiZjI4OTcyOC8iLCAi
+        dGFza19pZCI6ICI0YzgzMzVkMS1kZmJiLTQ5YTktOTUzMi00YTgyYmYyODk3
+        MjgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInJwbSJdLCJmaWx0ZXJzIjp7InVuaXQiOnsiZmlsZW5hbWUi
+        OnsiJGluIjpbIm1vZC05OS0xMDgucnBtIl19fX19fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '121'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzZkMzNmOTA4LWRkMmYtNGM2MC1iMTJiLWRhNjRjYjM4NTgwNy8iLCAi
+        dGFza19pZCI6ICI2ZDMzZjkwOC1kZDJmLTRjNjAtYjEyYi1kYTY0Y2IzODU4
+        MDcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInNycG0iXSwiZmlsdGVycyI6e319fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '76'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzZhMTM1Njk1LTY2OTAtNGM5Mi04ZGEyLWZiM2ViMWNiMGRjNi8iLCAi
+        dGFza19pZCI6ICI2YTEzNTY5NS02NjkwLTRjOTItOGRhMi1mYjNlYjFjYjBk
+        YzYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbImVycmF0dW0iXSwiZmlsdGVycyI6e319fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '79'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzIwYzNlODYzLTFlZDItNGVhOC1hMWNlLWI2ZWYwYjM3NjdiYy8iLCAi
+        dGFza19pZCI6ICIyMGMzZTg2My0xZWQyLTRlYTgtYTFjZS1iNmVmMGIzNzY3
+        YmMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInBhY2thZ2VfZ3JvdXAiXSwiZmlsdGVycyI6e319fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '85'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2QwMDRjMDlhLTU3ZTktNDA0NC1hMWVlLTE1YjgyYzNiYzg4OS8iLCAi
+        dGFza19pZCI6ICJkMDA0YzA5YS01N2U5LTQwNDQtYTFlZS0xNWI4MmMzYmM4
+        ODkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiXSwiZmlsdGVycyI6
+        e319fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '94'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzY1ZTVjZjg4LTcwNTktNDZjZi04M2FjLTNjNWJlNjY1ZmYzYS8iLCAi
+        dGFza19pZCI6ICI2NWU1Y2Y4OC03MDU5LTQ2Y2YtODNhYy0zYzViZTY2NWZm
+        M2EifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbImRpc3RyaWJ1dGlvbiJdLCJmaWx0ZXJzIjp7fX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '84'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2ZkZTQ2YTk1LTVjMDQtNDkwYy1hZDNjLWFlNTJhNGMxNjVjMS8iLCAi
+        dGFza19pZCI6ICJmZGU0NmE5NS01YzA0LTQ5MGMtYWQzYy1hZTUyYTRjMTY1
+        YzEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbIm1vZHVsZW1kIl0sImZpbHRlcnMiOnt9fX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '80'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzY5MmMwMGMyLTEzMzEtNDA5OC1iZjc3LTczYTk0YmQxZmZjZi8iLCAi
+        dGFza19pZCI6ICI2OTJjMDBjMi0xMzMxLTQwOTgtYmY3Ny03M2E5NGJkMWZm
+        Y2YifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbIm1vZHVsZW1kX2RlZmF1bHRzIl0sImZpbHRlcnMiOnt9fX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '89'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2VlYzFmYzgyLTkyNDctNGFkOC1iMTNkLWY4ODE3OGZmNTQ0Yy8iLCAi
+        dGFza19pZCI6ICJlZWMxZmM4Mi05MjQ3LTRhZDgtYjEzZC1mODgxNzhmZjU0
+        NGMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/4c8335d1-dfbb-49a9-9532-4a82bf289728/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"f31e41b786dd3ec417623aaef7ced6fb-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1046'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80YzgzMzVk
+        MS1kZmJiLTQ5YTktOTUzMi00YTgyYmYyODk3MjgvIiwgInRhc2tfaWQiOiAi
+        NGM4MzM1ZDEtZGZiYi00OWE5LTk1MzItNGE4MmJmMjg5NzI4IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sic2lnbmlu
+        Z19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAid2FscnVzIiwg
+        ImNoZWNrc3VtIjogIjZlOGQ2ZGMwNTdlM2UyYzk4MTlmMGRjN2U2YzdiN2Y4
+        NmJmMmU4NTcxYmJhNDE0YWRlYzdmYjYyMWE0NjFkZmQiLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJhcmNo
+        IjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBl
+        X2lkIjogInJwbSJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVy
+        IjogW119LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJj
+        MjE1ZmI2ZTk1YjQ5YmZjZDI3MSJ9LCAiaWQiOiAiNWM5YmMyMTVmYjZlOTVi
+        NDliZmNkMjcxIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/6a135695-6690-4c92-8da2-fb3eb1cb0dc6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"1c09daae8f8d3293b67eef7889f01e02-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '801'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82YTEzNTY5
+        NS02NjkwLTRjOTItOGRhMi1mYjNlYjFjYjBkYzYvIiwgInRhc2tfaWQiOiAi
+        NmExMzU2OTUtNjY5MC00YzkyLThkYTItZmIzZWIxY2IwZGM2IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW10sICJ1bml0
+        c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIxNWZiNmU5NWI0OWJmY2QyOWUi
+        fSwgImlkIjogIjVjOWJjMjE1ZmI2ZTk1YjQ5YmZjZDI5ZSJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/20c3e863-1ed2-4ea8-a1ce-b6ef0b3767bc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"fd0716bef579e8891df8966edc0b5ac7-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '985'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yMGMzZTg2
+        My0xZWQyLTRlYTgtYTFjZS1iNmVmMGIzNzY3YmMvIiwgInRhc2tfaWQiOiAi
+        MjBjM2U4NjMtMWVkMi00ZWE4LWExY2UtYjZlZjBiMzc2N2JjIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sidW5pdF9r
+        ZXkiOiB7ImlkIjogIlJIRUEtMjAxMDowMDAyIn0sICJ0eXBlX2lkIjogImVy
+        cmF0dW0ifSwgeyJ1bml0X2tleSI6IHsiaWQiOiAiUkhTQS0yMDEwOjA4NTgi
+        fSwgInR5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6
+        ICJSSEVBLTIwMTA6MDAwMSJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn1dLCAi
+        dW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM5YmMyMTVmYjZlOTViNDliZmNk
+        MmM3In0sICJpZCI6ICI1YzliYzIxNWZiNmU5NWI0OWJmY2QyYzcifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d004c09a-57e9-4044-a1ee-15b82c3bc889/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"1220caac179fccb1ee6c237f58344b8b-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1125'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9kMDA0YzA5
+        YS01N2U5LTQwNDQtYTFlZS0xNWI4MmMzYmM4ODkvIiwgInRhc2tfaWQiOiAi
+        ZDAwNGMwOWEtNTdlOS00MDQ0LWExZWUtMTViODJjM2JjODg5IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sidW5pdF9r
+        ZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIsICJpZCI6ICJiaXJkIn0sICJ0
+        eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAifSwgeyJ1bml0X2tleSI6IHsicmVw
+        b19pZCI6ICIzX3ZpZXcxIiwgImlkIjogIm1hbW1hbCJ9LCAidHlwZV9pZCI6
+        ICJwYWNrYWdlX2dyb3VwIn1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9m
+        aWx0ZXIiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRvcmFfMTci
+        LCAiaWQiOiAiYmlyZCJ9LCAidHlwZV9pZCI6ICJwYWNrYWdlX2dyb3VwIn0s
+        IHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImlkIjog
+        Im1hbW1hbCJ9LCAidHlwZV9pZCI6ICJwYWNrYWdlX2dyb3VwIn1dfSwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIxNWZiNmU5NWI0
+        OWJmY2QyZTMifSwgImlkIjogIjVjOWJjMjE1ZmI2ZTk1YjQ5YmZjZDJlMyJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/65e5cf88-7059-46cf-83ac-3c5be665ff3a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"d64732d10883f71e0f6f9a48d3bf20ec-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '801'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82NWU1Y2Y4
+        OC03MDU5LTQ2Y2YtODNhYy0zYzViZTY2NWZmM2EvIiwgInRhc2tfaWQiOiAi
+        NjVlNWNmODgtNzA1OS00NmNmLTgzYWMtM2M1YmU2NjVmZjNhIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW10sICJ1bml0
+        c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIxNWZiNmU5NWI0OWJmY2QzMDYi
+        fSwgImlkIjogIjVjOWJjMjE1ZmI2ZTk1YjQ5YmZjZDMwNiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/fde46a95-5c04-490c-ad3c-ae52a4c165c1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"bef503d9f88e092b4bff9dce62eeb712-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '974'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9mZGU0NmE5
+        NS01YzA0LTQ5MGMtYWQzYy1hZTUyYTRjMTY1YzEvIiwgInRhc2tfaWQiOiAi
+        ZmRlNDZhOTUtNWMwNC00OTBjLWFkM2MtYWU1MmE0YzE2NWMxIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sidW5pdF9r
+        ZXkiOiB7InZhcmlhbnQiOiAiVGVzdFZhcmlhbnQiLCAidmVyc2lvbiI6ICIx
+        NiIsICJhcmNoIjogIng4Nl82NCIsICJpZCI6ICJrcy1UZXN0IEZhbWlseS1U
+        ZXN0VmFyaWFudC0xNi14ODZfNjQiLCAiZmFtaWx5IjogIlRlc3QgRmFtaWx5
+        In0sICJ0eXBlX2lkIjogImRpc3RyaWJ1dGlvbiJ9XSwgInVuaXRzX2ZhaWxl
+        ZF9zaWduYXR1cmVfZmlsdGVyIjogW119LCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjVjOWJjMjE1ZmI2ZTk1YjQ5YmZjZDMxZSJ9LCAiaWQi
+        OiAiNWM5YmMyMTVmYjZlOTViNDliZmNkMzFlIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/692c00c2-1331-4098-bf77-73a94bd1ffcf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"1990aa483b37dc8e6f2659af7ed87d26-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '801'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82OTJjMDBj
+        Mi0xMzMxLTQwOTgtYmY3Ny03M2E5NGJkMWZmY2YvIiwgInRhc2tfaWQiOiAi
+        NjkyYzAwYzItMTMzMS00MDk4LWJmNzctNzNhOTRiZDFmZmNmIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW10sICJ1bml0
+        c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIxNWZiNmU5NWI0OWJmY2QzNGIi
+        fSwgImlkIjogIjVjOWJjMjE1ZmI2ZTk1YjQ5YmZjZDM0YiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/eec1fc82-9247-4ad8-b13d-f88178ff544c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"f0530174826e8c853d984e78c72df081-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '725'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9lZWMxZmM4
+        Mi05MjQ3LTRhZDgtYjEzZC1mODgxNzhmZjU0NGMvIiwgInRhc2tfaWQiOiAi
+        ZWVjMWZjODItOTI0Ny00YWQ4LWIxM2QtZjg4MTc4ZmY1NDRjIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6IG51bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRf
+        dGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3WiIsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijog
+        e30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0
+        YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjE1ZmI2
+        ZTk1YjQ5YmZjZDM3ZiJ9LCAiaWQiOiAiNWM5YmMyMTVmYjZlOTViNDliZmNk
+        MzdmIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/4c8335d1-dfbb-49a9-9532-4a82bf289728/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:57 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"f31e41b786dd3ec417623aaef7ced6fb-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1046'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80YzgzMzVk
+        MS1kZmJiLTQ5YTktOTUzMi00YTgyYmYyODk3MjgvIiwgInRhc2tfaWQiOiAi
+        NGM4MzM1ZDEtZGZiYi00OWE5LTk1MzItNGE4MmJmMjg5NzI4IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sic2lnbmlu
+        Z19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAid2FscnVzIiwg
+        ImNoZWNrc3VtIjogIjZlOGQ2ZGMwNTdlM2UyYzk4MTlmMGRjN2U2YzdiN2Y4
+        NmJmMmU4NTcxYmJhNDE0YWRlYzdmYjYyMWE0NjFkZmQiLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJhcmNo
+        IjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBl
+        X2lkIjogInJwbSJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVy
+        IjogW119LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJj
+        MjE1ZmI2ZTk1YjQ5YmZjZDI3MSJ9LCAiaWQiOiAiNWM5YmMyMTVmYjZlOTVi
+        NDliZmNkMjcxIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:57 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/6a135695-6690-4c92-8da2-fb3eb1cb0dc6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:58 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"1c09daae8f8d3293b67eef7889f01e02-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '801'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82YTEzNTY5
+        NS02NjkwLTRjOTItOGRhMi1mYjNlYjFjYjBkYzYvIiwgInRhc2tfaWQiOiAi
+        NmExMzU2OTUtNjY5MC00YzkyLThkYTItZmIzZWIxY2IwZGM2IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW10sICJ1bml0
+        c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIxNWZiNmU5NWI0OWJmY2QyOWUi
+        fSwgImlkIjogIjVjOWJjMjE1ZmI2ZTk1YjQ5YmZjZDI5ZSJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:58 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/20c3e863-1ed2-4ea8-a1ce-b6ef0b3767bc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:58 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"fd0716bef579e8891df8966edc0b5ac7-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '985'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yMGMzZTg2
+        My0xZWQyLTRlYTgtYTFjZS1iNmVmMGIzNzY3YmMvIiwgInRhc2tfaWQiOiAi
+        MjBjM2U4NjMtMWVkMi00ZWE4LWExY2UtYjZlZjBiMzc2N2JjIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sidW5pdF9r
+        ZXkiOiB7ImlkIjogIlJIRUEtMjAxMDowMDAyIn0sICJ0eXBlX2lkIjogImVy
+        cmF0dW0ifSwgeyJ1bml0X2tleSI6IHsiaWQiOiAiUkhTQS0yMDEwOjA4NTgi
+        fSwgInR5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6
+        ICJSSEVBLTIwMTA6MDAwMSJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn1dLCAi
+        dW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM5YmMyMTVmYjZlOTViNDliZmNk
+        MmM3In0sICJpZCI6ICI1YzliYzIxNWZiNmU5NWI0OWJmY2QyYzcifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:58 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d004c09a-57e9-4044-a1ee-15b82c3bc889/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:59 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"1220caac179fccb1ee6c237f58344b8b-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1125'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9kMDA0YzA5
+        YS01N2U5LTQwNDQtYTFlZS0xNWI4MmMzYmM4ODkvIiwgInRhc2tfaWQiOiAi
+        ZDAwNGMwOWEtNTdlOS00MDQ0LWExZWUtMTViODJjM2JjODg5IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sidW5pdF9r
+        ZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIsICJpZCI6ICJiaXJkIn0sICJ0
+        eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAifSwgeyJ1bml0X2tleSI6IHsicmVw
+        b19pZCI6ICIzX3ZpZXcxIiwgImlkIjogIm1hbW1hbCJ9LCAidHlwZV9pZCI6
+        ICJwYWNrYWdlX2dyb3VwIn1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9m
+        aWx0ZXIiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRvcmFfMTci
+        LCAiaWQiOiAiYmlyZCJ9LCAidHlwZV9pZCI6ICJwYWNrYWdlX2dyb3VwIn0s
+        IHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImlkIjog
+        Im1hbW1hbCJ9LCAidHlwZV9pZCI6ICJwYWNrYWdlX2dyb3VwIn1dfSwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIxNWZiNmU5NWI0
+        OWJmY2QyZTMifSwgImlkIjogIjVjOWJjMjE1ZmI2ZTk1YjQ5YmZjZDJlMyJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:59 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/65e5cf88-7059-46cf-83ac-3c5be665ff3a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:33:59 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"d64732d10883f71e0f6f9a48d3bf20ec-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '801'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82NWU1Y2Y4
+        OC03MDU5LTQ2Y2YtODNhYy0zYzViZTY2NWZmM2EvIiwgInRhc2tfaWQiOiAi
+        NjVlNWNmODgtNzA1OS00NmNmLTgzYWMtM2M1YmU2NjVmZjNhIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW10sICJ1bml0
+        c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIxNWZiNmU5NWI0OWJmY2QzMDYi
+        fSwgImlkIjogIjVjOWJjMjE1ZmI2ZTk1YjQ5YmZjZDMwNiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:33:59 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/fde46a95-5c04-490c-ad3c-ae52a4c165c1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:00 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"bef503d9f88e092b4bff9dce62eeb712-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '974'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9mZGU0NmE5
+        NS01YzA0LTQ5MGMtYWQzYy1hZTUyYTRjMTY1YzEvIiwgInRhc2tfaWQiOiAi
+        ZmRlNDZhOTUtNWMwNC00OTBjLWFkM2MtYWU1MmE0YzE2NWMxIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sidW5pdF9r
+        ZXkiOiB7InZhcmlhbnQiOiAiVGVzdFZhcmlhbnQiLCAidmVyc2lvbiI6ICIx
+        NiIsICJhcmNoIjogIng4Nl82NCIsICJpZCI6ICJrcy1UZXN0IEZhbWlseS1U
+        ZXN0VmFyaWFudC0xNi14ODZfNjQiLCAiZmFtaWx5IjogIlRlc3QgRmFtaWx5
+        In0sICJ0eXBlX2lkIjogImRpc3RyaWJ1dGlvbiJ9XSwgInVuaXRzX2ZhaWxl
+        ZF9zaWduYXR1cmVfZmlsdGVyIjogW119LCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjVjOWJjMjE1ZmI2ZTk1YjQ5YmZjZDMxZSJ9LCAiaWQi
+        OiAiNWM5YmMyMTVmYjZlOTViNDliZmNkMzFlIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:00 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/692c00c2-1331-4098-bf77-73a94bd1ffcf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:00 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"1990aa483b37dc8e6f2659af7ed87d26-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '801'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82OTJjMDBj
+        Mi0xMzMxLTQwOTgtYmY3Ny03M2E5NGJkMWZmY2YvIiwgInRhc2tfaWQiOiAi
+        NjkyYzAwYzItMTMzMS00MDk4LWJmNzctNzNhOTRiZDFmZmNmIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW10sICJ1bml0
+        c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIxNWZiNmU5NWI0OWJmY2QzNGIi
+        fSwgImlkIjogIjVjOWJjMjE1ZmI2ZTk1YjQ5YmZjZDM0YiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:01 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/eec1fc82-9247-4ad8-b13d-f88178ff544c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:01 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"8efd930e89355add6d24de7004a104b9-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '801'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9lZWMxZmM4
+        Mi05MjQ3LTRhZDgtYjEzZC1mODgxNzhmZjU0NGMvIiwgInRhc2tfaWQiOiAi
+        ZWVjMWZjODItOTI0Ny00YWQ4LWIxM2QtZjg4MTc4ZmY1NDRjIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjMzOjU3
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW10sICJ1bml0
+        c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIxNWZiNmU5NWI0OWJmY2QzN2Yi
+        fSwgImlkIjogIjVjOWJjMjE1ZmI2ZTk1YjQ5YmZjZDM3ZiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:01 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:02 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"578f45a4371219172041ba06d4bbd006-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2235'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
+        OiBbeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
+        MTktMDMtMjdUMTg6MzM6NTdaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3Ry
+        aWJ1dG9yLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9w
+        dWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0
+        X2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRj
+        aHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6
+        IHsiJG9pZCI6ICI1YzliYzIxNWRiMjg0ZTU5YmYxMjU5NDAifSwgImNvbmZp
+        ZyI6IHsiaHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29y
+        cG9yYXRpb24vbGlicmFyeS9MaWJyYXJ5Vmlldy9mZWRvcmFfMTdfbGFiZWwi
+        LCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6ICJleHBvcnRfZGlzdHJpYnV0b3Ii
+        fSwgeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
+        MTktMDMtMjdUMTg6MzM6NTdaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvM192aWV3MV9jbG9u
+        ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
+        aCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9jbG9uZV9k
+        aXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hw
+        YWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7
+        IiRvaWQiOiAiNWM5YmMyMTVkYjI4NGU1OWJmMTI1OTNmIn0sICJjb25maWci
+        OiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogIjNfdmlldzEifSwg
+        ImlkIjogIjNfdmlldzFfY2xvbmUifSwgeyJyZXBvX2lkIjogIjNfdmlldzEi
+        LCAibGFzdF91cGRhdGVkIjogIjIwMTktMDMtMjdUMTg6MzM6NTdaIiwgIl9o
+        cmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0
+        cmlidXRvcnMvM192aWV3MS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7
+        fSwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lk
+        IjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAi
+        c2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwg
+        Il9pZCI6IHsiJG9pZCI6ICI1YzliYzIxNWRiMjg0ZTU5YmYxMjU5M2UifSwg
+        ImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwg
+        Imh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0NvcnBvcmF0
+        aW9uL2xpYnJhcnkvTGlicmFyeVZpZXcvZmVkb3JhXzE3X2xhYmVsIn0sICJp
+        ZCI6ICIzX3ZpZXcxIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIwMTktMDMt
+        MjdUMTg6MzM6NTdaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
+        ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
+        aXRfY291bnRzIjogeyJwYWNrYWdlX2dyb3VwIjogMiwgImRpc3RyaWJ1dGlv
+        biI6IDEsICJycG0iOiAxLCAiZXJyYXR1bSI6IDN9LCAiX25zIjogInJlcG9z
+        IiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiM192aWV3MSIsICJsYXN0
+        X3VwZGF0ZWQiOiAiMjAxOS0wMy0yN1QxODozMzo1N1oiLCAiX2hyZWYiOiAi
+        L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy8zX3ZpZXcxL2ltcG9ydGVycy95
+        dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIsICJpbXBv
+        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJsYXN0X292ZXJyaWRl
+        X2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjogbnVsbCwgInNjcmF0Y2hwYWQi
+        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjE1ZGIyODRlNTliZjEy
+        NTkzZCJ9LCAiY29uZmlnIjoge30sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0s
+        ICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDYsICJfaWQiOiB7IiRvaWQiOiAi
+        NWM5YmMyMTVkYjI4NGU1OWJmMTI1OTNjIn0sICJ0b3RhbF9yZXBvc2l0b3J5
+        X3VuaXRzIjogNywgImlkIjogIjNfdmlldzEiLCAiX2hyZWYiOiAiL3B1bHAv
+        YXBpL3YyL3JlcG9zaXRvcmllcy8zX3ZpZXcxLyJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:02 GMT
+- request:
+    method: delete
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:02 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzBjOTg5NmNhLWIxN2EtNGJlZC05YWU0LTZhMjA0ZmVmMTg0OS8iLCAi
+        dGFza19pZCI6ICIwYzk4OTZjYS1iMTdhLTRiZWQtOWFlNC02YTIwNGZlZjE4
+        NDkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:02 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/0c9896ca-b17a-4bed-9ae4-6a204fef1849/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:02 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"2e0c7713dc43d830df3b8462f5302701-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '542'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wYzk4OTZjYS1iMTdhLTRiZWQtOWFlNC02YTIwNGZlZjE4
+        NDkvIiwgInRhc2tfaWQiOiAiMGM5ODk2Y2EtYjE3YS00YmVkLTlhZTQtNmEy
+        MDRmZWYxODQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICIiLCAic3RhdGUiOiAid2Fp
+        dGluZyIsICJ3b3JrZXJfbmFtZSI6IG51bGwsICJyZXN1bHQiOiBudWxsLCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjFhZmI2ZTk1
+        YjQ5YmZjZDQ1YyJ9LCAiaWQiOiAiNWM5YmMyMWFmYjZlOTViNDliZmNkNDVj
+        In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:02 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/0c9896ca-b17a-4bed-9ae4-6a204fef1849/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:02 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"34a01de54c7d15800e2fd7cc59147297-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '668'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wYzk4OTZjYS1iMTdhLTRiZWQtOWFlNC02YTIwNGZlZjE4
+        NDkvIiwgInRhc2tfaWQiOiAiMGM5ODk2Y2EtYjE3YS00YmVkLTlhZTQtNmEy
+        MDRmZWYxODQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5
+        LTAzLTI3VDE4OjM0OjAyWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5l
+        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0
+        ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjFhZmI2ZTk1YjQ5YmZjZDQ1
+        YyJ9LCAiaWQiOiAiNWM5YmMyMWFmYjZlOTViNDliZmNkNDVjIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:02 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/0c9896ca-b17a-4bed-9ae4-6a204fef1849/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:02 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"62ee03e1c08237dfee99a523c4e3fe0a-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '687'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8wYzk4OTZjYS1iMTdhLTRiZWQtOWFlNC02YTIwNGZlZjE4
+        NDkvIiwgInRhc2tfaWQiOiAiMGM5ODk2Y2EtYjE3YS00YmVkLTlhZTQtNmEy
+        MDRmZWYxODQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE5LTAzLTI3VDE4OjM0OjAyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjAyWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Yzli
+        YzIxYWZiNmU5NWI0OWJmY2Q0NWMifSwgImlkIjogIjVjOWJjMjFhZmI2ZTk1
+        YjQ5YmZjZDQ1YyJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:02 GMT
+- request:
+    method: delete
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:02 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzRmYTQ1MWJkLWQxNzktNDlkMi04MTgwLTUyMzA4NzA5ZjdkYS8iLCAi
+        dGFza19pZCI6ICI0ZmE0NTFiZC1kMTc5LTQ5ZDItODE4MC01MjMwODcwOWY3
+        ZGEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:02 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/4fa451bd-d179-49d2-8180-52308709f7da/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:02 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"0ad3f6e03749e6bbd9415d162ce8b247-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '648'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy80ZmE0NTFiZC1kMTc5LTQ5ZDItODE4MC01MjMwODcwOWY3
+        ZGEvIiwgInRhc2tfaWQiOiAiNGZhNDUxYmQtZDE3OS00OWQyLTgxODAtNTIz
+        MDg3MDlmN2RhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
+        IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0
+        YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzliYzIxYWZiNmU5NWI0OWJmY2Q0YjIifSwgImlkIjogIjVjOWJjMjFh
+        ZmI2ZTk1YjQ5YmZjZDRiMiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:02 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/4fa451bd-d179-49d2-8180-52308709f7da/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:02 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"880693c6da27f3d456622f37e7a79dc8-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '666'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy80ZmE0NTFiZC1kMTc5LTQ5ZDItODE4MC01MjMwODcwOWY3
+        ZGEvIiwgInRhc2tfaWQiOiAiNGZhNDUxYmQtZDE3OS00OWQyLTgxODAtNTIz
+        MDg3MDlmN2RhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
+        IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDowMloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhh
+        bXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVs
+        bG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIxYWZiNmU5NWI0OWJmY2Q0YjIi
+        fSwgImlkIjogIjVjOWJjMjFhZmI2ZTk1YjQ5YmZjZDRiMiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:02 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/4fa451bd-d179-49d2-8180-52308709f7da/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:02 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"2b99c4028a69a9d770cd3f308c2b3246-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '685'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy80ZmE0NTFiZC1kMTc5LTQ5ZDItODE4MC01MjMwODcwOWY3
+        ZGEvIiwgInRhc2tfaWQiOiAiNGZhNDUxYmQtZDE3OS00OWQyLTgxODAtNTIz
+        MDg3MDlmN2RhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
+        IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        OS0wMy0yN1QxODozNDowMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozNDowMloiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9y
+        dCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
+        dGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZp
+        bmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0wQHRoZXRhLnBhcnRlbGxvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
+        IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM5YmMy
+        MWFmYjZlOTViNDliZmNkNGIyIn0sICJpZCI6ICI1YzliYzIxYWZiNmU5NWI0
+        OWJmY2Q0YjIifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:02 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/errata_filter.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/errata_filter.yml
@@ -18533,158 +18533,6 @@ http_interactions:
     http_version: 
   recorded_at: Tue, 19 Mar 2019 17:57:54 GMT
 - request:
-    method: delete
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:44 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '404'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
-        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
-        OiByZXBvc2l0b3J5PUZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
-        djIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8iLCAiaHR0cF9zdGF0dXMiOiA0
-        MDQsICJlcnJvciI6IHsiY29kZSI6ICJQTFAwMDA5IiwgImRhdGEiOiB7InJl
-        c291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0sICJkZXNj
-        cmlwdGlvbiI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PUZl
-        ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
-        bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:44 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
-        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
-        b3J0ZXJfY29uZmlnIjp7ImRvd25sb2FkX3BvbGljeSI6Im9uX2RlbWFuZCIs
-        InJlbW92ZV9taXNzaW5nIjp0cnVlLCJmZWVkIjoiZmlsZTovLy92YXIvd3d3
-        L3Rlc3RfcmVwb3Mvem9vIiwidHlwZV9za2lwX2xpc3QiOm51bGwsInByb3h5
-        X2hvc3QiOm51bGwsImJhc2ljX2F1dGhfdXNlcm5hbWUiOm51bGwsImJhc2lj
-        X2F1dGhfcGFzc3dvcmQiOm51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJz
-        c2xfY2xpZW50X2NlcnQiOm51bGwsInNzbF9jbGllbnRfa2V5IjpudWxsLCJz
-        c2xfY2FfY2VydCI6bnVsbH0sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJycG0t
-        cmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQi
-        OiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsicmVs
-        YXRpdmVfdXJsIjoiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5L2ZlZG9yYV8x
-        N19sYWJlbCIsImh0dHAiOmZhbHNlLCJodHRwcyI6dHJ1ZSwicHJvdGVjdGVk
-        Ijp0cnVlLCJjaGVja3N1bV90eXBlIjpudWxsfSwiYXV0b19wdWJsaXNoIjp0
-        cnVlLCJkaXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xNyJ9LHsiZGlzdHJpYnV0
-        b3JfdHlwZV9pZCI6Inl1bV9jbG9uZV9kaXN0cmlidXRvciIsImRpc3RyaWJ1
-        dG9yX2NvbmZpZyI6eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6IkZl
-        ZG9yYV8xNyJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRvcl9p
-        ZCI6IkZlZG9yYV8xN19jbG9uZSJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9pZCI6
-        ImV4cG9ydF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJo
-        dHRwIjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxhdGl2ZV91cmwiOiJBQ01F
-        X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIn0sImF1dG9f
-        cHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3Ry
-        aWJ1dG9yIn1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '1045'
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:44 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '320'
-      Location:
-      - "/pulp/api/v2/repositories/Fedora_17/"
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWM5MTMxZDBkYjI4NGUwOTQyYTk1M2YwIn0sICJpZCI6ICJGZWRvcmFfMTci
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
-        MTcvIn0=
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:44 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
-        Ijp0cnVlfX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '53'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:44 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzRiYzY3MTFiLTkwYWQtNGEwOC1hYTRmLTE0ZmEyMjJhM2YzMy8iLCAi
-        dGFza19pZCI6ICI0YmM2NzExYi05MGFkLTRhMDgtYWE0Zi0xNGZhMjIyYTNm
-        MzMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:45 GMT
-- request:
     method: get
     uri: https://theta.partello.example.com/pulp/api/v2/tasks/4bc6711b-90ad-4a08-aa4f-14fa222a3f33/
     body:
@@ -20523,146 +20371,6 @@ http_interactions:
   recorded_at: Tue, 19 Mar 2019 18:15:45 GMT
 - request:
     method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IjNfdmlldzEiLCJkaXNwbGF5X25hbWUiOiJGZWRvcmEgMTcgeDg2
-        XzY0IiwiaW1wb3J0ZXJfdHlwZV9pZCI6Inl1bV9pbXBvcnRlciIsImltcG9y
-        dGVyX2NvbmZpZyI6e30sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJycG0tcmVw
-        byJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5
-        dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsicmVsYXRp
-        dmVfdXJsIjoiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5L0xpYnJhcnlWaWV3
-        L2ZlZG9yYV8xN19sYWJlbCIsImh0dHAiOmZhbHNlLCJodHRwcyI6dHJ1ZSwi
-        cHJvdGVjdGVkIjp0cnVlLCJjaGVja3N1bV90eXBlIjpudWxsfSwiYXV0b19w
-        dWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9pZCI6IjNfdmlldzEifSx7ImRp
-        c3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1fY2xvbmVfZGlzdHJpYnV0b3IiLCJk
-        aXN0cmlidXRvcl9jb25maWciOnsiZGVzdGluYXRpb25fZGlzdHJpYnV0b3Jf
-        aWQiOiIzX3ZpZXcxIn0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
-        dG9yX2lkIjoiM192aWV3MV9jbG9uZSJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9p
-        ZCI6ImV4cG9ydF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6
-        eyJodHRwIjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxhdGl2ZV91cmwiOiJB
-        Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvTGlicmFyeVZpZXcvZmVkb3JhXzE3
-        X2xhYmVsIn0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lk
-        IjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '790'
-  response:
-    status:
-      code: 201
-      message: CREATED
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:45 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '316'
-      Location:
-      - "/pulp/api/v2/repositories/3_view1/"
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
-        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
-        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
-        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWM5MTMxZDFkYjI4NGUwOTQyYTk1M2Y1In0sICJpZCI6ICIzX3ZpZXcxIiwg
-        Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS8i
-        fQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:45 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwiZmllbGRzIjp7InVu
-        aXQiOltdLCJhc3NvY2lhdGlvbiI6WyJ1bml0X2lkIl19fX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '80'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:45 GMT
-      Server:
-      - Apache
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1672'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIxN2ViMDMyMi1kMGU1LTQ3ZGEtYmZj
-        ZS05NjRjNjBhMzY3MWQiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
-        Il9pZCI6IHsiJG9pZCI6ICI1YzkxMzFkMWY3NDdlNjNjOGMwZTc0ZmMifSwg
-        InVuaXRfaWQiOiAiMTdlYjAzMjItZDBlNS00N2RhLWJmY2UtOTY0YzYwYTM2
-        NzFkIiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogIjNlNDYyYzEwLTk1ZGQtNGNiYi1hYmE3LWFhNzdiZDIzYTkxNiIs
-        ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
-        IjVjOTEzMWQxZjc0N2U2M2M4YzBlNzRlYSJ9LCAidW5pdF9pZCI6ICIzZTQ2
-        MmMxMC05NWRkLTRjYmItYWJhNy1hYTc3YmQyM2E5MTYiLCAidW5pdF90eXBl
-        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNDhlN2VmOTct
-        ZmNhMC00MDY3LTg1YWYtZjEyYjg4ODQ5ZDg4IiwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNWM5MTMxZDFmNzQ3ZTYz
-        YzhjMGU3NGYzIn0sICJ1bml0X2lkIjogIjQ4ZTdlZjk3LWZjYTAtNDA2Ny04
-        NWFmLWYxMmI4ODg0OWQ4OCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
-        bWV0YWRhdGEiOiB7Il9pZCI6ICI1ODczOWM0OS0xNjg5LTRjNDMtYTg3Mi0x
-        NmMzM2RhN2Y2ZjYiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1YzkxMzFkMWY3NDdlNjNjOGMwZTc0YjgifSwgInVu
-        aXRfaWQiOiAiNTg3MzljNDktMTY4OS00YzQzLWE4NzItMTZjMzNkYTdmNmY2
-        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
-        IjogImMzNjc2NDk0LTI3ZmEtNGRhZC04MThiLTFiZjM4OWE2YzdhOCIsICJf
-        Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjVj
-        OTEzMWQxZjc0N2U2M2M4YzBlNzRjYSJ9LCAidW5pdF9pZCI6ICJjMzY3NjQ5
-        NC0yN2ZhLTRkYWQtODE4Yi0xYmYzODlhNmM3YTgiLCAidW5pdF90eXBlX2lk
-        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiZGEyNDE0ODUtYjA2
-        Ni00YmQ0LTkzOWUtNjZkYTdiMDFlMzJkIiwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNWM5MTMxZDFmNzQ3ZTYzYzhj
-        MGU3NGUxIn0sICJ1bml0X2lkIjogImRhMjQxNDg1LWIwNjYtNGJkNC05Mzll
-        LTY2ZGE3YjAxZTMyZCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
-        YWRhdGEiOiB7Il9pZCI6ICJkYzFiZjkxMi1hYjI4LTQ3MDUtYWU0Yi0xZDRk
-        YmM4NjgyNjkiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1YzkxMzFkMWY3NDdlNjNjOGMwZTc0YzEifSwgInVuaXRf
-        aWQiOiAiZGMxYmY5MTItYWIyOC00NzA1LWFlNGItMWQ0ZGJjODY4MjY5Iiwg
-        InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
-        ImRmMzhmNjY5LWJhODMtNDlkZi1iN2VhLTM4OGEwZTNiY2IwZCIsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjVjOTEz
-        MWQxZjc0N2U2M2M4YzBlNzRkOCJ9LCAidW5pdF9pZCI6ICJkZjM4ZjY2OS1i
-        YTgzLTQ5ZGYtYjdlYS0zODhhMGUzYmNiMGQiLCAidW5pdF90eXBlX2lkIjog
-        InJwbSJ9XQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:45 GMT
-- request:
-    method: post
     uri: https://theta.partello.example.com/pulp/api/v2/content/units/rpm/search/
     body:
       encoding: UTF-8
@@ -20805,60 +20513,6 @@ http_interactions:
         Y2giOiAibm9hcmNoIiwgImNoaWxkcmVuIjoge30sICJfaHJlZiI6ICIvcHVs
         cC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vZGYzOGY2NjktYmE4My00OWRm
         LWI3ZWEtMzg4YTBlM2JjYjBkLyJ9XQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:45 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImZpZWxkcyI6
-        eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '84'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:45 GMT
-      Server:
-      - Apache
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '651'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIwOTEzN2JlYy03MzQyLTRlM2UtOTdh
-        OS05MmQwOGVhYTZlNGMiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
-        In0sICJfaWQiOiB7IiRvaWQiOiAiNWM5MTMxZDFmNzQ3ZTYzYzhjMGU3NTdh
-        In0sICJ1bml0X2lkIjogIjA5MTM3YmVjLTczNDItNGUzZS05N2E5LTkyZDA4
-        ZWFhNmU0YyIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
-        YXRhIjogeyJfaWQiOiAiYTVkM2VkNjItMGNlYy00NDVkLTg2OTctY2Y0NWMx
-        ZGFhMTJkIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
-        IjogeyIkb2lkIjogIjVjOTEzMWQxZjc0N2U2M2M4YzBlNzU5NiJ9LCAidW5p
-        dF9pZCI6ICJhNWQzZWQ2Mi0wY2VjLTQ0NWQtODY5Ny1jZjQ1YzFkYWExMmQi
-        LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogImI4ODBhOTk4LWEzNzMtNGQ2OC05MjdlLWFiNzdkMGI1MzBhOSIs
-        ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0ifSwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1YzkxMzFkMWY3NDdlNjNjOGMwZTc1NWQifSwgInVuaXRfaWQiOiAi
-        Yjg4MGE5OTgtYTM3My00ZDY4LTkyN2UtYWI3N2QwYjUzMGE5IiwgInVuaXRf
-        dHlwZV9pZCI6ICJlcnJhdHVtIn1d
     http_version: 
   recorded_at: Tue, 19 Mar 2019 18:15:45 GMT
 - request:
@@ -21016,95 +20670,6 @@ http_interactions:
   recorded_at: Tue, 19 Mar 2019 18:15:45 GMT
 - request:
     method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJtb2R1bGVtZCJdLCJmaWVsZHMi
-        OnsidW5pdCI6W10sImFzc29jaWF0aW9uIjpbInVuaXRfaWQiXX19fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '85'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:45 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '2'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: 'W10=
-
-'
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:45 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwYWNrYWdlX2dyb3VwIl0sImZp
-        ZWxkcyI6eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '90'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:45 GMT
-      Server:
-      - Apache
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '458'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI1M2JmNjk4OC05NTcxLTRmYmItODlk
-        ZC03YWNhMDg3MDQzNzQiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNrYWdl
-        X2dyb3VwIn0sICJfaWQiOiB7IiRvaWQiOiAiNWM5MTMxZDFmNzQ3ZTYzYzhj
-        MGU3NWIzIn0sICJ1bml0X2lkIjogIjUzYmY2OTg4LTk1NzEtNGZiYi04OWRk
-        LTdhY2EwODcwNDM3NCIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91
-        cCJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiODBkMmM4NDEtMWU3Ny00NWVm
-        LWJjYjQtMzBjYTdmNDI3ZTcyIiwgIl9jb250ZW50X3R5cGVfaWQiOiAicGFj
-        a2FnZV9ncm91cCJ9LCAiX2lkIjogeyIkb2lkIjogIjVjOTEzMWQxZjc0N2U2
-        M2M4YzBlNzVhNiJ9LCAidW5pdF9pZCI6ICI4MGQyYzg0MS0xZTc3LTQ1ZWYt
-        YmNiNC0zMGNhN2Y0MjdlNzIiLCAidW5pdF90eXBlX2lkIjogInBhY2thZ2Vf
-        Z3JvdXAifV0=
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:45 GMT
-- request:
-    method: post
     uri: https://theta.partello.example.com/pulp/api/v2/content/units/package_group/search/
     body:
       encoding: UTF-8
@@ -21173,483 +20738,6 @@ http_interactions:
         bmFtZXMiOiBbXX1d
     http_version: 
   recorded_at: Tue, 19 Mar 2019 18:15:45 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJ5dW1fcmVwb19tZXRhZGF0YV9m
-        aWxlIl0sImZpZWxkcyI6eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5p
-        dF9pZCJdfX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '99'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:45 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '2'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: 'W10=
-
-'
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:45 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJzcnBtIl0sImZpZWxkcyI6eyJ1
-        bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '81'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:45 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '2'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: 'W10=
-
-'
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:45 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkaXN0cmlidXRpb24iXX19
-
-'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '42'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:45 GMT
-      Server:
-      - Apache
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1198'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7ImZpbGVzIjogW3sicmVsYXRpdmVwYXRoIjogImlt
-        YWdlcy90ZXN0Mi5pbWciLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiIsICJj
-        aGVja3N1bSI6ICJlM2IwYzQ0Mjk4ZmMxYzE0OWFmYmY0Yzg5OTZmYjkyNDI3
-        YWU0MWU0NjQ5YjkzNGNhNDk1OTkxYjc4NTJiODU1In0sIHsicmVsYXRpdmVw
-        YXRoIjogImVtcHR5LmlzbyIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2Iiwg
-        ImNoZWNrc3VtIjogImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0
-        MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifSwgeyJyZWxhdGl2
-        ZXBhdGgiOiAiaW1hZ2VzL3Rlc3QxLmltZyIsICJjaGVja3N1bXR5cGUiOiAi
-        c2hhMjU2IiwgImNoZWNrc3VtIjogImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRj
-        ODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifV0s
-        ICJfc3RvcmFnZV9wYXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0
-        cy9kaXN0cmlidXRpb24vOWIvODMxMjU2YTEyNDcxOGJmMzkxNjZiNTY0ZDhl
-        Njg5OTU0ZmYwYThmMGY0NzliYTI0Y2ZhMjYzNTAxMDliYzUiLCAiZmFtaWx5
-        IjogIlRlc3QgRmFtaWx5IiwgImRvd25sb2FkZWQiOiBmYWxzZSwgInRpbWVz
-        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTU1MzAx
-        OTM0NSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
-        cmlhbnQiOiAiVGVzdFZhcmlhbnQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHkt
-        VGVzdFZhcmlhbnQtMTYteDg2XzY0IiwgInZlcnNpb24iOiAiMTYiLCAidmVy
-        c2lvbl9zb3J0X2luZGV4IjogIjAyLTE2IiwgInB1bHBfdXNlcl9tZXRhZGF0
-        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogIjExZGE3ZDQxLTYy
-        ZjAtNDJlMC1hMTRhLTQ3ODZiNjhkZjcxMCIsICJhcmNoIjogIng4Nl82NCIs
-        ICJfbnMiOiAidW5pdHNfZGlzdHJpYnV0aW9uIn0sICJ1cGRhdGVkIjogIjIw
-        MTktMDMtMTlUMTg6MTU6NDVaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        ImNyZWF0ZWQiOiAiMjAxOS0wMy0xOVQxODoxNTo0NVoiLCAidW5pdF90eXBl
-        X2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogIjExZGE3ZDQxLTYy
-        ZjAtNDJlMC1hMTRhLTQ3ODZiNjhkZjcxMCIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWM5MTMxZDFmNzQ3ZTYzYzhjMGU3NTM0In19XQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:45 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbInJwbSJdLCJmaWx0ZXJzIjp7InVuaXQiOnsiZmlsZW5hbWUi
-        OnsiJGluIjpbImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSJdfX19LCJm
-        aWVsZHMiOnsidW5pdCI6WyJuYW1lIiwiZXBvY2giLCJ2ZXJzaW9uIiwicmVs
-        ZWFzZSIsImFyY2giLCJjaGVja3N1bXR5cGUiLCJjaGVja3N1bSJdfX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '222'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:46 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzBjZWJkNTJlLTI2NDEtNGVhZS1hNTJkLTc1NmVhNTUwZGUyNC8iLCAi
-        dGFza19pZCI6ICIwY2ViZDUyZS0yNjQxLTRlYWUtYTUyZC03NTZlYTU1MGRl
-        MjQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:46 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbInNycG0iXSwiZmlsdGVycyI6e319fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '76'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:46 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzE4YWFkZDllLWYyZGUtNDgxZS04MGU1LTVkZmE1MTVjYjE4Ni8iLCAi
-        dGFza19pZCI6ICIxOGFhZGQ5ZS1mMmRlLTQ4MWUtODBlNS01ZGZhNTE1Y2Ix
-        ODYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:46 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbImVycmF0dW0iXSwiZmlsdGVycyI6e319fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '79'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:46 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzI5YzIyMGM4LTQ5NTUtNDE5Zi05ZTQ1LTk5ZTkwMDYzZDhlNS8iLCAi
-        dGFza19pZCI6ICIyOWMyMjBjOC00OTU1LTQxOWYtOWU0NS05OWU5MDA2M2Q4
-        ZTUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:46 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbInBhY2thZ2VfZ3JvdXAiXSwiZmlsdGVycyI6e319fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '85'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:46 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzUzMThiYjRlLWQzZmYtNGJhMS1iNDE4LTQ3OTUzMzczYzVmYS8iLCAi
-        dGFza19pZCI6ICI1MzE4YmI0ZS1kM2ZmLTRiYTEtYjQxOC00Nzk1MzM3M2M1
-        ZmEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:46 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiXSwiZmlsdGVycyI6
-        e319fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '94'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:46 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzYwNDY2YTkyLTgwNzAtNDMzMy04YmE3LTA4MTQwYmM4YTYwMC8iLCAi
-        dGFza19pZCI6ICI2MDQ2NmE5Mi04MDcwLTQzMzMtOGJhNy0wODE0MGJjOGE2
-        MDAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:46 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbImRpc3RyaWJ1dGlvbiJdLCJmaWx0ZXJzIjp7fX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '84'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:46 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzcyNjBkNWRjLTA3MGUtNDdmNy1iNThlLThkNmJhMDAxZDZkMy8iLCAi
-        dGFza19pZCI6ICI3MjYwZDVkYy0wNzBlLTQ3ZjctYjU4ZS04ZDZiYTAwMWQ2
-        ZDMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:46 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbIm1vZHVsZW1kIl0sImZpbHRlcnMiOnt9fX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '80'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:46 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2Q2ZjlkNjEyLTcwYmMtNGY1OC1iMWQ0LThjODM2NTc5NTlmZi8iLCAi
-        dGFza19pZCI6ICJkNmY5ZDYxMi03MGJjLTRmNTgtYjFkNC04YzgzNjU3OTU5
-        ZmYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:46 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbIm1vZHVsZW1kX2RlZmF1bHRzIl0sImZpbHRlcnMiOnt9fX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '89'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:46 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzM2YjA1ZGNiLWYyODctNGMxMi04NmIzLTM3NDdlMWJkOWQ4Mi8iLCAi
-        dGFza19pZCI6ICIzNmIwNWRjYi1mMjg3LTRjMTItODZiMy0zNzQ3ZTFiZDlk
-        ODIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:46 GMT
 - request:
     method: get
     uri: https://theta.partello.example.com/pulp/api/v2/tasks/0cebd52e-2641-4eae-a52d-756ea550de24/
@@ -22574,130 +21662,6 @@ http_interactions:
   recorded_at: Tue, 19 Mar 2019 18:15:50 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:50 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"da0d8a3c0fba182467cdd0341d84555c-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2235'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
-        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
-        OiBbeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MTktMDMtMTlUMTg6MTU6NDVaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
-        ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3Ry
-        aWJ1dG9yLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9w
-        dWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0
-        X2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRj
-        aHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6
-        IHsiJG9pZCI6ICI1YzkxMzFkMWRiMjg0ZTA5NDJhOTUzZjkifSwgImNvbmZp
-        ZyI6IHsiaHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29y
-        cG9yYXRpb24vbGlicmFyeS9MaWJyYXJ5Vmlldy9mZWRvcmFfMTdfbGFiZWwi
-        LCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6ICJleHBvcnRfZGlzdHJpYnV0b3Ii
-        fSwgeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MTktMDMtMTlUMTg6MTU6NDVaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
-        ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvM192aWV3MV9jbG9u
-        ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
-        aCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9jbG9uZV9k
-        aXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hw
-        YWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7
-        IiRvaWQiOiAiNWM5MTMxZDFkYjI4NGUwOTQyYTk1M2Y4In0sICJjb25maWci
-        OiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogIjNfdmlldzEifSwg
-        ImlkIjogIjNfdmlldzFfY2xvbmUifSwgeyJyZXBvX2lkIjogIjNfdmlldzEi
-        LCAibGFzdF91cGRhdGVkIjogIjIwMTktMDMtMTlUMTg6MTU6NDVaIiwgIl9o
-        cmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0
-        cmlidXRvcnMvM192aWV3MS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7
-        fSwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lk
-        IjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAi
-        c2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwg
-        Il9pZCI6IHsiJG9pZCI6ICI1YzkxMzFkMWRiMjg0ZTA5NDJhOTUzZjcifSwg
-        ImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwg
-        Imh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0NvcnBvcmF0
-        aW9uL2xpYnJhcnkvTGlicmFyeVZpZXcvZmVkb3JhXzE3X2xhYmVsIn0sICJp
-        ZCI6ICIzX3ZpZXcxIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIwMTktMDMt
-        MTlUMTg6MTU6NDZaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
-        ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
-        aXRfY291bnRzIjogeyJwYWNrYWdlX2dyb3VwIjogMiwgImRpc3RyaWJ1dGlv
-        biI6IDEsICJycG0iOiAxLCAiZXJyYXR1bSI6IDN9LCAiX25zIjogInJlcG9z
-        IiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiM192aWV3MSIsICJsYXN0
-        X3VwZGF0ZWQiOiAiMjAxOS0wMy0xOVQxODoxNTo0NVoiLCAiX2hyZWYiOiAi
-        L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy8zX3ZpZXcxL2ltcG9ydGVycy95
-        dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIsICJpbXBv
-        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJsYXN0X292ZXJyaWRl
-        X2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjogbnVsbCwgInNjcmF0Y2hwYWQi
-        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOTEzMWQxZGIyODRlMDk0MmE5
-        NTNmNiJ9LCAiY29uZmlnIjoge30sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0s
-        ICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDYsICJfaWQiOiB7IiRvaWQiOiAi
-        NWM5MTMxZDFkYjI4NGUwOTQyYTk1M2Y1In0sICJ0b3RhbF9yZXBvc2l0b3J5
-        X3VuaXRzIjogNywgImlkIjogIjNfdmlldzEiLCAiX2hyZWYiOiAiL3B1bHAv
-        YXBpL3YyL3JlcG9zaXRvcmllcy8zX3ZpZXcxLyJ9
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:50 GMT
-- request:
-    method: delete
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:50 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2I3YmVjZDA1LTU2NjYtNDc2Zi04YTZmLWZiMTE2MDg5NWFkNy8iLCAi
-        dGFza19pZCI6ICJiN2JlY2QwNS01NjY2LTQ3NmYtOGE2Zi1mYjExNjA4OTVh
-        ZDcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:50 GMT
-- request:
-    method: get
     uri: https://theta.partello.example.com/pulp/api/v2/tasks/b7becd05-5666-476f-8a6f-fb1160895ad7/
     body:
       encoding: US-ASCII
@@ -22852,43 +21816,6 @@ http_interactions:
     http_version: 
   recorded_at: Tue, 19 Mar 2019 18:15:50 GMT
 - request:
-    method: delete
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Tue, 19 Mar 2019 18:15:50 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzk5NTM0YWZiLTUwMzgtNDljZC1iNjg4LWUzYTNhOTcxNWEwNi8iLCAi
-        dGFza19pZCI6ICI5OTUzNGFmYi01MDM4LTQ5Y2QtYjY4OC1lM2EzYTk3MTVh
-        MDYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Tue, 19 Mar 2019 18:15:51 GMT
-- request:
     method: get
     uri: https://theta.partello.example.com/pulp/api/v2/tasks/99534afb-5038-49cd-b688-e3a3a9715a06/
     body:
@@ -23042,4 +21969,4887 @@ http_interactions:
         OGMwZTc5NWIifQ==
     http_version: 
   recorded_at: Tue, 19 Mar 2019 18:15:51 GMT
+- request:
+    method: delete
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '404'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkRFTEVURSIsICJleGNlcHRpb24i
+        OiBudWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMp
+        OiByZXBvc2l0b3J5PUZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
+        djIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8iLCAiaHR0cF9zdGF0dXMiOiA0
+        MDQsICJlcnJvciI6IHsiY29kZSI6ICJQTFAwMDA5IiwgImRhdGEiOiB7InJl
+        c291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0sICJkZXNj
+        cmlwdGlvbiI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiByZXBvc2l0b3J5PUZl
+        ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
+        bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkZlZG9yYV8xNyIsImRpc3BsYXlfbmFtZSI6IkZlZG9yYSAxNyB4
+        ODZfNjQiLCJpbXBvcnRlcl90eXBlX2lkIjoieXVtX2ltcG9ydGVyIiwiaW1w
+        b3J0ZXJfY29uZmlnIjp7ImRvd25sb2FkX3BvbGljeSI6Im9uX2RlbWFuZCIs
+        InJlbW92ZV9taXNzaW5nIjp0cnVlLCJmZWVkIjoiZmlsZTovLy92YXIvd3d3
+        L3Rlc3RfcmVwb3Mvem9vIiwidHlwZV9za2lwX2xpc3QiOm51bGwsInByb3h5
+        X2hvc3QiOm51bGwsImJhc2ljX2F1dGhfdXNlcm5hbWUiOm51bGwsImJhc2lj
+        X2F1dGhfcGFzc3dvcmQiOm51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJz
+        c2xfY2xpZW50X2NlcnQiOm51bGwsInNzbF9jbGllbnRfa2V5IjpudWxsLCJz
+        c2xfY2FfY2VydCI6bnVsbH0sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJycG0t
+        cmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQi
+        OiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsicmVs
+        YXRpdmVfdXJsIjoiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5L2ZlZG9yYV8x
+        N19sYWJlbCIsImh0dHAiOmZhbHNlLCJodHRwcyI6dHJ1ZSwicHJvdGVjdGVk
+        Ijp0cnVlLCJjaGVja3N1bV90eXBlIjpudWxsfSwiYXV0b19wdWJsaXNoIjp0
+        cnVlLCJkaXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xNyJ9LHsiZGlzdHJpYnV0
+        b3JfdHlwZV9pZCI6Inl1bV9jbG9uZV9kaXN0cmlidXRvciIsImRpc3RyaWJ1
+        dG9yX2NvbmZpZyI6eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6IkZl
+        ZG9yYV8xNyJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0cmlidXRvcl9p
+        ZCI6IkZlZG9yYV8xN19jbG9uZSJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9pZCI6
+        ImV4cG9ydF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJo
+        dHRwIjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxhdGl2ZV91cmwiOiJBQ01F
+        X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIn0sImF1dG9f
+        cHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lkIjoiZXhwb3J0X2Rpc3Ry
+        aWJ1dG9yIn1dfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1045'
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '320'
+      Location:
+      - "/pulp/api/v2/repositories/Fedora_17/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
+        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWM5YmMyMWNkYjI4NGU1OWJkNzFjODNjIn0sICJpZCI6ICJGZWRvcmFfMTci
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
+        MTcvIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
+        Ijp0cnVlfX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '53'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzM2MTg4Zjg0LTkzYzItNGE1MS1hNmQxLTU4MDlhNDdkMWI1MC8iLCAi
+        dGFza19pZCI6ICIzNjE4OGY4NC05M2MyLTRhNTEtYTZkMS01ODA5YTQ3ZDFi
+        NTAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/36188f84-93c2-4a51-a6d1-5809a47d1b50/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"1d11c9e5742858eec126940e2b8eae58-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '540'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNjE4OGY4NC05M2MyLTRhNTEtYTZkMS01ODA5YTQ3ZDFi
+        NTAvIiwgInRhc2tfaWQiOiAiMzYxODhmODQtOTNjMi00YTUxLWE2ZDEtNTgw
+        OWE0N2QxYjUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiIiwgInN0YXRlIjogIndhaXRp
+        bmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIxY2ZiNmU5NWI0
+        OWJmY2Q1MWYifSwgImlkIjogIjVjOWJjMjFjZmI2ZTk1YjQ5YmZjZDUxZiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/36188f84-93c2-4a51-a6d1-5809a47d1b50/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"40ceccc042379c8ef06a96577322968e-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1175'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNjE4OGY4NC05M2MyLTRhNTEtYTZkMS01ODA5YTQ3ZDFi
+        NTAvIiwgInRhc2tfaWQiOiAiMzYxODhmODQtOTNjMi00YTUxLWE2ZDEtNTgw
+        OWE0N2QxYjUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDowNFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiTk9UX1NU
+        QVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJJTl9QUk9HUkVTUyJ9
+        fX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0
+        YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjFjZmI2
+        ZTk1YjQ5YmZjZDUxZiJ9LCAiaWQiOiAiNWM5YmMyMWNmYjZlOTViNDliZmNk
+        NTFmIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/36188f84-93c2-4a51-a6d1-5809a47d1b50/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"7ae953d3b0c87c11399598a09392d1d5-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNjE4OGY4NC05M2MyLTRhNTEtYTZkMS01ODA5YTQ3ZDFi
+        NTAvIiwgInRhc2tfaWQiOiAiMzYxODhmODQtOTNjMi00YTUxLWE2ZDEtNTgw
+        OWE0N2QxYjUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDowNFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
+        Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiTk9UX1NU
+        QVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5w
+        YXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0
+        aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjFjZmI2ZTk1
+        YjQ5YmZjZDUxZiJ9LCAiaWQiOiAiNWM5YmMyMWNmYjZlOTViNDliZmNkNTFm
+        In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/36188f84-93c2-4a51-a6d1-5809a47d1b50/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"7ae953d3b0c87c11399598a09392d1d5-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNjE4OGY4NC05M2MyLTRhNTEtYTZkMS01ODA5YTQ3ZDFi
+        NTAvIiwgInRhc2tfaWQiOiAiMzYxODhmODQtOTNjMi00YTUxLWE2ZDEtNTgw
+        OWE0N2QxYjUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDowNFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
+        Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiTk9UX1NU
+        QVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5w
+        YXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0
+        aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjFjZmI2ZTk1
+        YjQ5YmZjZDUxZiJ9LCAiaWQiOiAiNWM5YmMyMWNmYjZlOTViNDliZmNkNTFm
+        In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/36188f84-93c2-4a51-a6d1-5809a47d1b50/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"7ae953d3b0c87c11399598a09392d1d5-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNjE4OGY4NC05M2MyLTRhNTEtYTZkMS01ODA5YTQ3ZDFi
+        NTAvIiwgInRhc2tfaWQiOiAiMzYxODhmODQtOTNjMi00YTUxLWE2ZDEtNTgw
+        OWE0N2QxYjUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDowNFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
+        Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiTk9UX1NU
+        QVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5w
+        YXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0
+        aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjFjZmI2ZTk1
+        YjQ5YmZjZDUxZiJ9LCAiaWQiOiAiNWM5YmMyMWNmYjZlOTViNDliZmNkNTFm
+        In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/36188f84-93c2-4a51-a6d1-5809a47d1b50/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"7ae953d3b0c87c11399598a09392d1d5-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNjE4OGY4NC05M2MyLTRhNTEtYTZkMS01ODA5YTQ3ZDFi
+        NTAvIiwgInRhc2tfaWQiOiAiMzYxODhmODQtOTNjMi00YTUxLWE2ZDEtNTgw
+        OWE0N2QxYjUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDowNFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
+        Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiTk9UX1NU
+        QVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
+        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5w
+        YXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0
+        aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjFjZmI2ZTk1
+        YjQ5YmZjZDUxZiJ9LCAiaWQiOiAiNWM5YmMyMWNmYjZlOTViNDliZmNkNTFm
+        In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/36188f84-93c2-4a51-a6d1-5809a47d1b50/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"f1e8bd9860990124f0ddea6ab2956136-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1169'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNjE4OGY4NC05M2MyLTRhNTEtYTZkMS01ODA5YTQ3ZDFi
+        NTAvIiwgInRhc2tfaWQiOiAiMzYxODhmODQtOTNjMi00YTUxLWE2ZDEtNTgw
+        OWE0N2QxYjUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDowNFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        Tk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        Tk9UX1NUQVJURUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiTk9UX1NUQVJU
+        RUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJx
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0
+        ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0
+        YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjFjZmI2ZTk1YjQ5
+        YmZjZDUxZiJ9LCAiaWQiOiAiNWM5YmMyMWNmYjZlOTViNDliZmNkNTFmIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/36188f84-93c2-4a51-a6d1-5809a47d1b50/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"e20d709cd7aefcff251db36b13bce9e1-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1163'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNjE4OGY4NC05M2MyLTRhNTEtYTZkMS01ODA5YTQ3ZDFi
+        NTAvIiwgInRhc2tfaWQiOiAiMzYxODhmODQtOTNjMi00YTUxLWE2ZDEtNTgw
+        OWE0N2QxYjUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDowNFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
+        T1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        Tk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiSU5fUFJPR1JFU1MifSwg
+        Im1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5l
+        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0
+        ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjFjZmI2ZTk1YjQ5YmZjZDUx
+        ZiJ9LCAiaWQiOiAiNWM5YmMyMWNmYjZlOTViNDliZmNkNTFmIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/36188f84-93c2-4a51-a6d1-5809a47d1b50/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"9da295a8ab5063e218f443bb02a8a577-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1160'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNjE4OGY4NC05M2MyLTRhNTEtYTZkMS01ODA5YTQ3ZDFi
+        NTAvIiwgInRhc2tfaWQiOiAiMzYxODhmODQtOTNjMi00YTUxLWE2ZDEtNTgw
+        OWE0N2QxYjUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDowNFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJJ
+        Tl9QUk9HUkVTUyJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        Tk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
+        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFt
+        cGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxs
+        by5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjFjZmI2ZTk1YjQ5YmZjZDUxZiJ9
+        LCAiaWQiOiAiNWM5YmMyMWNmYjZlOTViNDliZmNkNTFmIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/36188f84-93c2-4a51-a6d1-5809a47d1b50/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"29219b4d14a9b649bb39f0361faa0cce-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1154'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNjE4OGY4NC05M2MyLTRhNTEtYTZkMS01ODA5YTQ3ZDFi
+        NTAvIiwgInRhc2tfaWQiOiAiMzYxODhmODQtOTNjMi00YTUxLWE2ZDEtNTgw
+        OWE0N2QxYjUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDowNFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRl
+        bXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNlcnZl
+        ZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNv
+        bS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFt
+        cGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjVjOWJjMjFjZmI2ZTk1YjQ5YmZjZDUxZiJ9LCAiaWQi
+        OiAiNWM5YmMyMWNmYjZlOTViNDliZmNkNTFmIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/36188f84-93c2-4a51-a6d1-5809a47d1b50/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"29219b4d14a9b649bb39f0361faa0cce-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1154'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNjE4OGY4NC05M2MyLTRhNTEtYTZkMS01ODA5YTQ3ZDFi
+        NTAvIiwgInRhc2tfaWQiOiAiMzYxODhmODQtOTNjMi00YTUxLWE2ZDEtNTgw
+        OWE0N2QxYjUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDowNFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
+        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
+        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
+        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
+        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
+        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRl
+        bXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNlcnZl
+        ZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNv
+        bS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFt
+        cGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjVjOWJjMjFjZmI2ZTk1YjQ5YmZjZDUxZiJ9LCAiaWQi
+        OiAiNWM5YmMyMWNmYjZlOTViNDliZmNkNTFmIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/36188f84-93c2-4a51-a6d1-5809a47d1b50/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"173829739204f78813905384fd5aa0a3-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2403'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNjE4OGY4NC05M2MyLTRhNTEtYTZkMS01ODA5YTQ3ZDFi
+        NTAvIiwgInRhc2tfaWQiOiAiMzYxODhmODQtOTNjMi00YTUxLWE2ZDEtNTgw
+        OWE0N2QxYjUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        OS0wMy0yN1QxODozNDowNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozNDowNFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvYjIyZWZhNjctNWQ5OC00NzQwLWI3MWYtYzA2Y2U5ODNm
+        Y2MxLyIsICJ0YXNrX2lkIjogImIyMmVmYTY3LTVkOTgtNDc0MC1iNzFmLWMw
+        NmNlOTgzZmNjMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjog
+        bnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzdGFydGVkIjogIjIwMTktMDMtMjdUMTg6MzQ6MDRaIiwgIl9ucyI6
+        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wMy0y
+        N1QxODozNDowNFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJtb2R1
+        bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWM5
+        YmMyMWNkYjI4NGU0YWUyMjExOWNlIiwgImRldGFpbHMiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzaXplX3Rv
+        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
+        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
+        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzliYzIxY2ZiNmU5NWI0OWJmY2Q1MWYifSwgImlkIjogIjVjOWJjMjFj
+        ZmI2ZTk1YjQ5YmZjZDUxZiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/b22efa67-5d98-4740-b71f-c06ce983fcc1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"890022a8fb1728b367a5b89980008f80-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4294'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9iMjJlZmE2Ny01ZDk4LTQ3NDAtYjcxZi1jMDZj
+        ZTk4M2ZjYzEvIiwgInRhc2tfaWQiOiAiYjIyZWZhNjctNWQ5OC00NzQwLWI3
+        MWYtYzA2Y2U5ODNmY2MxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxOS0wMy0yN1QxODozNDowNFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJl
+        Yzg2YTY3OS01NWY0LTRlZTYtOWM4Yi1mOWJiYmI4MjVkZGIiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlw
+        ZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmE1ZGE5
+        ZWYtNjgxYS00NDAyLTg2YjUtOGJiMzUxOGQyMjQ4IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiMmEwZTdhMGItMTRiYS00NTZhLTg3OTAtZGU4ZDM3YzYw
+        ZTRiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3Rl
+        cF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFiZjY3ZDM0
+        LTUxMWQtNDhkNS1hMzYxLWQwYjQ2YmJiMDlkNiIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVt
+        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICI1YjM0ZTVlOS03NjNkLTQ2OTUtOWNlNS0zMGMzNDNj
+        ZjkyMDIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxlcyIsICJzdGVw
+        X3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNTM3YmNl
+        ZS1lYjMxLTRjMDItODJhZi1hMWIzMDVjYzEwN2QiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29tcHMiLCAi
+        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiNWY5Y2Y2MWMtZDY3OS00MGRmLThlN2UtOTgw
+        OTZmYWE2ODViIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIs
+        ICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        MGY0MDU4YWUtMjIyMy00ZWI3LWI5N2YtMzE4NGI4NTczZjllIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNs
+        b3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjllNTQz
+        NmQtNzQ2Yi00YjgxLWI1M2UtOWEwNjRiMGUyMjk2IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJH
+        ZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJh
+        dGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJjZGZjM2M4LTJhM2Yt
+        NGI4OS05Y2ZmLWJiZDIzZTRiZTlkOSIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcg
+        b2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9k
+        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjg5MWNlNTQwLTVmYmUtNDI5ZS04
+        YmIyLWVjYjBhZTlmNGU3OSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1M
+        IGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJhZjQxNmM0Ny1iNjkxLTQ5NTktYmFlMy1hMWI1ZGVlYjIwMTIi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBf
+        dHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICIxNzAxMjk2OC1kN2ZmLTQxYzEtODRkMi1mNmUwYmQ1NTA0NGIiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAi
+        aW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjEzODU0NTM0LTg2M2EtNDZjNS05N2M1LWFlN2JkODk2NTc0OCIsICJudW1f
+        cHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0wQHRoZXRhLnBhcnRlbGxvLmV4YW1wbGUuY29tLmRxMiIsICJz
+        dGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0wQHRoZXRhLnBhcnRlbGxvLmV4YW1wbGUuY29tIiwg
+        InJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNWM5YmMyMWNmYjZlOTViNDliZmNkNjkxIn0sICJpZCI6ICI1YzliYzIx
+        Y2ZiNmU5NWI0OWJmY2Q2OTEifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/36188f84-93c2-4a51-a6d1-5809a47d1b50/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"173829739204f78813905384fd5aa0a3-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2403'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNjE4OGY4NC05M2MyLTRhNTEtYTZkMS01ODA5YTQ3ZDFi
+        NTAvIiwgInRhc2tfaWQiOiAiMzYxODhmODQtOTNjMi00YTUxLWE2ZDEtNTgw
+        OWE0N2QxYjUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        OS0wMy0yN1QxODozNDowNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozNDowNFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvYjIyZWZhNjctNWQ5OC00NzQwLWI3MWYtYzA2Y2U5ODNm
+        Y2MxLyIsICJ0YXNrX2lkIjogImIyMmVmYTY3LTVkOTgtNDc0MC1iNzFmLWMw
+        NmNlOTgzZmNjMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjog
+        bnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzdGFydGVkIjogIjIwMTktMDMtMjdUMTg6MzQ6MDRaIiwgIl9ucyI6
+        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wMy0y
+        N1QxODozNDowNFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJtb2R1
+        bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWM5
+        YmMyMWNkYjI4NGU0YWUyMjExOWNlIiwgImRldGFpbHMiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzaXplX3Rv
+        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
+        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
+        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzliYzIxY2ZiNmU5NWI0OWJmY2Q1MWYifSwgImlkIjogIjVjOWJjMjFj
+        ZmI2ZTk1YjQ5YmZjZDUxZiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/b22efa67-5d98-4740-b71f-c06ce983fcc1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"fee943e8d25f07804d242ff14369db2a-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4288'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9iMjJlZmE2Ny01ZDk4LTQ3NDAtYjcxZi1jMDZj
+        ZTk4M2ZjYzEvIiwgInRhc2tfaWQiOiAiYjIyZWZhNjctNWQ5OC00NzQwLWI3
+        MWYtYzA2Y2U5ODNmY2MxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxOS0wMy0yN1QxODozNDowNFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlYzg2
+        YTY3OS01NWY0LTRlZTYtOWM4Yi1mOWJiYmI4MjVkZGIiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmE1ZGE5ZWYtNjgx
+        YS00NDAyLTg2YjUtOGJiMzUxOGQyMjQ4IiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiMmEwZTdhMGItMTRiYS00NTZhLTg3OTAtZGU4ZDM3YzYwZTRiIiwg
+        Im51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
+        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFiZjY3ZDM0LTUxMWQt
+        NDhkNS1hMzYxLWQwYjQ2YmJiMDlkNiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI1YjM0ZTVlOS03NjNkLTQ2OTUtOWNlNS0zMGMzNDNjZjkyMDIi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxlcyIsICJzdGVwX3R5cGUi
+        OiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
+        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNTM3YmNlZS1lYjMx
+        LTRjMDItODJhZi1hMWIzMDVjYzEwN2QiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiNWY5Y2Y2MWMtZDY3OS00MGRmLThlN2UtOTgwOTZmYWE2
+        ODViIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVw
+        X3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGY0MDU4
+        YWUtMjIyMy00ZWI3LWI5N2YtMzE4NGI4NTczZjllIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJD
+        bG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNsb3NlX3Jl
+        cG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjllNTQzNmQtNzQ2
+        Yi00YjgxLWI1M2UtOWEwNjRiMGUyMjk2IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
+        aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3Fs
+        aXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJjZGZjM2M4LTJhM2YtNGI4OS05
+        Y2ZmLWJiZDIzZTRiZTlkOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJl
+        cG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjg5MWNlNTQwLTVmYmUtNDI5ZS04YmIyLWVj
+        YjBhZTlmNGU3OSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVz
+        IiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICJhZjQxNmM0Ny1iNjkxLTQ5NTktYmFlMy1hMWI1ZGVlYjIwMTIiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6
+        ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNzAx
+        Mjk2OC1kN2ZmLTQxYzEtODRkMi1mNmUwYmQ1NTA0NGIiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
+        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjEzODU0
+        NTM0LTg2M2EtNDZjNS05N2M1LWFlN2JkODk2NTc0OCIsICJudW1fcHJvY2Vz
+        c2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
+        ci0wQHRoZXRhLnBhcnRlbGxvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6
+        ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0wQHRoZXRhLnBhcnRlbGxvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM5
+        YmMyMWNmYjZlOTViNDliZmNkNjkxIn0sICJpZCI6ICI1YzliYzIxY2ZiNmU5
+        NWI0OWJmY2Q2OTEifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/36188f84-93c2-4a51-a6d1-5809a47d1b50/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"173829739204f78813905384fd5aa0a3-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2403'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNjE4OGY4NC05M2MyLTRhNTEtYTZkMS01ODA5YTQ3ZDFi
+        NTAvIiwgInRhc2tfaWQiOiAiMzYxODhmODQtOTNjMi00YTUxLWE2ZDEtNTgw
+        OWE0N2QxYjUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        OS0wMy0yN1QxODozNDowNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozNDowNFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvYjIyZWZhNjctNWQ5OC00NzQwLWI3MWYtYzA2Y2U5ODNm
+        Y2MxLyIsICJ0YXNrX2lkIjogImIyMmVmYTY3LTVkOTgtNDc0MC1iNzFmLWMw
+        NmNlOTgzZmNjMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjog
+        bnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzdGFydGVkIjogIjIwMTktMDMtMjdUMTg6MzQ6MDRaIiwgIl9ucyI6
+        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wMy0y
+        N1QxODozNDowNFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJtb2R1
+        bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWM5
+        YmMyMWNkYjI4NGU0YWUyMjExOWNlIiwgImRldGFpbHMiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzaXplX3Rv
+        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
+        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
+        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzliYzIxY2ZiNmU5NWI0OWJmY2Q1MWYifSwgImlkIjogIjVjOWJjMjFj
+        ZmI2ZTk1YjQ5YmZjZDUxZiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/b22efa67-5d98-4740-b71f-c06ce983fcc1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"41ac49b549a638d91c1e018f4746a564-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4281'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9iMjJlZmE2Ny01ZDk4LTQ3NDAtYjcxZi1jMDZj
+        ZTk4M2ZjYzEvIiwgInRhc2tfaWQiOiAiYjIyZWZhNjctNWQ5OC00NzQwLWI3
+        MWYtYzA2Y2U5ODNmY2MxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxOS0wMy0yN1QxODozNDowNFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlYzg2
+        YTY3OS01NWY0LTRlZTYtOWM4Yi1mOWJiYmI4MjVkZGIiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmE1ZGE5ZWYtNjgx
+        YS00NDAyLTg2YjUtOGJiMzUxOGQyMjQ4IiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiMmEwZTdhMGItMTRiYS00NTZhLTg3OTAtZGU4ZDM3YzYwZTRiIiwgIm51
+        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
+        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWJmNjdkMzQtNTExZC00OGQ1LWEz
+        NjEtZDBiNDZiYmIwOWQ2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
+        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
+        InN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjViMzRlNWU5LTc2M2QtNDY5NS05Y2U1LTMwYzM0M2NmOTIwMiIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1
+        bGVzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE1MzdiY2VlLWViMzEtNGMwMi04
+        MmFmLWExYjMwNWNjMTA3ZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21w
+        cyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICI1ZjljZjYxYy1kNjc5LTQwZGYtOGU3ZS05ODA5NmZhYTY4NWIiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6
+        ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
+        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwZjQwNThhZS0yMjIz
+        LTRlYjctYjk3Zi0zMTg0Yjg1NzNmOWUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkNsb3Npbmcg
+        cmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRh
+        ZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2OWU1NDM2ZC03NDZiLTRiODEt
+        YjUzZS05YTA2NGIwZTIyOTYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3Fs
+        aXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAi
+        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiMmNkZmMzYzgtMmEzZi00Yjg5LTljZmYtYmJk
+        MjNlNGJlOWQ5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVwb2RhdGEi
+        LCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiODkxY2U1NDAtNWZiZS00MjllLThiYjItZWNiMGFlOWY0
+        ZTc5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAic3Rl
+        cF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFmNDE2
+        YzQ3LWI2OTEtNDk1OS1iYWUzLWExYjVkZWViMjAxMiIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        UHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxp
+        c2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
+        VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE3MDEyOTY4LWQ3
+        ZmYtNDFjMS04NGQyLWY2ZTBiZDU1MDQ0YiIsICJudW1fcHJvY2Vzc2VkIjog
+        MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiV3JpdGlu
+        ZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3Jl
+        cG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTM4NTQ1MzQtODYz
+        YS00NmM1LTk3YzUtYWU3YmQ4OTY1NzQ4IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhl
+        dGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5p
+        bmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVs
+        bCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIxY2Zi
+        NmU5NWI0OWJmY2Q2OTEifSwgImlkIjogIjVjOWJjMjFjZmI2ZTk1YjQ5YmZj
+        ZDY5MSJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/36188f84-93c2-4a51-a6d1-5809a47d1b50/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"173829739204f78813905384fd5aa0a3-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2403'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNjE4OGY4NC05M2MyLTRhNTEtYTZkMS01ODA5YTQ3ZDFi
+        NTAvIiwgInRhc2tfaWQiOiAiMzYxODhmODQtOTNjMi00YTUxLWE2ZDEtNTgw
+        OWE0N2QxYjUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        OS0wMy0yN1QxODozNDowNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozNDowNFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvYjIyZWZhNjctNWQ5OC00NzQwLWI3MWYtYzA2Y2U5ODNm
+        Y2MxLyIsICJ0YXNrX2lkIjogImIyMmVmYTY3LTVkOTgtNDc0MC1iNzFmLWMw
+        NmNlOTgzZmNjMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjog
+        bnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzdGFydGVkIjogIjIwMTktMDMtMjdUMTg6MzQ6MDRaIiwgIl9ucyI6
+        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wMy0y
+        N1QxODozNDowNFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJtb2R1
+        bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWM5
+        YmMyMWNkYjI4NGU0YWUyMjExOWNlIiwgImRldGFpbHMiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzaXplX3Rv
+        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
+        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
+        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzliYzIxY2ZiNmU5NWI0OWJmY2Q1MWYifSwgImlkIjogIjVjOWJjMjFj
+        ZmI2ZTk1YjQ5YmZjZDUxZiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/b22efa67-5d98-4740-b71f-c06ce983fcc1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"71d103b8478a54618fe2460d1f460232-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4268'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9iMjJlZmE2Ny01ZDk4LTQ3NDAtYjcxZi1jMDZj
+        ZTk4M2ZjYzEvIiwgInRhc2tfaWQiOiAiYjIyZWZhNjctNWQ5OC00NzQwLWI3
+        MWYtYzA2Y2U5ODNmY2MxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxOS0wMy0yN1QxODozNDowNFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlYzg2
+        YTY3OS01NWY0LTRlZTYtOWM4Yi1mOWJiYmI4MjVkZGIiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmE1ZGE5ZWYtNjgx
+        YS00NDAyLTg2YjUtOGJiMzUxOGQyMjQ4IiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiMmEwZTdhMGItMTRiYS00NTZhLTg3OTAtZGU4ZDM3YzYwZTRiIiwgIm51
+        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
+        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWJmNjdkMzQtNTExZC00OGQ1LWEz
+        NjEtZDBiNDZiYmIwOWQ2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
+        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjVi
+        MzRlNWU5LTc2M2QtNDY5NS05Y2U1LTMwYzM0M2NmOTIwMiIsICJudW1fcHJv
+        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1bGVz
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiYTUzN2JjZWUtZWIzMS00YzAyLTgyYWYtYTFi
+        MzA1Y2MxMDdkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUi
+        LCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjVmOWNm
+        NjFjLWQ2NzktNDBkZi04ZTdlLTk4MDk2ZmFhNjg1YiIsICJudW1fcHJvY2Vz
+        c2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        UHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjBmNDA1OGFlLTIyMjMtNGViNy1iOTdmLTMx
+        ODRiODU3M2Y5ZSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
+        IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjY5ZTU0MzZkLTc0NmItNGI4MS1iNTNlLTlhMDY0YjBl
+        MjI5NiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAi
+        c3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICIyY2RmYzNjOC0yYTNmLTRiODktOWNmZi1iYmQyM2U0YmU5ZDkiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUi
+        OiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4
+        OTFjZTU0MC01ZmJlLTQyOWUtOGJiMi1lY2IwYWU5ZjRlNzkiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVw
+        b3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWY0MTZjNDctYjY5MS00OTU5
+        LWJhZTMtYTFiNWRlZWIyMDEyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZp
+        bGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rvcnki
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMTcwMTI5NjgtZDdmZi00MWMxLTg0ZDIt
+        ZjZlMGJkNTUwNDRiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZp
+        bGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIxMzg1NDUzNC04NjNhLTQ2YzUtOTdjNS1h
+        ZTdiZDg5NjU3NDgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5l
+        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0
+        ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjFjZmI2ZTk1YjQ5YmZjZDY5
+        MSJ9LCAiaWQiOiAiNWM5YmMyMWNmYjZlOTViNDliZmNkNjkxIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/36188f84-93c2-4a51-a6d1-5809a47d1b50/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"173829739204f78813905384fd5aa0a3-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2403'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNjE4OGY4NC05M2MyLTRhNTEtYTZkMS01ODA5YTQ3ZDFi
+        NTAvIiwgInRhc2tfaWQiOiAiMzYxODhmODQtOTNjMi00YTUxLWE2ZDEtNTgw
+        OWE0N2QxYjUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        OS0wMy0yN1QxODozNDowNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozNDowNFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvYjIyZWZhNjctNWQ5OC00NzQwLWI3MWYtYzA2Y2U5ODNm
+        Y2MxLyIsICJ0YXNrX2lkIjogImIyMmVmYTY3LTVkOTgtNDc0MC1iNzFmLWMw
+        NmNlOTgzZmNjMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjog
+        bnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzdGFydGVkIjogIjIwMTktMDMtMjdUMTg6MzQ6MDRaIiwgIl9ucyI6
+        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wMy0y
+        N1QxODozNDowNFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJtb2R1
+        bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWM5
+        YmMyMWNkYjI4NGU0YWUyMjExOWNlIiwgImRldGFpbHMiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzaXplX3Rv
+        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
+        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
+        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzliYzIxY2ZiNmU5NWI0OWJmY2Q1MWYifSwgImlkIjogIjVjOWJjMjFj
+        ZmI2ZTk1YjQ5YmZjZDUxZiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/b22efa67-5d98-4740-b71f-c06ce983fcc1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"fdbebb0adf4708276e315c27e8fa6576-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4248'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9iMjJlZmE2Ny01ZDk4LTQ3NDAtYjcxZi1jMDZj
+        ZTk4M2ZjYzEvIiwgInRhc2tfaWQiOiAiYjIyZWZhNjctNWQ5OC00NzQwLWI3
+        MWYtYzA2Y2U5ODNmY2MxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxOS0wMy0yN1QxODozNDowNFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
+        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlYzg2
+        YTY3OS01NWY0LTRlZTYtOWM4Yi1mOWJiYmI4MjVkZGIiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmE1ZGE5ZWYtNjgx
+        YS00NDAyLTg2YjUtOGJiMzUxOGQyMjQ4IiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
+        OiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiMmEwZTdhMGItMTRiYS00NTZhLTg3OTAtZGU4ZDM3YzYwZTRiIiwgIm51
+        bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjog
+        ImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWJmNjdkMzQtNTExZC00OGQ1LWEz
+        NjEtZDBiNDZiYmIwOWQ2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0
+        YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjVi
+        MzRlNWU5LTc2M2QtNDY5NS05Y2U1LTMwYzM0M2NmOTIwMiIsICJudW1fcHJv
+        Y2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1bGVz
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiYTUzN2JjZWUtZWIzMS00YzAyLTgyYWYtYTFi
+        MzA1Y2MxMDdkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUi
+        LCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjVmOWNm
+        NjFjLWQ2NzktNDBkZi04ZTdlLTk4MDk2ZmFhNjg1YiIsICJudW1fcHJvY2Vz
+        c2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        UHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjBmNDA1OGFlLTIyMjMtNGViNy1iOTdmLTMx
+        ODRiODU3M2Y5ZSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
+        IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjY5ZTU0MzZkLTc0NmItNGI4MS1iNTNlLTlhMDY0YjBlMjI5
+        NiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
+        ZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJj
+        ZGZjM2M4LTJhM2YtNGI4OS05Y2ZmLWJiZDIzZTRiZTlkOSIsICJudW1fcHJv
+        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
+        OiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1v
+        dmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjg5MWNlNTQwLTVm
+        YmUtNDI5ZS04YmIyLWVjYjBhZTlmNGU3OSIsICJudW1fcHJvY2Vzc2VkIjog
+        MX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
+        dGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImFmNDE2YzQ3LWI2OTEtNDk1OS1iYWUzLWExYjVkZWVi
+        MjAxMiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAi
+        c3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjE3MDEyOTY4LWQ3ZmYtNDFjMS04NGQyLWY2ZTBiZDU1MDQ0YiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6
+        ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAx
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        MTM4NTQ1MzQtODYzYS00NmM1LTk3YzUtYWU3YmQ4OTY1NzQ4IiwgIm51bV9w
+        cm9jZXNzZWQiOiAxfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0
+        YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAi
+        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzliYzIxY2ZiNmU5NWI0OWJmY2Q2OTEifSwgImlkIjogIjVjOWJjMjFj
+        ZmI2ZTk1YjQ5YmZjZDY5MSJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/36188f84-93c2-4a51-a6d1-5809a47d1b50/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"173829739204f78813905384fd5aa0a3-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2403'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zNjE4OGY4NC05M2MyLTRhNTEtYTZkMS01ODA5YTQ3ZDFi
+        NTAvIiwgInRhc2tfaWQiOiAiMzYxODhmODQtOTNjMi00YTUxLWE2ZDEtNTgw
+        OWE0N2QxYjUwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        OS0wMy0yN1QxODozNDowNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozNDowNFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvdGFza3MvYjIyZWZhNjctNWQ5OC00NzQwLWI3MWYtYzA2Y2U5ODNm
+        Y2MxLyIsICJ0YXNrX2lkIjogImIyMmVmYTY3LTVkOTgtNDc0MC1iNzFmLWMw
+        NmNlOTgzZmNjMSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
+        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
+        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
+        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
+        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
+        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8u
+        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIs
+        ICJpbXBvcnRlcl9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjog
+        bnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzdGFydGVkIjogIjIwMTktMDMtMjdUMTg6MzQ6MDRaIiwgIl9ucyI6
+        ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wMy0y
+        N1QxODozNDowNFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0
+        ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5IjogeyJtb2R1
+        bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
+        RCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImVy
+        cmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJz
+        dGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUsICJyZW1v
+        dmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQiOiAiNWM5
+        YmMyMWNkYjI4NGU0YWUyMjExOWNlIiwgImRldGFpbHMiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzaXplX3Rv
+        dGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRldGFpbHMi
+        OiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBtX3RvdGFs
+        IjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtdfSwg
+        ImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGlj
+        YXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6
+        IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRhIjog
+        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1YzliYzIxY2ZiNmU5NWI0OWJmY2Q1MWYifSwgImlkIjogIjVjOWJjMjFj
+        ZmI2ZTk1YjQ5YmZjZDUxZiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/b22efa67-5d98-4740-b71f-c06ce983fcc1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:04 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"ae8e7d792b5c004b099cf68936a10c36-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '8518'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9iMjJlZmE2Ny01ZDk4LTQ3NDAtYjcxZi1jMDZj
+        ZTk4M2ZjYzEvIiwgInRhc2tfaWQiOiAiYjIyZWZhNjctNWQ5OC00NzQwLWI3
+        MWYtYzA2Y2U5ODNmY2MxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
+        bWUiOiAiMjAxOS0wMy0yN1QxODozNDowNFoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozNDowNFoiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJlYzg2YTY3OS01NWY0LTRlZTYtOWM4Yi1mOWJiYmI4
+        MjVkZGIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiMmE1ZGE5ZWYtNjgxYS00NDAyLTg2YjUtOGJiMzUxOGQyMjQ4Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJw
+        bXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMmEwZTdhMGItMTRiYS00NTZhLTg3OTAt
+        ZGU4ZDM3YzYwZTRiIiwgIm51bV9wcm9jZXNzZWQiOiA4fSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQ
+        TXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWJm
+        NjdkMzQtNTExZC00OGQ1LWEzNjEtZDBiNDZiYmIwOWQ2IiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjViMzRlNWU5LTc2M2QtNDY5NS05Y2U1LTMwYzM0
+        M2NmOTIwMiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0
+        ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTUzN2JjZWUt
+        ZWIzMS00YzAyLTgyYWYtYTFiMzA1Y2MxMDdkIiwgIm51bV9wcm9jZXNzZWQi
+        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJs
+        aXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0
+        ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjVmOWNmNjFjLWQ2NzktNDBkZi04ZTdlLTk4MDk2ZmFh
+        Njg1YiIsICJudW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3Rl
+        cF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBmNDA1OGFl
+        LTIyMjMtNGViNy1iOTdmLTMxODRiODU3M2Y5ZSIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xv
+        c2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjY5ZTU0MzZkLTc0NmItNGI4
+        MS1iNTNlLTlhMDY0YjBlMjI5NiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBz
+        cWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjJjZGZjM2M4LTJhM2YtNGI4OS05Y2ZmLWJiZDIz
+        ZTRiZTlkOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwg
+        InN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjg5MWNlNTQwLTVmYmUtNDI5ZS04YmIyLWVjYjBhZTlmNGU3OSIs
+        ICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
+        Y3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlw
+        ZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJT
+        S0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFmNDE2YzQ3LWI2OTEt
+        NDk1OS1iYWUzLWExYjVkZWViMjAxMiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
+        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjE3MDEyOTY4LWQ3ZmYtNDFjMS04NGQy
+        LWY2ZTBiZDU1MDQ0YiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
+        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiMTM4NTQ1MzQtODYzYS00NmM1LTk3YzUtYWU3
+        YmQ4OTY1NzQ4IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhh
+        bXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9u
+        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQHRoZXRhLnBhcnRl
+        bGxvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
+        c3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3
+        IiwgInN0YXJ0ZWQiOiAiMjAxOS0wMy0yN1QxODozNDowNFoiLCAiX25zIjog
+        InJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTAz
+        LTI3VDE4OjM0OjA0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0
+        b3JfdHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6IHsi
+        Z2VuZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQiLCAicnBtcyI6ICJGSU5JU0hF
+        RCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAi
+        cmVtb3ZlX29sZF9yZXBvZGF0YSI6ICJGSU5JU0hFRCIsICJtb2R1bGVzIjog
+        IlNLSVBQRUQiLCAiY2xvc2VfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIs
+        ICJkcnBtcyI6ICJTS0lQUEVEIiwgImNvbXBzIjogIkZJTklTSEVEIiwgImRp
+        c3RyaWJ1dGlvbiI6ICJGSU5JU0hFRCIsICJyZXBvdmlldyI6ICJTS0lQUEVE
+        IiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6
+        ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3Jf
+        bWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTci
+        LCAiaWQiOiAiNWM5YmMyMWNkYjI4NGU0YWUyMjExOWNmIiwgImRldGFpbHMi
+        OiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFs
+        aXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6
+        ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVjODZhNjc5LTU1
+        ZjQtNGVlNi05YzhiLWY5YmJiYjgyNWRkYiIsICJudW1fcHJvY2Vzc2VkIjog
+        MX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3Ry
+        aWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyYTVkYTllZi02ODFhLTQ0MDIt
+        ODZiNS04YmIzNTE4ZDIyNDgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        bV9zdWNjZXNzIjogOCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBN
+        cyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDgsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyYTBl
+        N2EwYi0xNGJhLTQ1NmEtODc5MC1kZThkMzdjNjBlNGIiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJhYmY2N2QzNC01MTFkLTQ4ZDUtYTM2MS1kMGI0
+        NmJiYjA5ZDYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0
+        ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNWIzNGU1ZTkt
+        NzYzZC00Njk1LTljZTUtMzBjMzQzY2Y5MjAyIiwgIm51bV9wcm9jZXNzZWQi
+        OiAzfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
+        aXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICJhNTM3YmNlZS1lYjMxLTRjMDItODJhZi1hMWIzMDVjYzEw
+        N2QiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVw
+        X3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNWY5Y2Y2MWMtZDY3
+        OS00MGRmLThlN2UtOTgwOTZmYWE2ODViIiwgIm51bV9wcm9jZXNzZWQiOiAz
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiMGY0MDU4YWUtMjIyMy00ZWI3LWI5N2YtMzE4NGI4NTcz
+        ZjllIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEs
+        ICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3Rl
+        cF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiNjllNTQzNmQtNzQ2Yi00YjgxLWI1M2UtOWEwNjRiMGUyMjk2IiwgIm51
+        bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUi
+        OiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmNkZmMzYzgt
+        MmEzZi00Yjg5LTljZmYtYmJkMjNlNGJlOWQ5IiwgIm51bV9wcm9jZXNzZWQi
+        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1v
+        dmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRf
+        cmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODkxY2U1NDAtNWZiZS00Mjll
+        LThiYjItZWNiMGFlOWY0ZTc5IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhU
+        TUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3Rv
+        dGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiYWY0MTZjNDctYjY5MS00OTU5LWJhZTMtYTFiNWRlZWIyMDEyIiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5
+        cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTcw
+        MTI5NjgtZDdmZi00MWMxLTg0ZDItZjZlMGJkNTUwNDRiIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
+        ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRp
+        YWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxMzg1NDUz
+        NC04NjNhLTQ2YzUtOTdjNS1hZTdiZDg5NjU3NDgiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDF9XX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM5
+        YmMyMWNmYjZlOTViNDliZmNkNjkxIn0sICJpZCI6ICI1YzliYzIxY2ZiNmU5
+        NWI0OWJmY2Q2OTEifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:04 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjNfdmlldzEiLCJkaXNwbGF5X25hbWUiOiJGZWRvcmEgMTcgeDg2
+        XzY0IiwiaW1wb3J0ZXJfdHlwZV9pZCI6Inl1bV9pbXBvcnRlciIsImltcG9y
+        dGVyX2NvbmZpZyI6e30sIm5vdGVzIjp7Il9yZXBvLXR5cGUiOiJycG0tcmVw
+        byJ9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5
+        dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsicmVsYXRp
+        dmVfdXJsIjoiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5L0xpYnJhcnlWaWV3
+        L2ZlZG9yYV8xN19sYWJlbCIsImh0dHAiOmZhbHNlLCJodHRwcyI6dHJ1ZSwi
+        cHJvdGVjdGVkIjp0cnVlLCJjaGVja3N1bV90eXBlIjpudWxsfSwiYXV0b19w
+        dWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9pZCI6IjNfdmlldzEifSx7ImRp
+        c3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1fY2xvbmVfZGlzdHJpYnV0b3IiLCJk
+        aXN0cmlidXRvcl9jb25maWciOnsiZGVzdGluYXRpb25fZGlzdHJpYnV0b3Jf
+        aWQiOiIzX3ZpZXcxIn0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1
+        dG9yX2lkIjoiM192aWV3MV9jbG9uZSJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9p
+        ZCI6ImV4cG9ydF9kaXN0cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6
+        eyJodHRwIjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJyZWxhdGl2ZV91cmwiOiJB
+        Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvTGlicmFyeVZpZXcvZmVkb3JhXzE3
+        X2xhYmVsIn0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9yX2lk
+        IjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '790'
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '316'
+      Location:
+      - "/pulp/api/v2/repositories/3_view1/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRk
+        ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
+        b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWM5YmMyMWRkYjI4NGU1OWJlOTZiYWRjIn0sICJpZCI6ICIzX3ZpZXcxIiwg
+        Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS8i
+        fQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwiZmllbGRzIjp7InVu
+        aXQiOltdLCJhc3NvY2lhdGlvbiI6WyJ1bml0X2lkIl19fX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '80'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1672'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIzOTYxNjhlZC1hMGE3LTQ3MGItYWY5
+        Zi02ZmIwYTUyYzljZmEiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1YzliYzIxY2ZiNmU5NWI0OWJmY2Q1NmQifSwg
+        InVuaXRfaWQiOiAiMzk2MTY4ZWQtYTBhNy00NzBiLWFmOWYtNmZiMGE1MmM5
+        Y2ZhIiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
+        X2lkIjogIjNhYjU1ODkyLTc0ZWMtNGM1NS1iNzhiLWNhNjJmNDU3ZDU3YSIs
+        ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
+        IjVjOWJjMjFjZmI2ZTk1YjQ5YmZjZDVhNCJ9LCAidW5pdF9pZCI6ICIzYWI1
+        NTg5Mi03NGVjLTRjNTUtYjc4Yi1jYTYyZjQ1N2Q1N2EiLCAidW5pdF90eXBl
+        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNDUwMDE5NzEt
+        ZjRlZC00YjllLTkwNWEtMDc0YzkwZGFhYjgwIiwgIl9jb250ZW50X3R5cGVf
+        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNWM5YmMyMWNmYjZlOTVi
+        NDliZmNkNTY0In0sICJ1bml0X2lkIjogIjQ1MDAxOTcxLWY0ZWQtNGI5ZS05
+        MDVhLTA3NGM5MGRhYWI4MCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
+        bWV0YWRhdGEiOiB7Il9pZCI6ICI5MjY1Y2QzYy05ZWU5LTQ0YTAtYmJhZC1l
+        Y2Y0MDJhNDJjMjgiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1YzliYzIxY2ZiNmU5NWI0OWJmY2Q1NzkifSwgInVu
+        aXRfaWQiOiAiOTI2NWNkM2MtOWVlOS00NGEwLWJiYWQtZWNmNDAyYTQyYzI4
+        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
+        IjogImJmNzQyMWY4LWE3ZTUtNDQ4MS1hMjlmLTUyZWU3NjQ4MzAxYSIsICJf
+        Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjVj
+        OWJjMjFjZmI2ZTk1YjQ5YmZjZDU4ZCJ9LCAidW5pdF9pZCI6ICJiZjc0MjFm
+        OC1hN2U1LTQ0ODEtYTI5Zi01MmVlNzY0ODMwMWEiLCAidW5pdF90eXBlX2lk
+        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiZDdmZjQ4MjMtNWI2
+        OC00MjM2LThhMGMtNDMyODMwODgwYzYzIiwgIl9jb250ZW50X3R5cGVfaWQi
+        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNWM5YmMyMWNmYjZlOTViNDli
+        ZmNkNTk2In0sICJ1bml0X2lkIjogImQ3ZmY0ODIzLTViNjgtNDIzNi04YTBj
+        LTQzMjgzMDg4MGM2MyIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
+        YWRhdGEiOiB7Il9pZCI6ICJlMjU1MWE0Yi1kZmIwLTQ5NDEtYmVhMi0wMjhh
+        MmFhMTliMDUiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
+        IHsiJG9pZCI6ICI1YzliYzIxY2ZiNmU5NWI0OWJmY2Q1ODQifSwgInVuaXRf
+        aWQiOiAiZTI1NTFhNGItZGZiMC00OTQxLWJlYTItMDI4YTJhYTE5YjA1Iiwg
+        InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
+        ImU4ZWI1MzU2LWE4ZDgtNGQ2Ny1iMjZlLTliYjQ5ZWRmN2YwNCIsICJfY29u
+        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjVjOWJj
+        MjFjZmI2ZTk1YjQ5YmZjZDU1YiJ9LCAidW5pdF9pZCI6ICJlOGViNTM1Ni1h
+        OGQ4LTRkNjctYjI2ZS05YmI0OWVkZjdmMDQiLCAidW5pdF90eXBlX2lkIjog
+        InJwbSJ9XQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/content/units/rpm/search/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJsaW1pdCI6OCwic2tpcCI6MCwiZmllbGRzIjpbIm5h
+        bWUiLCJ2ZXJzaW9uIiwicmVsZWFzZSIsImFyY2giLCJlcG9jaCIsInN1bW1h
+        cnkiLCJzb3VyY2VycG0iLCJjaGVja3N1bSIsImZpbGVuYW1lIiwiX2lkIiwi
+        aXNfbW9kdWxhciJdLCJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMzk2MTY4
+        ZWQtYTBhNy00NzBiLWFmOWYtNmZiMGE1MmM5Y2ZhIiwiM2FiNTU4OTItNzRl
+        Yy00YzU1LWI3OGItY2E2MmY0NTdkNTdhIiwiNDUwMDE5NzEtZjRlZC00Yjll
+        LTkwNWEtMDc0YzkwZGFhYjgwIiwiOTI2NWNkM2MtOWVlOS00NGEwLWJiYWQt
+        ZWNmNDAyYTQyYzI4IiwiYmY3NDIxZjgtYTdlNS00NDgxLWEyOWYtNTJlZTc2
+        NDgzMDFhIiwiZDdmZjQ4MjMtNWI2OC00MjM2LThhMGMtNDMyODMwODgwYzYz
+        IiwiZTI1NTFhNGItZGZiMC00OTQxLWJlYTItMDI4YTJhYTE5YjA1IiwiZThl
+        YjUzNTYtYThkOC00ZDY3LWIyNmUtOWJiNDllZGY3ZjA0Il19fX0sImluY2x1
+        ZGVfcmVwb3MiOnRydWV9
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '510'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4292'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiNTgxNTJiOWQtNTAyZS00
+        Y2ZkLWFkZjgtYWI2MjdkOTcyNGI4IiwgIkZlZG9yYV8xNyJdLCAic291cmNl
+        cnBtIjogImxpb24tMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAibGlvbiIs
+        ICJjaGVja3N1bSI6ICIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2Qz
+        ZmNkZDdhODk4MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0IiwgInN1bW1hcnki
+        OiAiQSBkdW1teSBwYWNrYWdlIG9mIGxpb24iLCAiZmlsZW5hbWUiOiAibGlv
+        bi0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9u
+        IjogIjAuMyIsICJpc19tb2R1bGFyIjogZmFsc2UsICJyZWxlYXNlIjogIjAu
+        OCIsICJfaWQiOiAiMzk2MTY4ZWQtYTBhNy00NzBiLWFmOWYtNmZiMGE1MmM5
+        Y2ZhIiwgImFyY2giOiAibm9hcmNoIiwgImNoaWxkcmVuIjoge30sICJfaHJl
+        ZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vMzk2MTY4ZWQt
+        YTBhNy00NzBiLWFmOWYtNmZiMGE1MmM5Y2ZhLyJ9LCB7InJlcG9zaXRvcnlf
+        bWVtYmVyc2hpcHMiOiBbIjU4MTUyYjlkLTUwMmUtNGNmZC1hZGY4LWFiNjI3
+        ZDk3MjRiOCIsICJGZWRvcmFfMTciXSwgInNvdXJjZXJwbSI6ICJzcXVpcnJl
+        bC0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJzcXVpcnJlbCIsICJjaGVj
+        a3N1bSI6ICIyNTE3NjhiZGQxNWYxM2Q3ODQ4N2MyNzYzOGFhNmFlY2QwMTU1
+        MWUyNTM3NTYwOTNjZGUxYzBhZTg3OGExN2QyIiwgInN1bW1hcnkiOiAiQSBk
+        dW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwgImZpbGVuYW1lIjogInNxdWly
+        cmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNp
+        b24iOiAiMC4zIiwgImlzX21vZHVsYXIiOiBmYWxzZSwgInJlbGVhc2UiOiAi
+        MC44IiwgIl9pZCI6ICIzYWI1NTg5Mi03NGVjLTRjNTUtYjc4Yi1jYTYyZjQ1
+        N2Q1N2EiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9o
+        cmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS8zYWI1NTg5
+        Mi03NGVjLTRjNTUtYjc4Yi1jYTYyZjQ1N2Q1N2EvIn0sIHsicmVwb3NpdG9y
+        eV9tZW1iZXJzaGlwcyI6IFsiNTgxNTJiOWQtNTAyZS00Y2ZkLWFkZjgtYWI2
+        MjdkOTcyNGI4IiwgIkZlZG9yYV8xNyJdLCAic291cmNlcnBtIjogImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogImVsZXBoYW50IiwgImNo
+        ZWNrc3VtIjogIjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMw
+        NmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCAic3VtbWFyeSI6ICJB
+        IGR1bW15IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCAiZmlsZW5hbWUiOiAiZWxl
+        cGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVy
+        c2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAicmVsZWFzZSI6
+        ICIwLjgiLCAiX2lkIjogIjQ1MDAxOTcxLWY0ZWQtNGI5ZS05MDVhLTA3NGM5
+        MGRhYWI4MCIsICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAi
+        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtLzQ1MDAx
+        OTcxLWY0ZWQtNGI5ZS05MDVhLTA3NGM5MGRhYWI4MC8ifSwgeyJyZXBvc2l0
+        b3J5X21lbWJlcnNoaXBzIjogWyI1ODE1MmI5ZC01MDJlLTRjZmQtYWRmOC1h
+        YjYyN2Q5NzI0YjgiLCAiRmVkb3JhXzE3Il0sICJzb3VyY2VycG0iOiAibW9u
+        a2V5LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogIm1vbmtleSIsICJjaGVj
+        a3N1bSI6ICIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1ZDM5YjAy
+        ODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwgInN1bW1hcnkiOiAiQSBk
+        dW1teSBwYWNrYWdlIG9mIG1vbmtleSIsICJmaWxlbmFtZSI6ICJtb25rZXkt
+        MC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
+        ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAicmVsZWFzZSI6ICIwLjgi
+        LCAiX2lkIjogIjkyNjVjZDNjLTllZTktNDRhMC1iYmFkLWVjZjQwMmE0MmMy
+        OCIsICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtLzkyNjVjZDNjLTll
+        ZTktNDRhMC1iYmFkLWVjZjQwMmE0MmMyOC8ifSwgeyJyZXBvc2l0b3J5X21l
+        bWJlcnNoaXBzIjogWyI1ODE1MmI5ZC01MDJlLTRjZmQtYWRmOC1hYjYyN2Q5
+        NzI0YjgiLCAiRmVkb3JhXzE3Il0sICJzb3VyY2VycG0iOiAiY2hlZXRhaC0w
+        LjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJjaGVldGFoIiwgImNoZWNrc3Vt
+        IjogIjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIzZTE3ZjU3OGY5MjRm
+        NzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCAic3VtbWFyeSI6ICJBIGR1bW15
+        IHBhY2thZ2Ugb2YgY2hlZXRhaCIsICJmaWxlbmFtZSI6ICJjaGVldGFoLTAu
+        My0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAi
+        MC4zIiwgImlzX21vZHVsYXIiOiBmYWxzZSwgInJlbGVhc2UiOiAiMC44Iiwg
+        Il9pZCI6ICJiZjc0MjFmOC1hN2U1LTQ0ODEtYTI5Zi01MmVlNzY0ODMwMWEi
+        LCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjog
+        Ii9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9iZjc0MjFmOC1hN2U1
+        LTQ0ODEtYTI5Zi01MmVlNzY0ODMwMWEvIn0sIHsicmVwb3NpdG9yeV9tZW1i
+        ZXJzaGlwcyI6IFsiNTgxNTJiOWQtNTAyZS00Y2ZkLWFkZjgtYWI2MjdkOTcy
+        NGI4IiwgIkZlZG9yYV8xNyJdLCAic291cmNlcnBtIjogIndhbHJ1cy0wLjMt
+        MC44LnNyYy5ycG0iLCAibmFtZSI6ICJ3YWxydXMiLCAiY2hlY2tzdW0iOiAi
+        NmU4ZDZkYzA1N2UzZTJjOTgxOWYwZGM3ZTZjN2I3Zjg2YmYyZTg1NzFiYmE0
+        MTRhZGVjN2ZiNjIxYTQ2MWRmZCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFj
+        a2FnZSBvZiB3YWxydXMiLCAiZmlsZW5hbWUiOiAid2FscnVzLTAuMy0wLjgu
+        bm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
+        ImlzX21vZHVsYXIiOiBmYWxzZSwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6
+        ICJkN2ZmNDgyMy01YjY4LTQyMzYtOGEwYy00MzI4MzA4ODBjNjMiLCAiYXJj
+        aCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxw
+        L2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9kN2ZmNDgyMy01YjY4LTQyMzYt
+        OGEwYy00MzI4MzA4ODBjNjMvIn0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlw
+        cyI6IFsiNTgxNTJiOWQtNTAyZS00Y2ZkLWFkZjgtYWI2MjdkOTcyNGI4Iiwg
+        IkZlZG9yYV8xNyJdLCAic291cmNlcnBtIjogInBlbmd1aW4tMC4zLTAuOC5z
+        cmMucnBtIiwgIm5hbWUiOiAicGVuZ3VpbiIsICJjaGVja3N1bSI6ICIzZmNi
+        MmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1NjRmYzIx
+        MGZkNmU0ODYzNWJlNjk0IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdl
+        IG9mIHBlbmd1aW4iLCAiZmlsZW5hbWUiOiAicGVuZ3Vpbi0wLjMtMC44Lm5v
+        YXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJp
+        c19tb2R1bGFyIjogZmFsc2UsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAi
+        ZTI1NTFhNGItZGZiMC00OTQxLWJlYTItMDI4YTJhYTE5YjA1IiwgImFyY2gi
+        OiAibm9hcmNoIiwgImNoaWxkcmVuIjoge30sICJfaHJlZiI6ICIvcHVscC9h
+        cGkvdjIvY29udGVudC91bml0cy9ycG0vZTI1NTFhNGItZGZiMC00OTQxLWJl
+        YTItMDI4YTJhYTE5YjA1LyJ9LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMi
+        OiBbIjU4MTUyYjlkLTUwMmUtNGNmZC1hZGY4LWFiNjI3ZDk3MjRiOCIsICJG
+        ZWRvcmFfMTciXSwgInNvdXJjZXJwbSI6ICJnaXJhZmZlLTAuMy0wLjguc3Jj
+        LnJwbSIsICJuYW1lIjogImdpcmFmZmUiLCAiY2hlY2tzdW0iOiAiZjI1ZDY3
+        ZDFkOWRhMDRmMTJlNTdjYTMyMzI0N2I0Mzg5MWFjNDY1MzNlMzU1YjgyZGU2
+        ZDE5MjIwMDlmOWYxNCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBv
+        ZiBnaXJhZmZlIiwgImZpbGVuYW1lIjogImdpcmFmZmUtMC4zLTAuOC5ub2Fy
+        Y2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNf
+        bW9kdWxhciI6IGZhbHNlLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogImU4
+        ZWI1MzU2LWE4ZDgtNGQ2Ny1iMjZlLTliYjQ5ZWRmN2YwNCIsICJhcmNoIjog
+        Im5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBp
+        L3YyL2NvbnRlbnQvdW5pdHMvcnBtL2U4ZWI1MzU2LWE4ZDgtNGQ2Ny1iMjZl
+        LTliYjQ5ZWRmN2YwNC8ifV0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImZpZWxkcyI6
+        eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '84'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '651'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI0NGZkZTY5MS04MTgzLTQ3OWQtODFm
+        MS1mYTlhODg5OWEzZTEiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
+        In0sICJfaWQiOiB7IiRvaWQiOiAiNWM5YmMyMWNmYjZlOTViNDliZmNkNjM5
+        In0sICJ1bml0X2lkIjogIjQ0ZmRlNjkxLTgxODMtNDc5ZC04MWYxLWZhOWE4
+        ODk5YTNlMSIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
+        YXRhIjogeyJfaWQiOiAiNzZhOTYwYjQtOTkzMi00ZWVkLTkzOGYtM2EzMjdl
+        NWNlZWFkIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
+        IjogeyIkb2lkIjogIjVjOWJjMjFjZmI2ZTk1YjQ5YmZjZDYxZiJ9LCAidW5p
+        dF9pZCI6ICI3NmE5NjBiNC05OTMyLTRlZWQtOTM4Zi0zYTMyN2U1Y2VlYWQi
+        LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0ifSwgeyJtZXRhZGF0YSI6IHsi
+        X2lkIjogImY0MmY5NjZjLWRmNzEtNDg3ZC04MWM0LTc0OGQxYmUwZTEwMyIs
+        ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0ifSwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1YzliYzIxY2ZiNmU5NWI0OWJmY2Q2MDAifSwgInVuaXRfaWQiOiAi
+        ZjQyZjk2NmMtZGY3MS00ODdkLTgxYzQtNzQ4ZDFiZTBlMTAzIiwgInVuaXRf
+        dHlwZV9pZCI6ICJlcnJhdHVtIn1d
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/content/units/erratum/search/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJsaW1pdCI6Mywic2tpcCI6MCwiZmlsdGVycyI6eyJf
+        aWQiOnsiJGluIjpbIjQ0ZmRlNjkxLTgxODMtNDc5ZC04MWYxLWZhOWE4ODk5
+        YTNlMSIsIjc2YTk2MGI0LTk5MzItNGVlZC05MzhmLTNhMzI3ZTVjZWVhZCIs
+        ImY0MmY5NjZjLWRmNzEtNDg3ZC04MWM0LTc0OGQxYmUwZTEwMyJdfX19LCJp
+        bmNsdWRlX3JlcG9zIjp0cnVlfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '199'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4976'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiNTgxNTJiOWQtNTAyZS00
+        Y2ZkLWFkZjgtYWI2MjdkOTcyNGI4IiwgIkZlZG9yYV8xNyJdLCAiX2hyZWYi
+        OiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvZXJyYXR1bS80NGZkZTY5
+        MS04MTgzLTQ3OWQtODFmMS1mYTlhODg5OWEzZTEvIiwgImlzc3VlZCI6ICIy
+        MDEwLTAxLTAxIDAxOjAxOjAxIiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFs
+        c2UsICJyZWZlcmVuY2VzIjogW10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7
+        fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJSSEVB
+        LTIwMTA6MDAwMiIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20iLCAi
+        c2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIk9uZSBwYWNrYWdlIGVycmF0YSIs
+        ICJjaGlsZHJlbiI6IHt9LCAidmVyc2lvbiI6ICIxIiwgInJlYm9vdF9zdWdn
+        ZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlzdCI6
+        IFt7InBhY2thZ2VzIjogW3sic3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJv
+        amVjdC5vcmciLCAibmFtZSI6ICJlbGVwaGFudCIsICJzdW0iOiBudWxsLCAi
+        ZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVw
+        b2NoIjogbnVsbCwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44
+        IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJjb2xsZWN0aW9uLTAi
+        LCAic2hvcnQiOiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIsICJ1cGRhdGVk
+        IjogIiIsICJkZXNjcmlwdGlvbiI6ICJPbmUgcGFja2FnZSBlcnJhdGEiLCAi
+        X2xhc3RfdXBkYXRlZCI6ICIyMDE5LTAzLTI3VDE4OjM0OjA0WiIsICJyZXN0
+        YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJyaWdo
+        dHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxl
+        YXNlIjogIjEiLCAiX2lkIjogIjQ0ZmRlNjkxLTgxODMtNDc5ZC04MWYxLWZh
+        OWE4ODk5YTNlMSJ9LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbIkZl
+        ZG9yYV8xNyJdLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5p
+        dHMvZXJyYXR1bS83NmE5NjBiNC05OTMyLTRlZWQtOTM4Zi0zYTMyN2U1Y2Vl
+        YWQvIiwgImlzc3VlZCI6ICIyMDEwLTExLTEwIDAwOjAwOjAwIiwgInJlbG9n
+        aW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjogW3siaHJlZiI6
+        ICJodHRwczovL3Jobi5yZWRoYXQuY29tL2VycmF0YS9SSFNBLTIwMTAtMDg1
+        OC5odG1sIiwgInR5cGUiOiAic2VsZiIsICJpZCI6IG51bGwsICJ0aXRsZSI6
+        ICJSSFNBLTIwMTA6MDg1OCJ9LCB7ImhyZWYiOiAiaHR0cHM6Ly9idWd6aWxs
+        YS5yZWRoYXQuY29tL2J1Z3ppbGxhL3Nob3dfYnVnLmNnaT9pZD02Mjc4ODIi
+        LCAidHlwZSI6ICJidWd6aWxsYSIsICJpZCI6ICI2Mjc4ODIiLCAidGl0bGUi
+        OiAiQ1ZFLTIwMTAtMDQwNSBiemlwMjogaW50ZWdlciBvdmVyZmxvdyBmbGF3
+        IGluIEJaMl9kZWNvbXByZXNzIn0sIHsiaHJlZiI6ICJodHRwczovL3d3dy5y
+        ZWRoYXQuY29tL3NlY3VyaXR5L2RhdGEvY3ZlL0NWRS0yMDEwLTA0MDUuaHRt
+        bCIsICJ0eXBlIjogImN2ZSIsICJpZCI6ICJDVkUtMjAxMC0wNDA1IiwgInRp
+        dGxlIjogIkNWRS0yMDEwLTA0MDUifSwgeyJocmVmIjogImh0dHA6Ly93d3cu
+        cmVkaGF0LmNvbS9zZWN1cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNp
+        bXBvcnRhbnQiLCAidHlwZSI6ICJvdGhlciIsICJpZCI6IG51bGwsICJ0aXRs
+        ZSI6IG51bGx9XSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRl
+        bnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIlJIU0EtMjAxMDowODU4
+        IiwgImZyb20iOiAic2VjdXJpdHlAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6
+        ICJJbXBvcnRhbnQiLCAidGl0bGUiOiAiSW1wb3J0YW50OiBiemlwMiBzZWN1
+        cml0eSB1cGRhdGUiLCAiY2hpbGRyZW4iOiB7fSwgInZlcnNpb24iOiAiMyIs
+        ICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5
+        IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJiemlwMi0x
+        LjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1kZXZlbCIs
+        ICJzdW0iOiBbInNoYTI1NiIsICJlYTY3YzY2NGRhMWZmOTZhNmRjOTRkMzMw
+        MDliNzNkOGZhYjMxYjU5ODI0MTgzZmI0NWU5YmEyZWJmODJkNTgzIl0sICJm
+        aWxlbmFtZSI6ICJiemlwMi1kZXZlbC0xLjAuNS03LmVsNl8wLmk2ODYucnBt
+        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNl
+        IjogIjcuZWw2XzAiLCAiYXJjaCI6ICJpNjg2In0sIHsic3JjIjogImJ6aXAy
+        LTEuMC41LTcuZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6aXAyLWxpYnMi
+        LCAic3VtIjogWyJzaGEyNTYiLCAiYzlmMDY0YTY4NjI1NzNmYjlmMmE2YWZm
+        N2MzNjIxZjE5NDBiNDkyZGYyZWRmYzJlYmJkYzBiODMwNWY1MTE0NyJdLCAi
+        ZmlsZW5hbWUiOiAiYnppcDItbGlicy0xLjAuNS03LmVsNl8wLmk2ODYucnBt
+        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNl
+        IjogIjcuZWw2XzAiLCAiYXJjaCI6ICJpNjg2In0sIHsic3JjIjogImJ6aXAy
+        LTEuMC41LTcuZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6aXAyIiwgInN1
+        bSI6IFsic2hhMjU2IiwgImI4YTNmNzJiYzJiMGQ4OWJhNzM3MDk5YWM5OGJm
+        OGQyYWY0YmVhMDJkMzE4ODRjMDJkYjk3ZjdmNjZjM2Q1YzIiXSwgImZpbGVu
+        YW1lIjogImJ6aXAyLTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIsICJlcG9j
+        aCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVs
+        Nl8wIiwgImFyY2giOiAieDg2XzY0In0sIHsic3JjIjogImJ6aXAyLTEuMC41
+        LTcuZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6aXAyLWRldmVsIiwgInN1
+        bSI6IFsic2hhMjU2IiwgIjdmNjMxMjRlNDY1NWI3YzkyZDIzZWM0YzM4MjI2
+        ZjVkMzc0NjU2ODg1M2RmZjc1MGZjODVlMDU4ZTc0YjVjZjYiXSwgImZpbGVu
+        YW1lIjogImJ6aXAyLWRldmVsLTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIs
+        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6
+        ICI3LmVsNl8wIiwgImFyY2giOiAieDg2XzY0In0sIHsic3JjIjogImJ6aXAy
+        LTEuMC41LTcuZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6aXAyLWxpYnMi
+        LCAic3VtIjogWyJzaGEyNTYiLCAiODAyZjQzOTlkYmRkMDE0NzZlMjU0YzNi
+        MzJjNDBhZmY1OWNmNWQyM2E0NWZhNDg4YzY5MTdjZTg5MDRkNmI0ZCJdLCAi
+        ZmlsZW5hbWUiOiAiYnppcDItbGlicy0xLjAuNS03LmVsNl8wLng4Nl82NC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVh
+        c2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9XSwgIm5hbWUiOiAi
+        Y29sbGVjdGlvbi0wIiwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6ICJmaW5h
+        bCIsICJ1cGRhdGVkIjogIjIwMTAtMTEtMTAgMDA6MDA6MDAiLCAiZGVzY3Jp
+        cHRpb24iOiAiYnppcDIgaXMgYSBmcmVlbHkgYXZhaWxhYmxlLCBoaWdoLXF1
+        YWxpdHkgZGF0YSBjb21wcmVzc29yLiBJdCBwcm92aWRlcyBib3RoXG5saWJi
+        ejIgbGlicmFyeSBtdXN0IGJlIHJlc3RhcnRlZCBmb3IgdGhlIHVwZGF0ZSB0
+        byB0YWtlIGVmZmVjdC4iLCAiX2xhc3RfdXBkYXRlZCI6ICIyMDE5LTAzLTI3
+        VDE4OjM0OjA0WiIsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVz
+        aGNvdW50IjogIiIsICJyaWdodHMiOiAiQ29weXJpZ2h0IDIwMTAgUmVkIEhh
+        dCBJbmMiLCAic29sdXRpb24iOiAiQmVmb3JlIGFwcGx5aW5nIHRoaXMgdXBk
+        YXRlLCBtYWtlIHN1cmUgYWxsIHByZXZpb3VzbHktcmVsZWFzZWQgZXJyYXRh
+        XG5yZWxldmFudCB0byB5b3VyIHN5c3RlbSBoYXZlIGJlZW4gYXBwbGllZC5c
+        blxuVGhpcyB1cGRhdGUgaXMgYXZhaWxhYmxlIHZpYSB0aGUgUmVkIEhhdCBO
+        ZXR3b3JrLiBEZXRhaWxzIG9uIGhvdyB0b1xudXNlIHRoZSBSZWQgSGF0IE5l
+        dHdvcmsgdG8gYXBwbHkgdGhpcyB1cGRhdGUgYXJlIGF2YWlsYWJsZSBhdFxu
+        aHR0cDovL2tiYXNlLnJlZGhhdC5jb20vZmFxL2RvY3MvRE9DLTExMjU5Iiwg
+        InN1bW1hcnkiOiAiVXBkYXRlZCBiemlwMiBwYWNrYWdlcyB0aGF0IGZpeCBv
+        bmUgc2VjdXJpdHkgaXNzdWUiLCAicmVsZWFzZSI6ICIiLCAiX2lkIjogIjc2
+        YTk2MGI0LTk5MzItNGVlZC05MzhmLTNhMzI3ZTVjZWVhZCJ9LCB7InJlcG9z
+        aXRvcnlfbWVtYmVyc2hpcHMiOiBbIjU4MTUyYjlkLTUwMmUtNGNmZC1hZGY4
+        LWFiNjI3ZDk3MjRiOCIsICJGZWRvcmFfMTciXSwgIl9ocmVmIjogIi9wdWxw
+        L2FwaS92Mi9jb250ZW50L3VuaXRzL2VycmF0dW0vZjQyZjk2NmMtZGY3MS00
+        ODdkLTgxYzQtNzQ4ZDFiZTBlMTAzLyIsICJpc3N1ZWQiOiAiMjAxMC0wMS0w
+        MSAwMTowMTowMSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVm
+        ZXJlbmNlcyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29u
+        dGVudF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiUkhFQS0yMDEwOjAw
+        MDEiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5
+        IjogIiIsICJ0aXRsZSI6ICJFbXB0eSBlcnJhdGEiLCAiY2hpbGRyZW4iOiB7
+        fSwgInZlcnNpb24iOiAiMSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2Us
+        ICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3QiOiBbXSwgInN0YXR1cyI6
+        ICJzdGFibGUiLCAidXBkYXRlZCI6ICIiLCAiZGVzY3JpcHRpb24iOiAiRW1w
+        dHkgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAiMjAxOS0wMy0yN1QxODoz
+        NDowNFoiLCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3Vu
+        dCI6ICIiLCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFy
+        eSI6ICIiLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJmNDJmOTY2Yy1kZjcx
+        LTQ4N2QtODFjNC03NDhkMWJlMGUxMDMifV0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJtb2R1bGVtZCJdLCJmaWVsZHMi
+        OnsidW5pdCI6W10sImFzc29jaWF0aW9uIjpbInVuaXRfaWQiXX19fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '85'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwYWNrYWdlX2dyb3VwIl0sImZp
+        ZWxkcyI6eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '90'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '458'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIyZGRhY2Q4Zi0xOTY5LTQyYzktODc5
+        NC03YWIwOTA4N2MxNjYiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNrYWdl
+        X2dyb3VwIn0sICJfaWQiOiB7IiRvaWQiOiAiNWM5YmMyMWNmYjZlOTViNDli
+        ZmNkNjRjIn0sICJ1bml0X2lkIjogIjJkZGFjZDhmLTE5NjktNDJjOS04Nzk0
+        LTdhYjA5MDg3YzE2NiIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91
+        cCJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYzZiYmMwOWMtYzliMC00NTY4
+        LWE4OGYtMzJiMmU4MDI5ZWI5IiwgIl9jb250ZW50X3R5cGVfaWQiOiAicGFj
+        a2FnZV9ncm91cCJ9LCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjFjZmI2ZTk1
+        YjQ5YmZjZDY1YSJ9LCAidW5pdF9pZCI6ICJjNmJiYzA5Yy1jOWIwLTQ1Njgt
+        YTg4Zi0zMmIyZTgwMjllYjkiLCAidW5pdF90eXBlX2lkIjogInBhY2thZ2Vf
+        Z3JvdXAifV0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/content/units/package_group/search/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJsaW1pdCI6Miwic2tpcCI6MCwiZmlsdGVycyI6eyJf
+        aWQiOnsiJGluIjpbIjJkZGFjZDhmLTE5NjktNDJjOS04Nzk0LTdhYjA5MDg3
+        YzE2NiIsImM2YmJjMDljLWM5YjAtNDU2OC1hODhmLTMyYjJlODAyOWViOSJd
+        fX19LCJpbmNsdWRlX3JlcG9zIjp0cnVlfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '160'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1272'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiRmVkb3JhXzE3Il0sICJt
+        YW5kYXRvcnlfcGFja2FnZV9uYW1lcyI6IFsicGVuZ3VpbiJdLCAicmVwb19p
+        ZCI6ICJGZWRvcmFfMTciLCAibmFtZSI6ICJiaXJkIiwgInVzZXJfdmlzaWJs
+        ZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9sYXN0X3VwZGF0ZWQiOiAi
+        MjAxOS0wMy0yN1QxODozMzo1NloiLCAiY2hpbGRyZW4iOiB7fSwgIm9wdGlv
+        bmFsX3BhY2thZ2VfbmFtZXMiOiBbXSwgInRyYW5zbGF0ZWRfbmFtZSI6IHt9
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcGFja2Fn
+        ZV9ncm91cC8yZGRhY2Q4Zi0xOTY5LTQyYzktODc5NC03YWIwOTA4N2MxNjYv
+        IiwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgInB1bHBfdXNlcl9t
+        ZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNrYWdlX25hbWVzIjogW10sICJf
+        Y29udGVudF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAiaWQiOiAiYmly
+        ZCIsICJfaWQiOiAiMmRkYWNkOGYtMTk2OS00MmM5LTg3OTQtN2FiMDkwODdj
+        MTY2IiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFj
+        a2FnZV9uYW1lcyI6IFtdfSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjog
+        WyJGZWRvcmFfMTciXSwgIm1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJl
+        bGVwaGFudCxnaXJhZmZlLGNoZWV0YWgsbGlvbixtb25rZXkscGVuZ3Vpbixz
+        cXVpcnJlbCx3YWxydXMiLCAicGVuZ3VpbiJdLCAicmVwb19pZCI6ICJGZWRv
+        cmFfMTciLCAibmFtZSI6ICJtYW1tYWwiLCAidXNlcl92aXNpYmxlIjogdHJ1
+        ZSwgImRlZmF1bHQiOiB0cnVlLCAiX2xhc3RfdXBkYXRlZCI6ICIyMDE5LTAz
+        LTI3VDE4OjMzOjU2WiIsICJjaGlsZHJlbiI6IHt9LCAib3B0aW9uYWxfcGFj
+        a2FnZV9uYW1lcyI6IFtdLCAidHJhbnNsYXRlZF9uYW1lIjoge30sICJfaHJl
+        ZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9wYWNrYWdlX2dyb3Vw
+        L2M2YmJjMDljLWM5YjAtNDU2OC1hODhmLTMyYjJlODAyOWViOS8iLCAidHJh
+        bnNsYXRlZF9kZXNjcmlwdGlvbiI6IHt9LCAicHVscF91c2VyX21ldGFkYXRh
+        Ijoge30sICJkZWZhdWx0X3BhY2thZ2VfbmFtZXMiOiBbXSwgIl9jb250ZW50
+        X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJpZCI6ICJtYW1tYWwiLCAi
+        X2lkIjogImM2YmJjMDljLWM5YjAtNDU2OC1hODhmLTMyYjJlODAyOWViOSIs
+        ICJkaXNwbGF5X29yZGVyIjogMTAyNCwgImNvbmRpdGlvbmFsX3BhY2thZ2Vf
+        bmFtZXMiOiBbXX1d
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJ5dW1fcmVwb19tZXRhZGF0YV9m
+        aWxlIl0sImZpZWxkcyI6eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5p
+        dF9pZCJdfX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '99'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJzcnBtIl0sImZpZWxkcyI6eyJ1
+        bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '81'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkaXN0cmlidXRpb24iXX19
+
+'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '42'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1198'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7ImZpbGVzIjogW3sicmVsYXRpdmVwYXRoIjogImlt
+        YWdlcy90ZXN0Mi5pbWciLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiIsICJj
+        aGVja3N1bSI6ICJlM2IwYzQ0Mjk4ZmMxYzE0OWFmYmY0Yzg5OTZmYjkyNDI3
+        YWU0MWU0NjQ5YjkzNGNhNDk1OTkxYjc4NTJiODU1In0sIHsicmVsYXRpdmVw
+        YXRoIjogImVtcHR5LmlzbyIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2Iiwg
+        ImNoZWNrc3VtIjogImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0
+        MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifSwgeyJyZWxhdGl2
+        ZXBhdGgiOiAiaW1hZ2VzL3Rlc3QxLmltZyIsICJjaGVja3N1bXR5cGUiOiAi
+        c2hhMjU2IiwgImNoZWNrc3VtIjogImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRj
+        ODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifV0s
+        ICJfc3RvcmFnZV9wYXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0
+        cy9kaXN0cmlidXRpb24vOWIvODMxMjU2YTEyNDcxOGJmMzkxNjZiNTY0ZDhl
+        Njg5OTU0ZmYwYThmMGY0NzliYTI0Y2ZhMjYzNTAxMDliYzUiLCAiZmFtaWx5
+        IjogIlRlc3QgRmFtaWx5IiwgImRvd25sb2FkZWQiOiBmYWxzZSwgInRpbWVz
+        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTU1Mzcx
+        MTY0NCwgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
+        cmlhbnQiOiAiVGVzdFZhcmlhbnQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHkt
+        VGVzdFZhcmlhbnQtMTYteDg2XzY0IiwgInZlcnNpb24iOiAiMTYiLCAidmVy
+        c2lvbl9zb3J0X2luZGV4IjogIjAyLTE2IiwgInB1bHBfdXNlcl9tZXRhZGF0
+        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogIjIxNzQwN2I4LWI3
+        OTktNGU5OS05YzJjLWM0MDUwNDkxMjE0ZiIsICJhcmNoIjogIng4Nl82NCIs
+        ICJfbnMiOiAidW5pdHNfZGlzdHJpYnV0aW9uIn0sICJ1cGRhdGVkIjogIjIw
+        MTktMDMtMjdUMTg6MzQ6MDRaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
+        ImNyZWF0ZWQiOiAiMjAxOS0wMy0yN1QxODozNDowNFoiLCAidW5pdF90eXBl
+        X2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogIjIxNzQwN2I4LWI3
+        OTktNGU5OS05YzJjLWM0MDUwNDkxMjE0ZiIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWM5YmMyMWNmYjZlOTViNDliZmNkNWRjIn19XQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInJwbSJdLCJmaWx0ZXJzIjp7InVuaXQiOnsiZmlsZW5hbWUi
+        OnsiJGluIjpbImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSJdfX19LCJm
+        aWVsZHMiOnsidW5pdCI6WyJuYW1lIiwiZXBvY2giLCJ2ZXJzaW9uIiwicmVs
+        ZWFzZSIsImFyY2giLCJjaGVja3N1bXR5cGUiLCJjaGVja3N1bSJdfX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '222'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzcyN2M4ZTEyLTdhYzgtNGUwMy05MmEyLWIzZGE4M2E2ZTg1OC8iLCAi
+        dGFza19pZCI6ICI3MjdjOGUxMi03YWM4LTRlMDMtOTJhMi1iM2RhODNhNmU4
+        NTgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInJwbSJdLCJmaWx0ZXJzIjp7InVuaXQiOnsiZmlsZW5hbWUi
+        OnsiJGluIjpbXX19fX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '105'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzdhN2U0NGI2LThkOWEtNDQzOS05NTFlLWE4NTM2MGJmMjZmOC8iLCAi
+        dGFza19pZCI6ICI3YTdlNDRiNi04ZDlhLTQ0MzktOTUxZS1hODUzNjBiZjI2
+        ZjgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInNycG0iXSwiZmlsdGVycyI6e319fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '76'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzlhNmYwNzllLTc3NDEtNDQ2My1iYjRlLWVlNjUxZDQ4MjAzMC8iLCAi
+        dGFza19pZCI6ICI5YTZmMDc5ZS03NzQxLTQ0NjMtYmI0ZS1lZTY1MWQ0ODIw
+        MzAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbImVycmF0dW0iXSwiZmlsdGVycyI6e319fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '79'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2Y5MjA4M2JhLThhNGUtNDIxOC1hMzM4LTZhM2RhNzcwY2IzNS8iLCAi
+        dGFza19pZCI6ICJmOTIwODNiYS04YTRlLTQyMTgtYTMzOC02YTNkYTc3MGNi
+        MzUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInBhY2thZ2VfZ3JvdXAiXSwiZmlsdGVycyI6e319fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '85'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzQ5MDU2NDdmLTA1NDQtNDkxNC04ZjIyLWY2Nzc4NDFkY2YxYS8iLCAi
+        dGFza19pZCI6ICI0OTA1NjQ3Zi0wNTQ0LTQ5MTQtOGYyMi1mNjc3ODQxZGNm
+        MWEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiXSwiZmlsdGVycyI6
+        e319fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '94'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzYxZGY2NzQ1LWNkYmQtNDk1OC1iOWExLTk4MzNkZTNiMDlkNy8iLCAi
+        dGFza19pZCI6ICI2MWRmNjc0NS1jZGJkLTQ5NTgtYjlhMS05ODMzZGUzYjA5
+        ZDcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbImRpc3RyaWJ1dGlvbiJdLCJmaWx0ZXJzIjp7fX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '84'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzNhZDAxNGU1LTRkYTUtNGJiMC1iOTdkLWYyNWU2N2UxMzFjNi8iLCAi
+        dGFza19pZCI6ICIzYWQwMTRlNS00ZGE1LTRiYjAtYjk3ZC1mMjVlNjdlMTMx
+        YzYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbIm1vZHVsZW1kIl0sImZpbHRlcnMiOnt9fX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '80'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2E1YjJiM2EwLTQyODMtNDEyMi04MDExLTEyNWZmNWQwYTJlYS8iLCAi
+        dGFza19pZCI6ICJhNWIyYjNhMC00MjgzLTQxMjItODAxMS0xMjVmZjVkMGEy
+        ZWEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: post
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbIm1vZHVsZW1kX2RlZmF1bHRzIl0sImZpbHRlcnMiOnt9fX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '89'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzgxZDgwYzY2LTg3Y2QtNDFiYS1hZDBmLTg5ZWNiZDg3MTE2OS8iLCAi
+        dGFza19pZCI6ICI4MWQ4MGM2Ni04N2NkLTQxYmEtYWQwZi04OWVjYmQ4NzEx
+        NjkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/727c8e12-7ac8-4e03-92a2-b3da83a6e858/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"b77693a5737d4e3917d41ca516533265-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1048'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy83MjdjOGUx
+        Mi03YWM4LTRlMDMtOTJhMi1iM2RhODNhNmU4NTgvIiwgInRhc2tfaWQiOiAi
+        NzI3YzhlMTItN2FjOC00ZTAzLTkyYTItYjNkYTgzYTZlODU4IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sic2lnbmlu
+        Z19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiZWxlcGhhbnQi
+        LCAiY2hlY2tzdW0iOiAiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2
+        MTQ1MzA2YmI5NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsICJlcG9jaCI6
+        ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgImFy
+        Y2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5
+        cGVfaWQiOiAicnBtIn1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0
+        ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM5
+        YmMyMWRmYjZlOTViNDliZmNkN2Q4In0sICJpZCI6ICI1YzliYzIxZGZiNmU5
+        NWI0OWJmY2Q3ZDgifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/9a6f079e-7741-4463-bb4e-ee651d482030/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"2029c44f8050cb02356f6a580105857d-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '801'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy85YTZmMDc5
+        ZS03NzQxLTQ0NjMtYmI0ZS1lZTY1MWQ0ODIwMzAvIiwgInRhc2tfaWQiOiAi
+        OWE2ZjA3OWUtNzc0MS00NDYzLWJiNGUtZWU2NTFkNDgyMDMwIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW10sICJ1bml0
+        c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIxZGZiNmU5NWI0OWJmY2Q4MDMi
+        fSwgImlkIjogIjVjOWJjMjFkZmI2ZTk1YjQ5YmZjZDgwMyJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/f92083ba-8a4e-4218-a338-6a3da770cb35/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"98dc7a578908eea934eff92e4d0ec905-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '985'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9mOTIwODNi
+        YS04YTRlLTQyMTgtYTMzOC02YTNkYTc3MGNiMzUvIiwgInRhc2tfaWQiOiAi
+        ZjkyMDgzYmEtOGE0ZS00MjE4LWEzMzgtNmEzZGE3NzBjYjM1IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sidW5pdF9r
+        ZXkiOiB7ImlkIjogIlJIRUEtMjAxMDowMDAyIn0sICJ0eXBlX2lkIjogImVy
+        cmF0dW0ifSwgeyJ1bml0X2tleSI6IHsiaWQiOiAiUkhTQS0yMDEwOjA4NTgi
+        fSwgInR5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6
+        ICJSSEVBLTIwMTA6MDAwMSJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn1dLCAi
+        dW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM5YmMyMWRmYjZlOTViNDliZmNk
+        ODI0In0sICJpZCI6ICI1YzliYzIxZGZiNmU5NWI0OWJmY2Q4MjQifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/4905647f-0544-4914-8f22-f677841dcf1a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"2909ade2e0a1a0e9ed85492901e44647-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1125'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80OTA1NjQ3
+        Zi0wNTQ0LTQ5MTQtOGYyMi1mNjc3ODQxZGNmMWEvIiwgInRhc2tfaWQiOiAi
+        NDkwNTY0N2YtMDU0NC00OTE0LThmMjItZjY3Nzg0MWRjZjFhIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sidW5pdF9r
+        ZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIsICJpZCI6ICJiaXJkIn0sICJ0
+        eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAifSwgeyJ1bml0X2tleSI6IHsicmVw
+        b19pZCI6ICIzX3ZpZXcxIiwgImlkIjogIm1hbW1hbCJ9LCAidHlwZV9pZCI6
+        ICJwYWNrYWdlX2dyb3VwIn1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9m
+        aWx0ZXIiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRvcmFfMTci
+        LCAiaWQiOiAiYmlyZCJ9LCAidHlwZV9pZCI6ICJwYWNrYWdlX2dyb3VwIn0s
+        IHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImlkIjog
+        Im1hbW1hbCJ9LCAidHlwZV9pZCI6ICJwYWNrYWdlX2dyb3VwIn1dfSwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIxZGZiNmU5NWI0
+        OWJmY2Q4NGEifSwgImlkIjogIjVjOWJjMjFkZmI2ZTk1YjQ5YmZjZDg0YSJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/61df6745-cdbd-4958-b9a1-9833de3b09d7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"1bc7598e577d73c9aab251d23dc64113-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '801'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82MWRmNjc0
+        NS1jZGJkLTQ5NTgtYjlhMS05ODMzZGUzYjA5ZDcvIiwgInRhc2tfaWQiOiAi
+        NjFkZjY3NDUtY2RiZC00OTU4LWI5YTEtOTgzM2RlM2IwOWQ3IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW10sICJ1bml0
+        c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIxZGZiNmU5NWI0OWJmY2Q4NjUi
+        fSwgImlkIjogIjVjOWJjMjFkZmI2ZTk1YjQ5YmZjZDg2NSJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/3ad014e5-4da5-4bb0-b97d-f25e67e131c6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"140168a9ac822371d59040956b8b25b8-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '974'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8zYWQwMTRl
+        NS00ZGE1LTRiYjAtYjk3ZC1mMjVlNjdlMTMxYzYvIiwgInRhc2tfaWQiOiAi
+        M2FkMDE0ZTUtNGRhNS00YmIwLWI5N2QtZjI1ZTY3ZTEzMWM2IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sidW5pdF9r
+        ZXkiOiB7InZhcmlhbnQiOiAiVGVzdFZhcmlhbnQiLCAidmVyc2lvbiI6ICIx
+        NiIsICJhcmNoIjogIng4Nl82NCIsICJpZCI6ICJrcy1UZXN0IEZhbWlseS1U
+        ZXN0VmFyaWFudC0xNi14ODZfNjQiLCAiZmFtaWx5IjogIlRlc3QgRmFtaWx5
+        In0sICJ0eXBlX2lkIjogImRpc3RyaWJ1dGlvbiJ9XSwgInVuaXRzX2ZhaWxl
+        ZF9zaWduYXR1cmVfZmlsdGVyIjogW119LCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjVjOWJjMjFkZmI2ZTk1YjQ5YmZjZDg4OSJ9LCAiaWQi
+        OiAiNWM5YmMyMWRmYjZlOTViNDliZmNkODg5In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/a5b2b3a0-4283-4122-8011-125ff5d0a2ea/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"0ab26ab9e9769984164d2130ab396534-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '725'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9hNWIyYjNh
+        MC00MjgzLTQxMjItODAxMS0xMjVmZjVkMGEyZWEvIiwgInRhc2tfaWQiOiAi
+        YTViMmIzYTAtNDI4My00MTIyLTgwMTEtMTI1ZmY1ZDBhMmVhIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6IG51bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRf
+        dGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1WiIsICJ0cmFjZWJhY2siOiBu
+        dWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijog
+        e30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0
+        YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjFkZmI2
+        ZTk1YjQ5YmZjZDg5YyJ9LCAiaWQiOiAiNWM5YmMyMWRmYjZlOTViNDliZmNk
+        ODljIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/81d80c66-87cd-41ba-ad0f-89ecbd871169/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"caed9b6860766f10e6ba7ed2742ec252-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '707'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84MWQ4MGM2
+        Ni04N2NkLTQxYmEtYWQwZi04OWVjYmQ4NzExNjkvIiwgInRhc2tfaWQiOiAi
+        ODFkODBjNjYtODdjZC00MWJhLWFkMGYtODllY2JkODcxMTY5IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6IG51bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRf
+        dGltZSI6IG51bGwsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNr
+        cyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5l
+        eGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAi
+        X2lkIjogeyIkb2lkIjogIjVjOWJjMjFkZmI2ZTk1YjQ5YmZjZDhiMCJ9LCAi
+        aWQiOiAiNWM5YmMyMWRmYjZlOTViNDliZmNkOGIwIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/727c8e12-7ac8-4e03-92a2-b3da83a6e858/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:05 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"b77693a5737d4e3917d41ca516533265-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1048'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy83MjdjOGUx
+        Mi03YWM4LTRlMDMtOTJhMi1iM2RhODNhNmU4NTgvIiwgInRhc2tfaWQiOiAi
+        NzI3YzhlMTItN2FjOC00ZTAzLTkyYTItYjNkYTgzYTZlODU4IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sic2lnbmlu
+        Z19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiZWxlcGhhbnQi
+        LCAiY2hlY2tzdW0iOiAiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2
+        MTQ1MzA2YmI5NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsICJlcG9jaCI6
+        ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgImFy
+        Y2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5
+        cGVfaWQiOiAicnBtIn1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0
+        ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM5
+        YmMyMWRmYjZlOTViNDliZmNkN2Q4In0sICJpZCI6ICI1YzliYzIxZGZiNmU5
+        NWI0OWJmY2Q3ZDgifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:05 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/9a6f079e-7741-4463-bb4e-ee651d482030/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:06 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"2029c44f8050cb02356f6a580105857d-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '801'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy85YTZmMDc5
+        ZS03NzQxLTQ0NjMtYmI0ZS1lZTY1MWQ0ODIwMzAvIiwgInRhc2tfaWQiOiAi
+        OWE2ZjA3OWUtNzc0MS00NDYzLWJiNGUtZWU2NTFkNDgyMDMwIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW10sICJ1bml0
+        c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIxZGZiNmU5NWI0OWJmY2Q4MDMi
+        fSwgImlkIjogIjVjOWJjMjFkZmI2ZTk1YjQ5YmZjZDgwMyJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:06 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/f92083ba-8a4e-4218-a338-6a3da770cb35/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:06 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"98dc7a578908eea934eff92e4d0ec905-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '985'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9mOTIwODNi
+        YS04YTRlLTQyMTgtYTMzOC02YTNkYTc3MGNiMzUvIiwgInRhc2tfaWQiOiAi
+        ZjkyMDgzYmEtOGE0ZS00MjE4LWEzMzgtNmEzZGE3NzBjYjM1IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sidW5pdF9r
+        ZXkiOiB7ImlkIjogIlJIRUEtMjAxMDowMDAyIn0sICJ0eXBlX2lkIjogImVy
+        cmF0dW0ifSwgeyJ1bml0X2tleSI6IHsiaWQiOiAiUkhTQS0yMDEwOjA4NTgi
+        fSwgInR5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6
+        ICJSSEVBLTIwMTA6MDAwMSJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn1dLCAi
+        dW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM5YmMyMWRmYjZlOTViNDliZmNk
+        ODI0In0sICJpZCI6ICI1YzliYzIxZGZiNmU5NWI0OWJmY2Q4MjQifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:06 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/4905647f-0544-4914-8f22-f677841dcf1a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:07 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"2909ade2e0a1a0e9ed85492901e44647-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1125'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy80OTA1NjQ3
+        Zi0wNTQ0LTQ5MTQtOGYyMi1mNjc3ODQxZGNmMWEvIiwgInRhc2tfaWQiOiAi
+        NDkwNTY0N2YtMDU0NC00OTE0LThmMjItZjY3Nzg0MWRjZjFhIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sidW5pdF9r
+        ZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIsICJpZCI6ICJiaXJkIn0sICJ0
+        eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAifSwgeyJ1bml0X2tleSI6IHsicmVw
+        b19pZCI6ICIzX3ZpZXcxIiwgImlkIjogIm1hbW1hbCJ9LCAidHlwZV9pZCI6
+        ICJwYWNrYWdlX2dyb3VwIn1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9m
+        aWx0ZXIiOiBbeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRvcmFfMTci
+        LCAiaWQiOiAiYmlyZCJ9LCAidHlwZV9pZCI6ICJwYWNrYWdlX2dyb3VwIn0s
+        IHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImlkIjog
+        Im1hbW1hbCJ9LCAidHlwZV9pZCI6ICJwYWNrYWdlX2dyb3VwIn1dfSwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIxZGZiNmU5NWI0
+        OWJmY2Q4NGEifSwgImlkIjogIjVjOWJjMjFkZmI2ZTk1YjQ5YmZjZDg0YSJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:07 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/61df6745-cdbd-4958-b9a1-9833de3b09d7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:07 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"1bc7598e577d73c9aab251d23dc64113-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '801'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82MWRmNjc0
+        NS1jZGJkLTQ5NTgtYjlhMS05ODMzZGUzYjA5ZDcvIiwgInRhc2tfaWQiOiAi
+        NjFkZjY3NDUtY2RiZC00OTU4LWI5YTEtOTgzM2RlM2IwOWQ3IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW10sICJ1bml0
+        c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIxZGZiNmU5NWI0OWJmY2Q4NjUi
+        fSwgImlkIjogIjVjOWJjMjFkZmI2ZTk1YjQ5YmZjZDg2NSJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:07 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/3ad014e5-4da5-4bb0-b97d-f25e67e131c6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:08 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"140168a9ac822371d59040956b8b25b8-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '974'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8zYWQwMTRl
+        NS00ZGE1LTRiYjAtYjk3ZC1mMjVlNjdlMTMxYzYvIiwgInRhc2tfaWQiOiAi
+        M2FkMDE0ZTUtNGRhNS00YmIwLWI5N2QtZjI1ZTY3ZTEzMWM2IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW3sidW5pdF9r
+        ZXkiOiB7InZhcmlhbnQiOiAiVGVzdFZhcmlhbnQiLCAidmVyc2lvbiI6ICIx
+        NiIsICJhcmNoIjogIng4Nl82NCIsICJpZCI6ICJrcy1UZXN0IEZhbWlseS1U
+        ZXN0VmFyaWFudC0xNi14ODZfNjQiLCAiZmFtaWx5IjogIlRlc3QgRmFtaWx5
+        In0sICJ0eXBlX2lkIjogImRpc3RyaWJ1dGlvbiJ9XSwgInVuaXRzX2ZhaWxl
+        ZF9zaWduYXR1cmVfZmlsdGVyIjogW119LCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjVjOWJjMjFkZmI2ZTk1YjQ5YmZjZDg4OSJ9LCAiaWQi
+        OiAiNWM5YmMyMWRmYjZlOTViNDliZmNkODg5In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:08 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/a5b2b3a0-4283-4122-8011-125ff5d0a2ea/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:09 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"ae33cd37e5d242506eca731640abeb25-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '801'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9hNWIyYjNh
+        MC00MjgzLTQxMjItODAxMS0xMjVmZjVkMGEyZWEvIiwgInRhc2tfaWQiOiAi
+        YTViMmIzYTAtNDI4My00MTIyLTgwMTEtMTI1ZmY1ZDBhMmVhIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW10sICJ1bml0
+        c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIxZGZiNmU5NWI0OWJmY2Q4OWMi
+        fSwgImlkIjogIjVjOWJjMjFkZmI2ZTk1YjQ5YmZjZDg5YyJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:09 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/81d80c66-87cd-41ba-ad0f-89ecbd871169/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:09 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"142f9d0f826a073f39baab3fee6f2e05-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '801'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84MWQ4MGM2
+        Ni04N2NkLTQxYmEtYWQwZi04OWVjYmQ4NzExNjkvIiwgInRhc2tfaWQiOiAi
+        ODFkODBjNjYtODdjZC00MWJhLWFkMGYtODllY2JkODcxMTY5IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjA1
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJ1bml0c19zdWNjZXNzZnVsIjogW10sICJ1bml0
+        c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIxZGZiNmU5NWI0OWJmY2Q4YjAi
+        fSwgImlkIjogIjVjOWJjMjFkZmI2ZTk1YjQ5YmZjZDhiMCJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:09 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:10 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"59cf6bdfe26611f95e82c0e4f1e1515c-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2235'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
+        IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
+        OiBbeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
+        MTktMDMtMjdUMTg6MzQ6MDVaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3Ry
+        aWJ1dG9yLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9w
+        dWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0
+        X2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRj
+        aHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6
+        IHsiJG9pZCI6ICI1YzliYzIxZGRiMjg0ZTU5YmU5NmJhZTAifSwgImNvbmZp
+        ZyI6IHsiaHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29y
+        cG9yYXRpb24vbGlicmFyeS9MaWJyYXJ5Vmlldy9mZWRvcmFfMTdfbGFiZWwi
+        LCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6ICJleHBvcnRfZGlzdHJpYnV0b3Ii
+        fSwgeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
+        MTktMDMtMjdUMTg6MzQ6MDVaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvM192aWV3MV9jbG9u
+        ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
+        aCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9jbG9uZV9k
+        aXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hw
+        YWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7
+        IiRvaWQiOiAiNWM5YmMyMWRkYjI4NGU1OWJlOTZiYWRmIn0sICJjb25maWci
+        OiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogIjNfdmlldzEifSwg
+        ImlkIjogIjNfdmlldzFfY2xvbmUifSwgeyJyZXBvX2lkIjogIjNfdmlldzEi
+        LCAibGFzdF91cGRhdGVkIjogIjIwMTktMDMtMjdUMTg6MzQ6MDVaIiwgIl9o
+        cmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0
+        cmlidXRvcnMvM192aWV3MS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7
+        fSwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lk
+        IjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAi
+        c2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwg
+        Il9pZCI6IHsiJG9pZCI6ICI1YzliYzIxZGRiMjg0ZTU5YmU5NmJhZGUifSwg
+        ImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwg
+        Imh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0NvcnBvcmF0
+        aW9uL2xpYnJhcnkvTGlicmFyeVZpZXcvZmVkb3JhXzE3X2xhYmVsIn0sICJp
+        ZCI6ICIzX3ZpZXcxIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIwMTktMDMt
+        MjdUMTg6MzQ6MDVaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
+        ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
+        aXRfY291bnRzIjogeyJwYWNrYWdlX2dyb3VwIjogMiwgImRpc3RyaWJ1dGlv
+        biI6IDEsICJycG0iOiAxLCAiZXJyYXR1bSI6IDN9LCAiX25zIjogInJlcG9z
+        IiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiM192aWV3MSIsICJsYXN0
+        X3VwZGF0ZWQiOiAiMjAxOS0wMy0yN1QxODozNDowNVoiLCAiX2hyZWYiOiAi
+        L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy8zX3ZpZXcxL2ltcG9ydGVycy95
+        dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIsICJpbXBv
+        cnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJsYXN0X292ZXJyaWRl
+        X2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjogbnVsbCwgInNjcmF0Y2hwYWQi
+        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjFkZGIyODRlNTliZTk2
+        YmFkZCJ9LCAiY29uZmlnIjoge30sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0s
+        ICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDYsICJfaWQiOiB7IiRvaWQiOiAi
+        NWM5YmMyMWRkYjI4NGU1OWJlOTZiYWRjIn0sICJ0b3RhbF9yZXBvc2l0b3J5
+        X3VuaXRzIjogNywgImlkIjogIjNfdmlldzEiLCAiX2hyZWYiOiAiL3B1bHAv
+        YXBpL3YyL3JlcG9zaXRvcmllcy8zX3ZpZXcxLyJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:10 GMT
+- request:
+    method: delete
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/Fedora_17/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:10 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2QyOGNiMzM2LWFmOGEtNGEwNC05ZThlLTUyOTQyZTBkOWRjNy8iLCAi
+        dGFza19pZCI6ICJkMjhjYjMzNi1hZjhhLTRhMDQtOWU4ZS01Mjk0MmUwZDlk
+        YzcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:10 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d28cb336-af8a-4a04-9e8e-52942e0d9dc7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:10 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"756164924f0cd39b20a487fe6e1d1e26-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '542'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMjhjYjMzNi1hZjhhLTRhMDQtOWU4ZS01Mjk0MmUwZDlk
+        YzcvIiwgInRhc2tfaWQiOiAiZDI4Y2IzMzYtYWY4YS00YTA0LTllOGUtNTI5
+        NDJlMGQ5ZGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
+        ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICIiLCAic3RhdGUiOiAid2Fp
+        dGluZyIsICJ3b3JrZXJfbmFtZSI6IG51bGwsICJyZXN1bHQiOiBudWxsLCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjIyZmI2ZTk1
+        YjQ5YmZjZDlkZSJ9LCAiaWQiOiAiNWM5YmMyMjJmYjZlOTViNDliZmNkOWRl
+        In0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:10 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d28cb336-af8a-4a04-9e8e-52942e0d9dc7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:10 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"145ff6eb85e8735c3ebd22dba884d259-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '668'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMjhjYjMzNi1hZjhhLTRhMDQtOWU4ZS01Mjk0MmUwZDlk
+        YzcvIiwgInRhc2tfaWQiOiAiZDI4Y2IzMzYtYWY4YS00YTA0LTllOGUtNTI5
+        NDJlMGQ5ZGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
+        bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5
+        LTAzLTI3VDE4OjM0OjEwWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5l
+        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0
+        ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOWJjMjIyZmI2ZTk1YjQ5YmZjZDlk
+        ZSJ9LCAiaWQiOiAiNWM5YmMyMjJmYjZlOTViNDliZmNkOWRlIn0=
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:10 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d28cb336-af8a-4a04-9e8e-52942e0d9dc7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:10 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"ee818eed41e3adc55c493032f22446b7-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '687'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9kMjhjYjMzNi1hZjhhLTRhMDQtOWU4ZS01Mjk0MmUwZDlk
+        YzcvIiwgInRhc2tfaWQiOiAiZDI4Y2IzMzYtYWY4YS00YTA0LTllOGUtNTI5
+        NDJlMGQ5ZGM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
+        MDE5LTAzLTI3VDE4OjM0OjEwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE5LTAzLTI3VDE4OjM0OjEwWiIsICJ0cmFjZWJh
+        Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
+        b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0
+        IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Yzli
+        YzIyMmZiNmU5NWI0OWJmY2Q5ZGUifSwgImlkIjogIjVjOWJjMjIyZmI2ZTk1
+        YjQ5YmZjZDlkZSJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:10 GMT
+- request:
+    method: delete
+    uri: https://theta.partello.example.com/pulp/api/v2/repositories/3_view1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:10 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzNmNjVkYThkLWI1MGYtNGI4MS1iMDE1LTkzZmU3Nzk2NzU2Mi8iLCAi
+        dGFza19pZCI6ICIzZjY1ZGE4ZC1iNTBmLTRiODEtYjAxNS05M2ZlNzc5Njc1
+        NjIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:10 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/3f65da8d-b50f-4b81-b015-93fe77967562/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:10 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"e5e549cb1cdf1bb3baa6375d7e48cffe-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '540'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zZjY1ZGE4ZC1iNTBmLTRiODEtYjAxNS05M2ZlNzc5Njc1
+        NjIvIiwgInRhc2tfaWQiOiAiM2Y2NWRhOGQtYjUwZi00YjgxLWIwMTUtOTNm
+        ZTc3OTY3NTYyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
+        IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiIiwgInN0YXRlIjogIndhaXRp
+        bmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIyMmZiNmU5NWI0
+        OWJmY2RhMmYifSwgImlkIjogIjVjOWJjMjIyZmI2ZTk1YjQ5YmZjZGEyZiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:10 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/3f65da8d-b50f-4b81-b015-93fe77967562/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:10 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"47f8b11547550d28231d1540d3a3d576-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '666'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zZjY1ZGE4ZC1iNTBmLTRiODEtYjAxNS05M2ZlNzc5Njc1
+        NjIvIiwgInRhc2tfaWQiOiAiM2Y2NWRhOGQtYjUwZi00YjgxLWIwMTUtOTNm
+        ZTc3OTY3NTYyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
+        IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDoxMFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhh
+        bXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVs
+        bG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIyMmZiNmU5NWI0OWJmY2RhMmYi
+        fSwgImlkIjogIjVjOWJjMjIyZmI2ZTk1YjQ5YmZjZGEyZiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:10 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/3f65da8d-b50f-4b81-b015-93fe77967562/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:10 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"47f8b11547550d28231d1540d3a3d576-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '666'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zZjY1ZGE4ZC1iNTBmLTRiODEtYjAxNS05M2ZlNzc5Njc1
+        NjIvIiwgInRhc2tfaWQiOiAiM2Y2NWRhOGQtYjUwZi00YjgxLWIwMTUtOTNm
+        ZTc3OTY3NTYyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
+        IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiBudWxs
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
+        My0yN1QxODozNDoxMFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhh
+        bXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVs
+        bG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzliYzIyMmZiNmU5NWI0OWJmY2RhMmYi
+        fSwgImlkIjogIjVjOWJjMjIyZmI2ZTk1YjQ5YmZjZGEyZiJ9
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:10 GMT
+- request:
+    method: get
+    uri: https://theta.partello.example.com/pulp/api/v2/tasks/3f65da8d-b50f-4b81-b015-93fe77967562/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Mar 2019 18:34:10 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"a805a0b617ccea6d5d858001901b86fb-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '685'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8zZjY1ZGE4ZC1iNTBmLTRiODEtYjAxNS05M2ZlNzc5Njc1
+        NjIvIiwgInRhc2tfaWQiOiAiM2Y2NWRhOGQtYjUwZi00YjgxLWIwMTUtOTNm
+        ZTc3OTY3NTYyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
+        IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
+        OS0wMy0yN1QxODozNDoxMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wMy0yN1QxODozNDoxMFoiLCAidHJhY2ViYWNr
+        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9y
+        dCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
+        dGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZp
+        bmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0wQHRoZXRhLnBhcnRlbGxvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
+        IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM5YmMy
+        MjJmYjZlOTViNDliZmNkYTJmIn0sICJpZCI6ICI1YzliYzIyMmZiNmU5NWI0
+        OWJmY2RhMmYifQ==
+    http_version: 
+  recorded_at: Wed, 27 Mar 2019 18:34:10 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
This commit contains code related to automatically copying all the
modular rpms from source repo to destination repo during a cv publish.
Modular rpms are dependencies bound by the modules they are attached to.
Since the content view publish copies all modules over, all the rpm
dependencies belonging to those modules must also get copied over.

This commit also adds code to prevent the user from adding a modular rpm
in a package rule. 