### PR TITLE
Fixes #26694 - content-url updates on import

### DIFF
--- a/app/lib/actions/candlepin/owner/import_products.rb
+++ b/app/lib/actions/candlepin/owner/import_products.rb
@@ -11,7 +11,7 @@ module Actions
           updated_content = []
           ::Katello::Product.without_auditing do
             User.as_anonymous_admin do
-              updated_content = organization.redhat_provider.import_products_from_cp
+              updated_content = organization.redhat_provider.import_products_from_cp.content_url_updated
             end
             ForemanTasks.async_task(Katello::Repository::UpdateContentUrls, updated_content) if updated_content.present?
           end

--- a/app/lib/actions/candlepin/owner/import_products.rb
+++ b/app/lib/actions/candlepin/owner/import_products.rb
@@ -8,12 +8,11 @@ module Actions
 
         def run
           organization = ::Organization.find(input[:organization_id])
-          updated_content = []
           ::Katello::Product.without_auditing do
             User.as_anonymous_admin do
               updated_content = organization.redhat_provider.import_products_from_cp.content_url_updated
+              ForemanTasks.async_task(Katello::Repository::UpdateContentUrls, updated_content) if updated_content.present?
             end
-            ForemanTasks.async_task(Katello::Repository::UpdateContentUrls, updated_content) if updated_content.present?
           end
         end
       end

--- a/app/lib/actions/candlepin/owner/import_products.rb
+++ b/app/lib/actions/candlepin/owner/import_products.rb
@@ -8,10 +8,12 @@ module Actions
 
         def run
           organization = ::Organization.find(input[:organization_id])
+          updated_content = []
           ::Katello::Product.without_auditing do
             User.as_anonymous_admin do
-              organization.redhat_provider.import_products_from_cp
+              updated_content = organization.redhat_provider.import_products_from_cp
             end
+            ForemanTasks.async_task(Katello::Repository::UpdateContentUrls, updated_content) if updated_content.present?
           end
         end
       end

--- a/app/lib/actions/katello/repository/update_content_urls.rb
+++ b/app/lib/actions/katello/repository/update_content_urls.rb
@@ -4,10 +4,6 @@ module Actions
       class UpdateContentUrls < Actions::EntryAction
         def plan(content_to_update)
           concurrence do
-            content_to_update = content_to_update.select do |content|
-
-            end
-
             content_to_update.flat_map(&:repositories).each do |repo|
               plan_action(Katello::Repository::UpdateRedhatRepository, repo)
             end

--- a/app/lib/actions/katello/repository/update_content_urls.rb
+++ b/app/lib/actions/katello/repository/update_content_urls.rb
@@ -1,0 +1,19 @@
+module Actions
+  module Katello
+    module Repository
+      class UpdateContentUrls < Actions::EntryAction
+        def plan(content_to_update)
+          concurrence do
+            content_to_update.each do |content|
+              content.root_repositories.each do |root|
+                root.repositories.each do |repo|
+                  plan_action(Katello::Repository::UpdateRedhatRepository, repo)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/repository/update_content_urls.rb
+++ b/app/lib/actions/katello/repository/update_content_urls.rb
@@ -4,8 +4,10 @@ module Actions
       class UpdateContentUrls < Actions::EntryAction
         def plan(content_to_update)
           concurrence do
-            content_to_update.flat_map(&:repositories).each do |repo|
-              plan_action(Katello::Repository::UpdateRedhatRepository, repo)
+            content_to_update.each do |content|
+              content.repositories.each do |repo|
+                plan_action(Katello::Repository::UpdateRedhatRepository, repo)
+              end
             end
           end
         end

--- a/app/lib/actions/katello/repository/update_content_urls.rb
+++ b/app/lib/actions/katello/repository/update_content_urls.rb
@@ -4,12 +4,12 @@ module Actions
       class UpdateContentUrls < Actions::EntryAction
         def plan(content_to_update)
           concurrence do
-            content_to_update.each do |content|
-              content.root_repositories.each do |root|
-                root.repositories.each do |repo|
-                  plan_action(Katello::Repository::UpdateRedhatRepository, repo)
-                end
-              end
+            content_to_update = content_to_update.select do |content|
+
+            end
+
+            content_to_update.flat_map(&:repositories).each do |repo|
+              plan_action(Katello::Repository::UpdateRedhatRepository, repo)
             end
           end
         end

