### PR TITLE
Fixes #26677 - Transient controller test

### DIFF
--- a/test/controllers/api/rhsm/candlepin_dynflow_proxy_controller_integration_test.rb
+++ b/test/controllers/api/rhsm/candlepin_dynflow_proxy_controller_integration_test.rb
@@ -14,12 +14,14 @@ module Katello
     end
 
     test 'params are not parsed in the controller' do
-      JSON.expects(:parse).never
       Api::Rhsm::CandlepinDynflowProxyController.any_instance.expects(:async_task).returns(nil)
       Resources::Candlepin::Consumer.expects(:get).returns({})
+      packages = [{"vendor" => "CentOS", "name" => "python-six", "epoch" => 0, "version" => "1.9.0", "release" => "2.el7", "arch" => "noarch"}]
 
-      put "/rhsm/consumers/#{@host.subscription_facet.uuid}/packages", params: {}.to_json, headers: { 'CONTENT_TYPE' => 'application/json' }
+      put "/rhsm/consumers/#{@host.subscription_facet.uuid}/packages", params: packages.to_json, headers: { 'CONTENT_TYPE' => 'application/json' }
 
+      assert_nil request.params['_json']
+      assert_equal 'text/plain', request.headers['CONTENT_TYPE']
       assert_response :success
     end
   end


### PR DESCRIPTION
This one has been failing often enough to be annoying with lots of extra [test katello] needed on a regular basis.

My suspicion is that something in Dynflow running in the same thread as the test is calling JSON.parse on something. So I've re-written the assertion to not depend on that, but rather check the content type and lack of json-parsed params.

You can observe the test fail by commenting out this line:

https://github.com/Katello/katello/blob/98945b3bb58ce5dd6ee6d005c55eaaa6f0336adb/lib/katello/prevent_json_parsing.rb#L10

`bundle exec ktest ~/katello/test/controllers/api/rhsm/candlepin_dynflow_proxy_controller_integration_test.rb`


The failures on PRs looks like this, for reference:

```
Error
not all expectations were satisfied...
Stacktrace
not all expectations were satisfied
unsatisfied expectations:
- expected never, invoked once: JSON.parse(any_parameters)
satisfied expectations:
- allowed any number of times, not yet invoked: Katello::Ping.ping(any_parameters)
- allowed any number of times, not yet invoked: Cert::Certs.ssl_client_key(any_parameters)
- allowed any number of times, not yet invoked: Cert::Certs.ssl_client_cert(any_parameters)
- allowed any number of times, not yet invoked: Cert::Certs.ca_cert(any_parameters)
- expected exactly once, invoked once: #<AnyInstance:Katello::Api::Rhsm::CandlepinDynflowProxyController>.async_task(any_parameters)
- expected exactly once, invoked once: Katello::Resources::Candlepin::Consumer.get(any_parameters)
(Minitest::Assertion)
/home/jenkins/workspace/katello-pr-test/test/controllers/api/rhsm/candlepin_dynflow_proxy_controller_integration_test.rb:17
```
