### PR TITLE
Fixes #26600 - Duplicate host record when hypervisor_id changes

### DIFF
--- a/test/fixtures/files/virt_who_altered_hypervisor_id.json
+++ b/test/fixtures/files/virt_who_altered_hypervisor_id.json
@@ -1,0 +1,47 @@
+{
+   "hypervisors":[
+      {
+         "hypervisorId":{
+            "hypervisorId":"2e78f643-1d2f-45d1-b191-d931147cbde1"
+         },
+         "name":"localhost",
+         "guestIds":[
+            {
+               "guestId":"ed66bb39-cdd8-4fab-a066-ce44eaadb5f7",
+               "state":1,
+               "attributes":{
+                  "active":1,
+                  "virtWhoType":"esx"
+               }
+            }
+         ],
+         "facts":{
+            "hypervisor.type":"VMware ESXi",
+            "hypervisor.version":"6.0.0",
+            "cpu.cpu_socket(s)":"1",
+            "dmi.system.uuid":"abcde-fghjigj"
+         }
+      },
+      {
+         "hypervisorId":{
+            "hypervisorId":"261c4dca-702f-42b3-b8ef-2a72b77f7ec2"
+         },
+         "name":"distanthost",
+         "guestIds":[
+            {
+               "guestId":"4213374-fc72-96e6-ecdb-13dad4eb",
+               "state":1,
+               "attributes":{
+                  "active":1,
+                  "virtWhoType":"esx"
+               }
+            }
+         ],
+         "facts":{
+            "hypervisor.type":"VMware ESXi",
+            "hypervisor.version":"6.0.0",
+            "cpu.cpu_socket(s)":"1"
+         }
+      }
+   ]
+}