--- a/app/lib/actions/katello/repository/update_metadata_sync.rb
+++ b/app/lib/actions/katello/repository/update_metadata_sync.rb
@@ -7,6 +7,7 @@ module Actions
             plan_action(Katello::Repository::MetadataGenerate, repository)
             concurrence do
               ::SmartProxy.with_repo(repository).each do |capsule|
+                next if capsule.pulp_master?
                 plan_action(Katello::CapsuleContent::Sync, capsule, repository_id: repository.id)
               end
             end

--- a/app/lib/actions/katello/repository/update_metadata_sync.rb
+++ b/app/lib/actions/katello/repository/update_metadata_sync.rb
@@ -1,0 +1,18 @@
+module Actions
+  module Katello
+    module Repository
+      class UpdateMetadataSync < Actions::Base
+        def plan(repository)
+          sequence do
+            plan_action(Katello::Repository::MetadataGenerate, repository)
+            concurrence do
+              ::SmartProxy.with_repo(repository).each do |capsule|
+                plan_action(Katello::CapsuleContent::Sync, capsule, repository_id: repository.id)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/repository/update_redhat_repository.rb
+++ b/app/lib/actions/katello/repository/update_redhat_repository.rb
@@ -26,7 +26,7 @@ module Actions
         end
 
         def relative_path(repo)
-          ::Katello::Glue::Pulp::Repos.repo_path_from_content_path(repo.environment, path(repo))
+          repo.generate_repo_path(path(repo))
         end
 
         def upstream_url(repo)

--- a/app/lib/actions/katello/repository/update_redhat_repository.rb
+++ b/app/lib/actions/katello/repository/update_redhat_repository.rb
@@ -1,0 +1,29 @@
+module Actions
+  module Katello
+    module Repository
+      class UpdateRedhatRepository < Actions::EntryAction
+        def plan(repo)
+          action_subject repo
+          repo.update_attributes!(relative_path: relative_path(repo))
+          plan_action(::Actions::Pulp::Repository::Refresh, repo)
+          plan_self(:repository_id => repo.id)
+        end
+
+        def run
+          repository = ::Katello::Repository.find(input[:repository_id])
+          ForemanTasks.async_task(Katello::Repository::MetadataGenerate, repository)
+        end
+
+        private
+
+        def relative_path(repo)
+          path = repo.content.content_url
+          repo.root.substitutions.each do |key, value|
+            path = path.gsub("$#{key}", value) if value
+          end
+          ::Katello::Glue::Pulp::Repos.repo_path_from_content_path(repo.environment, path)
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/repository/update_redhat_repository.rb
+++ b/app/lib/actions/katello/repository/update_redhat_repository.rb
@@ -4,6 +4,7 @@ module Actions
       class UpdateRedhatRepository < Actions::EntryAction
         def plan(repo)
           action_subject repo
+          repo.root.update_attributes!(:url => upstream_url(repo)) if repo.library_instance?
           repo.update_attributes!(relative_path: relative_path(repo))
           plan_action(::Actions::Pulp::Repository::Refresh, repo)
           plan_self(:repository_id => repo.id)
@@ -16,12 +17,20 @@ module Actions
 
         private
 
-        def relative_path(repo)
+        def path(repo)
           path = repo.content.content_url
           repo.root.substitutions.each do |key, value|
             path = path.gsub("$#{key}", value) if value
           end
-          ::Katello::Glue::Pulp::Repos.repo_path_from_content_path(repo.environment, path)
+          path
+        end
+
+        def relative_path(repo)
+          ::Katello::Glue::Pulp::Repos.repo_path_from_content_path(repo.environment, path(repo))
+        end
+
+        def upstream_url(repo)
+          repo.product.repo_url(path(repo))
         end
       end
     end

--- a/app/lib/actions/katello/repository/update_redhat_repository.rb
+++ b/app/lib/actions/katello/repository/update_redhat_repository.rb
@@ -12,7 +12,7 @@ module Actions
 
         def run
           repository = ::Katello::Repository.find(input[:repository_id])
-          ForemanTasks.async_task(Katello::Repository::MetadataGenerate, repository)
+          ForemanTasks.async_task(Katello::Repository::UpdateMetadataSync, repository)
         end
 
         private

--- a/app/lib/actions/katello/repository/update_redhat_repository.rb
+++ b/app/lib/actions/katello/repository/update_redhat_repository.rb
@@ -17,20 +17,12 @@ module Actions
 
         private
 
