### PR TITLE
Fixes #26447 - Remove version date from ostree branch

### DIFF
--- a/app/models/katello/ostree_branch.rb
+++ b/app/models/katello/ostree_branch.rb
@@ -9,7 +9,6 @@ module Katello
     scoped_search :on => :version, :complete_value => true
     scoped_search :on => :commit, :complete_value => true
     scoped_search :on => :pulp_id, :complete_value => true, :rename => :uuid
-    scoped_search :on => :version_date, :complete_value => true, :rename => :created
 
     CONTENT_TYPE = Pulp::OstreeBranch::CONTENT_TYPE
 
@@ -20,8 +19,7 @@ module Katello
     def update_from_json(json)
       update_attributes(:name => json[:branch],
                         :version => json[:metadata][:version],
-                        :commit => json[:commit],
-                        :version_date => json[:_created].to_datetime
+                        :commit => json[:commit]
                        )
     end
   end

--- a/app/views/katello/api/v2/ostree_branches/show.json.rabl
+++ b/app/views/katello/api/v2/ostree_branches/show.json.rabl
@@ -1,5 +1,5 @@
 object @resource
 
 attributes :pulp_id, :id
-attributes :name, :version, :commit, :version_date
+attributes :name, :version, :commit
 attributes :pulp_id => :uuid

--- a/db/migrate/20190326145039_remove_version_date_from_ostree_branch.rb
+++ b/db/migrate/20190326145039_remove_version_date_from_ostree_branch.rb
@@ -1,0 +1,5 @@
+class RemoveVersionDateFromOstreeBranch < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :katello_ostree_branches, :version_date, :timestamp
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/views/content-view-version-ostree-branches.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/views/content-view-version-ostree-branches.html
@@ -9,7 +9,6 @@
         <th bst-table-column translate>Name</th>
         <th bst-table-column translate>Version</th>
         <th bst-table-column translate>Commit</th>
-        <th bst-table-column translate>Date</th>
       </tr>
     </thead>
 
@@ -18,7 +17,6 @@
         <td bst-table-cell>{{ branch.name }}</td>
         <td bst-table-cell>{{ branch.version }}</td>
         <td bst-table-cell>{{ branch.commit }}</td>
-        <td bst-table-cell>{{ branch.version_date }}</td>
       </tr>
     </tbody>
   </table>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-ostree.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-ostree.html
@@ -18,7 +18,6 @@
         <th bst-table-column translate>Name</th>
         <th bst-table-column translate>Version</th>
         <th bst-table-column translate>Commit</th>
-        <th bst-table-column translate>Date</th>
       </tr>
     </thead>
 
@@ -27,7 +26,6 @@
         <td bst-table-cell>{{ branch.name }}</td>
         <td bst-table-cell>{{ branch.version }}</td>
         <td bst-table-cell>{{ branch.commit }}</td>
-        <td bst-table-cell>{{ branch.version_date }}</td>
       </tr>
     </tbody>
   </table>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/ostree-branches/details/views/ostree-branch-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/ostree-branches/details/views/ostree-branch-info.html
@@ -10,9 +10,6 @@
 
       <dt translate>Commit</dt>
       <dd>{{ branch.commit }}</dd>
-
-      <dt translate>Date</dt>
-      <dd>{{ branch.version_date }}</dd>
     </dl>
   </div>
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-manage-ostree-branches.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-manage-ostree-branches.html
@@ -19,7 +19,6 @@
           <th bst-table-column><span translate>Branch Name</span></th>
           <th bst-table-column><span translate>Version</span></th>
           <th bst-table-column><span translate>Commit</span></th>
-          <th bst-table-column><span translate>Date</span></th>
         </tr>
       </thead>
 
@@ -33,9 +32,6 @@
           </td>
           <td bst-table-cell>
             {{ item.commit }}
-          </td>
-          <td bst-table-cell>
-            {{ item.version_date }}
           </td>
         </tr>
       </tbody>

--- a/test/controllers/api/v2/ostree_branches_controller_test.rb
+++ b/test/controllers/api/v2/ostree_branches_controller_test.rb
@@ -19,7 +19,7 @@ module Katello
     end
 
     def test_index_version_date_sort
-      response = get :index, params: {sort_by: 'created', sort_order: 'desc'}
+      response = get :index, params: {sort_by: 'version', sort_order: 'desc'}
       body = JSON.parse(response.body)
 
       assert_response :success


### PR DESCRIPTION
 https://github.com/pulp/pulp_ostree/pull/104/ removed the _created_date field on ostree branch in pulp.
Katello has a field version_date on model ostree branch which tracks that field. We need to delete the field in katello following the dropping of the field in pulp.

Opening this PR on 3.11 since the upstream code has been refactored and cannot be cherry-picked to 6.5.