### PR TITLE
Fixes #25113 - Refactor Org handling in React

### DIFF
--- a/webpack/components/SelectOrg/SelectOrgAction.js
+++ b/webpack/components/SelectOrg/SelectOrgAction.js
@@ -25,17 +25,17 @@ export const getOrganiztionsList = () => (dispatch) => {
     });
 };
 
-export const changeCurrentOrganization = orgID => dispatch => foremanEndpoint
-  .get(`organizations/${orgID}/select`)
+export const changeCurrentOrganization = org => dispatch => foremanEndpoint
+  .get(`organizations/${org.id}/select`)
   .then(() => {
     dispatch({
       type: CHANGE_CURRENT_ORGANIZATION_SUCCESS,
-      payload: orgID,
+      payload: org,
     });
   })
   .catch(() => {
     dispatch({
       type: CHANGE_CURRENT_ORGANIZATION_FAILURE,
-      payload: orgID,
+      payload: org.id,
     });
   });

--- a/webpack/components/SelectOrg/SelectOrgReducer.js
+++ b/webpack/components/SelectOrg/SelectOrgReducer.js
@@ -19,11 +19,12 @@ export default (state = initialState, action) => {
         .set('list', payload.results)
         .set('loading', false);
 
-    case CHANGE_CURRENT_ORGANIZATION_SUCCESS:
+    case CHANGE_CURRENT_ORGANIZATION_SUCCESS: {
+      const { id } = payload;
       return state
-        .set('currentId', payload)
+        .set('currentId', id)
         .set('loading', false);
-
+    }
     case GET_ORGANIZATIONS_LIST_FAILURE:
       return state
         .set('error', payload);

--- a/webpack/components/SelectOrg/SetOrganization.js
+++ b/webpack/components/SelectOrg/SetOrganization.js
@@ -25,7 +25,7 @@ class SetOrganization extends Component {
 
   onSelectItem(e) {
     this.setState({
-      item: e.target.options[e.target.selectedIndex].text,
+      title: e.target.options[e.target.selectedIndex].text,
       id: e.target.value,
       disabled: false,
     });
@@ -37,13 +37,14 @@ class SetOrganization extends Component {
       changeCurrentOrganization,
       redirectPath,
     } = this.props;
-    const { id } = this.state;
+    const { id, title } = this.state;
 
-    changeCurrentOrganization(`${id}`).then(() =>
+    changeCurrentOrganization({ id, title }).then(() => {
+      window.tfm.nav.changeOrganization({ id: String(id), title });
       history.push({
         pathname: redirectPath,
-        state: { orgChanged: this.state.item },
-      }));
+      });
+    });
   }
 
   render() {

--- a/webpack/components/WithOrganization/__snapshots__/withOrganization.test.js.snap
+++ b/webpack/components/WithOrganization/__snapshots__/withOrganization.test.js.snap
@@ -1,7 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`subscriptions page should render select org page 1`] = `
+exports[`with organization should render a loading state when Katello org is still loading 1`] = `
 <Connect(CheckOrg)