-        def path(repo)
-          path = repo.content.content_url
-          repo.root.substitutions.each do |key, value|
-            path = path.gsub("$#{key}", value) if value
-          end
-          path
-        end
-
         def relative_path(repo)
-          repo.generate_repo_path(path(repo))
+          repo.generate_repo_path(repo.generate_content_path)
         end
 
         def upstream_url(repo)
-          repo.product.repo_url(path(repo))
+          repo.product.repo_url(repo.generate_content_path)
         end
       end
     end

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -56,7 +56,7 @@ module Katello
         }
         scope :with_content, -> { with_features(PULP_FEATURE, PULP_NODE_FEATURE) }
 
-        scope :with_repo, lambda do |repo|
+        def self.with_repo(repo)
           joins(:capsule_lifecycle_environments).
           where("#{Katello::CapsuleLifecycleEnvironment.table_name}.lifecycle_environment_id" => repo.environment_id)
         end

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -56,6 +56,11 @@ module Katello
         }
         scope :with_content, -> { with_features(PULP_FEATURE, PULP_NODE_FEATURE) }
 
+        scope :with_repo, lambda do |repo|
+          joins(:capsule_lifecycle_environments).
+          where("#{Katello::CapsuleLifecycleEnvironment.table_name}.lifecycle_environment_id" => repo.environment_id)
+        end
+
         def self.pulp_master
           unscoped.with_features(PULP_FEATURE).first
         end

--- a/app/models/katello/content.rb
+++ b/app/models/katello/content.rb
@@ -54,5 +54,13 @@ module Katello
         prod_content_importer.import
       end
     end
+
+    def can_update_to_url?(new_url)
+      # We need to match the substitutable variables from
+      # current content_url and new_url
+      current_subs = content_url.scan(/\$\w+/).sort
+      new_url_subs = new_url.scan(/\$\w+/).sort
+      current_subs == new_url_subs
+    end
   end
 end

--- a/app/models/katello/content.rb
+++ b/app/models/katello/content.rb
@@ -58,8 +58,8 @@ module Katello
     def can_update_to_url?(new_url)
       # We need to match the substitutable variables from
       # current content_url and new_url
-      current_subs = content_url.scan(/\$\w+/).sort
-      new_url_subs = new_url.scan(/\$\w+/).sort
+      current_subs = content_url&.scan(/\$\w+/)&.sort
+      new_url_subs = new_url&.scan(/\$\w+/)&.sort
       current_subs == new_url_subs
     end
   end

--- a/app/models/katello/glue/provider.rb
+++ b/app/models/katello/glue/provider.rb
@@ -136,6 +136,7 @@ module Katello
         end
         prod_content_importer.import
         self.index_subscriptions(self.organization)
+        prod_content_importer.content_url_updated
       end
 
       def import_product(product_json)

--- a/app/models/katello/glue/provider.rb
+++ b/app/models/katello/glue/provider.rb
@@ -136,7 +136,7 @@ module Katello
         end
         prod_content_importer.import
         self.index_subscriptions(self.organization)
-        prod_content_importer.content_url_updated
+        prod_content_importer
       end
 
       def import_product(product_json)

--- a/app/models/katello/glue/pulp/repos.rb
+++ b/app/models/katello/glue/pulp/repos.rb
@@ -118,7 +118,7 @@ module Katello
           content_url.dup
         else
           path = content_url.sub(%r{^/}, '')
-          repo_url = self.provider.repository_url.sub(%r{/$}, '')
+          repo_url = self.provider.repository_url&.sub(%r{/$}, '')
           "#{repo_url}/#{path}"
         end
       end

--- a/app/models/katello/glue/pulp/repos.rb
+++ b/app/models/katello/glue/pulp/repos.rb
@@ -117,7 +117,9 @@ module Katello
         if self.provider.provider_type == Provider::CUSTOM
           content_url.dup
         else
-          self.provider.repository_url + content_url
+          path = content_url.sub(%r{^/}, '')
+          repo_url = self.provider.repository_url.sub(%r{/$}, '')
+          "#{repo_url}/#{path}"
         end
       end
 

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -355,7 +355,7 @@ module Katello
 
     def generate_repo_path(content_path = nil)
       _org, _content, content_path = (self.library_instance || self).relative_path.split("/", 3) if content_path.blank?
