### PR TITLE
Fixes #26686 - Pulp3 changed contents

### DIFF
--- a/app/lib/actions/pulp3/orchestration/repository/generate_metadata.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/generate_metadata.rb
@@ -4,10 +4,11 @@ module Actions
       module Repository
         class GenerateMetadata < Pulp3::Abstract
           def plan(repository, smart_proxy, options = {})
+            options[:contents_changed] = (options && options.key?(:contents_changed)) ? options[:contents_changed] : true
             sequence do
               plan_action(Actions::Pulp3::Repository::CreateVersion, repository, smart_proxy) if options[:repository_creation]
               plan_action(Actions::Pulp3::Repository::CreatePublication, repository, smart_proxy, options)
-              plan_action(Actions::Pulp3::Repository::RefreshDistribution, repository, smart_proxy)
+              plan_action(Actions::Pulp3::Repository::RefreshDistribution, repository, smart_proxy, options)
             end
           end
         end

--- a/app/lib/actions/pulp3/orchestration/repository/sync.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/sync.rb
@@ -7,9 +7,9 @@ module Actions
           def plan(repository, smart_proxy, options)
             sequence do
               action_output = plan_action(Actions::Pulp3::Repository::Sync, repository, smart_proxy, options).output
-              plan_action(Pulp3::Repository::SaveVersion, repository, action_output[:pulp_tasks])
-              plan_action(Pulp3::Orchestration::Repository::GenerateMetadata, repository, smart_proxy, :force => true)
-              plan_self(:subaction_output => action_output)
+              version_output = plan_action(Pulp3::Repository::SaveVersion, repository, action_output[:pulp_tasks]).output
+              plan_action(Pulp3::Orchestration::Repository::GenerateMetadata, repository, smart_proxy, :force => true, :contents_changed => version_output[:contents_changed])
+              plan_self(:subaction_output => version_output)
             end
           end
         end

--- a/app/lib/actions/pulp3/repository/create_publication.rb
+++ b/app/lib/actions/pulp3/repository/create_publication.rb
@@ -2,10 +2,11 @@ module Actions
   module Pulp3
     module Repository
       class CreatePublication < Pulp3::AbstractAsyncTask
+        middleware.use Actions::Middleware::ExecuteIfContentsChanged
         def plan(repository, smart_proxy, options)
           sequence do
-            action = plan_self(:repository_id => repository.id, :smart_proxy_id => smart_proxy.id, :options => options)
-            plan_action(SavePublication, repository, action.output[:pulp_tasks])
+            action = plan_self(:repository_id => repository.id, :smart_proxy_id => smart_proxy.id, :contents_changed => options[:contents_changed], :options => options)
+            plan_action(SavePublication, repository, action.output[:post_sync_skipped] ? {} : action.output[:pulp_tasks], :contents_changed => options[:contents_changed])
           end
         end
 

--- a/app/lib/actions/pulp3/repository/refresh_distribution.rb
+++ b/app/lib/actions/pulp3/repository/refresh_distribution.rb
@@ -3,10 +3,11 @@ module Actions
     module Repository
       class RefreshDistribution < Pulp3::AbstractAsyncTask
         include Helpers::Presenter
+        middleware.use Actions::Middleware::ExecuteIfContentsChanged
 
-        def plan(repository, smart_proxy)
-          action = plan_self(:repository_id => repository.id, :smart_proxy_id => smart_proxy.id)
-          plan_action(SaveDistributionReferences, repository, smart_proxy, action.output[:pulp_tasks])
+        def plan(repository, smart_proxy, options = {})
+          action = plan_self(:repository_id => repository.id, :smart_proxy_id => smart_proxy.id, :contents_changed => options[:contents_changed])
+          plan_action(SaveDistributionReferences, repository, smart_proxy, action.output[:post_sync_skipped] ? {} : action.output[:pulp_tasks], :contents_changed => options[:contents_changed])
         end
 
         def invoke_external_task

--- a/app/lib/actions/pulp3/repository/save_distribution_references.rb
+++ b/app/lib/actions/pulp3/repository/save_distribution_references.rb
@@ -2,8 +2,10 @@ module Actions
   module Pulp3
     module Repository
       class SaveDistributionReferences < Pulp3::Abstract
-        def plan(repository, smart_proxy, tasks)
-          plan_self(repository_id: repository.id, smart_proxy_id: smart_proxy.id, tasks: tasks)
+        middleware.use Actions::Middleware::ExecuteIfContentsChanged
+
+        def plan(repository, smart_proxy, tasks, options = {})
+          plan_self(repository_id: repository.id, smart_proxy_id: smart_proxy.id, tasks: tasks, contents_changed: options[:contents_changed])
         end
 
         def run

--- a/app/lib/actions/pulp3/repository/save_publication.rb
+++ b/app/lib/actions/pulp3/repository/save_publication.rb
@@ -2,8 +2,9 @@ module Actions
   module Pulp3
     module Repository
       class SavePublication < Pulp3::Abstract
-        def plan(repository, tasks)
-          plan_self(:repository_id => repository.id, :tasks => tasks)
+        middleware.use Actions::Middleware::ExecuteIfContentsChanged
+        def plan(repository, tasks, options = {})
+          plan_self(:repository_id => repository.id, :tasks => tasks, :contents_changed => options[:contents_changed])
         end
 
         def run

