### PR TITLE
Fixes #26673 - Fix content host permissions

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-host-bulk-module-streams-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-host-bulk-module-streams-modal.html
@@ -41,7 +41,7 @@
               {{ module.name }}</a></td>
             <td bst-table-cell>{{ module.stream }}</td>
             <td bst-table-cell>
-              <div class="dropdown" ng-hide="!remoteExecutionPresent || denied('edit_content_hosts', contentHost)">
+              <div class="dropdown" ng-hide="!remoteExecutionPresent || denied('edit_hosts', host)">
                 <button class="btn btn-default dropdown-toggle" ng-disabled="$scope.working" type="button" id="dropdownMenu1" data-toggle="dropdown"> Actions
                   <span class="caret"></span>
                 </button>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
@@ -73,7 +73,7 @@
               Apply Selected
             </button>
             <button uib-dropdown-toggle class="btn btn-primary"
-                    ng-hide="!remoteExecutionPresent || denied('edit_content_hosts', contentHost)"
+                    ng-hide="!remoteExecutionPresent || denied('edit_hosts', host)"
                     ng-disabled="table.getSelected().length == 0"
                     type="button" id="use-remote-execution">
               <span class="caret"></span>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-module-streams.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-module-streams.html
@@ -72,7 +72,7 @@
               {{ module.installed_profiles.join(", ") }}
             </td>
             <td bst-table-cell>
-              <div class="dropdown" ng-hide="!remoteExecutionPresent || denied('edit_content_hosts', contentHost)">
+              <div class="dropdown" ng-hide="!remoteExecutionPresent || denied('edit_hosts', host)">
                 <button class="btn btn-default dropdown-toggle" ng-disabled="$scope.working" type="button" id="dropdownMenu1" data-toggle="dropdown"> Actions
                   <span class="caret"></span>
                 </button>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-actions.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-packages-actions.html
@@ -40,7 +40,7 @@
                 Perform
               </button>
               <button uib-dropdown-toggle class="btn btn-default"
-                      ng-hide="!remoteExecutionPresent || denied('edit_content_hosts', contentHost)"
+                      ng-hide="!remoteExecutionPresent || denied('edit_hosts', host)"
                       ng-disabled="working || packageAction.term === undefined || packageAction.term.length === 0"
                       type="button" id="use-remote-execution">
                 <span class="caret"></span>


### PR DESCRIPTION
In some pages, we are still using 'edit_content_hosts' permission, which was replaced a while ago with 'edit_hosts'. Users with 'edit_host' permission can't see parts of the page

To test:
- create a user with manager role (which has 'edit_hosts')
- go to pages in the content host details and make sure nothing is missing that an admin user can see
