### PR TITLE
Fixes #26470 - clarify 'Red Hat Registry' is registry.redhat.io

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/container-registries.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/container-registries.service.js
@@ -11,7 +11,7 @@ angular.module('Bastion.products').service('ContainerRegistries',
     ['translate', function () {
 
         this.registries = {
-            'redhat': { name: 'Red Hat Registry', url: "https://registry.redhat.io" },
+            'redhat': { name: 'Red Hat Registry (registry.redhat.io)', url: "https://registry.redhat.io" },
             'dockerhub': { name: 'Docker Hub', url: "https://index.docker.io",
                                                 createUrl: "https://registry-1.docker.io" },
             'quay': { name: 'Quay', url: "https://quay.io" },


### PR DESCRIPTION
Since there are currently mutliple registries from Red Hat,
this change is to make it clear that the registry selected
is registry.redhat.io.

If the user would like to specify a different registry,
it is still possible to select 'Custom' and provide the
URL and credentials for that registry.