### PR TITLE
Fixes #26721 - Use katello default CA to verify ueber cert

### DIFF
--- a/app/services/cert/certs.rb
+++ b/app/services/cert/certs.rb
@@ -19,7 +19,7 @@ module Cert
     def self.verify_ueber_cert(organization)
       ueber_cert = OpenSSL::X509::Certificate.new(self.ueber_cert(organization)[:cert])
       cert_store = OpenSSL::X509::Store.new
-      cert_store.add_file Setting[:ssl_ca_file]
+      cert_store.add_file SETTINGS[:katello][:candlepin][:ca_cert_file]
       organization.regenerate_ueber_cert unless cert_store.verify ueber_cert
     end
   end

--- a/test/services/cert/certs_test.rb
+++ b/test/services/cert/certs_test.rb
@@ -8,12 +8,12 @@ module Katello
     def setup
       @org = get_organization
       Resources::Candlepin::Owner.create(@org.label, @org.name)
-      @original_ssl_ca_file = Setting[:ssl_ca_file]
+      @original_ssl_ca_file = SETTINGS[:katello][:candlepin][:ca_cert_file]
     end
 
     def teardown
       Resources::Candlepin::Owner.destroy(@org.label)
-      Setting[:ssl_ca_file] = @original_ssl_ca_file
+      SETTINGS[:katello][:candlepin][:ca_cert_file] = @original_ssl_ca_file
     end
 
     def test_verify_ueber_cert_no_change
@@ -26,10 +26,9 @@ module Katello
     end
 
     def test_verify_ueber_cert_changes
-      Setting[:ssl_ca_file] = File.join("#{Katello::Engine.root}", "/ca/redhat-uep.pem")
+      SETTINGS[:katello][:candlepin][:ca_cert_file] = File.join("#{Katello::Engine.root}", "/ca/redhat-uep.pem")
       @org.expects(:regenerate_ueber_cert).once
       Cert::Certs.verify_ueber_cert(@org)
-      Setting[:ssl_ca_file] = @original_ssl_ca_file
     end
   end
 end


### PR DESCRIPTION
Use Setting[:ssl_ca_file] to verify the ueber certificate will
always fail when custom SSL certificates are set. Failed to verify
the ueber certificate will cause unexpected update of importer
and distributor configurations every time user performs a Capsule
content sync. This will also cause Pulp to always perform a force
full repo sync instead of optimized repo sync.