### PR TITLE
Refs #26165 - more robust migration

### DIFF
--- a/db/migrate/20180823081502_remove_foreman_docker_support.rb
+++ b/db/migrate/20180823081502_remove_foreman_docker_support.rb
@@ -9,7 +9,9 @@ class RemoveForemanDockerSupport < ActiveRecord::Migration[5.1]
       remove_column :docker_tags, :katello_repository_id
     end
     if table_exists?(:docker_container_wizard_states_images)
-      remove_column :docker_container_wizard_states_images, :capsule_id
+      if column_exists?(:docker_container_wizard_states_images, :capsule_id)
+        remove_column :docker_container_wizard_states_images, :capsule_id
+      end
     end
     if table_exists?(:containers)
       remove_column :containers, :capsule_id


### PR DESCRIPTION
TBH I have no idea how this can happen and I didn't fully follow what all needs to be dropped for docker removal, but this should fix the error seen at https://ci.centos.org/job/foreman-katello-nightly-test/402/consoleFull