### PR TITLE
Fixes #26364 - Copy modules on incremental update

### DIFF
--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -129,7 +129,7 @@ module Katello
       streams = packages.map do |pack|
         pack.module_streams
       end
-      return streams.flatten
+      return streams.flatten.uniq
     end
 
     class Jail < ::Safemode::Jail

--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -125,6 +125,13 @@ module Katello
       end
     end
 
+    def module_stream_objects
+      streams = packages.map do |pack|
+        pack.module_streams
+      end
+      return streams.flatten
+    end
+
     class Jail < ::Safemode::Jail
       allow :errata_id, :errata_type, :issued, :created_at, :severity, :package_names, :cves, :reboot_suggested
     end

--- a/app/services/katello/pulp/repository.rb
+++ b/app/services/katello/pulp/repository.rb
@@ -238,6 +238,19 @@ module Katello
         override_config[:resolve_dependencies] = true if options[:resolve_dependencies]
 
         smart_proxy.pulp_api.extensions.send(content_type).copy(repo.pulp_id, destination_repo.pulp_id, ids: unit_ids, override_config: override_config)
+
+        if content_type == ::Katello::Erratum::CONTENT_TYPE
+          # copy the modules belonging to this errarta over (pulp 2.19 should handle this case out of the box)
+          # remove this code after 2.19
+          module_stream_ids = units.map do |erratum|
+            erratum.module_streams.pluck(:pulp_id)
+          end
+          module_stream_ids.flatten!
+          smart_proxy.pulp_api.extensions.module.copy(repo.pulp_id,
+                                                      destination_repo.pulp_id,
+                                                      ids: module_stream_ids,
+                                                      override_config: override_config)
+        end
       end
 
       def content_unit_types

--- a/app/services/katello/pulp/repository.rb
+++ b/app/services/katello/pulp/repository.rb
@@ -238,12 +238,11 @@ module Katello
         override_config[:resolve_dependencies] = true if options[:resolve_dependencies]
 
         smart_proxy.pulp_api.extensions.send(content_type).copy(repo.pulp_id, destination_repo.pulp_id, ids: unit_ids, override_config: override_config)
-
         if content_type == ::Katello::Erratum::CONTENT_TYPE
           # copy the modules belonging to this errarta over (pulp 2.19 should handle this case out of the box)
           # remove this code after 2.19
           module_stream_ids = units.map do |erratum|
-            erratum.module_streams.pluck(:pulp_id)
+            erratum.module_stream_objects.map(&:pulp_id)
           end
           module_stream_ids.flatten!
           smart_proxy.pulp_api.extensions.module.copy(repo.pulp_id,


### PR DESCRIPTION
This commit copies modules associated to an errata on an incremental
publish.
Note:
This is likely to get fixed when pulp 2.19 shows up with the dep
solving features. Then the recursive:true to errata copy would
automatically copy the associated  modules. This commit is more of a
stopgap.