### PR TITLE
Fixes #26460 - fix ostree smart proxy sync

### DIFF
--- a/app/services/katello/pulp/repository/ostree.rb
+++ b/app/services/katello/pulp/repository/ostree.rb
@@ -14,7 +14,7 @@ module Katello
 
         def generate_mirror_importer
           config = {
-            feed: root.url,
+            feed: external_url(true),
             depth: PULP_MIRROR_SYNC_DEPTH
           }
           Runcible::Models::OstreeImporter.new(config.merge(mirror_importer_connection_options))
@@ -32,7 +32,7 @@ module Katello
         end
 
         def partial_repo_path
-          "/pulp/puppet/#{pulp_id}/"
+          "/pulp/ostree/web/#{repo.relative_path}".sub('//', '/')
         end
 
         def importer_class

--- a/test/services/katello/pulp/repository/ostree_test.rb
+++ b/test/services/katello/pulp/repository/ostree_test.rb
@@ -19,6 +19,12 @@ module Katello
         def delete_repo(repo)
           ::ForemanTasks.sync_task(::Actions::Pulp::Repository::Destroy, :pulp_id => repo.pulp_id) rescue ''
         end
+
+        def test_mirrored_importer
+          service = Katello::Pulp::Repository::Ostree.new(@repo, @mirror)
+
+          assert_include service.generate_mirror_importer.feed, URI(SmartProxy.pulp_master.pulp_url).host
+        end
       end
 
       class OstreeVcrTest < OstreeBaseTest


### PR DESCRIPTION
previously during refactorings, a bug was introduced
where instead of passing the main servers url to the smart proxy to sync,
the upstream url was passed