### PR TITLE
Fixes #26412 - retry cp object creation on conflict

### DIFF
--- a/app/lib/katello/util/support.rb
+++ b/app/lib/katello/util/support.rb
@@ -76,7 +76,7 @@ module Katello
       #  RecordNotUnique exceptions
       def self.active_record_retry(retries = 3)
         yield
-      rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+      rescue ActiveRecord::RecordNotUnique, PG::UniqueViolation, ActiveRecord::RecordInvalid => e
         retries -= 1
         if retries == 0
           raise e

--- a/app/models/katello/glue/candlepin/candlepin_object.rb
+++ b/app/models/katello/glue/candlepin/candlepin_object.rb
@@ -16,7 +16,9 @@ module Katello
       def import_candlepin_ids(organization)
         candlepin_ids = self.get_candlepin_ids(organization)
         candlepin_ids.each do |cp_id|
-          self.where(:cp_id => cp_id, :organization_id => organization.id).first_or_create unless cp_id.nil?
+          Katello::Util::Support.active_record_retry do
+            self.where(:cp_id => cp_id, :organization_id => organization.id).first_or_create unless cp_id.nil?
+          end
         end
         candlepin_ids
       end

--- a/app/models/katello/glue/candlepin/pool.rb
+++ b/app/models/katello/glue/candlepin/pool.rb
@@ -34,11 +34,12 @@ module Katello
       end
 
       def import_pool(cp_pool_id, index_hosts = true)
-        pool = nil
+        json = candlepin_data(cp_pool_id)
         ::Katello::Util::Support.active_record_retry do
-          pool = Katello::Pool.where(:cp_id => cp_pool_id).first_or_create
+          pool = Katello::Pool.where(:cp_id => cp_pool_id, :organization => Organization.find_by(:label => json['owner']['key'])).first_or_create
+          pool.backend_data = json
+          pool.import_data(index_hosts)
         end
-        pool.import_data(index_hosts)
       end
 
       def stacking_subscription(org_label, stacking_id)


### PR DESCRIPTION
This works around a race condition when a pool creation occurs
both as part of manifest import and as part of cp event listener