### PR TITLE
Fixes #26624: Update applicability counts on CV publish&promote

### DIFF
--- a/app/lib/actions/katello/content_view/promote_to_environment.rb
+++ b/app/lib/actions/katello/content_view/promote_to_environment.rb
@@ -43,6 +43,12 @@ module Actions
         end
 
         def finalize
+          # update errata applicability counts for all hosts in the CV & LE
+          ::Katello::Host::ContentFacet.where(:content_view_id => input[:content_view_id],
+                                              :lifecycle_environment_id => input[:environment_id]).each do |facet|
+            facet.update_applicability_counts
+          end
+
           history = ::Katello::ContentViewHistory.find(input[:history_id])
           history.status = ::Katello::ContentViewHistory::SUCCESSFUL
           history.save!

--- a/app/lib/actions/katello/content_view/publish.rb
+++ b/app/lib/actions/katello/content_view/publish.rb
@@ -107,6 +107,12 @@ module Actions
         end
 
         def finalize
+          # update errata applicability counts for all hosts in the CV & Library
+          ::Katello::Host::ContentFacet.where(:content_view_id => input[:content_view_id],
+                                              :lifecycle_environment_id => input[:environment_id]).each do |facet|
+            facet.update_applicability_counts
+          end
+
           history = ::Katello::ContentViewHistory.find(input[:history_id])
           history.status = ::Katello::ContentViewHistory::SUCCESSFUL
           history.save!


### PR DESCRIPTION
When CV publish or promote happens, we recalculate errata applicability
per each repo, but dont update the cummulative counts. Users see old values until
applicability is imported again or re-counted elsewhere.

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>