### PR TITLE
Fixes #26468 - Index modules before errata

### DIFF
--- a/app/models/katello/yum_metadata_file.rb
+++ b/app/models/katello/yum_metadata_file.rb
@@ -5,9 +5,9 @@ module Katello
     belongs_to :repository, :inverse_of => :yum_metadata_files, :class_name => "Katello::Repository"
     CONTENT_TYPE = "yum_repo_metadata_file".freeze
 
-    def self.import_for_repository(repository, force = true)
+    def self.import_for_repository(repository, _force = true)
       ::Katello::YumMetadataFile.where(:repository_id => repository).destroy_all
-      super(repository, force)
+      super(repository, true)
     end
 
     def self.manage_repository_association

--- a/app/services/katello/pulp/yum_metadata_file.rb
+++ b/app/services/katello/pulp/yum_metadata_file.rb
@@ -6,7 +6,7 @@ module Katello
       def update_model(model)
         shared_attributes = backend_data.keys & model.class.column_names
         shared_json = backend_data.select { |key, _v| shared_attributes.include?(key) }
-        repo = ::Katello::Repository.find_by(:pulp_id => shared_json['repo_id']).try(:id)
+        repo = ::Katello::Repository.find_by(:pulp_id => backend_data['repo_id']).try(:id)
         model.update_attributes!(shared_json.merge(repository_id: repo,
                                                   name: find_name_from_json(backend_data)))
       end

--- a/lib/katello/repository_types/yum.rb
+++ b/lib/katello/repository_types/yum.rb
@@ -3,8 +3,8 @@ Katello::RepositoryTypeManager.register(::Katello::Repository::YUM_TYPE) do
   prevent_unneeded_metadata_publish
 
   content_type Katello::Rpm, :priority => 1, :pulp2_service_class => ::Katello::Pulp::Rpm, :user_removable => true
-  content_type Katello::Erratum, :priority => 2, :pulp2_service_class => ::Katello::Pulp::Erratum
-  content_type Katello::ModuleStream, :priority => 3, :pulp2_service_class => ::Katello::Pulp::ModuleStream
+  content_type Katello::ModuleStream, :priority => 2, :pulp2_service_class => ::Katello::Pulp::ModuleStream
+  content_type Katello::Erratum, :priority => 3, :pulp2_service_class => ::Katello::Pulp::Erratum
   content_type Katello::PackageGroup, :pulp2_service_class => ::Katello::Pulp::PackageGroup
   content_type Katello::YumMetadataFile, :pulp2_service_class => ::Katello::Pulp::YumMetadataFile
   content_type Katello::Srpm, :pulp2_service_class => ::Katello::Pulp::Srpm

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -547,6 +547,16 @@ module Katello
       assert_nil @puppet_forge.capsule_download_policy(proxy)
       assert_not_nil @fedora_17_x86_64.download_policy
     end
+
+    def test_index_content_ordering
+      repo_type = @rhel6.repository_type
+      repo_types_hash = Hash[repo_type.content_types_to_index.map { |type| [type.model_class.content_type, type.priority] }]
+      # {"rpm"=>1, "modulemd"=>2, "erratum"=>3, "package_group"=>99, "yum_repo_metadata_file"=>99, "srpm"=>99}
+
+      # make sure rpms and module streams get indexed before errata
+      assert repo_types_hash[::Katello::Rpm.content_type] < repo_types_hash[::Katello::Erratum.content_type]
+      assert repo_types_hash[::Katello::ModuleStream.content_type] < repo_types_hash[::Katello::Erratum.content_type]
+    end
   end
 
   class RepositoryApplicabilityTest < RepositoryTestBase


### PR DESCRIPTION
This commit indexes module streams before errata. While indexing errata we need to find the module streams to associate it.