### PR TITLE
Refs #26191 - Raise error when host names mismatched

### DIFF
--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -262,6 +262,12 @@ module Katello
           fail _("Multiple profiles found. Consider removing %s which match this host.") % hostnames.join(', ')
         end
 
+        # check for hosts that were matched by dmi.system.uuid but whose name didn't match
+        if hosts.where(name: host_name).empty?
+          fail _("The host %{existing} matches this registration. Remove or rename it to %{new_host} before registering.") %
+            {existing: hosts.pluck(:name).first, new_host: host_name}
+        end
+
         hosts.first
       end
 


### PR DESCRIPTION
Rather than returning the host record which has a different hostname (resulting in a host record whose name that doesn't match the client hostname) raise an error telling user what to do.

**To test:**

register a content host w/ subscription-manager
subscription-manager clean (this preserves the record in Katello)
change the hostname: systemctl set-hostname "something.else"
subscription-manager register --force

Should get an error like: 
```
HTTP error (500 - Internal Server Error): The host katello-client.jturel.example.com-1 matches this registration. Remove or rename it to katello-client.jturel.example.com before registering.
```