### PR TITLE
Fixes #26683 - Prevent .info-paragraph from overflowing columns

### DIFF
--- a/engines/bastion/app/assets/stylesheets/bastion/nutupane.scss
+++ b/engines/bastion/app/assets/stylesheets/bastion/nutupane.scss
@@ -183,7 +183,7 @@ td.row-select {
 
 .info-paragraph {
   padding-left: 0px;
-  white-space: pre;
+  white-space: pre-wrap;
 }
 
 .detail:not(:last-child) {


### PR DESCRIPTION
The errata page has a two column layout with multiple .info-paragraphs in the left column and affected packages in the right column. With the white-space property set to pre, the left column can overflow into the right column as seen in https://bugzilla.redhat.com/show_bug.cgi?id=1699982

Setting the value to pre-wrap instead should preserve other features of the style while preventing the overflow