### PR TITLE
Fixes #26596 - Auto Publish puppet install distributor

### DIFF
--- a/app/services/katello/pulp/repository/puppet.rb
+++ b/app/services/katello/pulp/repository/puppet.rb
@@ -19,7 +19,7 @@ module Katello
         end
 
         def generate_distributors
-          puppet_install_dist = Runcible::Models::PuppetInstallDistributor.new(puppet_install_distributor_path, :subdir => 'modules', :id => repo.pulp_id, :auto_publish => false)
+          puppet_install_dist = Runcible::Models::PuppetInstallDistributor.new(puppet_install_distributor_path, :subdir => 'modules', :id => repo.pulp_id, :auto_publish => smart_proxy.try(:pulp_mirror?) || false)
           puppet_dist = Runcible::Models::PuppetDistributor.new(nil, (root.unprotected || false), true,
                                                                 :id => "#{repo.pulp_id}_puppet", :auto_publish => true)
           [puppet_dist, puppet_install_dist]


### PR DESCRIPTION
To test:

1. Start a server and a capsule.
2. Create a puppet repo
3. Create a cv and add some puppet modules
4. Publish the CV and promote to an environment tied to the capsule
5. Check in /etc/puppetlabs/code/environments directory and check if the puppet environment was created.