--- a/test/fixtures/vcr_cassettes/katello/host/hypervisors_vcr/altered_hypervisor_id.yml
+++ b/test/fixtures/vcr_cassettes/katello/host/hypervisors_vcr/altered_hypervisor_id.yml
@@ -1,0 +1,1258 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/owners/altered_hypervisor_id_test
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC", oauth_nonce="fivKyHmDBIuigKavvJlCqByfUv5X6Y8kfV9Z6QpHZbg",
+        oauth_signature="MZ7YuCy0P6F59%2Bbe%2Fmpp66UqnWo%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1555091477", oauth_version="1.0"
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - b82f9281-b60e-403c-97d3-ac8596639016
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:17 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wNC0xMlQxNzo0ODo1NSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDQtMTJUMTc6NDg6NTUrMDAwMCIsImlkIjoiNDAyOGY5ZmQ2
+        YTEyNDU4OTAxNmExMmFhYTk1YzAwY2MiLCJrZXkiOiJhbHRlcmVkX2h5cGVy
+        dmlzb3JfaWRfdGVzdCIsImRpc3BsYXlOYW1lIjoiYWx0ZXJlZF9oeXBlcnZp
+        c29yX2lkX3Rlc3QiLCJwYXJlbnRPd25lciI6bnVsbCwiY29udGVudFByZWZp
+        eCI6Ii9hbHRlcmVkX2h5cGVydmlzb3JfaWRfdGVzdC8kZW52IiwiZGVmYXVs
+        dFNlcnZpY2VMZXZlbCI6bnVsbCwidXBzdHJlYW1Db25zdW1lciI6bnVsbCwi
+        bG9nTGV2ZWwiOm51bGwsImF1dG9iaW5kRGlzYWJsZWQiOmZhbHNlLCJjb250
+        ZW50QWNjZXNzTW9kZSI6ImVudGl0bGVtZW50IiwiY29udGVudEFjY2Vzc01v
+        ZGVMaXN0IjoiZW50aXRsZW1lbnQiLCJsYXN0UmVmcmVzaGVkIjpudWxsLCJo
+        cmVmIjoiL293bmVycy9hbHRlcmVkX2h5cGVydmlzb3JfaWRfdGVzdCJ9
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:17 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/owners/altered_hypervisor_id_test
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC", oauth_nonce="84x5Kq6usJyLHRLovSkYFksX6IlwHUXE3RAbIt8O0",
+        oauth_signature="RQGq6oaSOvjPjoPJdWcR9YSZWws%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1555091477", oauth_version="1.0"
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - b7f336e0-8481-4643-aee3-54a997ed9cce
+      X-Version:
+      - 2.6.4-1
+      Date:
+      - Fri, 12 Apr 2019 17:51:17 GMT
+    body:
+      encoding: UTF-8
+      base64_string: ''
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:17 GMT
+- request:
+    method: post
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/owners/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJrZXkiOiJhbHRlcmVkX2h5cGVydmlzb3JfaWRfdGVzdCIsImRpc3BsYXlO
+        YW1lIjoiYWx0ZXJlZF9oeXBlcnZpc29yX2lkX3Rlc3QiLCJjb250ZW50UHJl
+        Zml4IjoiL2FsdGVyZWRfaHlwZXJ2aXNvcl9pZF90ZXN0LyRlbnYifQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC",
+        oauth_nonce="CVxVxVeKD0pDx9FCxo2Rx38SzBlFBiBF812vKGNGv0", oauth_signature="Rdxmz2O5KYY0dTTKwbjGrOc1Iww%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1555091477", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '130'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - c164136b-01c1-4001-8495-a002d048b3d1
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:17 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxNyswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDQtMTJUMTc6NTE6MTcrMDAwMCIsImlkIjoiNDAyOGY5ZmQ2
+        YTEyNDU4OTAxNmExMmFjZDU0YTAwZjMiLCJrZXkiOiJhbHRlcmVkX2h5cGVy
+        dmlzb3JfaWRfdGVzdCIsImRpc3BsYXlOYW1lIjoiYWx0ZXJlZF9oeXBlcnZp
+        c29yX2lkX3Rlc3QiLCJwYXJlbnRPd25lciI6bnVsbCwiY29udGVudFByZWZp
+        eCI6Ii9hbHRlcmVkX2h5cGVydmlzb3JfaWRfdGVzdC8kZW52IiwiZGVmYXVs
+        dFNlcnZpY2VMZXZlbCI6bnVsbCwidXBzdHJlYW1Db25zdW1lciI6bnVsbCwi
+        bG9nTGV2ZWwiOm51bGwsImF1dG9iaW5kRGlzYWJsZWQiOmZhbHNlLCJjb250
+        ZW50QWNjZXNzTW9kZSI6ImVudGl0bGVtZW50IiwiY29udGVudEFjY2Vzc01v
+        ZGVMaXN0IjoiZW50aXRsZW1lbnQiLCJsYXN0UmVmcmVzaGVkIjpudWxsLCJo
+        cmVmIjoiL293bmVycy9hbHRlcmVkX2h5cGVydmlzb3JfaWRfdGVzdCJ9
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:17 GMT
+- request:
+    method: post
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/owners/altered_hypervisor_id_test/environments
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjRhMGEzZjZkNTZhNDI4OWYzYmIwN2U1NzIxY2MzYzdhIiwibmFt
+        ZSI6IkxpYnJhcnkiLCJkZXNjcmlwdGlvbiI6bnVsbH0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC",
+        oauth_nonce="vZNkx3qpyaMmDCzb3UpNepbPrbJQUcG6Qltab77kQmo", oauth_signature="S%2BanhGFLZBPJfysNucCiWqIHxtU%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1555091477", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '77'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 4a3d3e4e-9046-4770-850e-edbdfff280ea
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:17 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxNyswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDQtMTJUMTc6NTE6MTcrMDAwMCIsImlkIjoiNGEwYTNmNmQ1
+        NmE0Mjg5ZjNiYjA3ZTU3MjFjYzNjN2EiLCJuYW1lIjoiTGlicmFyeSIsImRl
+        c2NyaXB0aW9uIjpudWxsLCJvd25lciI6eyJpZCI6IjQwMjhmOWZkNmExMjQ1
+        ODkwMTZhMTJhY2Q1NGEwMGYzIiwia2V5IjoiYWx0ZXJlZF9oeXBlcnZpc29y
+        X2lkX3Rlc3QiLCJkaXNwbGF5TmFtZSI6ImFsdGVyZWRfaHlwZXJ2aXNvcl9p
+        ZF90ZXN0IiwiaHJlZiI6Ii9vd25lcnMvYWx0ZXJlZF9oeXBlcnZpc29yX2lk
+        X3Rlc3QifSwiZW52aXJvbm1lbnRDb250ZW50IjpbXX0=
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/owners/altered_hypervisor_id_test/uebercert
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC", oauth_nonce="oyeAp7hjTeWxvMC5JLvAxxVVTKE24WDYDJEov354E",
+        oauth_signature="7YVoujF9pSZUASpSfo6va5AK%2Fd0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1555091477", oauth_version="1.0"
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 6a25a367-bc6e-4e2b-bc42-b14089d0889b
+      X-Version:
+      - 2.6.4-1
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:17 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJkaXNwbGF5TWVzc2FnZSI6InViZXIgY2VydGlmaWNhdGUgZm9yIG93bmVy
+        IGFsdGVyZWRfaHlwZXJ2aXNvcl9pZF90ZXN0IHdhcyBub3QgZm91bmQuIFBs
+        ZWFzZSBnZW5lcmF0ZSBvbmUuIiwicmVxdWVzdFV1aWQiOiI2YTI1YTM2Ny1i
+        YzZlLTRlMmItYmM0Mi1iMTQwODlkMDg4OWIifQ==
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:17 GMT
+- request:
+    method: post
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/owners/altered_hypervisor_id_test/uebercert
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC",
+        oauth_nonce="H2Y4vhZgBeqEcim4oQdGTCamq84LPwvHJQ4oNIsc4", oauth_signature="mgCPrfelXLtgGaW99AhGoSoBljo%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1555091477", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '2'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 32dabdf0-8275-4c39-9892-d6f508d50712
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:18 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxNyswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDQtMTJUMTc6NTE6MTgrMDAwMCIsImlkIjoiNDAyOGY5ZmQ2
+        YTEyNDU4OTAxNmExMmFjZDg2NzAwZjYiLCJrZXkiOiItLS0tLUJFR0lOIFJT
+        QSBQUklWQVRFIEtFWS0tLS0tXG5NSUlKS1FJQkFBS0NBZ0VBa1orRldzNmpG
+        M09RRys0V05PU0M4UHFLWVBLSFVwOFZlOVM3V2tMbU02YzUwRFRaXG5adjJR
+        L3BkeHNrZjlnSEo1LzBBeFlCOGdia1NNcnNmUnBMVlhNMDFhUUJ4RVgyd1JF
+        Z0xvdi9Ga2NuakNPWXBVXG5YWlp6aWJCZUkxRTZqQkxvT2Eyb1lEOEMwRjhh
+        Ync3TUFyZDZqTHI5TmxyR3QraUowRzhwa0NEZStkUlZDMFdTXG52Q0Mwb1Vh
+        Nk80WVNlSDF5Y1hkNUtNYUNqamdBNEhNT3Z1Ni9vRkVyV1ZYN0EyK3FPb2Yr
+        eitJSmN4SjZEc1IrXG5JRDM3OVZmRisvM3RaNFVxWEVaRUFWbzNMekRGaHpZ
+        WU9HR3RGSEtHV1NyLy9rSUpGQU9zWDRKOE1wQUlXYm5SXG4xU3UvSVZzb2hG
+        MW5KZlNoQ2NXWGJ0dzdmdGVmRmpBZHJBOHZKQVVRcTFRVXNxZGV4emhvZTdy
+        MWk4cGZUNEdhXG55V2ZNek83ZUVnSmxEUGc4bDdsaEgrWUp2MU1JckQ3Z05k
+        a013QjhRTVIrZTJ2WEd1UmZJbDRLSlcyZTk1THJTXG5od01mRjhOTTNsZlNa
+        aTY4L2pMVExVT1RzekFicGZLK0FrT096bG84WkpBTW1QWkR4akt3djE0Uzhq
+        aXZoTXRjXG5Ma1dHTWh6ckdKcHVyQUV5UTErYzl1K2dhS0xIY09XdVd0UVE1
+        clB5M0hPcVMxK0Fmb2JnSUFoLzBtb2pRRExqXG5lOEs1YU9ISEtTbGttN0Zh
+        Y1ltQlppS3BHYXJFYmIySDg5UE84ZHduV1BKNkRTdEJYRCtXbitSNG9PZ3Z5
+        MjVrXG4weTB5eEkyQUpoeHJVejl3ejI2M0U2R1RhS1NKOFYrczlpVmc2MHh2
+        U00wWmJVWUNyM09xa1JESDBta0NBd0VBXG5BUUtDQWdCZlZKWEJUNXIyNUVG
+        SDk0SDBHRkFjSDNmdFpYZnZQNU9aNERiU0xROTBheG51MGxvc0VQMFZuZURo
+        XG5mRDFaRkJnSFlHZXliRTRYd2FwelZQNUtIQ2k4dmZ2Q0VuODBGSlBNUGJs
+        T3htRWlpeWxpNzhxeEJhZ1hVQzBnXG5ZN0czTnoxdFhPRG9PUGZIbnlxMzMz
+        RHdxbHFBdkh5OVU0blpwVkpxOEFxK2ZyWlp5SVh2L2hqRUxZanlOMUg5XG5X
+        NVRGNmlHOFpDRWQ3MjVTV2hsQTFqR21EcmZGNUwxREc0VmF4NFFpRXh0ZHpi
+        U3Y3ejJXWTAzS0g2bk5BQ3ZzXG4vbHVuTkViNTUwbm50TDZCbHlVSWtnSWpE
+        dFoybDA2YUd3dEEwTXdPblNULzFYVW15S0dlMDRXcFRwMHQ0ZlpSXG5TTEFZ
+        NmQ5dWZUcllhVFpOb0N4V0l5T1ptc3NaZzJDQndpbmhEamxZd0RsNWdmblN3
+        Q0VRcWhwdlRwd01rcjJKXG43OEJ2ZVhOdEJFRSt3bEIwdC9sajkxL2ZnWUU5
+        NGprdjk4QS9ZcUJkVDZ3T1BpUUNSZUwxNXcraE5VYmh5SVB4XG4zbWRLR2N4
+        STdJLzNCc3FKUTFNS3JaZ2tQSW5QTEVkeDdGUXF6eHZkVGYwNzh5cFJvdVBm
+        YUxtT3RJSjd5bzBqXG5zNU02VWYxM1NMWndhTW90N1ZBUmE2akdMRnE4cVl3
+        dEtMUGN1R3hRdSt1M0FNOVlhSzdjbGVWWW5QMVovNGZEXG5uZHh3dklqL25G
+        RlYwK3FrNmxUeGljTy94dlBSRTY3RWlQS08vWFVBUDZsZ3lmVVFaWlZZVFFy
+        Q2RGU0JiSENvXG5CUDgxNjl3MnpTN3piY3N1MThFemt5dW8xSGJOQ1JYcEQy
+        aFZEbnBDbHFWTHJVNjdNUUtDQVFFQTNNanA1dGlaXG5TMGhGc256YlJpTWtv
+        THIwTTB2anh1cEJJLzhSU3VSS1l2Y0dsbzRXSTkyRUVBWjVKMVNQQWdzZm9D
+        eDgzRUo4XG42eEErU2VDYmpNOHlOMFQ0Y2lSdjVzRkpRMk55UVRxWEhESDZ3
+        M2NIb1lCNndDSFoyaEVpeXlRNUhsUVhrbGk5XG5namxhbWYwUWVVMUlUMnJQ
+        UHUxU0pVTkR2ckJiam91TDRJRkJGRnIxRStVMjdHeUhURTNoYlJObkF5aFB3
+        a080XG5iNlhLSFlFcTdwQlRPbWZCUFJENDhKTU5LSllVV1prNWN5ZzA2V3FH
+        eFpUNDd0cTQ3RWl5NmsyczE5MzhqZDFNXG4weVZleGdaU2U4SEpkbW5kdjNS
+        V0p5Z0xOM3BNdC9BN2hiQ2xZNEFNMm5ZUkE1bmV2OENsZFN4WUhzRmdpeGwz
+        XG5QdXhOcVpXYkNjNUlWUUtDQVFFQXFObWEyak1LT0pCejM1RUd0eGhGaUlG
+        emhNM0NBV2ovaSt0TDhMM2ZTbTlUXG5xcHRRRFVEc3QxdURZbmVzMG96dzRT
+        NitUTVorbzltZWszSWdKR3hMcytxNFRMcDUzczRNOFAvQkZGTWFPRHZqXG5L
+        cW5DOVltVEZvOHBjZ3lnSlNLbk1hb1puZkEvZHJLc2dYNUM3bWF6YnVheE1H
+        cTc4SjArdkpqZkhRcm9ZNTQyXG5JTGNUL0F0eUErUENsVGQ3ZDFLQ2d1SHBk
+        TFJxa0JjdHh5YVpuT2h4VFJzb0RaYk5mVUlkMmxKWEZyMjcyVWpuXG5oZGpX
+        Mk9WZHF5MHM1ZUtTV2MreThWOU0waXUvNkpNL1VQRmpUa1VEa25ZdVRaZ2dl
+        RC9oQjB0aEdkT3p6WG9BXG5PeVNZelcrWlRxYytnbWM0N3VKb05JU01xY3Jt
+        Y1hKSFVJa3I0WjZGeFFLQ0FRQnkwdnJ5MkF0Qm4rQy9wemZUXG5Ea3ZxVzlE
+        TkxOYlZpTmRBQlZQVkEwMjhrb1NXb0diYldFVnFvRE02UlR2cThDWU9nNVNj
+        YU9mV3lLZmNmRGZwXG56NGhxUGpDSURITTJLNmdTcUJHdjR1emIrUkpWdmYz
+        MS9IL2FsTUJjTFRWUE9ST0x0bWhiOEZMKyt4MG5vUG1FXG5YTEVTdkpYMFFE
+        RE11R0x2TllFb2JXTGQ2OXNRM3cwK3Y2TUU2cHlqRG80QzBHaHV0L1JqTUIw
+        bjA2MStFc05sXG5OeUpSNmN3U0dsV2RxSnpiVXRKYWx0bk9Ea2NXYmhTUmha
+        ekJmSGRZUzZiaFBHeDhDRE5sQkljRCtSZUZIWnlnXG5TSFNpWlFTeW9hcDh5
+        dEtxazZ4NnJUSUhvWXNpYUdKRzY4aUZldXppQlNzSCtYd0s0cjkzR0ZOd0lp
+        MXgyU0M4XG54TS9SQW9JQkFRQ2xmaktpYnFnejdKRkZyTFZ5TzUzYlAxWGo4
+        bStXUmoxQi9HdEFHRG1Fa1R6bDJMaExaVGtlXG5OZG0rWnlIQ2RGV2J2OTdS
+        RFRRT2tEczJ0UUwvOEF6NjJMR3VzbzdFYkJ5UEVYMUMySGk0YVNvc0pKdHJZ
+        VjREXG5IR280MkZzV1NyS29vTm5lelJ6RzBEVDM3ckxYUzEzTzh0ajBaWWl6
+        T3N2RXVlamtaRTZGWlFvVVlweDV5eFlDXG43ZmRIblV1c0ZmakpJM2RYNVlV
+        VW1VTkxFSEE3TkMvb3JSZEN5bTI1dVZYZEtCc250T3NxK3FQQnNsaFIyZTFH
+        XG4yMDVJT3h2S1h5STZKWGY3L3RsbnNQcTc4UHV1T1VKWkNQQTFLVWVaMUxK
+        UUhmZWNBcjBXUmQ5NEdGU1Q5aS9DXG53WFVwQnRic2ZJZzZBVGlGS3ROV21m
+        Vi80QkpjWHEwcEFvSUJBUUNQWWVPZVE5SWxCanpYWFROZzdpZ0tKbXN1XG5x
+        Vk8ydktUZ2F3aStnVm9VMXljL1k2MUhiMVJEYm4wODVnLzZyWDVBNjdUODY5
+        dnQ4dUtuUnhvaEZOeDl2UytRXG5MWVVVSitLYjg1cUJnaG9tVXZLNXlna1FR
+        a1ROMHc0dUhkRGs4SW56SHl6ajRRUWMzdVhnRmpHci9oaVI0NWRsXG5SOE0x
+        VWdXSWtHQ1hVNFlIWUw0NFVRdE02amNxWXNJNDRmNkdsQTdwZ25vbjYzQmNl
+        bVdBMmp3b0hOeUtVTGQ3XG5jSXg0cDlxM0dwZkMvRmtXQTUrUFAvWHU1OU9i
+        SFA3WitHUGw4QXFzdVBGaFA4bVNkNWs5NFFpZjFrTHdTQnROXG56TnBxL0R3
+        ZDdpU2NqRGJiQXU1TStpZ1NKc0VxdFBMQ3h3SzJ5OHZUOFRFd3B4RzRqbXh3
+        K21pUkNYUy9cbi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tXG4iLCJj
+        ZXJ0IjoiLS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tXG5NSUlIbkRDQ0Jv
+        U2dBd0lCQWdJSWJzOHNLcmM1T05Fd0RRWUpLb1pJaHZjTkFRRUxCUUF3Z1lz
+        eEN6QUpCZ05WXG5CQVlUQWxWVE1SY3dGUVlEVlFRSURBNU9iM0owYUNCRFlY
+        SnZiR2x1WVRFUU1BNEdBMVVFQnd3SFVtRnNaV2xuXG5hREVRTUE0R0ExVUVD
+        Z3dIUzJGMFpXeHNiekVVTUJJR0ExVUVDd3dMVTI5dFpVOXlaMVZ1YVhReEtU
+        QW5CZ05WXG5CQU1NSUdObGJuUnZjemN0WkdWMlpXd3VhblIxY21Wc0xtVjRZ
+        VzF3YkdVdVkyOXRNQjRYRFRFNU1EUXhNakUzXG5OVEV4TjFvWERUUTVNVEl3
+        TVRFek1EQXdNRm93SlRFak1DRUdBMVVFQ2d3YVlXeDBaWEpsWkY5b2VYQmxj
+        blpwXG5jMjl5WDJsa1gzUmxjM1F3Z2dJaU1BMEdDU3FHU0liM0RRRUJBUVVB
+        QTRJQ0R3QXdnZ0lLQW9JQ0FRQ1JuNFZhXG56cU1YYzVBYjdoWTA1SUx3K29w
+        ZzhvZFNueFY3MUx0YVF1WXpwem5RTk5sbS9aRCtsM0d5Ui8yQWNubi9RREZn
+        XG5IeUJ1Ukl5dXg5R2t0VmN6VFZwQUhFUmZiQkVTQXVpLzhXUnllTUk1aWxS
+        ZGxuT0pzRjRqVVRxTUV1ZzVyYWhnXG5Qd0xRWHhwdkRzd0N0M3FNdXYwMldz
+        YTM2SW5RYnltUUlONzUxRlVMUlpLOElMU2hScm83aGhKNGZYSnhkM2tvXG54
+        b0tPT0FEZ2N3Nis3citnVVN0WlZmc0RiNm82aC83UDRnbHpFbm9PeEg0Z1Bm
+        djFWOFg3L2UxbmhTcGNSa1FCXG5XamN2TU1XSE5oZzRZYTBVY29aWkt2LytR
+        Z2tVQTZ4Zmdud3lrQWhadWRIVks3OGhXeWlFWFdjbDlLRUp4WmR1XG4zRHQr
+        MTU4V01CMnNEeThrQlJDclZCU3lwMTdIT0doN3V2V0x5bDlQZ1pySlo4ek03
+        dDRTQW1VTStEeVh1V0VmXG41Z20vVXdpc1B1QTEyUXpBSHhBeEg1N2E5Y2E1
+        RjhpWGdvbGJaNzNrdXRLSEF4OFh3MHplVjlKbUxyeitNdE10XG5RNU96TUJ1
+        bDhyNENRNDdPV2p4a2tBeVk5a1BHTXJDL1hoTHlPSytFeTF3dVJZWXlIT3NZ
+        bW02c0FUSkRYNXoyXG43NkJvb3NkdzVhNWExQkRtcy9MY2M2cExYNEIraHVB
+        Z0NIL1NhaU5BTXVON3dybG80Y2NwS1dTYnNWcHhpWUZtXG5JcWtacXNSdHZZ
+        ZnowODd4M0NkWThub05LMEZjUDVhZjVIaWc2Qy9MYm1UVExUTEVqWUFtSEd0
+        VFAzRFBicmNUXG5vWk5vcElueFg2ejJKV0RyVEc5SXpSbHRSZ0t2YzZxUkVN
+        ZlNhUUlEQVFBQm80SURaekNDQTJNd0RnWURWUjBQXG5BUUgvQkFRREFnU3dN
+        Qk1HQTFVZEpRUU1NQW9HQ0NzR0FRVUZCd01DTUFrR0ExVWRFd1FDTUFBd0VR
+        WUpZSVpJXG5BWWI0UWdFQkJBUURBZ1dnTUIwR0ExVWREZ1FXQkJSMkM1MHpO
+        U0FocUtyd1huUmpPUk41Wmg5Q0JUQWZCZ05WXG5IU01FR0RBV2dCUy9LMGZP
+        L2x3cGxGdFpGVDJORW93MzJRbktaVEErQmhBckJnRUVBWklJQ1FHdG9aV3px
+        MWNCXG5CQ29NS0dGc2RHVnlaV1JmYUhsd1pYSjJhWE52Y2w5cFpGOTBaWE4w
+        WDNWbFltVnlYM0J5YjJSMVkzUXdGZ1lRXG5Ld1lCQkFHU0NBa0JyYUdWczZ0
+        WEF3UUNEQUF3RmdZUUt3WUJCQUdTQ0FrQnJhR1ZzNnRYQWdRQ0RBQXdGZ1lR
+        XG5Ld1lCQkFHU0NBa0JyYUdWczZ0WEJRUUNEQUF3R1FZUUt3WUJCQUdTQ0Fr
+        Q3JhR1ZzNnRZQVFRRkRBTjVkVzB3XG5KQVlSS3dZQkJBR1NDQWtDcmFHVnM2
+        dFlBUUVFRHd3TmRXVmlaWEpmWTI5dWRHVnVkREF5QmhFckJnRUVBWklJXG5D
+        UUt0b1pXenExZ0JBZ1FkREJzeE5UVTFNRGt4TkRjM09UYzFYM1ZsWW1WeVgy
+        TnZiblJsYm5Rd0hRWVJLd1lCXG5CQUdTQ0FrQ3JhR1ZzNnRZQVFVRUNBd0dR
+        M1Z6ZEc5dE1ESUdFU3NHQVFRQmtnZ0pBcTJobGJPcldBRUdCQjBNXG5HeTlo
+        YkhSbGNtVmtYMmg1Y0dWeWRtbHpiM0pmYVdSZmRHVnpkREFYQmhFckJnRUVB
+        WklJQ1FLdG9aV3pxMWdCXG5Cd1FDREFBd0dBWVJLd1lCQkFHU0NBa0NyYUdW
+        czZ0WUFRZ0VBd3dCTVRBNEJnb3JCZ0VFQVpJSUNRUUJCQ29NXG5LR0ZzZEdW
+        eVpXUmZhSGx3WlhKMmFYTnZjbDlwWkY5MFpYTjBYM1ZsWW1WeVgzQnliMlIx
+        WTNRd0VBWUtLd1lCXG5CQUdTQ0FrRUFnUUNEQUF3SFFZS0t3WUJCQUdTQ0Fr
+        RUF3UVBEQTB4TlRVMU1Ea3hORGMzT1RjMU1CRUdDaXNHXG5BUVFCa2dnSkJB
+        VUVBd3dCTVRBa0Jnb3JCZ0VFQVpJSUNRUUdCQllNRkRJd01Ua3RNRFF0TVRK
+        VU1UYzZOVEU2XG5NVGRhTUNRR0Npc0dBUVFCa2dnSkJBY0VGZ3dVTWpBME9T
+        MHhNaTB3TVZReE16b3dNRG93TUZvd0VRWUtLd1lCXG5CQUdTQ0FrRURBUURE
+        QUV3TUJBR0Npc0dBUVFCa2dnSkJBb0VBZ3dBTUJBR0Npc0dBUVFCa2dnSkJB
+        MEVBZ3dBXG5NQkVHQ2lzR0FRUUJrZ2dKQkE0RUF3d0JNREFSQmdvckJnRUVB
+        WklJQ1FRTEJBTU1BVEV3TkFZS0t3WUJCQUdTXG5DQWtGQVFRbURDUTJPVEZs
+        WlRJMFpTMDFPV1F4TFRReU5UWXRPV1ppWkMwd1pXRTVNbUUxTWpnMk56VXdE
+        UVlKXG5Lb1pJaHZjTkFRRUxCUUFEZ2dFQkFKWW81cnhCVCtNYTU2dEptdGdN
+        L1JwaVJJRUdDdHljd2c2SVF4cUVPdUhzXG5qVmpRNk9GZlV1TW5iTmZ0TE5K
+        bzFVOTVxVWJUcjVWcGk3bzdjQ0ZyWFRWRnhjd0Z4ZUFjc2RseElYZUowaXRL
+        XG43MGc2R0dWR2gybmp4OG50blgzQWRSZmpOVGVrQjlSMUpSYUZ4YklmcURJ
+        ZlV1Q2VObTJnYmxNSVFjUUdRUEJSXG5PbXBNamxYMFF4ZXliUVJJNHJ0WjFX
+        bzVTa0lHRklqcUo1anlxRzJRNSs5ZHRLS3NrWG9EUHkyVy8vOGxWOEpiXG5I
+        YVNVcXp6amZKMkJQM1pKU2s4TGhnN2NHMjVyRjNrN0xiVmkvRXByNVlCY05m
+        Y1UzQWFEN1p4ajd2TmRRL21GXG5vZFNNVmdrU1RkeWpOTjQ4RzNkdlJDZU1G
+        WUlxUnF4Wk4wUnF2Ujg4VHhNPVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0t
+        LVxuIiwic2VyaWFsIjp7ImNyZWF0ZWQiOiIyMDE5LTA0LTEyVDE3OjUxOjE3
+        KzAwMDAiLCJ1cGRhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxNyswMDAwIiwi
+        aWQiOjc5ODQ2NDkyMjYzMjU0MDc5NTMsInNlcmlhbCI6Nzk4NDY0OTIyNjMy
+        NTQwNzk1MywiZXhwaXJhdGlvbiI6IjIwNDktMTItMDFUMTM6MDA6MDArMDAw
+        MCIsImNvbGxlY3RlZCI6ZmFsc2UsInJldm9rZWQiOmZhbHNlfSwib3duZXIi
+        OnsiaWQiOiI0MDI4ZjlmZDZhMTI0NTg5MDE2YTEyYWNkNTRhMDBmMyIsImtl
+        eSI6ImFsdGVyZWRfaHlwZXJ2aXNvcl9pZF90ZXN0IiwiZGlzcGxheU5hbWUi
+        OiJhbHRlcmVkX2h5cGVydmlzb3JfaWRfdGVzdCIsImhyZWYiOiIvb3duZXJz
+        L2FsdGVyZWRfaHlwZXJ2aXNvcl9pZF90ZXN0In19
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:18 GMT
+- request:
+    method: post
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/hypervisors/altered_hypervisor_id_test
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJoeXBlcnZpc29ycyI6W3siaHlwZXJ2aXNvcklkIjp7Imh5cGVydmlzb3JJ
+        ZCI6IjJlNzhmNjQzLTFkMmYtNDVkMS1iMTkxLWQ5MzExNDdjYmRlMSJ9LCJu
+        YW1lIjoibG9jYWxob3N0IiwiZ3Vlc3RJZHMiOlt7Imd1ZXN0SWQiOiJlZDY2
+        YmIzOS1jZGQ4LTRmYWItYTA2Ni1jZTQ0ZWFhZGI1ZjciLCJzdGF0ZSI6MSwi
+        YXR0cmlidXRlcyI6eyJhY3RpdmUiOjEsInZpcnRXaG9UeXBlIjoiZXN4In19
+        XSwiZmFjdHMiOnsiaHlwZXJ2aXNvci50eXBlIjoiVk13YXJlIEVTWGkiLCJo
+        eXBlcnZpc29yLnZlcnNpb24iOiI2LjAuMCIsImNwdS5jcHVfc29ja2V0KHMp
+        IjoiMSIsImRtaS5zeXN0ZW0udXVpZCI6ImFiY2RlLWZnaGppZ2oifX0seyJo
+        eXBlcnZpc29ySWQiOnsiaHlwZXJ2aXNvcklkIjoiMjYxYzRkY2EtNzAyZi00
+        MmIzLWI4ZWYtMmE3MmI3N2Y3ZWMyIn0sIm5hbWUiOiJkaXN0YW50aG9zdCIs
+        Imd1ZXN0SWRzIjpbeyJndWVzdElkIjoiNDIxMzM3NC1mYzcyLTk2ZTYtZWNk
+        Yi0xM2RhZDRlYiIsInN0YXRlIjoxLCJhdHRyaWJ1dGVzIjp7ImFjdGl2ZSI6
+        MSwidmlydFdob1R5cGUiOiJlc3gifX1dLCJmYWN0cyI6eyJoeXBlcnZpc29y
+        LnR5cGUiOiJWTXdhcmUgRVNYaSIsImh5cGVydmlzb3IudmVyc2lvbiI6IjYu
+        MC4wIiwiY3B1LmNwdV9zb2NrZXQocykiOiIxIn19XSwib3duZXIiOiJhbHRl
+        cmVkX2h5cGVydmlzb3JfaWRfdGVzdCJ9
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC",
+        oauth_nonce="40bzA4FhPfeHWXiuWp8bbkTxT2FM8z5JbZCruzRiXE", oauth_signature="gEWwrhtkovKtSzhM5vX%2BBDRknOs%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1555091478", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - text/plain
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '699'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 9dfa234a-cb36-4dcc-b24e-4334827ea78f
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:18 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxOCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDQtMTJUMTc6NTE6MTgrMDAwMCIsImlkIjoiaHlwZXJ2aXNv
+        cl91cGRhdGVfZjA0M2ViMzktNDUyNi00MTg5LTk0NTQtNzM5YjdlODA5MGIw
+        Iiwic3RhdGUiOiJDUkVBVEVEIiwic3RhcnRUaW1lIjpudWxsLCJmaW5pc2hU
+        aW1lIjpudWxsLCJyZXN1bHQiOm51bGwsInByaW5jaXBhbE5hbWUiOiJmb3Jl
+        bWFuX2FkbWluIiwidGFyZ2V0VHlwZSI6Im93bmVyIiwidGFyZ2V0SWQiOiJh
+        bHRlcmVkX2h5cGVydmlzb3JfaWRfdGVzdCIsIm93bmVySWQiOiJhbHRlcmVk
+        X2h5cGVydmlzb3JfaWRfdGVzdCIsImNvcnJlbGF0aW9uSWQiOm51bGwsInJl
+        c3VsdERhdGEiOm51bGwsImRvbmUiOmZhbHNlLCJzdGF0dXNQYXRoIjoiL2pv
+        YnMvaHlwZXJ2aXNvcl91cGRhdGVfZjA0M2ViMzktNDUyNi00MTg5LTk0NTQt
+        NzM5YjdlODA5MGIwIiwiZ3JvdXAiOiJhc3luYyBncm91cCJ9
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:18 GMT
+- request:
+    method: get
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/jobs/hypervisor_update_f043eb39-4526-4189-9454-739b7e8090b0?result_data=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC", oauth_nonce="naVvtW7VWwdBQPSL4ljF9If9txXNRcldseJVwzGXOg",
+        oauth_signature="qXJXyUjYflTZWa1NaFSEqmhIR%2FA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1555091478", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 46859391-da15-4010-b78a-54ffa9a00416
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:18 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxOCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDQtMTJUMTc6NTE6MTgrMDAwMCIsImlkIjoiaHlwZXJ2aXNv
+        cl91cGRhdGVfZjA0M2ViMzktNDUyNi00MTg5LTk0NTQtNzM5YjdlODA5MGIw
+        Iiwic3RhdGUiOiJGSU5JU0hFRCIsInN0YXJ0VGltZSI6IjIwMTktMDQtMTJU
+        MTc6NTE6MTgrMDAwMCIsImZpbmlzaFRpbWUiOiIyMDE5LTA0LTEyVDE3OjUx
+        OjE4KzAwMDAiLCJyZXN1bHQiOiJDcmVhdGVkOiAyLCBVcGRhdGVkOiAwLCBV
+        bmNoYW5nZWQ6IDAsIEZhaWxlZDogMCIsInByaW5jaXBhbE5hbWUiOiJmb3Jl
+        bWFuX2FkbWluIiwidGFyZ2V0VHlwZSI6Im93bmVyIiwidGFyZ2V0SWQiOiJh
+        bHRlcmVkX2h5cGVydmlzb3JfaWRfdGVzdCIsIm93bmVySWQiOiJhbHRlcmVk
+        X2h5cGVydmlzb3JfaWRfdGVzdCIsImNvcnJlbGF0aW9uSWQiOm51bGwsInJl
+        c3VsdERhdGEiOnsiY3JlYXRlZCI6W3sidXVpZCI6IjIzN2E5ZTNkLTFkOWMt
+        NGRjMy1iZTMyLWUxNDAxNjA2M2MwYiIsIm5hbWUiOiJsb2NhbGhvc3QiLCJv
+        d25lciI6eyJrZXkiOiJhbHRlcmVkX2h5cGVydmlzb3JfaWRfdGVzdCJ9fSx7
+        InV1aWQiOiI3YzUyMjZmZi00ZmVkLTQyYTktODg1My04MmNlMTViYjZhYjki
+        LCJuYW1lIjoiZGlzdGFudGhvc3QiLCJvd25lciI6eyJrZXkiOiJhbHRlcmVk
+        X2h5cGVydmlzb3JfaWRfdGVzdCJ9fV0sInVwZGF0ZWQiOltdLCJ1bmNoYW5n
+        ZWQiOltdLCJmYWlsZWRVcGRhdGUiOltdfSwiZG9uZSI6dHJ1ZSwic3RhdHVz
+        UGF0aCI6Ii9qb2JzL2h5cGVydmlzb3JfdXBkYXRlX2YwNDNlYjM5LTQ1MjYt
+        NDE4OS05NDU0LTczOWI3ZTgwOTBiMCIsImdyb3VwIjoiYXN5bmMgZ3JvdXAi
+        fQ==
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:18 GMT
+- request:
+    method: get
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/consumers/237a9e3d-1d9c-4dc3-be32-e14016063c0b
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC", oauth_nonce="8v1qIADYwPv8aVEG8cRloMurmkN4qKMQ9wcyLfeeyHw",
+        oauth_signature="iYD9upkDNGJN9IMnqrFXvg8XVmk%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1555091478", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 3bca586e-cc9d-4458-9441-27206a8ac381
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:18 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxOCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDQtMTJUMTc6NTE6MTgrMDAwMCIsImlkIjoiNDAyOGY5ZmQ2
+        YTEyNDU4OTAxNmExMmFjZDhkOTAwZmEiLCJ1dWlkIjoiMjM3YTllM2QtMWQ5
+        Yy00ZGMzLWJlMzItZTE0MDE2MDYzYzBiIiwibmFtZSI6ImxvY2FsaG9zdCIs
+        InVzZXJuYW1lIjoiZm9yZW1hbl9hZG1pbiIsImVudGl0bGVtZW50U3RhdHVz
+        IjpudWxsLCJzZXJ2aWNlTGV2ZWwiOiIiLCJyb2xlIjpudWxsLCJ1c2FnZSI6
+        bnVsbCwiYWRkT25zIjpbXSwic3lzdGVtUHVycG9zZVN0YXR1cyI6bnVsbCwi
+        b3duZXIiOnsiaWQiOiI0MDI4ZjlmZDZhMTI0NTg5MDE2YTEyYWNkNTRhMDBm
+        MyIsImtleSI6ImFsdGVyZWRfaHlwZXJ2aXNvcl9pZF90ZXN0IiwiZGlzcGxh
+        eU5hbWUiOiJhbHRlcmVkX2h5cGVydmlzb3JfaWRfdGVzdCIsImhyZWYiOiIv
+        b3duZXJzL2FsdGVyZWRfaHlwZXJ2aXNvcl9pZF90ZXN0In0sImVudmlyb25t
+        ZW50IjpudWxsLCJlbnRpdGxlbWVudENvdW50IjowLCJmYWN0cyI6eyJoeXBl
+        cnZpc29yLnR5cGUiOiJWTXdhcmUgRVNYaSIsImNwdS5jcHVfc29ja2V0KHMp
+        IjoiMSIsImRtaS5zeXN0ZW0udXVpZCI6ImFiY2RlLWZnaGppZ2oiLCJoeXBl
+        cnZpc29yLnZlcnNpb24iOiI2LjAuMCJ9LCJsYXN0Q2hlY2tpbiI6IjIwMTkt
+        MDQtMTJUMTc6NTE6MTgrMDAwMCIsImluc3RhbGxlZFByb2R1Y3RzIjpbXSwi
+        Y2FuQWN0aXZhdGUiOmZhbHNlLCJjYXBhYmlsaXRpZXMiOltdLCJoeXBlcnZp
+        c29ySWQiOnsiY3JlYXRlZCI6IjIwMTktMDQtMTJUMTc6NTE6MTgrMDAwMCIs
+        InVwZGF0ZWQiOiIyMDE5LTA0LTEyVDE3OjUxOjE4KzAwMDAiLCJpZCI6IjQw
+        MjhmOWZkNmExMjQ1ODkwMTZhMTJhY2Q4ZDkwMGZjIiwiaHlwZXJ2aXNvcklk
+        IjoiMmU3OGY2NDMtMWQyZi00NWQxLWIxOTEtZDkzMTE0N2NiZGUxIiwicmVw
+        b3J0ZXJJZCI6bnVsbH0sImNvbnRlbnRUYWdzIjpbXSwiYXV0b2hlYWwiOnRy
+        dWUsImFubm90YXRpb25zIjpudWxsLCJjb250ZW50QWNjZXNzTW9kZSI6bnVs
+        bCwidHlwZSI6eyJpZCI6IjEwMDQiLCJsYWJlbCI6Imh5cGVydmlzb3IiLCJt
+        YW5pZmVzdCI6ZmFsc2V9LCJndWVzdElkcyI6W10sImhyZWYiOiIvY29uc3Vt
+        ZXJzLzIzN2E5ZTNkLTFkOWMtNGRjMy1iZTMyLWUxNDAxNjA2M2MwYiIsInJl
+        bGVhc2VWZXIiOnsicmVsZWFzZVZlciI6bnVsbH0sImlkQ2VydCI6bnVsbH0=
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:18 GMT
+- request:
+    method: get
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/consumers/7c5226ff-4fed-42a9-8853-82ce15bb6ab9
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC", oauth_nonce="nWFdaxBuDcpijvww5zOjCru3zUJM7JHWPNlxVOPj8",
+        oauth_signature="UNNdY0a72GtVVOK%2BRrUhQl8NmTw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1555091478", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - c33a05a7-08bd-41eb-b7dd-861ee2976157
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:18 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxOCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDQtMTJUMTc6NTE6MTgrMDAwMCIsImlkIjoiNDAyOGY5ZmQ2
+        YTEyNDU4OTAxNmExMmFjZDhkOTAwZjciLCJ1dWlkIjoiN2M1MjI2ZmYtNGZl
+        ZC00MmE5LTg4NTMtODJjZTE1YmI2YWI5IiwibmFtZSI6ImRpc3RhbnRob3N0
+        IiwidXNlcm5hbWUiOiJmb3JlbWFuX2FkbWluIiwiZW50aXRsZW1lbnRTdGF0
+        dXMiOm51bGwsInNlcnZpY2VMZXZlbCI6IiIsInJvbGUiOm51bGwsInVzYWdl
+        IjpudWxsLCJhZGRPbnMiOltdLCJzeXN0ZW1QdXJwb3NlU3RhdHVzIjpudWxs
+        LCJvd25lciI6eyJpZCI6IjQwMjhmOWZkNmExMjQ1ODkwMTZhMTJhY2Q1NGEw
+        MGYzIiwia2V5IjoiYWx0ZXJlZF9oeXBlcnZpc29yX2lkX3Rlc3QiLCJkaXNw
+        bGF5TmFtZSI6ImFsdGVyZWRfaHlwZXJ2aXNvcl9pZF90ZXN0IiwiaHJlZiI6
+        Ii9vd25lcnMvYWx0ZXJlZF9oeXBlcnZpc29yX2lkX3Rlc3QifSwiZW52aXJv
+        bm1lbnQiOm51bGwsImVudGl0bGVtZW50Q291bnQiOjAsImZhY3RzIjp7Imh5
+        cGVydmlzb3IudHlwZSI6IlZNd2FyZSBFU1hpIiwiY3B1LmNwdV9zb2NrZXQo
+        cykiOiIxIiwiaHlwZXJ2aXNvci52ZXJzaW9uIjoiNi4wLjAifSwibGFzdENo
+        ZWNraW4iOiIyMDE5LTA0LTEyVDE3OjUxOjE4KzAwMDAiLCJpbnN0YWxsZWRQ
+        cm9kdWN0cyI6W10sImNhbkFjdGl2YXRlIjpmYWxzZSwiY2FwYWJpbGl0aWVz
+        IjpbXSwiaHlwZXJ2aXNvcklkIjp7ImNyZWF0ZWQiOiIyMDE5LTA0LTEyVDE3
+        OjUxOjE4KzAwMDAiLCJ1cGRhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxOCsw
+        MDAwIiwiaWQiOiI0MDI4ZjlmZDZhMTI0NTg5MDE2YTEyYWNkOGQ5MDBmOSIs
+        Imh5cGVydmlzb3JJZCI6IjI2MWM0ZGNhLTcwMmYtNDJiMy1iOGVmLTJhNzJi
+        NzdmN2VjMiIsInJlcG9ydGVySWQiOm51bGx9LCJjb250ZW50VGFncyI6W10s
+        ImF1dG9oZWFsIjp0cnVlLCJhbm5vdGF0aW9ucyI6bnVsbCwiY29udGVudEFj
+        Y2Vzc01vZGUiOm51bGwsInR5cGUiOnsiaWQiOiIxMDA0IiwibGFiZWwiOiJo
+        eXBlcnZpc29yIiwibWFuaWZlc3QiOmZhbHNlfSwiZ3Vlc3RJZHMiOltdLCJo
+        cmVmIjoiL2NvbnN1bWVycy83YzUyMjZmZi00ZmVkLTQyYTktODg1My04MmNl
+        MTViYjZhYjkiLCJyZWxlYXNlVmVyIjp7InJlbGVhc2VWZXIiOm51bGx9LCJp
+        ZENlcnQiOm51bGx9
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:18 GMT
+- request:
+    method: get
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/consumers/237a9e3d-1d9c-4dc3-be32-e14016063c0b/guests
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC", oauth_nonce="ERFPmxUl6dXBLqHHL3JkFBQpE1szHwFwUpfxhmrA",
+        oauth_signature="JjdhJ67ZKDYPl%2FQ0g61CmIJLtIs%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1555091479", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 23926238-edb6-45de-9fb4-7e6c53543c7b
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:18 GMT
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:19 GMT
+- request:
+    method: get
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/consumers/7c5226ff-4fed-42a9-8853-82ce15bb6ab9/guests
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC", oauth_nonce="ypyK1FzAUKm3ssC7y0u0PhgkZxWpbe83EGzdv03h2c",
+        oauth_signature="Ix1S%2BnggEo4yrcvn%2F8tWXJDib0M%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1555091479", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 16b5ee61-072d-49ba-b49f-67c68f49540e
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:18 GMT
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:19 GMT
+- request:
+    method: post
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/hypervisors/altered_hypervisor_id_test
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJoeXBlcnZpc29ycyI6W3siaHlwZXJ2aXNvcklkIjp7Imh5cGVydmlzb3JJ
+        ZCI6Im1vcmVfdXNlZnVsX2lkZW50aWZpZXIifSwibmFtZSI6ImxvY2FsaG9z
+        dCIsImd1ZXN0SWRzIjpbeyJndWVzdElkIjoiZWQ2NmJiMzktY2RkOC00ZmFi
+        LWEwNjYtY2U0NGVhYWRiNWY3Iiwic3RhdGUiOjEsImF0dHJpYnV0ZXMiOnsi
+        YWN0aXZlIjoxLCJ2aXJ0V2hvVHlwZSI6ImVzeCJ9fV0sImZhY3RzIjp7Imh5
+        cGVydmlzb3IudHlwZSI6IlZNd2FyZSBFU1hpIiwiaHlwZXJ2aXNvci52ZXJz
+        aW9uIjoiNi4wLjAiLCJjcHUuY3B1X3NvY2tldChzKSI6IjEiLCJkbWkuc3lz
+        dGVtLnV1aWQiOiJhYmNkZS1mZ2hqaWdqIn19LHsiaHlwZXJ2aXNvcklkIjp7
+        Imh5cGVydmlzb3JJZCI6IjI2MWM0ZGNhLTcwMmYtNDJiMy1iOGVmLTJhNzJi
+        NzdmN2VjMiJ9LCJuYW1lIjoiZGlzdGFudGhvc3QiLCJndWVzdElkcyI6W3si
+        Z3Vlc3RJZCI6IjQyMTMzNzQtZmM3Mi05NmU2LWVjZGItMTNkYWQ0ZWIiLCJz
+        dGF0ZSI6MSwiYXR0cmlidXRlcyI6eyJhY3RpdmUiOjEsInZpcnRXaG9UeXBl
+        IjoiZXN4In19XSwiZmFjdHMiOnsiaHlwZXJ2aXNvci50eXBlIjoiVk13YXJl
+        IEVTWGkiLCJoeXBlcnZpc29yLnZlcnNpb24iOiI2LjAuMCIsImNwdS5jcHVf
+        c29ja2V0KHMpIjoiMSJ9fV0sIm93bmVyIjoiYWx0ZXJlZF9oeXBlcnZpc29y
+        X2lkX3Rlc3QifQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC",
+        oauth_nonce="Easkt6YQRT2O6Zm3xsrQmFIKCFvsGnEBR650fmoxiI", oauth_signature="smBmCjn9rc6efNsWbJM%2B4kgolZQ%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1555091479", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - text/plain
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '685'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 9ade62ad-80bb-4340-a461-a926539b1286
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:18 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxOSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDQtMTJUMTc6NTE6MTkrMDAwMCIsImlkIjoiaHlwZXJ2aXNv
+        cl91cGRhdGVfMjdkMjFlOGQtM2YyYS00MWQzLThhY2MtNTA3NGFhMGVlNWRh
+        Iiwic3RhdGUiOiJDUkVBVEVEIiwic3RhcnRUaW1lIjpudWxsLCJmaW5pc2hU
+        aW1lIjpudWxsLCJyZXN1bHQiOm51bGwsInByaW5jaXBhbE5hbWUiOiJmb3Jl
+        bWFuX2FkbWluIiwidGFyZ2V0VHlwZSI6Im93bmVyIiwidGFyZ2V0SWQiOiJh
+        bHRlcmVkX2h5cGVydmlzb3JfaWRfdGVzdCIsIm93bmVySWQiOiJhbHRlcmVk
+        X2h5cGVydmlzb3JfaWRfdGVzdCIsImNvcnJlbGF0aW9uSWQiOm51bGwsInJl
+        c3VsdERhdGEiOm51bGwsImRvbmUiOmZhbHNlLCJzdGF0dXNQYXRoIjoiL2pv
+        YnMvaHlwZXJ2aXNvcl91cGRhdGVfMjdkMjFlOGQtM2YyYS00MWQzLThhY2Mt
+        NTA3NGFhMGVlNWRhIiwiZ3JvdXAiOiJhc3luYyBncm91cCJ9
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:19 GMT
+- request:
+    method: get
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/jobs/hypervisor_update_27d21e8d-3f2a-41d3-8acc-5074aa0ee5da?result_data=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC", oauth_nonce="GkW39BgIpLGy76tehrDbhHr0TakwlkZWckM7TYMZ8I",
+        oauth_signature="%2BjGEsMfr5sGfs3ouyYbxl2YdpLg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1555091479", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - ae70f307-1db8-4c22-8aa8-52eea53d6950
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:18 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxOSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDQtMTJUMTc6NTE6MTkrMDAwMCIsImlkIjoiaHlwZXJ2aXNv
+        cl91cGRhdGVfMjdkMjFlOGQtM2YyYS00MWQzLThhY2MtNTA3NGFhMGVlNWRh
+        Iiwic3RhdGUiOiJGSU5JU0hFRCIsInN0YXJ0VGltZSI6IjIwMTktMDQtMTJU
+        MTc6NTE6MTkrMDAwMCIsImZpbmlzaFRpbWUiOiIyMDE5LTA0LTEyVDE3OjUx
+        OjE5KzAwMDAiLCJyZXN1bHQiOiJDcmVhdGVkOiAwLCBVcGRhdGVkOiAxLCBV
+        bmNoYW5nZWQ6IDEsIEZhaWxlZDogMCIsInByaW5jaXBhbE5hbWUiOiJmb3Jl
+        bWFuX2FkbWluIiwidGFyZ2V0VHlwZSI6Im93bmVyIiwidGFyZ2V0SWQiOiJh
+        bHRlcmVkX2h5cGVydmlzb3JfaWRfdGVzdCIsIm93bmVySWQiOiJhbHRlcmVk
+        X2h5cGVydmlzb3JfaWRfdGVzdCIsImNvcnJlbGF0aW9uSWQiOm51bGwsInJl
+        c3VsdERhdGEiOnsiY3JlYXRlZCI6W10sInVwZGF0ZWQiOlt7InV1aWQiOiIy
+        MzdhOWUzZC0xZDljLTRkYzMtYmUzMi1lMTQwMTYwNjNjMGIiLCJuYW1lIjoi
+        bG9jYWxob3N0Iiwib3duZXIiOnsia2V5IjoiYWx0ZXJlZF9oeXBlcnZpc29y
+        X2lkX3Rlc3QifX1dLCJ1bmNoYW5nZWQiOlt7InV1aWQiOiI3YzUyMjZmZi00
+        ZmVkLTQyYTktODg1My04MmNlMTViYjZhYjkiLCJuYW1lIjoiZGlzdGFudGhv
+        c3QiLCJvd25lciI6eyJrZXkiOiJhbHRlcmVkX2h5cGVydmlzb3JfaWRfdGVz
+        dCJ9fV0sImZhaWxlZFVwZGF0ZSI6W119LCJkb25lIjp0cnVlLCJzdGF0dXNQ
+        YXRoIjoiL2pvYnMvaHlwZXJ2aXNvcl91cGRhdGVfMjdkMjFlOGQtM2YyYS00
+        MWQzLThhY2MtNTA3NGFhMGVlNWRhIiwiZ3JvdXAiOiJhc3luYyBncm91cCJ9
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:19 GMT
+- request:
+    method: get
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/consumers/237a9e3d-1d9c-4dc3-be32-e14016063c0b
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC", oauth_nonce="69LVottNIqz32tpvNEfBGagiQ781yM5my7ppzmP0A",
+        oauth_signature="B67z%2FQKonZicQBIHUArD5OsH9GA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1555091479", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 94fa4b6c-9db7-4674-973b-caee88d26cb8
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:18 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxOCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDQtMTJUMTc6NTE6MTkrMDAwMCIsImlkIjoiNDAyOGY5ZmQ2
+        YTEyNDU4OTAxNmExMmFjZDhkOTAwZmEiLCJ1dWlkIjoiMjM3YTllM2QtMWQ5
+        Yy00ZGMzLWJlMzItZTE0MDE2MDYzYzBiIiwibmFtZSI6ImxvY2FsaG9zdCIs
+        InVzZXJuYW1lIjoiZm9yZW1hbl9hZG1pbiIsImVudGl0bGVtZW50U3RhdHVz
+        IjpudWxsLCJzZXJ2aWNlTGV2ZWwiOiIiLCJyb2xlIjpudWxsLCJ1c2FnZSI6
+        bnVsbCwiYWRkT25zIjpbXSwic3lzdGVtUHVycG9zZVN0YXR1cyI6bnVsbCwi
+        b3duZXIiOnsiaWQiOiI0MDI4ZjlmZDZhMTI0NTg5MDE2YTEyYWNkNTRhMDBm
+        MyIsImtleSI6ImFsdGVyZWRfaHlwZXJ2aXNvcl9pZF90ZXN0IiwiZGlzcGxh
+        eU5hbWUiOiJhbHRlcmVkX2h5cGVydmlzb3JfaWRfdGVzdCIsImhyZWYiOiIv
+        b3duZXJzL2FsdGVyZWRfaHlwZXJ2aXNvcl9pZF90ZXN0In0sImVudmlyb25t
+        ZW50IjpudWxsLCJlbnRpdGxlbWVudENvdW50IjowLCJmYWN0cyI6eyJoeXBl
+        cnZpc29yLnR5cGUiOiJWTXdhcmUgRVNYaSIsImNwdS5jcHVfc29ja2V0KHMp
+        IjoiMSIsImRtaS5zeXN0ZW0udXVpZCI6ImFiY2RlLWZnaGppZ2oiLCJoeXBl
+        cnZpc29yLnZlcnNpb24iOiI2LjAuMCJ9LCJsYXN0Q2hlY2tpbiI6IjIwMTkt
+        MDQtMTJUMTc6NTE6MTkrMDAwMCIsImluc3RhbGxlZFByb2R1Y3RzIjpbXSwi
+        Y2FuQWN0aXZhdGUiOmZhbHNlLCJjYXBhYmlsaXRpZXMiOltdLCJoeXBlcnZp
+        c29ySWQiOnsiY3JlYXRlZCI6IjIwMTktMDQtMTJUMTc6NTE6MTgrMDAwMCIs
+        InVwZGF0ZWQiOiIyMDE5LTA0LTEyVDE3OjUxOjE5KzAwMDAiLCJpZCI6IjQw
+        MjhmOWZkNmExMjQ1ODkwMTZhMTJhY2Q4ZDkwMGZjIiwiaHlwZXJ2aXNvcklk
+        IjoibW9yZV91c2VmdWxfaWRlbnRpZmllciIsInJlcG9ydGVySWQiOm51bGx9
+        LCJjb250ZW50VGFncyI6W10sImF1dG9oZWFsIjp0cnVlLCJhbm5vdGF0aW9u
+        cyI6bnVsbCwiY29udGVudEFjY2Vzc01vZGUiOm51bGwsInR5cGUiOnsiaWQi
+        OiIxMDA0IiwibGFiZWwiOiJoeXBlcnZpc29yIiwibWFuaWZlc3QiOmZhbHNl
+        fSwiZ3Vlc3RJZHMiOltdLCJocmVmIjoiL2NvbnN1bWVycy8yMzdhOWUzZC0x
+        ZDljLTRkYzMtYmUzMi1lMTQwMTYwNjNjMGIiLCJyZWxlYXNlVmVyIjp7InJl
+        bGVhc2VWZXIiOm51bGx9LCJpZENlcnQiOm51bGx9
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:19 GMT
+- request:
+    method: get
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/consumers/7c5226ff-4fed-42a9-8853-82ce15bb6ab9
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC", oauth_nonce="3R9efFUiEkGzTKuQSsOlG7PuqubjpUwpnmb9GaIVHjc",
+        oauth_signature="xo0DYu%2Bgp7R6J0D68iiaMZrpTLM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1555091479", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 3f02a53a-962c-4a74-9ed2-0b6ad65fe66d
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:18 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxOCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDQtMTJUMTc6NTE6MTkrMDAwMCIsImlkIjoiNDAyOGY5ZmQ2
+        YTEyNDU4OTAxNmExMmFjZDhkOTAwZjciLCJ1dWlkIjoiN2M1MjI2ZmYtNGZl
+        ZC00MmE5LTg4NTMtODJjZTE1YmI2YWI5IiwibmFtZSI6ImRpc3RhbnRob3N0
+        IiwidXNlcm5hbWUiOiJmb3JlbWFuX2FkbWluIiwiZW50aXRsZW1lbnRTdGF0
+        dXMiOm51bGwsInNlcnZpY2VMZXZlbCI6IiIsInJvbGUiOm51bGwsInVzYWdl
+        IjpudWxsLCJhZGRPbnMiOltdLCJzeXN0ZW1QdXJwb3NlU3RhdHVzIjpudWxs
+        LCJvd25lciI6eyJpZCI6IjQwMjhmOWZkNmExMjQ1ODkwMTZhMTJhY2Q1NGEw
+        MGYzIiwia2V5IjoiYWx0ZXJlZF9oeXBlcnZpc29yX2lkX3Rlc3QiLCJkaXNw
+        bGF5TmFtZSI6ImFsdGVyZWRfaHlwZXJ2aXNvcl9pZF90ZXN0IiwiaHJlZiI6
+        Ii9vd25lcnMvYWx0ZXJlZF9oeXBlcnZpc29yX2lkX3Rlc3QifSwiZW52aXJv
+        bm1lbnQiOm51bGwsImVudGl0bGVtZW50Q291bnQiOjAsImZhY3RzIjp7Imh5
+        cGVydmlzb3IudHlwZSI6IlZNd2FyZSBFU1hpIiwiY3B1LmNwdV9zb2NrZXQo
+        cykiOiIxIiwiaHlwZXJ2aXNvci52ZXJzaW9uIjoiNi4wLjAifSwibGFzdENo
+        ZWNraW4iOiIyMDE5LTA0LTEyVDE3OjUxOjE4KzAwMDAiLCJpbnN0YWxsZWRQ
+        cm9kdWN0cyI6W10sImNhbkFjdGl2YXRlIjpmYWxzZSwiY2FwYWJpbGl0aWVz
+        IjpbXSwiaHlwZXJ2aXNvcklkIjp7ImNyZWF0ZWQiOiIyMDE5LTA0LTEyVDE3
+        OjUxOjE4KzAwMDAiLCJ1cGRhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxOCsw
+        MDAwIiwiaWQiOiI0MDI4ZjlmZDZhMTI0NTg5MDE2YTEyYWNkOGQ5MDBmOSIs
+        Imh5cGVydmlzb3JJZCI6IjI2MWM0ZGNhLTcwMmYtNDJiMy1iOGVmLTJhNzJi
+        NzdmN2VjMiIsInJlcG9ydGVySWQiOm51bGx9LCJjb250ZW50VGFncyI6W10s
+        ImF1dG9oZWFsIjp0cnVlLCJhbm5vdGF0aW9ucyI6bnVsbCwiY29udGVudEFj
+        Y2Vzc01vZGUiOm51bGwsInR5cGUiOnsiaWQiOiIxMDA0IiwibGFiZWwiOiJo
+        eXBlcnZpc29yIiwibWFuaWZlc3QiOmZhbHNlfSwiZ3Vlc3RJZHMiOltdLCJo
+        cmVmIjoiL2NvbnN1bWVycy83YzUyMjZmZi00ZmVkLTQyYTktODg1My04MmNl
+        MTViYjZhYjkiLCJyZWxlYXNlVmVyIjp7InJlbGVhc2VWZXIiOm51bGx9LCJp
+        ZENlcnQiOm51bGx9
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:19 GMT
+- request:
+    method: get
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/consumers/237a9e3d-1d9c-4dc3-be32-e14016063c0b/guests
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC", oauth_nonce="nhG2YnbNV47P6wVtUGzL1Rkuhpj1dbEc7oE26l7IY",
+        oauth_signature="qVS9f5uPEr9SJiIE4kTaMY6egfs%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1555091479", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - a184c68d-035a-428b-8f3e-5c51bc46a590
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:18 GMT
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:19 GMT
+- request:
+    method: get
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/consumers/7c5226ff-4fed-42a9-8853-82ce15bb6ab9/guests
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC", oauth_nonce="RHi9tsEQvNF60sxLEHfbbsHIArCzwJd70cXqXWxI",
+        oauth_signature="ReWFrvhlu1hxPRlAEcJaLXxlaIE%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1555091479", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - b3eb2f88-891e-4a9d-abc8-fe89a656c83d
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:18 GMT
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:19 GMT
+- request:
+    method: get
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/consumers/?include=uuid&owner=altered_hypervisor_id_test&page=1&per_page=1000
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC", oauth_nonce="3zYWJ06tVPZJtgfSFG3syJPcNYcUedLuMOIdPgleYTY",
+        oauth_signature="bzwbfhCvsefhqlWCWXSuZbERfjc%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1555091479", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 1c7f2407-7bb3-4cbc-b786-09a8cd6ae864
+      Link:
+      - <https://localhost:8443/candlepin/consumers/?owner=altered_hypervisor_id_test&include=uuid&per_page=1000&page=1&owner=altered_hypervisor_id_test&include=uuid&per_page=1000&page=1>;
+        rel="first", <https://localhost:8443/candlepin/consumers/?owner=altered_hypervisor_id_test&include=uuid&per_page=1000&page=1&owner=altered_hypervisor_id_test&include=uuid&per_page=1000&page=1>;
+        rel="last"
+      X-Total-Count:
+      - '2'
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:19 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        W3sidXVpZCI6IjIzN2E5ZTNkLTFkOWMtNGRjMy1iZTMyLWUxNDAxNjA2M2Mw
+        YiJ9LHsidXVpZCI6IjdjNTIyNmZmLTRmZWQtNDJhOS04ODUzLTgyY2UxNWJi
+        NmFiOSJ9XQ==
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:19 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/host/hypervisors_vcr/duplicate_hostname.yml
+++ b/test/fixtures/vcr_cassettes/katello/host/hypervisors_vcr/duplicate_hostname.yml
@@ -2,483 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel.balmora.example.com:8443/candlepin/owners/duplicate_hostname_test
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Authorization:
-      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="JhAMBl0l3KWCQ3No4bLNKcunPICNtD2j3lcbRppXHS4",
-        oauth_signature="ZKb0aiD04vEKmS6inFBnFjfK7pU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1552666704", oauth_version="1.0"
-      Cp-User:
-      - foreman_admin
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 7efbd75a-f079-45ed-ab28-216c85c801cb
-      X-Version:
-      - 2.5.7-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Fri, 15 Mar 2019 16:18:24 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wMy0xNVQxNjoxMjo1MCswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDMtMTVUMTY6MTI6NTArMDAwMCIsImlkIjoiNDAyOGY5Zjc2
-        OTZhN2VmZjAxNjk4MjIwYTEwYTAxM2YiLCJrZXkiOiJkdXBsaWNhdGVfaG9z
-        dG5hbWVfdGVzdCIsImRpc3BsYXlOYW1lIjoiZHVwbGljYXRlX2hvc3RuYW1l
-        X3Rlc3QiLCJwYXJlbnRPd25lciI6bnVsbCwiY29udGVudFByZWZpeCI6Ii9k
-        dXBsaWNhdGVfaG9zdG5hbWVfdGVzdC8kZW52IiwiZGVmYXVsdFNlcnZpY2VM
-        ZXZlbCI6bnVsbCwidXBzdHJlYW1Db25zdW1lciI6bnVsbCwibG9nTGV2ZWwi
-        Om51bGwsImF1dG9iaW5kRGlzYWJsZWQiOmZhbHNlLCJjb250ZW50QWNjZXNz
-        TW9kZSI6ImVudGl0bGVtZW50IiwiY29udGVudEFjY2Vzc01vZGVMaXN0Ijoi
-        ZW50aXRsZW1lbnQiLCJsYXN0UmVmcmVzaGVkIjpudWxsLCJocmVmIjoiL293
-        bmVycy9kdXBsaWNhdGVfaG9zdG5hbWVfdGVzdCJ9
-    http_version: 
-  recorded_at: Fri, 15 Mar 2019 16:18:24 GMT
-- request:
-    method: delete
-    uri: https://devel.balmora.example.com:8443/candlepin/owners/duplicate_hostname_test
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Authorization:
-      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="6Lt8x3uT89a75tMvb27kRog5czrz2o4ZWb5u9j8xCYU",
-        oauth_signature="5ac%2Bo9qB8T9D1ILNH3WWy6QKB1s%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1552666704", oauth_version="1.0"
-      Cp-User:
-      - foreman_admin
-  response:
-    status:
-      code: 204
-      message: No Content
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 5d7cc2e2-386f-4363-9197-1e39ecf0f7b3
-      X-Version:
-      - 2.5.7-1
-      Date:
-      - Fri, 15 Mar 2019 16:18:24 GMT
-    body:
-      encoding: UTF-8
-      base64_string: ''
-    http_version: 
-  recorded_at: Fri, 15 Mar 2019 16:18:24 GMT
-- request:
-    method: post
-    uri: https://devel.balmora.example.com:8443/candlepin/owners/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJrZXkiOiJkdXBsaWNhdGVfaG9zdG5hbWVfdGVzdCIsImRpc3BsYXlOYW1l
-        IjoiZHVwbGljYXRlX2hvc3RuYW1lX3Rlc3QiLCJjb250ZW50UHJlZml4Ijoi
-        L2R1cGxpY2F0ZV9ob3N0bmFtZV90ZXN0LyRlbnYifQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD",
-        oauth_nonce="xxOAolG8FcstMiT9HoBAfSsSy1fuJrifxxwdnQao", oauth_signature="uk9bz%2BDjRbew%2FYzXKWTRGGL0VcY%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1552666705", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-      Content-Length:
-      - '121'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 2f13fe5f-886a-4146-a1a8-7fb1706d7afb
-      X-Version:
-      - 2.5.7-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Fri, 15 Mar 2019 16:18:24 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wMy0xNVQxNjoxODoyNSswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDMtMTVUMTY6MTg6MjUrMDAwMCIsImlkIjoiNDAyOGY5Zjc2
-        OTZhN2VmZjAxNjk4MjI1YmQ0MTAxNGMiLCJrZXkiOiJkdXBsaWNhdGVfaG9z
-        dG5hbWVfdGVzdCIsImRpc3BsYXlOYW1lIjoiZHVwbGljYXRlX2hvc3RuYW1l
-        X3Rlc3QiLCJwYXJlbnRPd25lciI6bnVsbCwiY29udGVudFByZWZpeCI6Ii9k
-        dXBsaWNhdGVfaG9zdG5hbWVfdGVzdC8kZW52IiwiZGVmYXVsdFNlcnZpY2VM
-        ZXZlbCI6bnVsbCwidXBzdHJlYW1Db25zdW1lciI6bnVsbCwibG9nTGV2ZWwi
-        Om51bGwsImF1dG9iaW5kRGlzYWJsZWQiOmZhbHNlLCJjb250ZW50QWNjZXNz
-        TW9kZSI6ImVudGl0bGVtZW50IiwiY29udGVudEFjY2Vzc01vZGVMaXN0Ijoi
-        ZW50aXRsZW1lbnQiLCJsYXN0UmVmcmVzaGVkIjpudWxsLCJocmVmIjoiL293
-        bmVycy9kdXBsaWNhdGVfaG9zdG5hbWVfdGVzdCJ9
-    http_version: 
-  recorded_at: Fri, 15 Mar 2019 16:18:25 GMT
-- request:
-    method: post
-    uri: https://devel.balmora.example.com:8443/candlepin/owners/duplicate_hostname_test/environments
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6ImU2ZWI3Nzk1NzUxNTZmYjdkYmFmYTIyMmUxNTFkOGE3IiwibmFt
-        ZSI6IkxpYnJhcnkiLCJkZXNjcmlwdGlvbiI6bnVsbH0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD",
-        oauth_nonce="9h6Y9dKSl39SXVCp6JCPCas8cZXTjBKgYeDM6Zbo", oauth_signature="scci328fVis6XV67i6prZV0HeE4%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1552666705", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-      Content-Length:
-      - '77'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 9af3230c-627f-43e4-8c3f-4a635233691d
-      X-Version:
-      - 2.5.7-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Fri, 15 Mar 2019 16:18:24 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wMy0xNVQxNjoxODoyNSswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDMtMTVUMTY6MTg6MjUrMDAwMCIsImlkIjoiZTZlYjc3OTU3
-        NTE1NmZiN2RiYWZhMjIyZTE1MWQ4YTciLCJuYW1lIjoiTGlicmFyeSIsImRl
-        c2NyaXB0aW9uIjpudWxsLCJvd25lciI6eyJpZCI6IjQwMjhmOWY3Njk2YTdl
-        ZmYwMTY5ODIyNWJkNDEwMTRjIiwia2V5IjoiZHVwbGljYXRlX2hvc3RuYW1l
-        X3Rlc3QiLCJkaXNwbGF5TmFtZSI6ImR1cGxpY2F0ZV9ob3N0bmFtZV90ZXN0
-        IiwiaHJlZiI6Ii9vd25lcnMvZHVwbGljYXRlX2hvc3RuYW1lX3Rlc3QifSwi
-        ZW52aXJvbm1lbnRDb250ZW50IjpbXX0=
-    http_version: 
-  recorded_at: Fri, 15 Mar 2019 16:18:25 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com:8443/candlepin/owners/duplicate_hostname_test/uebercert
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Authorization:
-      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="cIoKvRRsihb21icq2ZHtTVIHB6XjtvPfCP8yUqp4gk",
-        oauth_signature="LB%2BAH5YM6rms3jVS08Ia69bXrao%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1552666705", oauth_version="1.0"
-      Cp-User:
-      - foreman_admin
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - ebae9c91-6f81-493f-b0fa-a14fea3d3d62
-      X-Version:
-      - 2.5.7-1
-      - 2.5.7-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Fri, 15 Mar 2019 16:18:24 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJkaXNwbGF5TWVzc2FnZSI6InViZXIgY2VydGlmaWNhdGUgZm9yIG93bmVy
-        IGR1cGxpY2F0ZV9ob3N0bmFtZV90ZXN0IHdhcyBub3QgZm91bmQuIFBsZWFz
-        ZSBnZW5lcmF0ZSBvbmUuIiwicmVxdWVzdFV1aWQiOiJlYmFlOWM5MS02Zjgx
-        LTQ5M2YtYjBmYS1hMTRmZWEzZDNkNjIifQ==
-    http_version: 
-  recorded_at: Fri, 15 Mar 2019 16:18:25 GMT
-- request:
-    method: post
-    uri: https://devel.balmora.example.com:8443/candlepin/owners/duplicate_hostname_test/uebercert
-    body:
-      encoding: UTF-8
-      base64_string: 'e30=
-
-'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD",
-        oauth_nonce="DQRqqYVVieZAJ8jfQgfuPoDibi3Ju7WV4JqqOic4", oauth_signature="FxtfVihO5iy4KZAp4KuBpPJYKaY%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1552666705", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-      Content-Length:
-      - '2'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 4455441b-f214-457a-ab12-fcc501c3ad6e
-      X-Version:
-      - 2.5.7-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Fri, 15 Mar 2019 16:18:24 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wMy0xNVQxNjoxODoyNSswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDMtMTVUMTY6MTg6MjUrMDAwMCIsImlkIjoiNDAyOGY5Zjc2
-        OTZhN2VmZjAxNjk4MjI1YmRjZjAxNGYiLCJrZXkiOiItLS0tLUJFR0lOIFJT
-        QSBQUklWQVRFIEtFWS0tLS0tXG5NSUlFb3dJQkFBS0NBUUVBMElyUU9FVkJZ
-        M3hVQVlGczVHN2t4K29xb0ZCeVF1MktHNEZrSElmQVRMMHhpdS8yXG5lay9w
-        WWcxdFNyODM1OGl0dk1vaC9FaGlXWlZnZTRiS3FENlQ2UXlTcDVtVjA1UnJO
-        SzZHQU4zNThWME55WXpXXG4rWGFicTJ3UDNyQ0hzbzhDd2ttYkpMaEpVUTdC
-        V0lIL2JqUUkzTndXb2Y3M1llUGpNYzBXbzlKZDdiR25QY1U0XG56RWZHaTZN
-        bWdhRzY1OTk0NTFOV1VlOEpoU2VaMTNJNXRBdmhrbnJ6eDh4SmFhVllPU1pK
-        cnJNeHBhTk0zY2I4XG5iR1duU2VwUnpjQVBwNHNSQ1BRdHF3UUovcnNSTGpS
-        VTFWQlZDdzc3MEV3R29vZm5lTDkxYnhQeFlhUjdVZHdvXG56Tzc4K2E2bVJT
-        dXZYcnVtZzEzWWl3VWhINUpZSlI3bzNLdmxjd0lEQVFBQkFvSUJBRGQwOHJK
-        RUdJTndTSmF0XG42RnRHOGlnSHFaWkFUbUpsOE5nbnJJdTV2ZldxU2taOFVi
-        dHRETTg2YXRuNXg5QW5tYXdleExMbVBPRTl6QTZOXG5aYzhmOVEyQWZtOTdk
-        RkJ6bzU2NjJuL1loK01icjlMdFZTMjUwT1BoTk1jdmdxYUZTV0tKV0d5SFpW
-        ZmM2S1cwXG56RXh1SWYwNXVmc1Nabzd0bnpsYkpLNGovejU2Q051RkVQSTJG
-        cTBya2lmcTE2YkhBMDg4bG5sNXltQ0VIZm1mXG5aV1VQTlU1T0dIa2RFTFht
-        M2ZCUWVwdkRsK2JBeHh5cGIxNG4yVXVHQkdHNnVZMFFCZ2FpWTM1MkhXdnhC
-        dTZyXG5LRDVkaVh2QWxqTkZVeG9QWEpnaFFEam5BMzJ4angvZWdOSjU1dUpT
-        LytlRGZhYWl3dlFIWXVCeHhTU2k2M0dKXG54TUZWcmFFQ2dZRUE3MzFTL0ov
-        M0c3ZHlJZUx4NFBXOGFRQ1paRUV1UzFzSHFiUysxWkt0V3BOYktLR0tJMVJk
-        XG56L1VVZW5sWUxXb1hwZFJycjhYQ04yOGkxZjNOSzJ3czJlSDFTZEp6SGRX
-        NUhGNVlIMlJpQUZPMTVwcUt0OTZWXG5UQnNaLzl0OWdXSWlsYVhyd2tvRE56
-        Rm9lYWhNZklKbzBFNi9aOWZ3UEl6Y2lIa1VhK2NJcTY4Q2dZRUEzdXRQXG5V
-        NzZ3eDNRMXVub3ZUS3d0bTRnRFhZOEVCVWpDUG95ZUlzbDJITTFkMjV6ZFBP
-        VklMbEtMK3FBa1FzWDIrT3ZhXG5ZMlZCSld1Qlk1dkpYSkUvQjRWYURGRCtD
-        TDZCZVRHWmVsYnZSZk1TakFSS0haaDlwTGNwMU5qZlNnZ0MrTjBuXG5GNVp5
-        WE5jNnJ5RzZabm5YcVNoTjllYmxHZFJXK2xKNm5xUFFQMzBDZ1lCQ2dRUEZn
-        VXBtbVBlSnIzTEpySk9vXG5lUEVmcFBZTkdQYzB5aXRnTlg0TU0vVlJnQ0pU
-        RXorRjJ5SFhyTkN1czlKalMyeW4vL3VoMXl2T1RzOWxxb0Y5XG44OEJnd3A4
-        Uy91R0xuaXRNZEZ5K2lJQnZ6Q1NQVUxFVzFFUFJDQXQvSFZoTFJDc0c1ZlNr
-        cEFUR0c5VTVraUUzXG5EMWNacUI1ZlFpS1BoMGdEZXNHdW93S0JnUUNINHcx
-        U1VYWFZ2K05ZcjA3U0FFczAraTZEQThGQnIxNnBYbkt2XG5aZnVZQnlCbDFU
-        T1FBWHlFc0ZFZ0VDcktnWDdSc29SSC90czlnbEUzZFNuRVFjNFlPWlB3Mmha
-        aElqQXV2cXQrXG5SaXhKaWFrT3JUYTQzOUlIYkpnVlpiYUhuR2FqYWJ5QXhu
-        Y2tYUmNxMXZhWHJVSm5uV2dZdEEySU4wWm1CWTAxXG4wMG9JeVFLQmdFUno1
-        YXB3TVFOM1J0c0RnMEJEa0FCZjZ0YzFlS3RiVW5QdXFvbjdnWWVHSlZVdXNw
-        VUlNd3ovXG5scU82Yi9wdy8xaTVkcGhOeEdBbUxaL0s3VFZXRmRDQWF6cElH
-        NGMxdnhKbi9scHhiVzRobjR3TVlHNVBMME9ZXG45Vnc2VmJXYTgzNUFsbWdR
-        c1l6MWNRU082Yk1HUXFmbzRnaHIxb0xRcndVOG5iUkxaMUdVXG4tLS0tLUVO
-        RCBSU0EgUFJJVkFURSBLRVktLS0tLVxuIiwiY2VydCI6Ii0tLS0tQkVHSU4g
-        Q0VSVElGSUNBVEUtLS0tLVxuTUlJR2lUQ0NCWEdnQXdJQkFnSUlMc0FkNmxu
-        N3VVMHdEUVlKS29aSWh2Y05BUUVMQlFBd2dZUXhDekFKQmdOVlxuQkFZVEFs
-        VlRNUmN3RlFZRFZRUUlEQTVPYjNKMGFDQkRZWEp2YkdsdVlURVFNQTRHQTFV
-        RUJ3d0hVbUZzWldsblxuYURFUU1BNEdBMVVFQ2d3SFMyRjBaV3hzYnpFVU1C
-        SUdBMVVFQ3d3TFUyOXRaVTl5WjFWdWFYUXhJakFnQmdOVlxuQkFNTUdXUmxk
-        bVZzTG1KaGJHMXZjbUV1WlhoaGJYQnNaUzVqYjIwd0hoY05NVGt3TXpFMU1U
-        WXhPREkxV2hjTlxuTkRreE1qQXhNVE13TURBd1dqQWlNU0F3SGdZRFZRUUtE
-        QmRrZFhCc2FXTmhkR1ZmYUc5emRHNWhiV1ZmZEdWelxuZERDQ0FTSXdEUVlK
-        S29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTkNLMERoRlFXTjhW
-        QUdCYk9SdVxuNU1mcUtxQlFja0x0aWh1QlpCeUh3RXk5TVlydjlucFA2V0lO
-        YlVxL04rZklyYnpLSWZ4SVlsbVZZSHVHeXFnK1xuaytrTWtxZVpsZE9VYXpT
-        dWhnRGQrZkZkRGNtTTF2bDJtNnRzRDk2d2g3S1BBc0pKbXlTNFNWRU93VmlC
-        LzI0MFxuQ056Y0ZxSCs5MkhqNHpITkZxUFNYZTJ4cHozRk9NeEh4b3VqSm9H
-        aHV1ZmZlT2RUVmxIdkNZVW5tZGR5T2JRTFxuNFpKNjg4Zk1TV21sV0RrbVNh
-        NnpNYVdqVE4zRy9HeGxwMG5xVWMzQUQ2ZUxFUWowTGFzRUNmNjdFUzQwVk5W
-        UVxuVlFzTys5Qk1CcUtINTNpL2RXOFQ4V0drZTFIY0tNenUvUG11cGtVcnIx
-        Njdwb05kMklzRklSK1NXQ1VlNk55clxuNVhNQ0F3RUFBYU9DQTE0d2dnTmFN
-        QTRHQTFVZER3RUIvd1FFQXdJRXNEQVRCZ05WSFNVRUREQUtCZ2dyQmdFRlxu
-        QlFjREFqQUpCZ05WSFJNRUFqQUFNQkVHQ1dDR1NBR0crRUlCQVFRRUF3SUZv
-        REFkQmdOVkhRNEVGZ1FVdC9lNFxuY0llcTlFdUQzdS9SVlNacG1KeG5PTk13
-        SHdZRFZSMGpCQmd3Rm9BVThBTER2VVVvSUhHaVBBV3oxZnVKZ0YxRVxuT0VN
-        d093WVFLd1lCQkFHU0NBa0JyWmlSbHZzNkFRUW5EQ1ZrZFhCc2FXTmhkR1Zm
-        YUc5emRHNWhiV1ZmZEdWelxuZEY5MVpXSmxjbDl3Y205a2RXTjBNQllHRUNz
-        R0FRUUJrZ2dKQWEyWWtaYjdPZ01FQWd3QU1CWUdFQ3NHQVFRQlxua2dnSkFh
-        MllrWmI3T2dJRUFnd0FNQllHRUNzR0FRUUJrZ2dKQWEyWWtaYjdPZ1VFQWd3
-        QU1Ca0dFQ3NHQVFRQlxua2dnSkFxMllrWmI3T3dFRUJRd0RlWFZ0TUNRR0VT
-        c0dBUVFCa2dnSkFxMllrWmI3T3dFQkJBOE1EWFZsWW1WeVxuWDJOdmJuUmxi
-        blF3TWdZUkt3WUJCQUdTQ0FrQ3JaaVJsdnM3QVFJRUhRd2JNVFUxTWpZMk5q
-        Y3dOVE16T0Y5MVxuWldKbGNsOWpiMjUwWlc1ME1CMEdFU3NHQVFRQmtnZ0pB
-        cTJZa1piN093RUZCQWdNQmtOMWMzUnZiVEF2QmhFclxuQmdFRUFaSUlDUUt0
-        bUpHVyt6c0JCZ1FhREJndlpIVndiR2xqWVhSbFgyaHZjM1J1WVcxbFgzUmxj
-        M1F3RndZUlxuS3dZQkJBR1NDQWtDclppUmx2czdBUWNFQWd3QU1CZ0dFU3NH
-        QVFRQmtnZ0pBcTJZa1piN093RUlCQU1NQVRFd1xuTlFZS0t3WUJCQUdTQ0Fr
-        RUFRUW5EQ1ZrZFhCc2FXTmhkR1ZmYUc5emRHNWhiV1ZmZEdWemRGOTFaV0ps
-        Y2w5d1xuY205a2RXTjBNQkFHQ2lzR0FRUUJrZ2dKQkFJRUFnd0FNQjBHQ2lz
-        R0FRUUJrZ2dKQkFNRUR3d05NVFUxTWpZMlxuTmpjd05UTXpPREFSQmdvckJn
-        RUVBWklJQ1FRRkJBTU1BVEV3SkFZS0t3WUJCQUdTQ0FrRUJnUVdEQlF5TURF
-        NVxuTFRBekxURTFWREUyT2pFNE9qSTFXakFrQmdvckJnRUVBWklJQ1FRSEJC
-        WU1GREl3TkRrdE1USXRNREZVTVRNNlxuTURBNk1EQmFNQkVHQ2lzR0FRUUJr
-        Z2dKQkF3RUF3d0JNREFRQmdvckJnRUVBWklJQ1FRS0JBSU1BREFRQmdvclxu
-        QmdFRUFaSUlDUVFOQkFJTUFEQVJCZ29yQmdFRUFaSUlDUVFPQkFNTUFUQXdF
-        UVlLS3dZQkJBR1NDQWtFQ3dRRFxuREFFeE1EUUdDaXNHQVFRQmtnZ0pCUUVF
-        Smd3a01UVmhNbVpsTVdNdE1tRXlaUzAwWW1Oa0xXRmhaamt0TldSa1xuTnpr
-        MU5HTXhaVEpoTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCUCt5Vm1mc01V
-        SjNSNkhuNy9yeWwvL2UrVVxuL08xTDUyTmlaaHptc3c4RUtOa1V5dm9QZHFh
-        WkVhVmpQYmxLV3FjUVQ0L0VOMEpudnVucVBJMDl6SHM4MEJDQ1xuYU1mbi81
-        ZEQ2QWVTd1RNaWQzeGlYMlFmZ0NuazZpUXZxZzVtU242L0k4OTB5eElkRjln
-        ZWY3bEYxUEZKSE8vZ1xuaDJwajUyMjdkSkFjRkhiNWxEbWY0VkVZK2VRWGkw
-        NS93NjI3V0JYWklheEZUL3l1NWdmeFd1cXZSZnhlMU1peVxucSt0ZktiWEd2
-        N0dGOG5CaVNtRWM4azhCalNKTWRxbmFrWk1IWkxYOWNFSnNoOG52NmdnNW4v
-        RjFWUmZQOG5yZ1xuaVFvaEMyWGswVzI2ei9uTmRBckt2RmdmUlBXM25mK3BX
-        MVhrWnFuTEZjZE1tN1lEM01jVGc0OWRHbFg0XG4tLS0tLUVORCBDRVJUSUZJ
-        Q0FURS0tLS0tXG4iLCJzZXJpYWwiOnsiY3JlYXRlZCI6IjIwMTktMDMtMTVU
-        MTY6MTg6MjUrMDAwMCIsInVwZGF0ZWQiOiIyMDE5LTAzLTE1VDE2OjE4OjI1
-        KzAwMDAiLCJpZCI6MzM2ODcyNTQxMzY0MjM1Mjk3Mywic2VyaWFsIjozMzY4
-        NzI1NDEzNjQyMzUyOTczLCJleHBpcmF0aW9uIjoiMjA0OS0xMi0wMVQxMzow
-        MDowMCswMDAwIiwiY29sbGVjdGVkIjpmYWxzZSwicmV2b2tlZCI6ZmFsc2V9
-        LCJvd25lciI6eyJpZCI6IjQwMjhmOWY3Njk2YTdlZmYwMTY5ODIyNWJkNDEw
-        MTRjIiwia2V5IjoiZHVwbGljYXRlX2hvc3RuYW1lX3Rlc3QiLCJkaXNwbGF5
-        TmFtZSI6ImR1cGxpY2F0ZV9ob3N0bmFtZV90ZXN0IiwiaHJlZiI6Ii9vd25l
-        cnMvZHVwbGljYXRlX2hvc3RuYW1lX3Rlc3QifX0=
-    http_version: 
-  recorded_at: Fri, 15 Mar 2019 16:18:25 GMT
-- request:
-    method: post
-    uri: https://devel.balmora.example.com:8443/candlepin/hypervisors/duplicate_hostname_test
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJoeXBlcnZpc29ycyI6W3siaHlwZXJ2aXNvcklkIjp7Imh5cGVydmlzb3JJ
-        ZCI6IjJlNzhmNjQzLTFkMmYtNDVkMS1iMTkxLWQ5MzExNDdjYmRlMSJ9LCJu
-        YW1lIjoibG9jYWxob3N0IiwiZ3Vlc3RJZHMiOlt7Imd1ZXN0SWQiOiJlZDY2
-        YmIzOS1jZGQ4LTRmYWItYTA2Ni1jZTQ0ZWFhZGI1ZjciLCJzdGF0ZSI6MSwi
-        YXR0cmlidXRlcyI6eyJhY3RpdmUiOjEsInZpcnRXaG9UeXBlIjoiZXN4In19
-        XSwiZmFjdHMiOnsiaHlwZXJ2aXNvci50eXBlIjoiVk13YXJlIEVTWGkiLCJo
-        eXBlcnZpc29yLnZlcnNpb24iOiI2LjAuMCIsImNwdS5jcHVfc29ja2V0KHMp
-        IjoiMSJ9fSx7Imh5cGVydmlzb3JJZCI6eyJoeXBlcnZpc29ySWQiOiIyNjFj
-        NGRjYS03MDJmLTQyYjMtYjhlZi0yYTcyYjc3ZjdlYzIifSwibmFtZSI6Imxv
-        Y2FsaG9zdCIsImd1ZXN0SWRzIjpbeyJndWVzdElkIjoiNDIxMzM3NC1mYzcy
-        LTk2ZTYtZWNkYi0xM2RhZDRlYiIsInN0YXRlIjoxLCJhdHRyaWJ1dGVzIjp7
-        ImFjdGl2ZSI6MSwidmlydFdob1R5cGUiOiJlc3gifX1dLCJmYWN0cyI6eyJo
-        eXBlcnZpc29yLnR5cGUiOiJWTXdhcmUgRVNYaSIsImh5cGVydmlzb3IudmVy
-        c2lvbiI6IjYuMC4wIiwiY3B1LmNwdV9zb2NrZXQocykiOiIxIn19XSwib3du
-        ZXIiOiJkdXBsaWNhdGVfaG9zdG5hbWVfdGVzdCJ9
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD",
-        oauth_nonce="BBJso7E8CJTOQc0mmxqHeHDDdcKrM5yCAug86vFPVI", oauth_signature="sW6zLEz3%2Fuv3YHFjHyMEGRYTvV0%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1552666705", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - text/plain
-      Cp-User:
-      - foreman_admin
-      Content-Length:
-      - '660'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - a49b4dcf-cebf-4dc3-ae2d-475e2417500e
-      X-Version:
-      - 2.5.7-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Fri, 15 Mar 2019 16:18:24 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wMy0xNVQxNjoxODoyNSswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDMtMTVUMTY6MTg6MjUrMDAwMCIsImlkIjoiaHlwZXJ2aXNv
-        cl91cGRhdGVfNjYzYzE0MmEtNWE3NS00NThkLTg0OGUtMDJiZGNlZmNlM2Fm
-        Iiwic3RhdGUiOiJDUkVBVEVEIiwic3RhcnRUaW1lIjpudWxsLCJmaW5pc2hU
-        aW1lIjpudWxsLCJyZXN1bHQiOm51bGwsInByaW5jaXBhbE5hbWUiOiJmb3Jl
-        bWFuX2FkbWluIiwidGFyZ2V0VHlwZSI6Im93bmVyIiwidGFyZ2V0SWQiOiJk
-        dXBsaWNhdGVfaG9zdG5hbWVfdGVzdCIsIm93bmVySWQiOiJkdXBsaWNhdGVf
-        aG9zdG5hbWVfdGVzdCIsImNvcnJlbGF0aW9uSWQiOm51bGwsInJlc3VsdERh
-        dGEiOm51bGwsImRvbmUiOmZhbHNlLCJzdGF0dXNQYXRoIjoiL2pvYnMvaHlw
-        ZXJ2aXNvcl91cGRhdGVfNjYzYzE0MmEtNWE3NS00NThkLTg0OGUtMDJiZGNl
-        ZmNlM2FmIiwiZ3JvdXAiOiJhc3luYyBncm91cCJ9
-    http_version: 
-  recorded_at: Fri, 15 Mar 2019 16:18:25 GMT
-- request:
-    method: get
     uri: https://devel.balmora.example.com:8443/candlepin/jobs/hypervisor_update_663c142a-5a75-458d-848e-02bdcefce3af?result_data=true
     body:
       encoding: US-ASCII