-
+      content_path = content_path.sub(%r|^/|, '')
       if self.environment
         cve = ContentViewEnvironment.where(:environment_id => self.environment,
                                            :content_view_id => self.content_view).first

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -345,6 +345,14 @@ module Katello
       return task && task.main_action.pulp_task_id == pulp_task_id
     end
 
+    def generate_content_path
+      path = content.content_url
+      root.substitutions.each do |key, value|
+        path = path.gsub("$#{key}", value) if value
+      end
+      path
+    end
+
     def generate_repo_path(content_path = nil)
       _org, _content, content_path = (self.library_instance || self).relative_path.split("/", 3) if content_path.blank?
 

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -345,8 +345,8 @@ module Katello
       return task && task.main_action.pulp_task_id == pulp_task_id
     end
 
-    def generate_repo_path
-      _org, _content, content_path = (self.library_instance || self).relative_path.split("/", 3)
+    def generate_repo_path(content_path = nil)
+      _org, _content, content_path = (self.library_instance || self).relative_path.split("/", 3) if content_path.blank?
 
       if self.environment
         cve = ContentViewEnvironment.where(:environment_id => self.environment,

--- a/app/services/katello/product_content_importer.rb
+++ b/app/services/katello/product_content_importer.rb
@@ -106,8 +106,13 @@ module Katello
 
       new_url = prod_content_json[:content][:contentUrl]
       if content.content_url != new_url
-        attrs_to_update[:content_url] = new_url
-        @content_url_updated << content
+        if content.can_update_to_url?(new_url)
+          attrs_to_update[:content_url] = new_url
+          @content_url_updated << content
+        else
+          Rails.logger.warn(_("Substitution Mismatch. Unable to update for content: (%{content}). From [%{content_url}] To [%{new_url}].") %
+                      { content: content.inspect, content_url: content.content_url, new_url: new_url })
+        end
       end
       content.update_attributes!(attrs_to_update) unless attrs_to_update.blank?
     end

--- a/app/services/katello/product_content_importer.rb
+++ b/app/services/katello/product_content_importer.rb
@@ -20,13 +20,13 @@ module Katello
     #    },
     #    "enabled":false
     # }
-    attr_accessor :content_url_updated
+    attr_reader :content_url_updated
 
     def initialize
       @contents_to_create = []
       @product_contents_to_create = []
       @product_mapping = {}
-      self.content_url_updated = []
+      @content_url_updated = []
     end
 
     def add_product_content(product, product_content_json)
@@ -100,14 +100,16 @@ module Katello
 
     #cannot use activerecord-improt to update content, as we rely on after_update callback
     private def update_content(content, prod_content_json)
+      attrs_to_update = {}
       new_name = prod_content_json[:content][:name]
-      content.update_attributes!(:name => new_name) if content.name != new_name
+      attrs_to_update[:name] = new_name if content.name != new_name
 
       new_url = prod_content_json[:content][:contentUrl]
       if content.content_url != new_url
-        content.update_attributes!(:content_url => new_url)
-        self.content_url_updated << content
+        attrs_to_update[:content_url] = new_url
+        @content_url_updated << content
       end
+      content.update_attributes!(attrs_to_update) unless attrs_to_update.blank?
     end
 
     private def update_product_content(product_content, new_enabled_value)

--- a/app/services/katello/product_content_importer.rb
+++ b/app/services/katello/product_content_importer.rb
@@ -20,11 +20,13 @@ module Katello
     #    },
     #    "enabled":false
     # }
+    attr_accessor :content_url_updated
 
     def initialize
       @contents_to_create = []
       @product_contents_to_create = []
       @product_mapping = {}
+      self.content_url_updated = []
     end
 
     def add_product_content(product, product_content_json)
@@ -100,6 +102,12 @@ module Katello
     private def update_content(content, prod_content_json)
       new_name = prod_content_json[:content][:name]
       content.update_attributes!(:name => new_name) if content.name != new_name
+
+      new_url = prod_content_json[:content][:contentUrl]
+      if content.content_url != new_url
+        content.update_attributes!(:content_url => new_url)
+        self.content_url_updated << content
+      end
     end
 
     private def update_product_content(product_content, new_enabled_value)

--- a/test/actions/katello/repository/update_metadata_sync_test.rb
+++ b/test/actions/katello/repository/update_metadata_sync_test.rb
@@ -1,0 +1,30 @@
+require 'katello_test_helper'
+
+module Actions
+  describe Katello::Repository::UpdateMetadataSync do
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include FactoryBot::Syntax::Methods
+
+    let(:action_class) { ::Actions::Katello::Repository::UpdateMetadataSync }
+    let(:metadata_generate_class) { ::Actions::Katello::Repository::MetadataGenerate }
+    let(:capsule_sync_class) { ::Actions::Katello::CapsuleContent::Sync }
+    let(:repo) { katello_repositories(:fedora_17_x86_64) }
+
+    it 'plans' do
+      action = create_action(action_class)
+      master = smart_proxies(:one)
+      master.expects(:pulp_master?).returns(true)
+
+      mirror = smart_proxies(:two)
+      mirror.expects(:pulp_master?).returns(false)
+
+      SmartProxy.expects(:with_repo).with(repo).returns([master, mirror])
+      plan_action(action, repo)
+
+      # master capsule sync should get ignored
+      assert_action_planed_with(action, capsule_sync_class, mirror, repository_id: repo.id)
+      assert_action_planed_with(action, metadata_generate_class, repo)
+    end
+  end
+end

--- a/test/actions/katello/repository/update_redhat_repository_test.rb
+++ b/test/actions/katello/repository/update_redhat_repository_test.rb
@@ -7,7 +7,7 @@ module Actions
     include FactoryBot::Syntax::Methods
 
     let(:action_class) { ::Actions::Katello::Repository::UpdateRedhatRepository }
-    let(:pulp_import_class) { ::Actions::Pulp::Repository::Refresh }
+    let(:refresh_class) { ::Actions::Pulp::Repository::Refresh }
     let(:repo) { katello_repositories(:fedora_17_x86_64) }
 
     it 'plans' do
@@ -28,7 +28,7 @@ module Actions
       assert_equal expected_upstream_url, repo.root.url
       assert_equal expected_relative_path, repo.relative_path
 
-      assert_action_planed_with(action, pulp_import_class, repo)
+      assert_action_planed_with(action, refresh_class, repo)
     end
   end
 end

--- a/test/actions/katello/repository/update_redhat_repository_test.rb
+++ b/test/actions/katello/repository/update_redhat_repository_test.rb
@@ -1,0 +1,34 @@
+require 'katello_test_helper'
+
+module Actions
+  describe Katello::Repository::UpdateRedhatRepository do
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include FactoryBot::Syntax::Methods
+
+    let(:action_class) { ::Actions::Katello::Repository::UpdateRedhatRepository }
+    let(:pulp_import_class) { ::Actions::Pulp::Repository::Refresh }
+    let(:repo) { katello_repositories(:fedora_17_x86_64) }
+
+    it 'plans' do
+      action = create_action(action_class)
+
+      repo.content.update_attributes!(content_url: "/foo/bar")
+      repo.product.provider.update_attributes!(repository_url: "http://cdn.com")
+
+      expected_relative_path = repo.generate_repo_path(repo.generate_content_path)
+      expected_upstream_url = repo.product.repo_url(repo.generate_content_path)
+
+      action.expects(:action_subject).with(repo)
+      # now change the actual values
+      repo.root.update_attributes!(:url => "http://foo")
+      repo.update_attributes!(relative_path: "1/#{repo.relative_path}")
+      plan_action(action, repo)
+
+      assert_equal expected_upstream_url, repo.root.url
+      assert_equal expected_relative_path, repo.relative_path
+
+      assert_action_planed_with(action, pulp_import_class, repo)
+    end
+  end
+end

--- a/test/fixtures/models/katello_root_repositories.yml
+++ b/test/fixtures/models/katello_root_repositories.yml
@@ -45,6 +45,7 @@ rhel_6_x86_64_root:
   content_id:           69
   major:                6
   minor:                6Server
+  arch:                 x86_64
   content_type:         yum
   label:                rhel_6_x86_64_label
   product_id:           <%= ActiveRecord::FixtureSet.identify(:redhat) %>

--- a/test/models/content_test.rb
+++ b/test/models/content_test.rb
@@ -55,6 +55,7 @@ module Katello
       fixtures = [
         { from: '/content/rhel/x64', to: '/content/foo', expected_result: true },
         { from: '/content/rhel/$aaa/$bbb/', to: '/content/foo/$bbb/$aaa', expected_result: true },
+        { from: '/content/rhel/$aaa/$bbb/', to: '/content/foo/xxxx-$bbb/yyyy-$aaa', expected_result: true },
         { from: '/content/rhel/$aaa/$bbb', to: '$aaa/content/$bbb', expected_result: true },
         { from: '/content/rhel/$aaa', to: '/content/foo', expected_result: false },
         { from: '/content/rhel/$aaa', to: '/content/$bbb', expected_result: false }

--- a/test/models/content_test.rb
+++ b/test/models/content_test.rb
@@ -50,5 +50,20 @@ module Katello
       assert contents.size > 0
       assert_equal contents.size, org_products.flatten.flatten.size
     end
+
+    def test_can_update_url
+      fixtures = [
+        { from: '/content/rhel/x64', to: '/content/foo', expected_result: true },
+        { from: '/content/rhel/$aaa/$bbb/', to: '/content/foo/$bbb/$aaa', expected_result: true },
+        { from: '/content/rhel/$aaa/$bbb', to: '$aaa/content/$bbb', expected_result: true },
+        { from: '/content/rhel/$aaa', to: '/content/foo', expected_result: false },
+        { from: '/content/rhel/$aaa', to: '/content/$bbb', expected_result: false }
+      ]
+      fixtures.each do |fixture|
+        @content.content_url = fixture[:from]
+        fail_message = "comparing #{fixture[:from]} to #{fixture[:to]}. expected_result = #{fixture[:expected_result]}"
+        assert_equal(fixture[:expected_result], @content.can_update_to_url?(fixture[:to]), fail_message)
+      end
+    end
   end
 end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -477,6 +477,23 @@ module Katello
       assert_equal "#{@fedora_17_x86_64.organization.label}/library_default_view_library/fedora_17_label", @fedora_17_x86_64.generate_repo_path
     end
 
+    def test_generate_content_path
+      repo = katello_repositories(:rhel_6_x86_64)
+      fixtures = [
+        { input: '/content/rhel/x64',  expected: '/content/rhel/x64' },
+        { input: '/content/$releasever/$basearch',  expected: '/content/rhel/6Server/x86_64' },
+        { input: '/content/$releasever/f00-$basearch',  expected: '/content/rhel/6Server/f00-x86_64' },
+
+      ]
+
+      fixtures.each do |fixture|
+        content = repo.content
+        content.content_url = fixture[:input]
+        fail_message = "comparing #{fixture[:input]} - expected_result = #{fixture[:expected]}"
+        assert_equal(fixture[:expected], repo.generate_content_path, fail_message)
+      end
+    end
+
     def test_docker_clone_repo_path
       @repo = build(:katello_repository, :docker,
                     :content_view_version => @fedora_17_x86_64.content_view_version,

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -480,15 +480,14 @@ module Katello
     def test_generate_content_path
       repo = katello_repositories(:rhel_6_x86_64)
       fixtures = [
-        { input: '/content/rhel/x64',  expected: '/content/rhel/x64' },
-        { input: '/content/$releasever/$basearch',  expected: '/content/rhel/6Server/x86_64' },
-        { input: '/content/$releasever/f00-$basearch',  expected: '/content/rhel/6Server/f00-x86_64' },
-
+        { input: '/content/rhel/x64', expected: '/content/rhel/x64' },
+        { input: '/content/$releasever/$basearch', expected: '/content/6Server/x86_64' },
+        { input: '/content/$releasever/f00-$basearch', expected: '/content/6Server/f00-x86_64' },
+        { input: '/content/$basearch/foo/$releasever', expected: '/content/x86_64/foo/6Server' }
       ]
 
       fixtures.each do |fixture|
-        content = repo.content
-        content.content_url = fixture[:input]
+        repo.content.update_attributes!(content_url: fixture[:input])
         fail_message = "comparing #{fixture[:input]} - expected_result = #{fixture[:expected]}"
         assert_equal(fixture[:expected], repo.generate_content_path, fail_message)
       end


### PR DESCRIPTION
RCM wants the ability to change content urls. We would want to
support this as long as the number of substitutions remain the same.
One of the proposed transforms is to go from something like:

/foo/$arch/$release/bar
to
/foo/$arch/$release/baz

This commit tries to achieve this. When an updated manifest with different
content urls gets uploaded these changes do the following
1) Track the changed content urls
2) Update the relative paths in repositories connected to this content
3) Refresh all the enabled repositories affected by this
4) Regenerate metadata for all the repos