### PR TITLE
Fixes #26365 - Speeds up Pool import

### DIFF
--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -191,7 +191,7 @@ module Katello
       end
 
       def create_activation_key_associations
-        keys = Rails.cache.fetch("#{organization.label}/activation_keys", expires_in: 2.minutes) do
+        keys = Rails.cache.fetch("#{organization.label}/activation_keys_id_pool_id", expires_in: 2.minutes) do
           Resources::Candlepin::ActivationKey.get(nil, "?include=id&include=pools.pool.id", organization.label)
         end
         activation_key_ids = keys.collect do |key|

--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -191,7 +191,9 @@ module Katello
       end
 
       def create_activation_key_associations
-        keys = Resources::Candlepin::ActivationKey.get(nil, "?include=id&include=pools.pool.id", organization.label)
+        keys = Rails.cache.fetch("#{organization.label}/activation_keys", expires_in: 2.minutes) do
+          Resources::Candlepin::ActivationKey.get(nil, "?include=id&include=pools.pool.id", organization.label)
+        end
         activation_key_ids = keys.collect do |key|
           key['id'] if key['pools'].present? && key['pools'].any? { |pool| pool['pool'].try(:[], 'id') == cp_id }
         end


### PR DESCRIPTION
rake katello:import subscription call wastefully gets all the
activationkeys belonging to an organization on every pool import. This
means if the user had 100 pools, one would see 100 activation key calls
for the organization.

This commit addresses that issue by simply caching the call for a few
min and there by cutting down on the network load.