### PR TITLE
Fixes #26422 - Matching content not considered before publish

### DIFF
--- a/app/lib/actions/middleware/skip_if_matching_content.rb
+++ b/app/lib/actions/middleware/skip_if_matching_content.rb
@@ -12,7 +12,8 @@ module Actions
       private
 
       def execute?
-        if action.input.keys.include?('matching_content') && action.input['matching_content']
+        options = action.input[:options]
+        if options && options['matching_content']
           self.action.output[:matching_content_skip] = true
           false
         else


### PR DESCRIPTION
**To test:** 
Publish a cv with some yum repos and then re-publish without changes.
The 2 distributor publish dynflow task should be passed an option matching_content : true since nothing changed between the 2 versions. 