### PR TITLE
Fixes #26720 - CV Publish: copy correct errata

### DIFF
--- a/app/controllers/katello/api/v2/errata_controller.rb
+++ b/app/controllers/katello/api/v2/errata_controller.rb
@@ -18,6 +18,8 @@ module Katello
     param :host_id, :number, :desc => N_("Host id to list applicable errata for")
     param :errata_restrict_applicable, :bool, :desc => N_("Return errata that are applicable to one or more hosts (defaults to true if host_id is specified)")
     param :errata_restrict_installable, :bool, :desc => N_("Return errata that are upgradable on one or more hosts")
+    param :modular_only, :boolean, :desc => N_("Return errata that contains a module streams")
+    param :non_modular_only, :boolean, :desc => N_("Return errata that do not contain any module streams")
     param :available_for, String, :desc => N_("Return errata that can be added to the specified object.  The values 'content_view_version' and 'content_view_filter are supported.")
     param_group :search, Api::V2::ApiController
     def index
@@ -42,7 +44,7 @@ module Katello
       collection = collection.where("#{date_type} >= ?", params[:start_date]) if params[:start_date]
       collection = collection.where("#{date_type} <= ?", params[:end_date]) if params[:end_date]
       collection = collection.of_type(params[:types]) if params[:types]
-      collection
+      collection.non_modular
     end
 
     def custom_index_relation(collection)
@@ -58,6 +60,8 @@ module Katello
           collection = collection.applicable_to_hosts(hosts)
         end
       end
+      collection = collection.modular if ::Foreman::Cast.to_bool(params[:modular_only])
+      collection = collection.non_modular if ::Foreman::Cast.to_bool(params[:non_modular_only])
       collection
     end
 

--- a/app/controllers/katello/api/v2/packages_controller.rb
+++ b/app/controllers/katello/api/v2/packages_controller.rb
@@ -40,6 +40,8 @@ module Katello
     param :packages_restrict_applicable, :boolean, :desc => N_("Return packages that are applicable to one or more hosts (defaults to true if host_id is specified)")
     param :packages_restrict_upgradable, :boolean, :desc => N_("Return packages that are upgradable on one or more hosts")
     param :packages_restrict_latest, :boolean, :desc => N_("Return only the latest version of each package")
+    param :modular_only, :boolean, :desc => N_("Return packages that belong to a module streams")
+    param :non_modular_only, :boolean, :desc => N_("Return packages that do not belong any module streams")
     param :available_for, String, :desc => N_("Return packages that can be added to the specified object.  Only the value 'content_view_version' is supported.")
     param_group :search, ::Katello::Api::V2::ApiController
     def index
@@ -62,6 +64,8 @@ module Katello
           collection = collection.applicable_to_hosts(hosts)
         end
       end
+      collection = collection.modular if ::Foreman::Cast.to_bool(params[:modular_only])
+      collection = collection.non_modular if ::Foreman::Cast.to_bool(params[:non_modular_only])
       collection
     end
 

--- a/app/lib/katello/util/erratum_clause_generator.rb
+++ b/app/lib/katello/util/erratum_clause_generator.rb
@@ -20,21 +20,21 @@ module Katello
       def collect_clauses(repo, filters)
         return if filters.blank?
 
-        pulp_content_clauses = filters.collect do |filter|
+        content_clauses = filters.collect do |filter|
           filter.generate_clauses(repo)
         end
-        pulp_content_clauses.flatten!
-        pulp_content_clauses.compact!
+        content_clauses.flatten!
+        content_clauses.compact!
 
-        unless pulp_content_clauses.empty?
-          [errata_clauses_from_content(pulp_content_clauses)]
+        unless content_clauses.empty?
+          [errata_clauses_from_content(content_clauses)]
         end
       end
 
       # input ->  [{"type"=>{"$in"=>[:bugfix, :security]}}] <- Errata Pulp Clauses
       # output -> {"filename" => {"$in" => {"foo.el6.noarch", "..."}}} <- Packages belonging to those errata