+  history={
+    Object {
+      "push": [MockFunction],
+    }
+  }
+  location={Object {}}
   store={
     Object {
       "clearActions": [Function],
@@ -15,7 +21,176 @@ exports[`subscriptions page should render select org page 1`] = `
 >
   <CheckOrg
     default={[Function]}
+    history={
+      Object {
+        "push": [MockFunction],
+      }
+    }
+    layoutOrganization={
+      Object {
+        "id": 1,
+        "title": "Test",
+      }
+    }
     loadOrganization={[Function]}
+    location={Object {}}
+    organization={
+      Object {
+        "loading": true,
+      }
+    }
+    saveOrganization={[Function]}
+    store={
+      Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      }
+    }
+    storeSubscription={
+      Subscription {
+        "listeners": Object {
+          "clear": [Function],
+          "get": [Function],
+          "notify": [Function],
+          "subscribe": [Function],
+        },
+        "onStateChange": [Function],
+        "parentSub": undefined,
+        "store": Object {
+          "clearActions": [Function],
+          "dispatch": [Function],
+          "getActions": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+        },
+        "unsubscribe": [Function],
+      }
+    }
+  >
+    <LoadingState
+      loading={true}
+      loadingText="Loading"
+      timeout={300}
+    />
+  </CheckOrg>
+</Connect(CheckOrg)>
+`;
+
+exports[`with organization should render a loading state when Katello org isn't loaded 1`] = `
+<Connect(CheckOrg)
+  history={
+    Object {
+      "push": [MockFunction],
+    }
+  }
+  location={Object {}}
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <CheckOrg
+    default={[Function]}
+    history={
+      Object {
+        "push": [MockFunction],
+      }
+    }
+    layoutOrganization={
+      Object {
+        "id": 1,
+        "title": "Test",
+      }
+    }
+    loadOrganization={[Function]}
+    location={Object {}}
+    organization={Object {}}
+    saveOrganization={[Function]}
+    store={
+      Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      }
+    }
+    storeSubscription={
+      Subscription {
+        "listeners": Object {
+          "clear": [Function],
+          "get": [Function],
+          "notify": [Function],
+          "subscribe": [Function],
+        },
+        "onStateChange": [Function],
+        "parentSub": undefined,
+        "store": Object {
+          "clearActions": [Function],
+          "dispatch": [Function],
+          "getActions": [Function],
+          "getState": [Function],
+          "replaceReducer": [Function],
+          "subscribe": [Function],
+        },
+        "unsubscribe": [Function],
+      }
+    }
+  >
+    <LoadingState
+      loading={true}
+      loadingText="Loading"
+      timeout={300}
+    />
+  </CheckOrg>
+</Connect(CheckOrg)>
+`;
+
+exports[`with organization should render the select org page when org is 'Any Organization' 1`] = `
+<Connect(CheckOrg)
+  history={
+    Object {
+      "push": [MockFunction],
+    }
+  }
+  location={Object {}}
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <CheckOrg
+    default={[Function]}
+    history={
+      Object {
+        "push": [MockFunction],
+      }
+    }
+    layoutOrganization={
+      Object {
+        "title": "Any Organization",
+      }
+    }
+    loadOrganization={[Function]}
+    location={Object {}}
     organization={Object {}}
     saveOrganization={[Function]}
     store={
@@ -72,15 +247,19 @@ exports[`subscriptions page should render select org page 1`] = `
         </SideEffect(NullComponent)>
       </HelmetWrapper>
     </Header>
-    <Connect(withRouter(SetOrganization))
-      redirectPath="/test"
-    />
+    <Connect(withRouter(SetOrganization)) />
   </CheckOrg>
 </Connect(CheckOrg)>
 `;
 
-exports[`subscriptions page should render the wrapped component 1`] = `
+exports[`with organization should render the wrapped component when katello org is Loaded 1`] = `
 <Connect(CheckOrg)
+  history={
+    Object {
+      "push": [MockFunction],
+    }
+  }
+  location={Object {}}
   store={
     Object {
       "clearActions": [Function],
@@ -94,8 +273,25 @@ exports[`subscriptions page should render the wrapped component 1`] = `
 >
   <CheckOrg
     default={[Function]}
+    history={
+      Object {
+        "push": [MockFunction],
+      }
+    }
+    layoutOrganization={
+      Object {
+        "id": 1,
+        "title": "Test",
+      }
+    }
     loadOrganization={[Function]}
-    organization={Object {}}
+    location={Object {}}
+    organization={
+      Object {
+        "id": 1,
+        "title": "Test",
+      }
+    }
     saveOrganization={[Function]}
     store={
       Object {
@@ -129,47 +325,70 @@ exports[`subscriptions page should render the wrapped component 1`] = `
       }
     }
   >
-    <WrappedComponent
-      default={[Function]}
-      loadOrganization={[Function]}
-      organization={Object {}}
-      saveOrganization={[Function]}
-      store={
-        Object {
-          "clearActions": [Function],
-          "dispatch": [Function],
-          "getActions": [Function],
-          "getState": [Function],
-          "replaceReducer": [Function],
-          "subscribe": [Function],
+    <LoadingState
+      loading={false}
+      loadingText="Loading"
+      timeout={300}
+    >
+      <WrappedComponent
+        default={[Function]}
+        history={
+          Object {
+            "push": [MockFunction],
+          }
         }
-      }
-      storeSubscription={
-        Subscription {
-          "listeners": Object {
-            "clear": [Function],
-            "get": [Function],
-            "notify": [Function],
-            "subscribe": [Function],
-          },
-          "onStateChange": [Function],
-          "parentSub": undefined,
-          "store": Object {
+        layoutOrganization={
+          Object {
+            "id": 1,
+            "title": "Test",
+          }
+        }
+        loadOrganization={[Function]}
+        location={Object {}}
+        organization={
+          Object {
+            "id": 1,
+            "title": "Test",
+          }
+        }
+        saveOrganization={[Function]}
+        store={
+          Object {
             "clearActions": [Function],
             "dispatch": [Function],
             "getActions": [Function],
             "getState": [Function],
             "replaceReducer": [Function],
             "subscribe": [Function],
-          },
-          "unsubscribe": [Function],
+          }
         }
-      }
-    >
-      <div>
-         Wrapped! 
-      </div>
-    </WrappedComponent>
+        storeSubscription={
+          Subscription {
+            "listeners": Object {
+              "clear": [Function],
+              "get": [Function],
+              "notify": [Function],
+              "subscribe": [Function],
+            },
+            "onStateChange": [Function],
+            "parentSub": undefined,
+            "store": Object {
+              "clearActions": [Function],
+              "dispatch": [Function],
+              "getActions": [Function],
+              "getState": [Function],
+              "replaceReducer": [Function],
+              "subscribe": [Function],
+            },
+            "unsubscribe": [Function],
+          }
+        }
+      >
+        <div>
+           Wrapped! 
+        </div>
+      </WrappedComponent>
+    </LoadingState>
   </CheckOrg>
 </Connect(CheckOrg)>
 `;

--- a/webpack/components/WithOrganization/withOrganization.js
+++ b/webpack/components/WithOrganization/withOrganization.js
@@ -2,71 +2,132 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-
 import { translate as __ } from 'foremanReact/common/I18n';
-import { get } from 'lodash';
+
+import { LoadingState } from '../../move_to_pf/LoadingState';
+import { orgId } from '../../services/api';
 import SetOrganization from '../SelectOrg/SetOrganization';
 import Header from '../../containers/Application/Headers';
 import * as organizationActions from '../../scenes/Organizations/OrganizationActions';
 
 const mapStateToProps = state => ({
+  // the current organization showing in the layout bar, tracked by Foreman
+  layoutOrganization: state.layout.currentOrganization,
+  // the organization as tracked in Katello
   organization: state.katello.organization,
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({ ...organizationActions }, dispatch);
 
-function withOrganization(WrappedComponent, redirectPath) {
+function withOrganization(WrappedComponent, redirectPath, requiresOrg = true) {
   class CheckOrg extends Component {
     constructor(props) {
       super(props);
-      this.state = { orgId: null };
+      this.state = { orgIsChanging: false };
     }
-    static getDerivedStateFromProps(newProps, state) {
-      const orgNodeId = document.getElementById('organization-id').dataset.id;
 
-      if (state.orgId !== orgNodeId) {
-        return { orgId: orgNodeId };
+    componentDidMount() {
+      this.synchronizeKatelloOrg();
+    }
+
+    static getDerivedStateFromProps(props, state) {
+      const { layoutOrganization: currentForemanOrg } = props;
+      if (!state.prevForemanOrgId) return { prevForemanOrgId: currentForemanOrg.id };
+
+      // This state change is necessary to catch when the org is changing before the component
+      // renders. This prevents trying to render the wrapped component with the previous
+      // organization after the org has been switched. Right after the change in the org switcher,
+      // the organization in katello's state will still be the previous organization and the
+      // loading flag will still be false. this is changed when `componentDidUpdate` is run and
+      // the organization in Katello is updated. Until then, the `orgIsChanging` state can be used
+      // in the render method
+      if (currentForemanOrg.id !== state.prevForemanOrgId) {
+        return {
+          prevForemanOrgId: currentForemanOrg.id,
+          orgIsChanging: true,
+        };
       }
+
       return null;
     }
 
-    componentDidUpdate(prevProps) {
-      const { location } = this.props;
-      const orgTitle = get(location, 'state.orgChanged');
-      const prevOrgTitle = get(prevProps, 'location.state.orgChanged');
+    componentDidUpdate() {
+      const {
+        location,
+        history,
+        layoutOrganization: currentForemanOrg,
+        organization: currentKatelloOrg,
+      } = this.props;
 
-      if (orgTitle !== prevOrgTitle) {
-        window.tfm.nav.changeOrganization(orgTitle);
+      this.synchronizeKatelloOrg();
+
+      if (currentForemanOrg.id === currentKatelloOrg.id) {
+        // Here we turn off the state setting that is set in getDerivedStateFromProps.
+        // The matching IDs means katello has updated from the org updating in Foreman,
+        // and we can safely assume the org is no longer changing.
+        // eslint-disable-next-line react/no-did-update-set-state
+        if (this.state.orgIsChanging) this.setState({ orgIsChanging: false });
+      }
+
+      const splitPath = location.pathname.split('/');
+
+      // Navigate back to the redirect page when the org changes if on subpage
+      if (this.state.orgIsChanging &&
+          splitPath.length > 1 &&
+          location.pathname !== redirectPath &&
+          !this.anyOrgSelected()) {
+        history.push(redirectPath);
       }
     }
 
+    anyOrgSelected = () => {
+      const { layoutOrganization } = this.props;
+      return layoutOrganization && layoutOrganization.title === 'Any Organization';
+    };
+
+    // Check if Katello's org and Foreman's org are matching
+    orgsDontMatch = () => {
+      const { organization } = this.props;
+      return organization && orgId() !== organization.id;
+    };
+
+    synchronizeKatelloOrg = () => {
+      const { organization, loadOrganization } = this.props;
+      if (!this.anyOrgSelected() && !organization.loading && this.orgsDontMatch()) {
+        loadOrganization();
+      }
+    };
+
+    katelloOrgIsLoaded = () => {
+      const { orgIsChanging } = this.state;
+      const { organization } = this.props;
+
+      return (!orgIsChanging && !organization.loading && !!organization.id);
+    };
+
     render() {
-      const { organization, location } = this.props;
-      const newOrgSelected = get(location, 'state.orgChanged');
-
-      if (newOrgSelected) {
-        if (!organization.label && !organization.loading) { this.props.loadOrganization(); }
-
-        return <WrappedComponent {...this.props} />;
-      } else if (this.state.orgId === '') {
+      if (this.anyOrgSelected() && requiresOrg) {
         return (
           <React.Fragment>
             <Header title={__('Select Organization')} />
             <SetOrganization redirectPath={redirectPath} />
-          </React.Fragment>);
+          </React.Fragment>
+        );
       }
-      return <WrappedComponent {...this.props} />;
+      return (
+        <LoadingState loading={requiresOrg && !this.katelloOrgIsLoaded()}>
+          <WrappedComponent {...this.props} />
+        </LoadingState>
+      );
     }
   }
 
   CheckOrg.propTypes = {
-    location: PropTypes.shape({}),
+    location: PropTypes.shape({}).isRequired,
+    history: PropTypes.shape({}).isRequired,
     loadOrganization: PropTypes.func.isRequired,
     organization: PropTypes.shape({}).isRequired,
-  };
-
-  CheckOrg.defaultProps = {
-    location: undefined,
+    layoutOrganization: PropTypes.shape({}).isRequired,
   };
 
   return connect(mapStateToProps, mapDispatchToProps)(CheckOrg);

--- a/webpack/components/WithOrganization/withOrganization.test.js
+++ b/webpack/components/WithOrganization/withOrganization.test.js
@@ -7,24 +7,55 @@ import withOrganization from './withOrganization';
 
 jest.mock('../SelectOrg/SetOrganization');
 const mockStore = configureMockStore([thunk]);
-const store = mockStore({ katello: { organization: {} } });
-
-describe('subscriptions page', () => {
+const orgInfo = { id: 1, title: 'Test' };
+const anyOrgInfo = { title: 'Any Organization' };
+describe('with organization', () => {
   const WrappedComponent = () => <div> Wrapped! </div>;
+  const Component = withOrganization(WrappedComponent);
+  const props = { location: {}, history: { push: jest.fn() } };
 
-  it('should render the wrapped component', () => {
-    global.document.getElementById = () => ({ dataset: { id: 1 } });
+  it("should render a loading state when Katello org isn't loaded", () => {
+    const store = mockStore({
+      katello: { organization: {} },
+      layout: { currentOrganization: orgInfo },
+    });
 
-    const Component = withOrganization(WrappedComponent, '/test');
-    const page = mount(<Component store={store} />);
+    const page = mount(<Component store={store} {...props} />);
     expect(toJson(page)).toMatchSnapshot();
+    expect(page.find('LoadingState')).toHaveLength(1);
   });
 
-  it('should render select org page', () => {
-    global.document.getElementById = () => ({ dataset: { id: '' } });
+  it('should render a loading state when Katello org is still loading', () => {
+    const store = mockStore({
+      katello: { organization: { loading: true } },
+      layout: { currentOrganization: orgInfo },
+    });
 
-    const Component = withOrganization(WrappedComponent, '/test');
-    const page = mount(<Component store={store} />);
+    const page = mount(<Component store={store} {...props} />);
     expect(toJson(page)).toMatchSnapshot();
+    expect(page.find('LoadingState')).toHaveLength(1);
+  });
+
+
+  it("should render the select org page when org is 'Any Organization'", () => {
+    const store = mockStore({
+      katello: { organization: {} },
+      layout: { currentOrganization: anyOrgInfo },
+    });
+
+    const page = mount(<Component store={store} {...props} />);
+    expect(toJson(page)).toMatchSnapshot();
+    expect(page.find('Connect(withRouter(SetOrganization))')).toHaveLength(1);
+  });
+
+  it('should render the wrapped component when katello org is Loaded', () => {
+    const store = mockStore({
+      katello: { organization: orgInfo },
+      layout: { currentOrganization: orgInfo },
+    });
+
+    const page = mount(<Component store={store} {...props} />);
+    expect(toJson(page)).toMatchSnapshot();
+    expect(page.find(WrappedComponent)).toHaveLength(1);
   });
 });

--- a/webpack/containers/Application/config.js
+++ b/webpack/containers/Application/config.js
@@ -27,12 +27,18 @@ export const links = [
   },
   {
     path: 'subscriptions/add',
-    component: withHeader(UpstreamSubscriptions, { title: __('Add Subscriptions') }),
+    component: WithOrganization(
+      withHeader(UpstreamSubscriptions, { title: __('Add Subscriptions') }),
+      '/subscriptions/add',
+    ),
   },
   {
     // eslint-disable-next-line no-useless-escape
     path: 'subscriptions/:id([0-9]+)',
-    component: withHeader(SubscriptionDetails, { title: __('Subscription Details') }),
+    component: WithOrganization(
+      withHeader(SubscriptionDetails, { title: __('Subscription Details') }),
+      '/subscriptions',
+    ),
   },
   {
     path: 'organization_select',
@@ -40,10 +46,10 @@ export const links = [
   },
   {
     path: 'module_streams',
-    component: withHeader(ModuleStreams, { title: __('Module Streams') }),
+    component: WithOrganization(withHeader(ModuleStreams, { title: __('Module Streams') }), '/module_streams', false),
   },
   {
     path: 'module_streams/:id([0-9]+)',
-    component: withHeader(ModuleStreamDetails, { title: __('Module Stream Details') }),
+    component: WithOrganization(withHeader(ModuleStreamDetails, { title: __('Module Stream Details') }), '/module_streams', false),
   },
 ];

--- a/webpack/containers/Application/index.js
+++ b/webpack/containers/Application/index.js
@@ -1,41 +1,15 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
-import { orgId } from '../../services/api';
-import * as actions from '../../scenes/Organizations/OrganizationActions';
 import reducer from '../../scenes/Organizations/OrganizationReducer';
 import Routes from './Routes';
 import './overrides.scss';
 
-const mapStateToProps = state => ({ organization: state.organization });
-const mapDispatchToProps = dispatch => bindActionCreators(actions, dispatch);
-
 export const organization = reducer;
 
-class Application extends Component {
-  componentDidMount() {
-    this.loadData();
-  }
+const Application = () => (
+  <Router>
+    <Routes />
+  </Router>
+);
 
-  loadData() {
-    if (orgId()) {
-      this.props.loadOrganization();
-    }
-  }
-
-  render() {
-    return (
-      <Router>
-        <Routes />
-      </Router>
-    );
-  }
-}
-
-Application.propTypes = {
-  loadOrganization: PropTypes.func.isRequired,
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(Application);
+export default Application;

--- a/webpack/move_to_pf/LoadingState/LoadingState.js
+++ b/webpack/move_to_pf/LoadingState/LoadingState.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Spinner } from 'patternfly-react';
 import './LoadingState.scss';
 
+/* eslint-disable no-underscore-dangle */
 class LoadingState extends Component {
   constructor(props) {
     super(props);
@@ -12,9 +13,18 @@ class LoadingState extends Component {
   }
 
   componentDidMount() {
+    this._ismounted = true;
+
     setTimeout(() => {
-      this.setState({ render: true });
+      // Check if mounted to avoid updating the state on an unmounted component
+      if (this._ismounted) {
+        this.setState({ render: true });
+      }
     }, this.props.timeout);
+  }
+
+  componentWillUnmount() {
+    this._ismounted = false;
   }
 
   render() {
@@ -45,4 +55,5 @@ LoadingState.defaultProps = {
   timeout: 300,
 };
 
+/* eslint-enable no-underscore-dangle */
 export default LoadingState;

--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -34,6 +34,7 @@ class SubscriptionsPage extends Component {
   componentDidMount() {
     this.props.resetTasks();
     this.props.loadSetting('content_disconnected');
+    this.pollTasks();
   }
 
   componentDidUpdate(prevProps) {

--- a/webpack/scenes/Subscriptions/index.js
+++ b/webpack/scenes/Subscriptions/index.js
@@ -1,5 +1,6 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 import * as settingActions from 'foremanReact/components/Settings/SettingsActions';
 
 import * as subscriptionActions from './SubscriptionActions';
@@ -56,4 +57,4 @@ const mapDispatchToProps = dispatch => bindActionCreators(actions, dispatch);
 export const subscriptions = reducer;
 
 // export connected component
-export default connect(mapStateToProps, mapDispatchToProps)(SubscriptionsPage);
+export default connect(mapStateToProps, mapDispatchToProps)(withRouter(SubscriptionsPage));

--- a/webpack/services/api/index.js
+++ b/webpack/services/api/index.js
@@ -114,11 +114,15 @@ const orgNode = () => document.getElementById('organization-id');
 const userNode = () => document.getElementById('user-id');
 // This node does not exist while testing
 export const orgId = () => {
+  // get the org id from the html attribute
   const node = orgNode();
   const id = node && node.dataset.id;
-  const { katello: { setOrganization: { currentId } } } = store.getState();
 
-  return id === '' ? currentId : id;
+  // get the org id from Foreman's store
+  const { layout: { currentOrganization: { id: currentId } } } = store.getState();
+
+  const resolvedId = currentId || id;
+  return parseInt(resolvedId, 10) || null;
 };
 
 export const userId = () => (userNode() ? userNode().dataset.id : '1');


### PR DESCRIPTION
This commit refactors org handling in our React pages by updating the `withOrganization` component to handle the Organization logic and then passing the Organization to the wrapped component. This keeps the logic separate and always tracks the Organization in Foreman.

My understanding of how Foreman handles an organization is this:

- Foreman passes the current org title from [the rails side](https://github.com/theforeman/foreman/blob/84ae69c6bf191837e8c7b4ccadb4583eebeda172/app/helpers/layout_helper.rb#L39) to react when the components [are mounted](https://github.com/theforeman/foreman/blob/84ae69c6bf191837e8c7b4ccadb4583eebeda172/app/helpers/layout_helper.rb#L3)
- A currentOrganization prop is passed to Layout from Redux.
  - The layout reducer [starts with "Any Organization"](https://github.com/theforeman/foreman/blob/84ae69c6bf191837e8c7b4ccadb4583eebeda172/webpack/assets/javascripts/react_app/components/Layout/LayoutReducer.js#L21)
  - The [`changeOrganization`](https://github.com/theforeman/foreman/blob/84ae69c6bf191837e8c7b4ccadb4583eebeda172/webpack/assets/javascripts/react_app/components/Layout/LayoutActions.js#L40-L45) action can change this value in Redux
- Foreman checks if the `currentOrganization` is the same as what is being passed in from Rails [here](https://github.com/theforeman/foreman/blob/84ae69c6bf191837e8c7b4ccadb4583eebeda172/webpack/assets/javascripts/react_app/components/Layout/Layout.js#L49-L59) and updating if they are not the same.
- So as long as the `Layout` component is rendering, the Org in Redux always equals the org set in Rails

Then in Katello:

- The index file for the top-level `Application` Component [loads the organization](https://github.com/Katello/katello/blob/master/webpack/containers/Application/index.js#L22-L25)
  - This fetches the organization details [with an action](https://github.com/Katello/katello/blob/master/webpack/scenes/Organizations/OrganizationActions.js#L14-L35) and uses the [`orgId()` function](https://github.com/Katello/katello/blob/master/webpack/services/api/index.js#L116-L122) which pulls the organization from a data attribute on the html element itself
  - Then it is [saved by the reducer](https://github.com/Katello/katello/blob/master/webpack/scenes/Organizations/OrganizationReducer.js#L22)
  - This is then passed back to the Application as a prop [here](https://github.com/Katello/katello/blob/6ef62d1f497f905848f6185a279ca12d0c170eb8/webpack/containers/Application/index.js#L12)

(I had to write this out for my own understanding too)

This means we can use the `layout` organization from Foreman to track the organization in Katello instead of grabbing the org id from the DOM itself. We also have more information added to the org in Katello, so we need to make the call to load the org using our API. This logic is moved to the `withOrganization` HOC.

The `withOrganization` logic is:

- Is the Foreman org "Any Organization?"
  - Show org switcher
- else is the Foreman Org loaded?
  - Load the org in Katello if it is not loaded or doesn't match
  - Once the org is loaded into Katello's store, render the wrapped component and pass the org

The goal is to always keep the Foreman and Katello organizations in sync and render the wrapped components when they are in sync.

This commit also adds a redirect back to the base page when a user is on a subpage and switches organizations. For example, I am on `subscriptions/34` and I change my org in the org switcher, I will be redirected back to `/subscriptions`. 

There are also updated tests to reflect this new logic