### PR TITLE
Fixes #26350 - proxy accessible_content to candlepin

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -481,7 +481,8 @@ module Katello
         end
       when "rhsm_proxy_owner_servicelevels_path"
         (User.consumer? || ::User.current.can?(:view_organizations, self))
-      when "rhsm_proxy_consumer_certificates_path", "rhsm_proxy_consumer_releases_path", "rhsm_proxy_certificate_serials_path",
+      when "rhsm_proxy_consumer_accessible_content_path", "rhsm_proxy_consumer_certificates_path",
+           "rhsm_proxy_consumer_releases_path", "rhsm_proxy_certificate_serials_path",
            "rhsm_proxy_consumer_entitlements_path", "rhsm_proxy_consumer_entitlements_post_path",
            "rhsm_proxy_consumer_entitlements_delete_path", "rhsm_proxy_consumer_entitlements_pool_delete_path",
            "rhsm_proxy_consumer_certificates_put_path", "rhsm_proxy_consumer_dryrun_path",

--- a/config/routes/api/rhsm.rb
+++ b/config/routes/api/rhsm.rb
@@ -25,6 +25,7 @@ Katello::Engine.routes.draw do
       match '/consumers/:id' => 'candlepin_proxies#regenerate_identity_certificates', :via => :post
       match '/consumers/:id' => 'candlepin_proxies#consumer_destroy', :via => :delete
       match '/users/:login/owners' => 'candlepin_proxies#list_owners', :via => :get, :constraints => {:login => /\S+/}
+      match '/consumers/:id/accessible_content' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_accessible_content_path
       match '/consumers/:id/certificates' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_certificates_path
       match '/consumers/:id/certificates' => 'candlepin_proxies#put', :via => :put, :as => :proxy_consumer_certificates_put_path
       match '/consumers/:id/release' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_releases_path


### PR DESCRIPTION
Users are reporting the following in the logs during subscription-manager
refresh:

[I] Started GET "/rhsm/consumers/803c9cb8-60cc-416d-b05f-d1d034dff787/accessible_content" for 10.19.34.79 at 2019-03-13 16:17:41 -0400
[F]
 | ActionController::RoutingError (No route matches [GET] "/rhsm/consumers/803c9cb8-60cc-416d-b05f-d1d034dff787/accessible_content"):
 |   lib/middleware/tagged_logging.rb:18:in `call'
 |
 |

This change will proxy the api call to candlepin resulting in:

[I] Started GET "/rhsm/consumers/803c9cb8-60cc-416d-b05f-d1d034dff787/accessible_content" for 10.19.34.79 at 2019-03-13 16:11:12 -0400
[I] Processing by Katello::Api::Rhsm::CandlepinProxiesController#get as JSON
[I]   Parameters: {"id"=>"803c9cb8-60cc-416d-b05f-d1d034dff787"}
[I] Current user: 803c9cb8-60cc-416d-b05f-d1d034dff787 (regular user)
[I] Completed 200 OK in 67ms (Views: 0.2ms | ActiveRecord: 0.6ms)