@@ -779,4 +302,827 @@ http_interactions:
 '
     http_version: 
   recorded_at: Fri, 15 Mar 2019 16:18:26 GMT
+- request:
+    method: get
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/owners/duplicate_hostname_test
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC", oauth_nonce="yK6UM0sm9cgRRR8JTXoRmGdRWY4Lc4qbwPHrwsHI",
+        oauth_signature="Uqlo%2F4QaCBG6VACeYC0lBa4flP4%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1555091473", oauth_version="1.0"
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - cb0bdd96-aca8-4c80-b689-77996e50ad20
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:14 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wNC0xMlQxNzo0ODo1OSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDQtMTJUMTc6NDg6NTkrMDAwMCIsImlkIjoiNDAyOGY5ZmQ2
+        YTEyNDU4OTAxNmExMmFhYjcwYTAwZDkiLCJrZXkiOiJkdXBsaWNhdGVfaG9z
+        dG5hbWVfdGVzdCIsImRpc3BsYXlOYW1lIjoiZHVwbGljYXRlX2hvc3RuYW1l
+        X3Rlc3QiLCJwYXJlbnRPd25lciI6bnVsbCwiY29udGVudFByZWZpeCI6Ii9k
+        dXBsaWNhdGVfaG9zdG5hbWVfdGVzdC8kZW52IiwiZGVmYXVsdFNlcnZpY2VM
+        ZXZlbCI6bnVsbCwidXBzdHJlYW1Db25zdW1lciI6bnVsbCwibG9nTGV2ZWwi
+        Om51bGwsImF1dG9iaW5kRGlzYWJsZWQiOmZhbHNlLCJjb250ZW50QWNjZXNz
+        TW9kZSI6ImVudGl0bGVtZW50IiwiY29udGVudEFjY2Vzc01vZGVMaXN0Ijoi
+        ZW50aXRsZW1lbnQiLCJsYXN0UmVmcmVzaGVkIjpudWxsLCJocmVmIjoiL293
+        bmVycy9kdXBsaWNhdGVfaG9zdG5hbWVfdGVzdCJ9
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:14 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/owners/duplicate_hostname_test
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC", oauth_nonce="5I3WIK3d3Gx5EuovEYTGjBohnalagCYLseELvek3M",
+        oauth_signature="FjaphAxdYt7fYtlPaO3ASFgdi0g%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1555091474", oauth_version="1.0"
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - '08cc982a-5bf9-4734-afd5-db3b80e34f66'
+      X-Version:
+      - 2.6.4-1
+      Date:
+      - Fri, 12 Apr 2019 17:51:14 GMT
+    body:
+      encoding: UTF-8
+      base64_string: ''
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:14 GMT
+- request:
+    method: post
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/owners/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJrZXkiOiJkdXBsaWNhdGVfaG9zdG5hbWVfdGVzdCIsImRpc3BsYXlOYW1l
+        IjoiZHVwbGljYXRlX2hvc3RuYW1lX3Rlc3QiLCJjb250ZW50UHJlZml4Ijoi
+        L2R1cGxpY2F0ZV9ob3N0bmFtZV90ZXN0LyRlbnYifQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC",
+        oauth_nonce="ki8HVcdGkhYdCte7UW4BpfStqF2Vwwp3Y9Fl9qz8D0", oauth_signature="WO3F1XJYa4Hqe5ZH8sjaT7RFz4s%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1555091474", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '121'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 7701cdca-6c85-4334-af72-0765b8116ce9
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:14 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxNCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDQtMTJUMTc6NTE6MTQrMDAwMCIsImlkIjoiNDAyOGY5ZmQ2
+        YTEyNDU4OTAxNmExMmFjYzkwODAwZTYiLCJrZXkiOiJkdXBsaWNhdGVfaG9z
+        dG5hbWVfdGVzdCIsImRpc3BsYXlOYW1lIjoiZHVwbGljYXRlX2hvc3RuYW1l
+        X3Rlc3QiLCJwYXJlbnRPd25lciI6bnVsbCwiY29udGVudFByZWZpeCI6Ii9k
+        dXBsaWNhdGVfaG9zdG5hbWVfdGVzdC8kZW52IiwiZGVmYXVsdFNlcnZpY2VM
+        ZXZlbCI6bnVsbCwidXBzdHJlYW1Db25zdW1lciI6bnVsbCwibG9nTGV2ZWwi
+        Om51bGwsImF1dG9iaW5kRGlzYWJsZWQiOmZhbHNlLCJjb250ZW50QWNjZXNz
+        TW9kZSI6ImVudGl0bGVtZW50IiwiY29udGVudEFjY2Vzc01vZGVMaXN0Ijoi
+        ZW50aXRsZW1lbnQiLCJsYXN0UmVmcmVzaGVkIjpudWxsLCJocmVmIjoiL293
+        bmVycy9kdXBsaWNhdGVfaG9zdG5hbWVfdGVzdCJ9
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:14 GMT
+- request:
+    method: post
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/owners/duplicate_hostname_test/environments
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6ImU2ZWI3Nzk1NzUxNTZmYjdkYmFmYTIyMmUxNTFkOGE3IiwibmFt
+        ZSI6IkxpYnJhcnkiLCJkZXNjcmlwdGlvbiI6bnVsbH0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC",
+        oauth_nonce="7pRQUDojymx5PWXNWGk9EMAdkDNm3vN92L9seANWg", oauth_signature="Em7feVkl1XjaUovy9EycAwTpfCY%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1555091474", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '77'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - b283022b-ad9e-4233-83fc-1b8c0f71cd8a
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:14 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxNCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDQtMTJUMTc6NTE6MTQrMDAwMCIsImlkIjoiZTZlYjc3OTU3
+        NTE1NmZiN2RiYWZhMjIyZTE1MWQ4YTciLCJuYW1lIjoiTGlicmFyeSIsImRl
+        c2NyaXB0aW9uIjpudWxsLCJvd25lciI6eyJpZCI6IjQwMjhmOWZkNmExMjQ1
+        ODkwMTZhMTJhY2M5MDgwMGU2Iiwia2V5IjoiZHVwbGljYXRlX2hvc3RuYW1l
+        X3Rlc3QiLCJkaXNwbGF5TmFtZSI6ImR1cGxpY2F0ZV9ob3N0bmFtZV90ZXN0
+        IiwiaHJlZiI6Ii9vd25lcnMvZHVwbGljYXRlX2hvc3RuYW1lX3Rlc3QifSwi
+        ZW52aXJvbm1lbnRDb250ZW50IjpbXX0=
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:14 GMT
+- request:
+    method: get
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/owners/duplicate_hostname_test/uebercert
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC", oauth_nonce="mtHqGVVTQesSNjMBX9EMYjJmbqTUX9q1IHwSu3VDKU",
+        oauth_signature="quaEOm9V4MKDASq3b5Wt3TtXf2A%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1555091474", oauth_version="1.0"
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 2d3a563f-a756-46e4-968d-d036753cdbc3
+      X-Version:
+      - 2.6.4-1
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:14 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJkaXNwbGF5TWVzc2FnZSI6InViZXIgY2VydGlmaWNhdGUgZm9yIG93bmVy
+        IGR1cGxpY2F0ZV9ob3N0bmFtZV90ZXN0IHdhcyBub3QgZm91bmQuIFBsZWFz
+        ZSBnZW5lcmF0ZSBvbmUuIiwicmVxdWVzdFV1aWQiOiIyZDNhNTYzZi1hNzU2
+        LTQ2ZTQtOTY4ZC1kMDM2NzUzY2RiYzMifQ==
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:14 GMT
+- request:
+    method: post
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/owners/duplicate_hostname_test/uebercert
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC",
+        oauth_nonce="OTr91dLMW7gjyYfmNhlSC5C1IU1ZoJelh9dokfRyqI", oauth_signature="Pndq8%2BgHDPv%2FUEeFmEyZ%2FQ1Z4AA%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1555091474", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '2'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - ee475dfd-2c5e-4abc-baf6-a69c5d513393
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:16 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxNCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDQtMTJUMTc6NTE6MTYrMDAwMCIsImlkIjoiNDAyOGY5ZmQ2
+        YTEyNDU4OTAxNmExMmFjY2UyODAwZTkiLCJrZXkiOiItLS0tLUJFR0lOIFJT
+        QSBQUklWQVRFIEtFWS0tLS0tXG5NSUlKS0FJQkFBS0NBZ0VBblRwcjVmVlpi
+        R0RQUUNGWGZ0WjdoZmxWQm81Q2xVQzJvclBWRkVmaVh1bDM3TWN3XG5mMlVW
+        Z2pBb3lMWUJjT09GQ3hBbUNVb2RRTTZ1Zlh0Z0xIZHloU3NqaDVQOTcrNUN4
+        bERqY2NzNnhESDdTQUFMXG5ZQTJzVytFTS9zT0NZaTdwekFvQzFQZURPNmxv
+        ckxMdzlCdy9FU01GcVROQ2lHcXluanJma2JWbDdGT2hqZlhQXG41Y29Ta05r
+        bmNDN3A5UTFpRHExdXZRYkYxR3Y2R3Q0SUswQTB6UjNzdW1wdGNoai9scFRS
+        ZWJnSzYwSkxiM0xnXG5MblRYb2Z1UlNkMzY4ODcvUDB0emVkd21wWlhLRGNt
+        ZG45U1NBcEZXVkpXdHVXWTIxU2ZRT3d3Q2xxcDRrczJwXG5maHBvdnNoaG4r
+        NjNJd0E5Vkl1eU9SZnFicmNHWlBVMi9oNk8zMXFzTXJVSFhLZGF4S1hrbzVm
+        VWJvTGFhaVlsXG5SY3VvRG9xQ0c3ZXJqdXN1ZHROanJwSGFrMG9MeDEwUUZR
+        aTAzVUNidi9Na2gxMnFlVjlNWmRoYzI2UE5iU2tMXG5RbE1hZDEvRG03MHEx
+        ZFF2ZlVFdEUrK2s3dkUrQ0dURW96M241MFFGVGVHMlEvWSs2Z1lIaHZZK1FM
+        Y1doRTJOXG5IMXF6RXJIQi9ZZzVSL2hrcHFOZkxLTStOKzJCejk4d2tCazNX
+        YjVOeklZeVF6WG1KODZBODY3cVNFVTlEcmNkXG5SSm9IS2RFSXI0MXdIZUFW
+        TkVFR1NrTlg2ZXB5ZGNiYmJVdjg3VlFjS1YrM2RNcTVNbU1pbk1LRCt4b1JE
+        aUNKXG5IUW9WbXI5U0t6aTZlYjJITFJBdFFtd3F0SHprNlNpMjVORnpoNmpU
+        SStCMTMvSWUxb1hpNmlUQ09ma0NBd0VBXG5BUUtDQWdCZGI5R2RlSUFyRXlF
+        M1NGazU3SGE5K0oyWjVzTVU5YjlUMDdGR2V5M0JIOWdBSTZQam9ZdjFzVzhi
+        XG5VR1pzMHhsR3FOTWg1Q1NjVmZlR1pPS1RxbXlwVFNpeE1yYlBkblhDYTJH
+        dlI0cGwvQm9NQU5MQnczNXhuNzNjXG5UUTNZRVc4cHJhMWZLTFNacVNTbXRU
+        VFNyVktoZVlHc3V1VElNemh4SmlXazd2dGlSWlVWeTBaQWxpVVFaYXkxXG5V
+        M3dBQUhNTXErN0tjUkx5R1RVcDhGZEVkTVNzUFNObzZVU2ZjTkc3aURjd3Ni
+        bnpjNU5tNlFybk1OTFExYkxUXG5CaE5UL3VqYmtaaFBqQkIvaVJQcHU2NXJ4
+        S1Q4MTZoSlhpWStyc3JaUSs3UW1HT1ZiRHQ1YXJWV1ZwVjNBNWhZXG50a0dw
+        a0VQaVVaNlpwV2ZSWWYxdjAvWlpjSW1RckJDRmI2VzNUTWVlN3lEVGNMc3VM
+        K2hscmhuM244N1dTMWI5XG5DQ3V4dWw2WCtvSmVacEE3SzNZNUkydC9VMFF1
+        eHRkaXg1eVZtcDFVTk1kdXAwS1pjamF2RHEvT3AveHdVV3EyXG5XRWYyS05k
+        QTRsV2pQdGVKd1JFMzB2U2xJQms0WGVHdGxiZ0QyVkN2UTBKdFlYTW9VMEdU
+        ZklSdFlUUFZ5MmlzXG5rWDEvVGVDNzZ6U1hOODd3Rnl0ekpWRFdFRVpoQTVz
+        N2hIZjRYUWpwb3hjTjJQa0oyckVxdGUrdVVTQVpNSUVMXG5vU3ozdHEwRk1G
+        RUNaVFllclZkaitQcUFvOVdCWWtqN3VJYnFqSGFoNnE0OERwTjRteTQ0RUVr
+        V2dwWTNERjcyXG5ocGpFb1dYSDlTYWdvUGd2WkFXTjB0bWFNQzkwZFpYR283
+        cmYxUlVDbm5DQ1lNQklBUUtDQVFFQTVtZUtheDQ3XG54Vm93VnN3bUMzYnM3
+        T3d4TXdXR3VLT3ZHbGQ4ZlpXazgxQnBHYlZTeHE2UzFUN3hOTEVZZVdES1Vy
+        ZjMwWmxFXG5OMURXY2ZsYTVBNGRBS3k2Y3B1K1dOYkRyZS9wQkw2Mkpkc3ZI
+        NUp2UnhxVE9tdW1lMmVYVklEOE9LRGN2TUh1XG4wRXJRK05CT3AyZTFRMkV3
+        V2JXQ2NCbUc4TGZuNmxISkVzc1RuUXFLSEtiWWJ2YjR4ajRmMnVQT2Rlenpm
+        ZXV1XG4wVDJYTmpvR2tPWnZ6alRFWUlNSEluc1loTWZLSytSTjNKUHE1aHBv
+        TUpOaGZGR2pDU3JudUdIdFh3SFVHM2ZMXG54Zk4xcU4rTFhFQjloYVZPQjBM
+        MysySEtJOTU1Z2NCOWlhMUhRSXVKRitzSHBCZWtzVWYxL2xYU2FoRTVYZDBM
+        XG5NQ1Yvcjdpa3FFVGRBUUtDQVFFQXJySFRYRmNub3ZzRGk4eVoyczNFZ1ZI
+        NzczM083Zzk1VjJDeUprMTA3YWhJXG5yWjRHY1hjc09tVnBsOTJCaWw1M00y
+        UllvNlJGY3ZXVk53bHFWbkQ4VE5LcTllbU1XbDVCUjEwQStwKzdlZkl5XG5x
+        Sis2RndJZzBOYUxQZDZ4U24xME9zcExicWRubHd1dlIxbURpekhZZmVkYlpI
+        K0FpVlpSSWxaQ2JrR0R4elptXG4xYWtXeVhiZXVsTytNMGtKSTFxeGtoenRo
+        QS85NEpKTjJpck05amRPbHp2SmwzRmpGRVBwelppY3YxOU9xS0RFXG5CTmlo
+        OEZKVmNLdnB3NDVlN01mbnh0QXB0Q2d2K3ZON3FMZXg3eGRPTHhRNDVRZlFZ
+        cjg5djZaSm0zckU1d3JrXG5DV3NDN2hYVU1SUDdMbDFiT29NaDI1Tk9JTE9Q
+        VnhXVjQ0Vkx5Qk5FK1FLQ0FRQm1LRTZGUkRoNFBvN2tUVXdwXG5GU2Zqdksz
+        cjAyMXlmSkRzK3hGbGxXNDN1OVY5NHBtN0lqaFVlTDMyQVBlN0NhRnJuOG92
+        a3VkZUoyZU56V1B4XG5iaGlKN2d3Vk9OempBd1pzSHMyUW53YWdMbGpzaEw3
+        MkplQlZyTmw2S2VvOU81dVplQ21uUDgybGFTYlN5M20wXG5YQlZRdE16OVdh
+        OW1DTXQ5Kyt6R1JsRURGaXV5RzdRMUUvMHU1aTVUcDhQMEI4SEpJN0NxaWs5
+        TzB5SXlsdlBHXG5WNFlIUmZvMFdLUlhNNEVoam53ampleS8rbzNTVEs4WnFw
+        ODB3ZldwNE80eElLcGd6NnkrS1JXZXhWM0w3S0liXG4yelJNaDRqYlMyUXNm
+        NlZpMWdmRjhoVTNjQzhCZlZ6aDBBSHBUZHBtQ0dRWHl2R3F1Y3hYdytSc0Nw
+        UmMwMStlXG5oRG9CQW9JQkFBbVY0RThVeVN2OE1mbWR4R05wSHZzcGtIVlhw
+        ZDhTSWtwVkYvRmFGcXhqcTNrN1RvY3pUczMxXG5lcEhHcWJENTlmaHY3UjB0
+        aWxJQWY2dUJiTUJKZXM2TVVLMGxuM25sNmhjTVYxMXBIbFJXb2NqMjJyTWdm
+        c1IyXG53VFVuM3ZxRFg3bEtHRkYrQmdVWHN3cHJNdmlVUjVqQTlSYlNtQzd3
+        K1lxMHlQaGJ4K3RLWk9JY1lRKzA0Z3UvXG5SSlJ6MFhpTEpXc3JBeTFYNDBw
+        TFBOSlh2dDlUc1pCQ3k1RHZ1OHdFM2ZOV0NHUEh5djBkdFNPKzcwUE1nTHVw
+        XG44eTJ6eGltZjNtdmVTQ3VHZVB1QUdLenRSMm9qRVRzc0ZPTWNScWJrYjNM
+        d29PRlRIeksrT2p6NkRqTWFKNFo1XG4zakp4Rk94ay9acWF2cEsweDR5enRv
+        SEJjcU1MeTZFQ2dnRUJBTDJkaUJ6Q2lrSytiMytHNGMxRWJZa1NQNEtEXG40
+        cFhQdnhmZnp3TmM4djJLeEVOSVNuK3oxM0UvMnJ3dGFwd1B4RzhwdW41ek9a
+        dFlscExWRURmWjFROXVGT05MXG5Sc3ZqcFljejl6L3o0a2dPMGd3dE50M0FH
+        RjFZRHlaTld3ODNhQUo4UzFpNHZSQk5Kbnk5aTZXbEhMWExFak9TXG5UNUZp
+        YnZGZDVnUm1iN0p1MW1GY0hvdzZHZjJhTk9ldHdPMDRYQWdxZzBWa05qNGJK
+        NTJZc1BZOUxnbXNLN1pWXG43dy9vdUFUSXkveFYwNEx5aGN1MWpOV25HNXNl
+        K2YxTXBnMk5NL0l2RDQzWnhqQzZ0UTFNTCtOVS9NQ2FuYnh6XG44SXduVXhC
+        dmNSUkJRTDBDNlVrZ1lDOXorMWpqNU9scFpSbVIwQ09BRW5tK2cwTHpoNk82
+        WE0wVnBpRT1cbi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tXG4iLCJj
+        ZXJ0IjoiLS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tXG5NSUlIa0RDQ0Ju
+        aWdBd0lCQWdJSVVERlVIekVPY2lFd0RRWUpLb1pJaHZjTkFRRUxCUUF3Z1lz
+        eEN6QUpCZ05WXG5CQVlUQWxWVE1SY3dGUVlEVlFRSURBNU9iM0owYUNCRFlY
+        SnZiR2x1WVRFUU1BNEdBMVVFQnd3SFVtRnNaV2xuXG5hREVRTUE0R0ExVUVD
+        Z3dIUzJGMFpXeHNiekVVTUJJR0ExVUVDd3dMVTI5dFpVOXlaMVZ1YVhReEtU
+        QW5CZ05WXG5CQU1NSUdObGJuUnZjemN0WkdWMlpXd3VhblIxY21Wc0xtVjRZ
+        VzF3YkdVdVkyOXRNQjRYRFRFNU1EUXhNakUzXG5OVEV4TkZvWERUUTVNVEl3
+        TVRFek1EQXdNRm93SWpFZ01CNEdBMVVFQ2d3WFpIVndiR2xqWVhSbFgyaHZj
+        M1J1XG5ZVzFsWDNSbGMzUXdnZ0lpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElD
+        RHdBd2dnSUtBb0lDQVFDZE9tdmw5VmxzXG5ZTTlBSVZkKzFudUYrVlVHamtL
+        VlFMYWlzOVVVUitKZTZYZnN4ekIvWlJXQ01Dakl0Z0Z3NDRVTEVDWUpTaDFB
+        XG56cTU5ZTJBc2QzS0ZLeU9Iay8zdjdrTEdVT054eXpyRU1mdElBQXRnRGF4
+        YjRReit3NEppTHVuTUNnTFU5NE03XG5xV2lzc3ZEMEhEOFJJd1dwTTBLSWFy
+        S2VPdCtSdFdYc1U2R045Yy9seWhLUTJTZHdMdW4xRFdJT3JXNjlCc1hVXG5h
+        L29hM2dnclFEVE5IZXk2YW0xeUdQK1dsTkY1dUFyclFrdHZjdUF1ZE5laCs1
+        RkozZnJ6enY4L1MzTjUzQ2FsXG5sY29OeVoyZjFKSUNrVlpVbGEyNVpqYlZK
+        OUE3REFLV3FuaVN6YWwrR21pK3lHR2Y3cmNqQUQxVWk3STVGK3B1XG50d1pr
+        OVRiK0hvN2ZXcXd5dFFkY3AxckVwZVNqbDlSdWd0cHFKaVZGeTZnT2lvSWJ0
+        NnVPNnk1MjAyT3VrZHFUXG5TZ3ZIWFJBVkNMVGRRSnUvOHlTSFhhcDVYMHhs
+        MkZ6Ym84MXRLUXRDVXhwM1g4T2J2U3JWMUM5OVFTMFQ3NlR1XG44VDRJWk1T
+        alBlZm5SQVZONGJaRDlqN3FCZ2VHOWo1QXR4YUVUWTBmV3JNU3NjSDlpRGxI
+        K0dTbW8xOHNvejQzXG43WUhQM3pDUUdUZFp2azNNaGpKRE5lWW56b0R6cnVw
+        SVJUME90eDFFbWdjcDBRaXZqWEFkNEJVMFFRWktRMWZwXG42bkoxeHR0dFMv
+        enRWQndwWDdkMHlya3lZeUtjd29QN0doRU9JSWtkQ2hXYXYxSXJPTHA1dllj
+        dEVDMUNiQ3EwXG5mT1RwS0xiazBYT0hxTk1qNEhYZjhoN1doZUxxSk1JNStR
+        SURBUUFCbzRJRFhqQ0NBMW93RGdZRFZSMFBBUUgvXG5CQVFEQWdTd01CTUdB
+        MVVkSlFRTU1Bb0dDQ3NHQVFVRkJ3TUNNQWtHQTFVZEV3UUNNQUF3RVFZSllJ
+        WklBWWI0XG5RZ0VCQkFRREFnV2dNQjBHQTFVZERnUVdCQlQ3STBnbi9vVUZJ
+        MDJmUlF3TzZMTWpnQ3diNGpBZkJnTlZIU01FXG5HREFXZ0JTL0swZk8vbHdw
+        bEZ0WkZUMk5Fb3czMlFuS1pUQTdCaEFyQmdFRUFaSUlDUUd0b1pXemt5b0JC
+        Q2NNXG5KV1IxY0d4cFkyRjBaVjlvYjNOMGJtRnRaVjkwWlhOMFgzVmxZbVZ5
+        WDNCeWIyUjFZM1F3RmdZUUt3WUJCQUdTXG5DQWtCcmFHVnM1TXFBd1FDREFB
+        d0ZnWVFLd1lCQkFHU0NBa0JyYUdWczVNcUFnUUNEQUF3RmdZUUt3WUJCQUdT
+        XG5DQWtCcmFHVnM1TXFCUVFDREFBd0dRWVFLd1lCQkFHU0NBa0NyYUdWczVN
+        ckFRUUZEQU41ZFcwd0pBWVJLd1lCXG5CQUdTQ0FrQ3JhR1ZzNU1yQVFFRUR3
+        d05kV1ZpWlhKZlkyOXVkR1Z1ZERBeUJoRXJCZ0VFQVpJSUNRS3RvWld6XG5r
+        eXNCQWdRZERCc3hOVFUxTURreE5EYzBPRFU0WDNWbFltVnlYMk52Ym5SbGJu
+        UXdIUVlSS3dZQkJBR1NDQWtDXG5yYUdWczVNckFRVUVDQXdHUTNWemRHOXRN
+        QzhHRVNzR0FRUUJrZ2dKQXEyaGxiT1RLd0VHQkJvTUdDOWtkWEJzXG5hV05o
+        ZEdWZmFHOXpkRzVoYldWZmRHVnpkREFYQmhFckJnRUVBWklJQ1FLdG9aV3pr
+        eXNCQndRQ0RBQXdHQVlSXG5Ld1lCQkFHU0NBa0NyYUdWczVNckFRZ0VBd3dC
+        TVRBMUJnb3JCZ0VFQVpJSUNRUUJCQ2NNSldSMWNHeHBZMkYwXG5aVjlvYjNO
+        MGJtRnRaVjkwWlhOMFgzVmxZbVZ5WDNCeWIyUjFZM1F3RUFZS0t3WUJCQUdT
+        Q0FrRUFnUUNEQUF3XG5IUVlLS3dZQkJBR1NDQWtFQXdRUERBMHhOVFUxTURr
+        eE5EYzBPRFU0TUJFR0Npc0dBUVFCa2dnSkJBVUVBd3dCXG5NVEFrQmdvckJn
+        RUVBWklJQ1FRR0JCWU1GREl3TVRrdE1EUXRNVEpVTVRjNk5URTZNVFJhTUNR
+        R0Npc0dBUVFCXG5rZ2dKQkFjRUZnd1VNakEwT1MweE1pMHdNVlF4TXpvd01E
+        b3dNRm93RVFZS0t3WUJCQUdTQ0FrRURBUUREQUV3XG5NQkFHQ2lzR0FRUUJr
+        Z2dKQkFvRUFnd0FNQkFHQ2lzR0FRUUJrZ2dKQkEwRUFnd0FNQkVHQ2lzR0FR
+        UUJrZ2dKXG5CQTRFQXd3Qk1EQVJCZ29yQmdFRUFaSUlDUVFMQkFNTUFURXdO
+        QVlLS3dZQkJBR1NDQWtGQVFRbURDUmpPR05rXG5ZMkptWkMwM1l6SXpMVFJq
+        TkRRdE9HWmlOeTFpTjJVMU16bGtZakJoWVdNd0RRWUpLb1pJaHZjTkFRRUxC
+        UUFEXG5nZ0VCQUpNMG1Mdy9ySlBJcytmWlJIWjl1TWFicHFRQU4zQldVL2l1
+        bVVvQnJwdjJkcHY4U3VzeENnNWorRzBSXG5lV2VERmV4T3VHeHloRU5EQUxI
+        bVVVMm1Bb3JoSDhPOXQ3M21Cb3Y1MjRYcXpQSU5vS2RhWmlybzhLMGRyTDFT
+        XG5rRUVUeVZ5SWg5SFg5bnhSckJIRitZaUloTUNZRC9laGhNQ2IwdElBVURZ
+        YkxXUmdXeGZucTZmUjRydEVvT3dJXG5Kd2ttZ1NiWlpUN0Vqa0F0VkszOGZq
+        aWdsVjJCQ0xuSzYwMC9RbFE2bHY5aHpoQS95bzZ5QmVRb1RybStqN2JhXG5K
+        S2ZWQW03b2J4Qk5uOGNTbWt5NjJhMHlrY1NZUzBIMEdyYlNVbFpRWXVyQm50
+        K2xZbjFkektTNU40QlAxeWwvXG4zQU5FbHhaQnh1Tkp0YWNtQ1kzZmovZDBl
+        TEE9XG4tLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tXG4iLCJzZXJpYWwiOnsi
+        Y3JlYXRlZCI6IjIwMTktMDQtMTJUMTc6NTE6MTQrMDAwMCIsInVwZGF0ZWQi
+        OiIyMDE5LTA0LTEyVDE3OjUxOjE0KzAwMDAiLCJpZCI6NTc3ODQ5MjI4OTgz
+        NjgwNjY4OSwic2VyaWFsIjo1Nzc4NDkyMjg5ODM2ODA2Njg5LCJleHBpcmF0
+        aW9uIjoiMjA0OS0xMi0wMVQxMzowMDowMCswMDAwIiwiY29sbGVjdGVkIjpm
+        YWxzZSwicmV2b2tlZCI6ZmFsc2V9LCJvd25lciI6eyJpZCI6IjQwMjhmOWZk
+        NmExMjQ1ODkwMTZhMTJhY2M5MDgwMGU2Iiwia2V5IjoiZHVwbGljYXRlX2hv
+        c3RuYW1lX3Rlc3QiLCJkaXNwbGF5TmFtZSI6ImR1cGxpY2F0ZV9ob3N0bmFt
+        ZV90ZXN0IiwiaHJlZiI6Ii9vd25lcnMvZHVwbGljYXRlX2hvc3RuYW1lX3Rl
+        c3QifX0=
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:16 GMT
+- request:
+    method: post
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/hypervisors/duplicate_hostname_test
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJoeXBlcnZpc29ycyI6W3siaHlwZXJ2aXNvcklkIjp7Imh5cGVydmlzb3JJ
+        ZCI6IjJlNzhmNjQzLTFkMmYtNDVkMS1iMTkxLWQ5MzExNDdjYmRlMSJ9LCJu
+        YW1lIjoibG9jYWxob3N0IiwiZ3Vlc3RJZHMiOlt7Imd1ZXN0SWQiOiJlZDY2
+        YmIzOS1jZGQ4LTRmYWItYTA2Ni1jZTQ0ZWFhZGI1ZjciLCJzdGF0ZSI6MSwi
+        YXR0cmlidXRlcyI6eyJhY3RpdmUiOjEsInZpcnRXaG9UeXBlIjoiZXN4In19
+        XSwiZmFjdHMiOnsiaHlwZXJ2aXNvci50eXBlIjoiVk13YXJlIEVTWGkiLCJo
+        eXBlcnZpc29yLnZlcnNpb24iOiI2LjAuMCIsImNwdS5jcHVfc29ja2V0KHMp
+        IjoiMSJ9fSx7Imh5cGVydmlzb3JJZCI6eyJoeXBlcnZpc29ySWQiOiIyNjFj
+        NGRjYS03MDJmLTQyYjMtYjhlZi0yYTcyYjc3ZjdlYzIifSwibmFtZSI6Imxv
+        Y2FsaG9zdCIsImd1ZXN0SWRzIjpbeyJndWVzdElkIjoiNDIxMzM3NC1mYzcy
+        LTk2ZTYtZWNkYi0xM2RhZDRlYiIsInN0YXRlIjoxLCJhdHRyaWJ1dGVzIjp7
+        ImFjdGl2ZSI6MSwidmlydFdob1R5cGUiOiJlc3gifX1dLCJmYWN0cyI6eyJo
+        eXBlcnZpc29yLnR5cGUiOiJWTXdhcmUgRVNYaSIsImh5cGVydmlzb3IudmVy
+        c2lvbiI6IjYuMC4wIiwiY3B1LmNwdV9zb2NrZXQocykiOiIxIn19XSwib3du
+        ZXIiOiJkdXBsaWNhdGVfaG9zdG5hbWVfdGVzdCJ9
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC",
+        oauth_nonce="WP4OYr3iMkwDbXmyD7ldzvBMolnVpRRp4TmkezAXdQ", oauth_signature="28egN8Uy8MWBARBxBhPeoy%2FYK9E%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1555091476", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - text/plain
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '660'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - b0a40a64-8d82-462b-90f2-b45d6cd616c4
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:16 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxNiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDQtMTJUMTc6NTE6MTYrMDAwMCIsImlkIjoiaHlwZXJ2aXNv
+        cl91cGRhdGVfNTc5NmQ4OWQtZjA2Ni00NGQ0LWIwMGUtOTExMjE2NDQxNWJl
+        Iiwic3RhdGUiOiJDUkVBVEVEIiwic3RhcnRUaW1lIjpudWxsLCJmaW5pc2hU
+        aW1lIjpudWxsLCJyZXN1bHQiOm51bGwsInByaW5jaXBhbE5hbWUiOiJmb3Jl
+        bWFuX2FkbWluIiwidGFyZ2V0VHlwZSI6Im93bmVyIiwidGFyZ2V0SWQiOiJk
+        dXBsaWNhdGVfaG9zdG5hbWVfdGVzdCIsIm93bmVySWQiOiJkdXBsaWNhdGVf
+        aG9zdG5hbWVfdGVzdCIsImNvcnJlbGF0aW9uSWQiOm51bGwsInJlc3VsdERh
+        dGEiOm51bGwsImRvbmUiOmZhbHNlLCJzdGF0dXNQYXRoIjoiL2pvYnMvaHlw
+        ZXJ2aXNvcl91cGRhdGVfNTc5NmQ4OWQtZjA2Ni00NGQ0LWIwMGUtOTExMjE2
+        NDQxNWJlIiwiZ3JvdXAiOiJhc3luYyBncm91cCJ9
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:16 GMT
+- request:
+    method: get
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/jobs/hypervisor_update_5796d89d-f066-44d4-b00e-9112164415be?result_data=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC", oauth_nonce="V73MhlzN9Km1NXuC9w5auXaeIVp9qEcFR8yKT61PdU",
+        oauth_signature="auN2kkMKIgAEefDYdkgPbzA%2FH10%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1555091476", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - f728a3d6-1aa0-4d27-976b-50cc71e42c44
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:16 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxNiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDQtMTJUMTc6NTE6MTYrMDAwMCIsImlkIjoiaHlwZXJ2aXNv
+        cl91cGRhdGVfNTc5NmQ4OWQtZjA2Ni00NGQ0LWIwMGUtOTExMjE2NDQxNWJl
+        Iiwic3RhdGUiOiJGSU5JU0hFRCIsInN0YXJ0VGltZSI6IjIwMTktMDQtMTJU
+        MTc6NTE6MTYrMDAwMCIsImZpbmlzaFRpbWUiOiIyMDE5LTA0LTEyVDE3OjUx
+        OjE2KzAwMDAiLCJyZXN1bHQiOiJDcmVhdGVkOiAyLCBVcGRhdGVkOiAwLCBV
+        bmNoYW5nZWQ6IDAsIEZhaWxlZDogMCIsInByaW5jaXBhbE5hbWUiOiJmb3Jl
+        bWFuX2FkbWluIiwidGFyZ2V0VHlwZSI6Im93bmVyIiwidGFyZ2V0SWQiOiJk
+        dXBsaWNhdGVfaG9zdG5hbWVfdGVzdCIsIm93bmVySWQiOiJkdXBsaWNhdGVf
+        aG9zdG5hbWVfdGVzdCIsImNvcnJlbGF0aW9uSWQiOm51bGwsInJlc3VsdERh
+        dGEiOnsiY3JlYXRlZCI6W3sidXVpZCI6IjEwMjUwYmNiLTRlYzUtNDUzYi1h
+        MzRlLTkyNWE5MzQxN2QxZiIsIm5hbWUiOiJsb2NhbGhvc3QiLCJvd25lciI6
+        eyJrZXkiOiJkdXBsaWNhdGVfaG9zdG5hbWVfdGVzdCJ9fSx7InV1aWQiOiIx
+        MzAyNDMzYi05N2EwLTQ5YjgtOGFlNi0yMjFiODA4NTI5MTIiLCJuYW1lIjoi
+        bG9jYWxob3N0Iiwib3duZXIiOnsia2V5IjoiZHVwbGljYXRlX2hvc3RuYW1l
+        X3Rlc3QifX1dLCJ1cGRhdGVkIjpbXSwidW5jaGFuZ2VkIjpbXSwiZmFpbGVk
+        VXBkYXRlIjpbXX0sImRvbmUiOnRydWUsInN0YXR1c1BhdGgiOiIvam9icy9o
+        eXBlcnZpc29yX3VwZGF0ZV81Nzk2ZDg5ZC1mMDY2LTQ0ZDQtYjAwZS05MTEy
+        MTY0NDE1YmUiLCJncm91cCI6ImFzeW5jIGdyb3VwIn0=
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:16 GMT
+- request:
+    method: get
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/consumers/10250bcb-4ec5-453b-a34e-925a93417d1f
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC", oauth_nonce="5c0aIvFYk10XTfMQlrV1Hy6c2Nrapw0lB7JYd2bBJM",
+        oauth_signature="d5wiwD0XuBV4tVH40Tz%2FsUp9hb0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1555091476", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 4d8c1b68-37ff-4161-983f-746a9d740c23
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:16 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxNiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDQtMTJUMTc6NTE6MTYrMDAwMCIsImlkIjoiNDAyOGY5ZmQ2
+        YTEyNDU4OTAxNmExMmFjY2U5ZDAwZWEiLCJ1dWlkIjoiMTAyNTBiY2ItNGVj
+        NS00NTNiLWEzNGUtOTI1YTkzNDE3ZDFmIiwibmFtZSI6ImxvY2FsaG9zdCIs
+        InVzZXJuYW1lIjoiZm9yZW1hbl9hZG1pbiIsImVudGl0bGVtZW50U3RhdHVz
+        IjpudWxsLCJzZXJ2aWNlTGV2ZWwiOiIiLCJyb2xlIjpudWxsLCJ1c2FnZSI6
+        bnVsbCwiYWRkT25zIjpbXSwic3lzdGVtUHVycG9zZVN0YXR1cyI6bnVsbCwi
+        b3duZXIiOnsiaWQiOiI0MDI4ZjlmZDZhMTI0NTg5MDE2YTEyYWNjOTA4MDBl
+        NiIsImtleSI6ImR1cGxpY2F0ZV9ob3N0bmFtZV90ZXN0IiwiZGlzcGxheU5h
+        bWUiOiJkdXBsaWNhdGVfaG9zdG5hbWVfdGVzdCIsImhyZWYiOiIvb3duZXJz
+        L2R1cGxpY2F0ZV9ob3N0bmFtZV90ZXN0In0sImVudmlyb25tZW50IjpudWxs
+        LCJlbnRpdGxlbWVudENvdW50IjowLCJmYWN0cyI6eyJoeXBlcnZpc29yLnR5
+        cGUiOiJWTXdhcmUgRVNYaSIsImNwdS5jcHVfc29ja2V0KHMpIjoiMSIsImh5
+        cGVydmlzb3IudmVyc2lvbiI6IjYuMC4wIn0sImxhc3RDaGVja2luIjoiMjAx
+        OS0wNC0xMlQxNzo1MToxNiswMDAwIiwiaW5zdGFsbGVkUHJvZHVjdHMiOltd
+        LCJjYW5BY3RpdmF0ZSI6ZmFsc2UsImNhcGFiaWxpdGllcyI6W10sImh5cGVy
+        dmlzb3JJZCI6eyJjcmVhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxNiswMDAw
+        IiwidXBkYXRlZCI6IjIwMTktMDQtMTJUMTc6NTE6MTYrMDAwMCIsImlkIjoi
+        NDAyOGY5ZmQ2YTEyNDU4OTAxNmExMmFjY2U5ZTAwZWMiLCJoeXBlcnZpc29y
+        SWQiOiIyNjFjNGRjYS03MDJmLTQyYjMtYjhlZi0yYTcyYjc3ZjdlYzIiLCJy
+        ZXBvcnRlcklkIjpudWxsfSwiY29udGVudFRhZ3MiOltdLCJhdXRvaGVhbCI6
+        dHJ1ZSwiYW5ub3RhdGlvbnMiOm51bGwsImNvbnRlbnRBY2Nlc3NNb2RlIjpu
+        dWxsLCJ0eXBlIjp7ImlkIjoiMTAwNCIsImxhYmVsIjoiaHlwZXJ2aXNvciIs
+        Im1hbmlmZXN0IjpmYWxzZX0sImd1ZXN0SWRzIjpbXSwiaHJlZiI6Ii9jb25z
+        dW1lcnMvMTAyNTBiY2ItNGVjNS00NTNiLWEzNGUtOTI1YTkzNDE3ZDFmIiwi
+        cmVsZWFzZVZlciI6eyJyZWxlYXNlVmVyIjpudWxsfSwiaWRDZXJ0IjpudWxs
+        fQ==
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:16 GMT
+- request:
+    method: get
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/consumers/1302433b-97a0-49b8-8ae6-221b80852912
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC", oauth_nonce="j6ban7Mp6xbqxiMkU0alIhash6l39TZngj8oeO8QI",
+        oauth_signature="Ca90l7lCuG0ZXil5%2BWnedzuBGo4%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1555091476", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 3e9b9548-f1d4-4ecb-b3b8-8fa35de7dfba
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:16 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxNiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDQtMTJUMTc6NTE6MTYrMDAwMCIsImlkIjoiNDAyOGY5ZmQ2
+        YTEyNDU4OTAxNmExMmFjY2U5ZTAwZWQiLCJ1dWlkIjoiMTMwMjQzM2ItOTdh
+        MC00OWI4LThhZTYtMjIxYjgwODUyOTEyIiwibmFtZSI6ImxvY2FsaG9zdCIs
+        InVzZXJuYW1lIjoiZm9yZW1hbl9hZG1pbiIsImVudGl0bGVtZW50U3RhdHVz
+        IjpudWxsLCJzZXJ2aWNlTGV2ZWwiOiIiLCJyb2xlIjpudWxsLCJ1c2FnZSI6
+        bnVsbCwiYWRkT25zIjpbXSwic3lzdGVtUHVycG9zZVN0YXR1cyI6bnVsbCwi
+        b3duZXIiOnsiaWQiOiI0MDI4ZjlmZDZhMTI0NTg5MDE2YTEyYWNjOTA4MDBl
+        NiIsImtleSI6ImR1cGxpY2F0ZV9ob3N0bmFtZV90ZXN0IiwiZGlzcGxheU5h
+        bWUiOiJkdXBsaWNhdGVfaG9zdG5hbWVfdGVzdCIsImhyZWYiOiIvb3duZXJz
+        L2R1cGxpY2F0ZV9ob3N0bmFtZV90ZXN0In0sImVudmlyb25tZW50IjpudWxs
+        LCJlbnRpdGxlbWVudENvdW50IjowLCJmYWN0cyI6eyJoeXBlcnZpc29yLnR5
+        cGUiOiJWTXdhcmUgRVNYaSIsImNwdS5jcHVfc29ja2V0KHMpIjoiMSIsImh5
+        cGVydmlzb3IudmVyc2lvbiI6IjYuMC4wIn0sImxhc3RDaGVja2luIjoiMjAx
+        OS0wNC0xMlQxNzo1MToxNiswMDAwIiwiaW5zdGFsbGVkUHJvZHVjdHMiOltd
+        LCJjYW5BY3RpdmF0ZSI6ZmFsc2UsImNhcGFiaWxpdGllcyI6W10sImh5cGVy
+        dmlzb3JJZCI6eyJjcmVhdGVkIjoiMjAxOS0wNC0xMlQxNzo1MToxNiswMDAw
+        IiwidXBkYXRlZCI6IjIwMTktMDQtMTJUMTc6NTE6MTYrMDAwMCIsImlkIjoi
+        NDAyOGY5ZmQ2YTEyNDU4OTAxNmExMmFjY2U5ZTAwZWYiLCJoeXBlcnZpc29y
+        SWQiOiIyZTc4ZjY0My0xZDJmLTQ1ZDEtYjE5MS1kOTMxMTQ3Y2JkZTEiLCJy
+        ZXBvcnRlcklkIjpudWxsfSwiY29udGVudFRhZ3MiOltdLCJhdXRvaGVhbCI6
+        dHJ1ZSwiYW5ub3RhdGlvbnMiOm51bGwsImNvbnRlbnRBY2Nlc3NNb2RlIjpu
+        dWxsLCJ0eXBlIjp7ImlkIjoiMTAwNCIsImxhYmVsIjoiaHlwZXJ2aXNvciIs
+        Im1hbmlmZXN0IjpmYWxzZX0sImd1ZXN0SWRzIjpbXSwiaHJlZiI6Ii9jb25z
+        dW1lcnMvMTMwMjQzM2ItOTdhMC00OWI4LThhZTYtMjIxYjgwODUyOTEyIiwi
+        cmVsZWFzZVZlciI6eyJyZWxlYXNlVmVyIjpudWxsfSwiaWRDZXJ0IjpudWxs
+        fQ==
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:16 GMT
+- request:
+    method: get
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/consumers/10250bcb-4ec5-453b-a34e-925a93417d1f/guests
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC", oauth_nonce="oDmyWAuSgiGsNMdx6Db6JzqzbPezUrvk692Gd2Jt8",
+        oauth_signature="QYWPiyHkI3ZjF3JkYFSvWM8bGmQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1555091476", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 87cae1f8-7d02-47ac-a171-146614842235
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:16 GMT
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:16 GMT
+- request:
+    method: get
+    uri: https://centos7-devel.jturel.example.com:8443/candlepin/consumers/1302433b-97a0-49b8-8ae6-221b80852912/guests
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      Authorization:
+      - OAuth oauth_consumer_key="5TryPa686WnEVgHKeBs2fZJ4sn9EDeJC", oauth_nonce="t9iP2yH5Q0X2n5vFpA8fFC48eqFvVIxabGva8Wo",
+        oauth_signature="7gCIjspGH%2BVmzP%2FafpORSqRVtmc%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1555091476", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 13a80329-6ff0-4db0-ab18-4565011640a2
+      X-Version:
+      - 2.6.4-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 12 Apr 2019 17:51:16 GMT
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 12 Apr 2019 17:51:16 GMT
 recorded_with: VCR 3.0.3

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -175,6 +175,17 @@ class ActiveSupport::TestCase
   include FixtureTestCase
   include ForemanTasks::TestHelpers::WithInThreadExecutor
 
