### PR TITLE
Fixes #26514 - CV version - OSTree branches is broken

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version-content.controller.js
@@ -62,7 +62,7 @@
                 params: {
                     'content_type': "ostree",
                     'content_view_version_id': $scope.$stateParams.versionId,
-                    'sort_by': 'created',
+                    'sort_by': 'version',
                     'sort_order': 'DESC'
                 }
             },


### PR DESCRIPTION
If a user attempts to list the OSTree Branches on a content view
version, they will observe an error indicating the following:

"the field 'created' in the order statement is not valid
field for search'.

This is a regression introduced by a combination of:
  b7dc5d44d9d2af3b64a0c063a67f1e810be891cb and
  e53d750fc691b2e63beef202c5e3749ab84fc616

Refer to issue for steps to reproduce and screenshot.