-      def errata_clauses_from_content(pulp_content_clauses)
-        errata_ids = Katello::Erratum.list_errata_id_by_clauses(@repo, pulp_content_clauses)
+      def errata_clauses_from_content(content_clauses)
+        errata_ids = Katello::Erratum.list_errata_id_by_clauses(@repo, content_clauses)
         {'id' => {"$in" => errata_ids}} unless errata_ids.empty?
       end
     end

--- a/app/lib/katello/util/erratum_clause_generator.rb
+++ b/app/lib/katello/util/erratum_clause_generator.rb
@@ -1,0 +1,42 @@
+module Katello
+  module Util
+    class ErratumClauseGenerator
+      include Util::FilterClauseGenerator
+
+      protected
+
+      def fetch_filters
+        ContentViewFilter.yum_errata_only
+      end
+
+      def whitelist_non_matcher_clause
+        {"id" => {"$not" => {"$exists" => true}}}
+      end
+
+      def whitelist_all_matcher_clause
+        {"id" => {"$exists" => true}}
+      end
+
+      def collect_clauses(repo, filters)
+        return if filters.blank?
+
+        pulp_content_clauses = filters.collect do |filter|
+          filter.generate_clauses(repo)
+        end
+        pulp_content_clauses.flatten!
+        pulp_content_clauses.compact!
+
+        unless pulp_content_clauses.empty?
+          [errata_clauses_from_content(pulp_content_clauses)]
+        end
+      end
+
+      # input ->  [{"type"=>{"$in"=>[:bugfix, :security]}}] <- Errata Pulp Clauses
+      # output -> {"filename" => {"$in" => {"foo.el6.noarch", "..."}}} <- Packages belonging to those errata
+      def errata_clauses_from_content(pulp_content_clauses)
+        errata_ids = Katello::Erratum.list_errata_id_by_clauses(@repo, pulp_content_clauses)
+        {'id' => {"$in" => errata_ids}} unless errata_ids.empty?
+      end
+    end
+  end
+end

--- a/app/models/katello/content_view_filter.rb
+++ b/app/models/katello/content_view_filter.rb
@@ -38,6 +38,10 @@ module Katello
                                       DOCKER.to_sym => "Katello::ContentViewDockerFilter"}
     scoped_search :on => :inclusion, :rename => :inclusion_type, :complete_value => {:include => true, :exclude => :false}
 
