### PR TITLE
Fixes #26447 - Remove version date from ostree branch

### DIFF
--- a/app/models/katello/ostree_branch.rb
+++ b/app/models/katello/ostree_branch.rb
@@ -9,7 +9,6 @@ module Katello
     scoped_search :on => :version, :complete_value => true
     scoped_search :on => :commit, :complete_value => true
     scoped_search :on => :pulp_id, :complete_value => true, :rename => :uuid
-    scoped_search :on => :version_date, :complete_value => true, :rename => :created
 
     CONTENT_TYPE = "ostree".freeze
 

--- a/app/services/katello/pulp/ostree_branch.rb
+++ b/app/services/katello/pulp/ostree_branch.rb
@@ -6,8 +6,7 @@ module Katello
       def update_model(model)
         model.update_attributes(:name => backend_data[:branch],
                           :version => backend_data[:metadata][:version],
-                          :commit => backend_data[:commit],
-                          :version_date => backend_data[:_created] ? backend_data[:_created].to_datetime : nil
+                          :commit => backend_data[:commit]
                          )
       end
     end

--- a/app/views/katello/api/v2/ostree_branches/show.json.rabl
+++ b/app/views/katello/api/v2/ostree_branches/show.json.rabl
@@ -1,5 +1,5 @@
 object @resource
 
 attributes :pulp_id, :id
-attributes :name, :version, :commit, :version_date
+attributes :name, :version, :commit
 attributes :pulp_id => :uuid

--- a/db/migrate/20190326145039_remove_version_date_from_ostree_branch.rb
+++ b/db/migrate/20190326145039_remove_version_date_from_ostree_branch.rb
@@ -1,0 +1,5 @@
+class RemoveVersionDateFromOstreeBranch < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :katello_ostree_branches, :version_date, :timestamp
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/views/content-view-version-ostree-branches.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/views/content-view-version-ostree-branches.html
@@ -9,7 +9,6 @@
         <th bst-table-column translate>Name</th>
         <th bst-table-column translate>Version</th>
         <th bst-table-column translate>Commit</th>
-        <th bst-table-column translate>Date</th>
       </tr>
     </thead>
 
@@ -18,7 +17,6 @@
         <td bst-table-cell>{{ branch.name }}</td>
         <td bst-table-cell>{{ branch.version }}</td>
         <td bst-table-cell>{{ branch.commit }}</td>
-        <td bst-table-cell>{{ branch.version_date }}</td>
       </tr>
     </tbody>
   </table>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-ostree.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/views/environment-ostree.html
@@ -13,7 +13,6 @@
         <th bst-table-column translate>Name</th>
         <th bst-table-column translate>Version</th>
         <th bst-table-column translate>Commit</th>
-        <th bst-table-column translate>Date</th>
       </tr>
     </thead>
 
@@ -22,7 +21,6 @@
         <td bst-table-cell>{{ branch.name }}</td>
         <td bst-table-cell>{{ branch.version }}</td>
         <td bst-table-cell>{{ branch.commit }}</td>
-        <td bst-table-cell>{{ branch.version_date }}</td>
       </tr>
     </tbody>
   </table>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/ostree-branches/details/views/ostree-branch-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/ostree-branches/details/views/ostree-branch-info.html
@@ -10,9 +10,6 @@
 
       <dt translate>Commit</dt>
       <dd>{{ branch.commit }}</dd>
-
-      <dt translate>Date</dt>
-      <dd>{{ branch.version_date }}</dd>
     </dl>
   </div>
 </div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-manage-ostree-branches.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-manage-ostree-branches.html
@@ -19,7 +19,6 @@
           <th bst-table-column><span translate>Branch Name</span></th>
           <th bst-table-column><span translate>Version</span></th>
           <th bst-table-column><span translate>Commit</span></th>
-          <th bst-table-column><span translate>Date</span></th>
         </tr>
       </thead>
 
@@ -33,9 +32,6 @@
           </td>
           <td bst-table-cell>
             {{ item.commit }}
-          </td>
-          <td bst-table-cell>
-            {{ item.version_date }}
           </td>
         </tr>
       </tbody>

--- a/test/controllers/api/v2/ostree_branches_controller_test.rb
+++ b/test/controllers/api/v2/ostree_branches_controller_test.rb
@@ -18,8 +18,8 @@ module Katello
       assert_template "katello/api/v2/ostree_branches/index"
     end
 
-    def test_index_version_date_sort
-      response = get :index, params: {sort_by: 'created', sort_order: 'desc'}
+    def test_index_sort
+      response = get :index, params: {sort_by: 'version', sort_order: 'desc'}
       body = JSON.parse(response.body)
 
       assert_response :success

--- a/test/services/katello/pulp/ostree_branch_test.rb
+++ b/test/services/katello/pulp/ostree_branch_test.rb
@@ -18,18 +18,6 @@ module Katello
 
         assert_equal @branches[0][:commit], @model.commit
         assert_equal @branches[0][:branch], @model.name
-        refute_nil @model.version_date
-      end
-
-      def test_update_model_nil_created
-        @branches[0][:_created] = nil
-        service = ::Katello::Pulp::OstreeBranch.new(@model.pulp_id)
-        service.backend_data = @branches[0]
-        service.update_model(@model)
-
-        assert_equal @branches[0][:commit], @model.commit
-        assert_equal @branches[0][:branch], @model.name
-        assert_nil @model.version_date
       end
     end
   end


### PR DESCRIPTION
pulp/pulp_ostree#104 removed the _created_date field on ostree branch in pulp.
Katello has a field version_date on model ostree branch which tracks that field. We need to delete the field in katello following the dropping of the field in pulp.