### PR TITLE
Refs #26600 - Fix intermittent HypervisorsVcrTest

### DIFF
--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -175,21 +175,14 @@ class ActiveSupport::TestCase
   include FixtureTestCase
   include ForemanTasks::TestHelpers::WithInThreadExecutor
 
-  setup :global_setup
-  teardown :global_teardown
-
-  def global_setup
-    @original_candlepin_bulk_size = SETTINGS[:katello][:candlepin][:bulk_load_size]
-  end
-
-  def global_teardown
-    SETTINGS[:katello][:candlepin][:bulk_load_size] = @original_candlepin_bulk_size
-  end
-
   before do
     stub_ping
     stub_certs
     Setting::Content.load_defaults
+  end
+
+  teardown do
+    SETTINGS[:katello][:candlepin][:bulk_load_size] = 1000
   end
 
   def self.stubbed_ping_response


### PR DESCRIPTION
In my recent PR #8076 I attempted to work around the candlepin bulk_load_size being modified by one of the rake task tests using setup & teardown callbacks to save and restore the setting value. It seems that sometimes the value of the setting is nil at setup, and this will also break the HypervisorsVcrTest since the recorded cassette won't match as bulk_load_size affects the page_size param of the URL.

I made the code a little dumber by just hard-coding the default value of 1000 to be restored after each test run.

1000 comes from here: https://github.com/Katello/katello/blob/6ebf1e36fac8f8b9ca83dec4fbfb27ec5eaa88df/lib/katello/engine.rb#L42