### PR TITLE
Fixes #26397 - Handle repos and cv puppet envs properly

### DIFF
--- a/app/lib/actions/katello/content_view_puppet_environment/clear.rb
+++ b/app/lib/actions/katello/content_view_puppet_environment/clear.rb
@@ -3,7 +3,7 @@ module Actions
     module ContentViewPuppetEnvironment
       class Clear < Actions::Base
         def plan(repo)
-          plan_action(Pulp::Repository::RemoveUnits, repo_id: repo.id)
+          plan_action(Pulp::Repository::RemoveUnits, content_view_puppet_environment_id: repo.id)
         end
       end
     end

--- a/app/lib/actions/katello/content_view_version/incremental_update.rb
+++ b/app/lib/actions/katello/content_view_version/incremental_update.rb
@@ -248,7 +248,7 @@ module Actions
         end
 
         def remove_puppet_modules(repo, puppet_module_ids)
-          plan_action(Pulp::Repository::RemoveUnits, :repo_id => repo.id, :contents => puppet_module_ids, :content_unit_type => ::Katello::PuppetModule::CONTENT_TYPE)
+          plan_action(Pulp::Repository::RemoveUnits, :content_view_puppet_environment_id => repo.id, :contents => puppet_module_ids, :content_unit_type => ::Katello::PuppetModule::CONTENT_TYPE)
         end
 
         def copy_puppet_content(new_repo, puppet_module_ids)

--- a/app/lib/actions/pulp/repository/remove_units.rb
+++ b/app/lib/actions/pulp/repository/remove_units.rb
@@ -4,16 +4,17 @@ module Actions
       class RemoveUnits < Pulp::AbstractAsyncTask
         input_format do
           param :repo_id
+          param :content_view_puppet_environment_id
           param :contents
           param :content_unit_type
         end
 
         def invoke_external_task
           fail _("Cannot pass content units without content unit type") if (input[:contents] && !input[:content_unit_type])
-          repo = ::Katello::Repository.find_by(:id => input[:repo_id])
-          if repo.nil?
-            repo = ::Katello::ContentViewPuppetEnvironment.find_by(:id => input[:repo_id])
-            repo = repo.nonpersisted_repository
+          if input[:repo_id]
+            repo = ::Katello::Repository.find(input[:repo_id])
+          else
+            repo = ::Katello::ContentViewPuppetEnvironment.find(input[:content_view_puppet_environment_id]).nonpersisted_repository
           end
           fail _("An error occurred during content removal. Could not find repository with id: %s" % input[:repo_id]) unless repo
           tasks = []

--- a/test/actions/katello/content_view_puppet_environment_test.rb
+++ b/test/actions/katello/content_view_puppet_environment_test.rb
@@ -32,7 +32,7 @@ module ::Actions::Katello::ContentViewPuppetEnvironment
 
     it 'plans' do
       plan_action action, puppet_env
-      assert_action_planed_with action, ::Actions::Pulp::Repository::RemoveUnits, :repo_id => puppet_env.id
+      assert_action_planed_with action, ::Actions::Pulp::Repository::RemoveUnits, :content_view_puppet_environment_id => puppet_env.id
     end
   end
 


### PR DESCRIPTION
Keeping the params repo_id and content_view_puppet_environment_id separate to avoid unintended clashes.