### PR TITLE
Fixes #26682 - fixed seed test for bcrypt setting

### DIFF
--- a/test/lib/tasks/seeds_test.rb
+++ b/test/lib/tasks/seeds_test.rb
@@ -10,6 +10,7 @@ module Katello
       Setting.stubs(:[]).with(:default_location_puppet_content).returns('')
       Setting.stubs(:[]).with(:authorize_login_delegation_auth_source_user_autocreate).returns('EXTERNAL')
       Setting.stubs(:[]).with(:entries_per_page).returns(20)
+      Setting.stubs(:[]).with(:bcrypt_cost).returns(5)
     end
 
     def seed


### PR DESCRIPTION
For https://github.com/theforeman/foreman/pull/5633

There is a new seed in core now.