--- a/app/lib/actions/pulp3/repository/save_version.rb
+++ b/app/lib/actions/pulp3/repository/save_version.rb
@@ -7,10 +7,13 @@ module Actions
         end
 
         def run
-          publication_href = input[:tasks].first[:created_resources].first
-          if publication_href
-            repo = ::Katello::Repository.find(input[:repository_id])
-            repo.update_attributes(:version_href => publication_href)
+          version_href = input[:tasks].first[:created_resources].first
+          repo = ::Katello::Repository.find(input[:repository_id])
+          repo_version = repo.backend_service(::SmartProxy.pulp_master).lookup_version version_href
+          content_summary = send(:eval, repo_version.content_summary)
+          output[:contents_changed] = !(content_summary.dig(:added).empty? && content_summary.dig(:removed).empty?)
+          if version_href && output[:contents_changed]
+            repo.update_attributes(:version_href => version_href)
           end
         end
       end

--- a/app/lib/actions/pulp3/repository/sync.rb
+++ b/app/lib/actions/pulp3/repository/sync.rb
@@ -14,7 +14,6 @@ module Actions
         end
 
         def external_task=(tasks)
-          output[:contents_changed] = false
           output[:create_version] = true
           super
         end

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -12,6 +12,7 @@ module ::Actions::Katello::Repository
 
     let(:action) { create_action action_class }
     let(:repository) { katello_repositories(:rhel_6_x86_64) }
+    let(:repository_pulp3) { katello_repositories(:pulp3_file_1) }
     let(:custom_repository) { katello_repositories(:fedora_17_x86_64) }
     let(:puppet_repository) { katello_repositories(:p_forge) }
     let(:docker_repository) { katello_repositories(:redis) }
@@ -326,6 +327,7 @@ module ::Actions::Katello::Repository
     let(:action_class) { ::Actions::Katello::Repository::Sync }
     let(:pulp2_action_class) { ::Actions::Pulp::Orchestration::Repository::Sync }
     let(:pulp3_action_class) { ::Actions::Pulp3::Orchestration::Repository::Sync }
+    let(:pulp3_metadata_generate_action_class) {::Actions::Pulp3::Orchestration::Repository::GenerateMetadata}
 
     it 'plans' do
       action = create_action action_class
@@ -339,6 +341,20 @@ module ::Actions::Katello::Repository
       assert_action_planed_with action, ::Actions::Katello::Repository::ErrataMail do |repo, _task_id, contents_changed|
         contents_changed.must_be_kind_of Dynflow::ExecutionPlan::OutputReference
         repo.id.must_equal repository.id
+      end
+    end
+
+    it 'plans with pulp3 file repo' do
+      action = create_action action_class
+      action.stubs(:action_subject).with(repository_pulp3)
+      plan_action action, repository_pulp3
+      assert_action_planed_with(action, ::Actions::Katello::PulpSelector, [pulp2_action_class, pulp3_action_class], repository_pulp3, proxy,
+                                smart_proxy_id: proxy.id, repo_id: repository_pulp3.id, source_url: nil, options: {})
+      assert_action_planed action, ::Actions::Katello::Repository::IndexContent
+
+      assert_action_planed_with action, ::Actions::Katello::Repository::ErrataMail do |repo, _task_id, contents_changed|
+        contents_changed.must_be_kind_of Dynflow::ExecutionPlan::OutputReference
+        repo.id.must_equal repository_pulp3.id
       end
     end
 
@@ -385,6 +401,24 @@ module ::Actions::Katello::Repository
       assert_action_planed_with(action, Actions::Pulp::Repository::Download, pulp_id: repository.pulp_id,
                                 options: {:verify_all_units => true})
       assert_action_planed_with(action, Actions::Katello::Repository::MetadataGenerate, repository, :force => true)
+    end
+
+    it 'plans pulp3 orchestration actions with file repo' do
+      action = create_action pulp3_action_class
+      action.stubs(:action_subject).with(repository_pulp3)
+      plan_action action, repository_pulp3, proxy, {}
+      assert_action_planed_with(action, ::Actions::Pulp3::Repository::Sync, repository_pulp3, proxy, {})
+      assert_action_planed action, ::Actions::Pulp3::Repository::SaveVersion
+      assert_action_planed action, ::Actions::Pulp3::Orchestration::Repository::GenerateMetadata
+    end
+
+    it 'plans pulp3 metadata generate with contents_changed' do
+      action = create_action pulp3_metadata_generate_action_class
+      action.stubs(:action_subject).with(repository_pulp3)
+      plan_action action, repository_pulp3, proxy, {:contents_changed => true}
+      refute_action_planed action, ::Actions::Pulp3::Repository::CreateVersion
+      assert_action_planed_with(action, ::Actions::Pulp3::Repository::CreatePublication, repository_pulp3, proxy, {:contents_changed => true})
+      assert_action_planed_with(action, ::Actions::Pulp3::Repository::RefreshDistribution, repository_pulp3, proxy, {:contents_changed => true})
     end
 
     describe 'progress' do


### PR DESCRIPTION
After a pulp3 sync, we get a new version href from pulp3. We want to check in the new version created if any new content was added. Based on that we save the version, create new publication and refresh distribution.
The same contents_changed is passed to index action to either run or skip indexing.

To do:
- [ ] Re-record VCRs