+  setup :global_setup
+  teardown :global_teardown
+
+  def global_setup
+    @original_candlepin_bulk_size = SETTINGS[:katello][:candlepin][:bulk_load_size]
+  end
+
+  def global_teardown
+    SETTINGS[:katello][:candlepin][:bulk_load_size] = @original_candlepin_bulk_size
+  end
+
   before do
     stub_ping
     stub_certs


### PR DESCRIPTION
The intention of this change is to ensure we don't create orphaned host records in our database when a hypervisor that's checking in has modified its hypervisor_id in the virt-who config. Hypervisor records are already created based on the hypervisorId field, and this change will update the name on the host record if the hypervisorId has changed.

Candlepin has been updated so that it will key off of the dmi.system.uuid fact in the case that `hypervisorId` has changed and update *that* record instead of creating a new one. Since we are doing our side of the work after Candlepin we don't need to duplicate that lookup and work around it.

**Open questions:** 

- The downstream RFE asks that the host name is updated and that's what I've done here. Is that always desireable? Maybe we could have a setting that controls whether the host name will be updated. Should it be disabled or enabled by default?

**To test:**
- Update to Candlepin 2.6 locally (not strictly required, but it's the latest in nightly repos)
- Apply this change
- Using the fixture provided in this PR for the tests, issue a request to perform a hypervisor checkin:
```
curl -u "admin:changeme" -k -X POST -H 'Content-type: application/json' https://localhost/rhsm/hypervisors/Default_Organization -d '@./virt_who_altered_hypervisor_id.json'
```
- There should be two hosts in the UI
- Alter the hypervisorId field of the first hypervisor record in the fixture (notice that it has a dmi.system.uuid fact) to be anything else.
- Issue the hypervisor checkin request again.
- Check the UI and see there are still two hosts, but one of them has a new name reflecting the hypervisorId you modified