### PR TITLE
Fixes #26376 - remove lazy_accesor change tracking

### DIFF
--- a/app/lib/katello/lazy_accessor.rb
+++ b/app/lib/katello/lazy_accessor.rb
@@ -36,22 +36,6 @@ module Katello
           options[:in_group] = args.size > 1
           @lazy_attributes_options[symbol.to_s] = options
 
-          send :define_method, "#{symbol}_will_change!" do
-            lazy_attribute_will_change!(symbol)
-          end
-
-          send :define_method, "#{symbol.to_s}_changed?" do
-            remote_attribute_changed?(symbol.to_s)
-          end
-
-          send :define_method, "#{symbol.to_s}_change" do
-            lazy_attribute_change(symbol)
-          end
-
-          send :define_method, "#{symbol.to_s}_was" do
-            lazy_attribute_was(symbol)
-          end
-
           send :define_method, "#{symbol.to_s}=" do |val|
             lazy_attribute_set(symbol, val)
           end
@@ -70,10 +54,6 @@ module Katello
 
       def changed_remote_attributes=(val)
         @changed_remote_attributes = val
-      end
-
-      def remote_attribute_changed?(attr)
-        changed_remote_attributes.key?(attr)
       end
 
       def save(*)
@@ -103,30 +83,8 @@ module Katello
 
       private
 
-      def lazy_attribute_will_change!(attr)
-        changed_remote_attributes[attr.to_s] ||=
-          instance_variable_get("@#{attr}").nil? ? remote_attribute_value(attr) : instance_variable_get("@#{attr}")
-      end
-
-      def lazy_attribute_change(attr)
-        attr = attr.to_s
-        if remote_attribute_changed?(attr)
-          return [changed_remote_attributes[attr], __send__(attr)]
-        end
-      end
-
-      def lazy_attribute_was(attr)
-        attr = attr.to_s
-        remote_attribute_changed?(attr) ? changed_remote_attributes[attr] : __send__(attr)
-      end
-
       def lazy_attribute_set(attr, val)
-        attr = attr.to_s
-
-        old = instance_variable_get("@#{attr}").nil? ? self.send(attr) : instance_variable_get("@#{attr}")
-        changed_remote_attributes[attr] = old if old != val
-
-        instance_variable_set("@#{attr}", val)
+        instance_variable_set("@#{attr.to_s}", val)
       end
 
       def lazy_attribute_get(attr)

--- a/spec/models/lazy_accessor_spec.rb
+++ b/spec/models/lazy_accessor_spec.rb
@@ -46,37 +46,6 @@ module Katello
         @c.b = Something::ANOTHER_VALUE
         @c.b.must_equal(Something::ANOTHER_VALUE)
       end
-
-      it "should mark changed attribute as dirty" do
-        @c.a = Something::ANOTHER_VALUE
-        @c.a_changed?.must_equal(true)
-      end
-
-      it "should mark object dirty" do
-        @c.a = Something::ANOTHER_VALUE
-        @c.remote_attribute_changed?('a').must_equal(true)
-      end
-
-      it "should return the change" do
-        @c.a = Something::ANOTHER_VALUE
-        @c.a_change.must_equal([Something::DEFAULT_VALUE, Something::ANOTHER_VALUE])
-      end
-
-      it "should cache the old value after changes were retrieved" do
-        @c.a = Something::ANOTHER_VALUE
-        @c.a_change
-        @c.changed_remote_attributes['a'].must_equal(Something::DEFAULT_VALUE)
-      end
-
-      it "should return previous value" do
-        @c.a = Something::ANOTHER_VALUE
-        @c.a_was.must_equal(Something::DEFAULT_VALUE)
-      end
-
-      it "should mark object dirty after changes" do
-        @c.a = Something::ANOTHER_VALUE
-        @c.changed_remote_attributes.wont_be_empty
-      end
     end
   end
 end


### PR DESCRIPTION
This was from long ago when we would use lazy accessor to propagate
changes to backend systems.  We no longer do that instead use
foreman-tasks for such things.  The result is that when calling a
setter on a lazy accessor, the data gets loaded from the backend service
when trying to prepload data