### PR TITLE
Fixes #26640 - Don't unregister existing hosts upon registration

### DIFF
--- a/app/lib/katello/api/v2/error_handling.rb
+++ b/app/lib/katello/api/v2/error_handling.rb
@@ -21,6 +21,7 @@ module Katello
           rescue_from Errors::UnsupportedActionException, :with => :rescue_from_unsupported_action_exception
           rescue_from Errors::MaxHostsReachedException, :with => :rescue_from_max_hosts_reached_exception
           rescue_from Errors::CdnSubstitutionError, :with => :rescue_from_bad_data
+          rescue_from Errors::RegistrationError, :with => :rescue_from_bad_data
           rescue_from ActionController::ParameterMissing, :with => :rescue_from_missing_param
         end
 

--- a/app/lib/katello/errors.rb
+++ b/app/lib/katello/errors.rb
@@ -8,6 +8,8 @@ module Katello
 
     class NotFound < StandardError; end
 
+    class RegistrationError < StandardError; end
+
     # unauthorized access
     class SecurityViolation < StandardError; end
 

--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -244,31 +244,30 @@ module Katello
 
       def self.find_host(facts, organization)
         host_name = propose_existing_hostname(facts)
+        host_uuid = facts['dmi.system.uuid']
         uuid_fact_id = RhsmFactName.find_by(name: 'dmi::system::uuid')&.id || -1
+
         hosts = ::Host.unscoped.distinct.left_outer_joins(:fact_values)
                 .where("#{::Host.table_name}.name = ? OR (#{FactValue.table_name}.fact_name_id = ?
-		AND #{FactValue.table_name}.value = ?)", host_name, uuid_fact_id, facts['dmi.system.uuid'])
+               AND #{FactValue.table_name}.value = ?)", host_name, uuid_fact_id, host_uuid)
 
-        return nil if hosts.empty?
+        return if hosts.empty?
 
-        if hosts.where("organization_id = #{organization.id} OR organization_id is NULL").empty? #not in the correct org
+        hosts = hosts.where(organization_id: [organization.id, nil])
+        hosts_size = hosts.size
+
+        if hosts_size == 0 # not in the correct org
           #TODO: http://projects.theforeman.org/issues/11532
-          fail _("Host with name %{host_name} is currently registered to a different org, please migrate host to %{org_name}.") %
+          fail Katello::Errors::RegistrationError, _("Host with name %{host_name} is currently registered to a different org, please migrate host to %{org_name}.") %
                    {:org_name => organization.name, :host_name => host_name }
         end
 
-        if hosts.size > 1
-          hostnames = hosts.pluck(:name).sort
-          fail _("Multiple profiles found. Consider removing %s which match this host.") % hostnames.join(', ')
+        if hosts_size == 1 && hosts.joins(:subscription_facet).empty?
+          return hosts.first
         end
 
-        # check for hosts that were matched by dmi.system.uuid but whose name didn't match
-        if hosts.where(name: host_name).empty?
-          fail _("The host %{existing} matches this registration. Remove or rename it to %{new_host} before registering.") %
-            {existing: hosts.pluck(:name).first, new_host: host_name}
-        end
-
-        hosts.first
+        hostnames = hosts.pluck(:name).sort.join(', ')
+        fail Katello::Errors::RegistrationError, _("Please unregister or remove hosts which match this host before registering: %{existing}") % {existing: hostnames}
       end
 
       def self.sanitize_name(name)


### PR DESCRIPTION
This PR fixes security issues with host registrations causing unregistration of other hosts due to how we match existing hosts by name or the dmi.system.uuid fact. The intention of the original code was to re-use the host record in Katello while unregistering & creating new registrations in backend Pulp and Candlepin.

**The change here completely removes the ability for a host to be unregistered by the registration of some other system even when they have the same hostname and dmi.system.uuid fact. We only reuse an existing host record when the hostname and dmi.system.uuid fact match the registering system *and* the matched host is not currently registered.**

To test:

- check out this PR
- register a client to your devel box (katello-client in Forklift makes it easy)
- note the dmi.system.uuid => `subscription-manager facts | grep dmi.system.uuid`
- trick the client into thinking it's unregistered: `subscription-manager clean` (the host profile remains in Katello)
- alter the dmi.system.uuid => `echo '{"dmi.system.uuid": "batmobile"}' > /etc/rhsm/facts/uuid.facts` (change can be verified by `subscription-manager facts`)
- attempt to register the host - the registration should fail:
```
root@katello-client vagrant]# subscription-manager register --username=admin --password=changeme --org=Default_Organization --environment=Library
Registering to: centos7-devel.jturel.example.com:443/rhsm
HTTP error (500 - Internal Server Error): Please remove hosts which match this host before registering: katello-client-a.jturel.example.com
```
- registration should also fail after restoring the original dmi.system.uuid and changing the hostname to something unique (since the UUID matches the first registration)

- Registration should be successful again only when the original host has been unregistered or removed from Katello (via API/UI/CLI) or the hostname *and* dmi.system.uuuid fact on the client are unique across all registered hosts

- The same steps can be followed when registering with an Activation Key `subscription-manager register --activationkey=MyKey --org=Default_Organization` and the results should be the same as described above


