### PR TITLE
Fixes #26433 - Bulk update via agent fails

### DIFF
--- a/app/lib/actions/katello/host/package/update.rb
+++ b/app/lib/actions/katello/host/package/update.rb
@@ -21,7 +21,7 @@ module Actions
           end
 
           def humanized_input
-            [(input[:packages] && input[:packages].join(", ") || "all packages")] + super
+            [(input[:packages].present? && input[:packages].join(", ") || "all packages")] + super
           end
 
           def presenter
@@ -34,7 +34,15 @@ module Actions
 
           def finalize
             host = ::Host.find_by(:id => input[:host_id])
-            host.update(audit_comment: (_("Update of package(s) requested: %{packages}") % {packages: input[:packages].join(", ")}).truncate(255))
+            host.update(audit_comment: audit_comment)
+          end
+
+          def audit_comment
+            if input[:packages].present?
+              (_("Update of package(s) requested: %{packages}") % {packages: input[:packages].join(", ")}).truncate(255)
+            else
+              _("Update of all packages requested")
+            end
           end
         end
       end

--- a/app/lib/actions/pulp/consumer/abstract_content_action.rb
+++ b/app/lib/actions/pulp/consumer/abstract_content_action.rb
@@ -47,6 +47,8 @@ module Actions
         # by default runcible puts whatever we pass into a hash under the 'name' key
         # here we can make the unit hash more precise
         def parse_units_for_type
+          return unless input[:args]
+
           if input[:type] == 'rpm'
             input[:args].collect do |unit|
               ::Katello::Util::Package.parse_nvrea_nvre(unit) || unit


### PR DESCRIPTION
To Test:

- Register a client to your devel box with this PR applied ('katello-client' forklift box will automatically register to your devel box)
- Install katello-agent on the client
- From the content host UI for the registered client attempt to update a single package via katello-agent
- Then check update all packages via katello-agent
- Make sure both tasks succeed in Monitor -> Tasks