+    def self.yum_errata_only
+      where(:type => ::Katello::ContentViewErratumFilter.name)
+    end
+
     def self.yum
       where(:type => [::Katello::ContentViewPackageGroupFilter.name,
                       ::Katello::ContentViewErratumFilter.name,

--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -44,6 +44,7 @@ module Katello
     scope :bugfix, -> { of_type(Erratum::BUGZILLA) }
     scope :enhancement, -> { of_type(Erratum::ENHANCEMENT) }
     scope :modular, -> { joins(:packages => :module_stream_errata_packages) }
+    scope :non_modular, -> { where.not(:id => modular) }
 
     def self.repository_association_class
       RepositoryErratum

--- a/test/fixtures/models/katello_errata.yml
+++ b/test/fixtures/models/katello_errata.yml
@@ -38,3 +38,12 @@ singletonissue:
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
   issued: <%= 3.days.ago %>
+
+modular:
+  errata_id: "RHEA-2019-002"
+  errata_type: "bugfix"
+  title: "modularissue"
+  pulp_id: "modularissue"
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+  issued: <%= 3.days.ago %>

--- a/test/fixtures/models/katello_erratum_packages.yml
+++ b/test/fixtures/models/katello_erratum_packages.yml
@@ -3,3 +3,9 @@ security_package:
   filename: "foobar-1.3.4.rpm"
   name: "foobar"
   nvrea: "foobar-1.2.3"
+
+modular_package:
+  erratum_id: <%= ActiveRecord::FixtureSet.identify(:modular) %>
+  filename: "foobarmod-1.3.4.rpm"
+  name: "foobarmod"
+  nvrea: "foobarmod-1.2.3"

--- a/test/fixtures/models/katello_module_stream_erratum_packages.yml
+++ b/test/fixtures/models/katello_module_stream_erratum_packages.yml
@@ -1,0 +1,3 @@
+modular:
+  erratum_package_id: <%= ActiveRecord::FixtureSet.identify(:modular_package) %>
+  module_stream_id: <%= ActiveRecord::FixtureSet.identify(:three) %>

--- a/test/lib/util/erratum_clause_generator_test.rb
+++ b/test/lib/util/erratum_clause_generator_test.rb
@@ -1,0 +1,155 @@
+require 'katello_test_helper'
+
+module Katello
+  class Util::ErratumClauseGeneratorTest < ActiveSupport::TestCase
+    INCLUDE_ALL_ERRATA = {"id" => {"$exists" => true}}.freeze
+
+    def setup
+      User.current = User.find(users(:admin).id)
+      organization = get_organization
+      Repository.any_instance.stubs(:package_count).returns(2)
+      @repo = katello_repositories(:fedora_17_x86_64)
+      @rpm = katello_rpms(:one)
+      @rpm2 = katello_rpms(:two)
+      @rpm3 = katello_rpms(:three)
+
+      @repo.rpms = [@rpm, @rpm2, @rpm3]
+      @repo.rpms.each do |rpm|
+        rpm.version_sortable = Util::Package.sortable_version(rpm.version)
+        rpm.release_sortable = Util::Package.sortable_version(rpm.release)
+        rpm.save!
+      end
+
+      @content_view = FactoryBot.build(:katello_content_view, :organization => organization)
+      @content_view.save!
+      @content_view.repositories << @repo
+      @from = Date.today - 5
+      @to = Date.today
+    end
+
+    def test_errata_ids
+      @filter = FactoryBot.create(:katello_content_view_erratum_filter, :content_view => @content_view)
+      foo_rule = FactoryBot.create(:katello_content_view_erratum_filter_rule,
+                                    :filter => @filter, :errata_id => "Foo1")
+      goo_rule = FactoryBot.create(:katello_content_view_erratum_filter_rule,
+                                    :filter => @filter, :errata_id => "Foo2")
+
+      expected_errata = [erratum_arel[:errata_id].in(["Foo1", "Foo2"])]
+      assert_errata_rules([foo_rule, goo_rule], expected_errata)
+    end
+
+    def test_errata_dates_default
+      types = ["bugfix", "enhancement", "security"]
+
+      @filter = FactoryBot.create(:katello_content_view_erratum_filter, :content_view => @content_view)
+      foo_rule = FactoryBot.create(:katello_content_view_erratum_filter_rule,
+                                    :filter => @filter, :start_date => @from.to_s, :end_date => @to.to_s,
+                                    :types => types)
+
+      types_query = erratum_arel[:errata_type].in(types)
+      date_query = erratum_arel[:updated].gteq(@from).and(erratum_arel[:updated].lteq(@to))
+
+      expected = [date_query.and(types_query)]
+      assert_errata_rules([foo_rule], expected)
+    end
+
+    def test_errata_dates_issued
+      types = ["bugfix", "security"]
+
+      @filter = FactoryBot.create(:katello_content_view_erratum_filter, :content_view => @content_view)
+      foo_rule = FactoryBot.create(:katello_content_view_erratum_filter_rule,
+                                    :date_type => ContentViewErratumFilterRule::ISSUED,
+                                    :filter => @filter, :start_date => @from.to_s, :end_date => @to.to_s,
+                                    :types => types)
+
+      types_query = erratum_arel[:errata_type].in(types)
+      date_query = erratum_arel[:issued].gteq(@from).and(erratum_arel[:issued].lteq(@to))
+
+      expected = [date_query.and(types_query)]
+      assert_errata_rules([foo_rule], expected)
+    end
+
+    def test_errata_dates_updated
+      types = ["security"]
+
+      @filter = FactoryBot.create(:katello_content_view_erratum_filter, :content_view => @content_view)
+      foo_rule = FactoryBot.create(:katello_content_view_erratum_filter_rule,
+                                    :date_type => ContentViewErratumFilterRule::UPDATED,
+                                    :filter => @filter, :start_date => @from.to_s, :end_date => @to.to_s,
+                                    :types => types)
+
+      types_query = erratum_arel[:errata_type].in(types)
+      date_query = erratum_arel[:updated].gteq(@from).and(erratum_arel[:updated].lteq(@to))
+
+      expected = [date_query.and(types_query)]
+      assert_errata_rules([foo_rule], expected)
+    end
+
+    def test_errata_types
+      types = ["security", "bugfix"]
+
+      @filter = FactoryBot.create(:katello_content_view_erratum_filter, :content_view => @content_view)
+      foo_rule = FactoryBot.create(:katello_content_view_erratum_filter_rule,
+                                    :filter => @filter,
+                                    :types => types)
+
+      types_query = erratum_arel[:errata_type].in(types)
+      expected = [types_query]
+      assert_errata_rules([foo_rule], expected)
+    end
+
+    private
+
+    def assert_errata_rules(rules, expected_errata_clauses)
+      returned_errata = {'id' => {"$in" => ["foo", "bar"]}}
+
+      clause_gen = setup_whitelist_filter(rules) do |gen|
+        gen.expects(:errata_clauses_from_content).once.
+                    returns(returned_errata).with do |clauses|
+                      clauses.map(&:to_sql).must_equal(expected_errata_clauses.map(&:to_sql))
+                    end
+      end
+      assert_equal returned_errata, clause_gen.copy_clause
+      assert_nil clause_gen.remove_clause
+
+      clause_gen = setup_blacklist_filter(rules) do |gen|
+        gen.expects(:errata_clauses_from_content).once.
+                    returns(returned_errata).with do |clauses|
+                      clauses.map(&:to_sql).must_equal(expected_errata_clauses.map(&:to_sql))
+                    end
+      end
+      expected = {"$and" => [INCLUDE_ALL_ERRATA, {"$nor" => [returned_errata]}]}
+
+      assert_equal expected, clause_gen.copy_clause
+      assert_equal returned_errata, clause_gen.remove_clause
+    end
+
+    def erratum_arel
+      ::Katello::Erratum.arel_table
+    end
+
+    def array_to_struct(items)
+      items.collect do |item|
+        OpenStruct.new(item)
+      end
+    end
+
+    def setup_whitelist_filter(filter_rules, &block)
+      setup_filter_clause(true, filter_rules, &block)
+    end
+
+    def setup_blacklist_filter(filter_rules, &block)
+      setup_filter_clause(false, filter_rules, &block)
+    end
+
+    def setup_filter_clause(inclusion, filter_rules, &_block)
+      filter = filter_rules.first.filter
+      filter.inclusion = inclusion
+      filter.save!
+      clause_gen = Util::ErratumClauseGenerator.new(@repo, [filter])
+      yield clause_gen if block_given?
+      clause_gen.generate
+      clause_gen
+    end
+  end
+end

--- a/test/models/erratum_test.rb
+++ b/test/models/erratum_test.rb
@@ -28,6 +28,11 @@ module Katello
       assert_includes Katello::Erratum.search_for("reboot_suggested = true"), @security
     end
 
+    def test_search_modular
+      assert_includes Katello::Erratum.search_for("modular = false"), @security
+      assert_includes Katello::Erratum.search_for("modular = true"), katello_errata(:modular)
+    end
+
     def test_create_truncates_long_title
       attrs = {:pulp_id => 'foo', :title => "This life, which had been the tomb of " \
         "his virtue and of his honour is but a walking shadow; a poor player, " \


### PR DESCRIPTION
This commit tweaks the cv publish algorithm slightly to copy errata
selectively.

Prior to this commit errata that got copied to the destination repo were
based on the RPMs in the destination repo.
This lead to issues in dealing with rpms that belong to 2 errata. For
example if we had a content view filter that says "Include only Errata
between X and Y days" and same rpm belonged to 2 errata, then both
errata would automatically get included in the destination repo even
if one of the errata was issued much after Y or before X.

This commit addresses that issue by only copying errata that matched the
filters. We were already using this logic to copy rpms belonging to
errata. Now we copy the appropriate errata the same way.