### PR TITLE
Fixes #26734 - Sync plan run without repos

### DIFF
--- a/app/lib/actions/katello/sync_plan/run.rb
+++ b/app/lib/actions/katello/sync_plan/run.rb
@@ -16,16 +16,10 @@ module Actions
           add_missing_task_group(sync_plan)
           action_subject(sync_plan)
           User.as_anonymous_admin do
-            fail _("No products in sync plan") unless sync_plan.products
-
             syncable_products = sync_plan.products.syncable
             syncable_roots = ::Katello::RootRepository.where(:product_id => syncable_products).has_url
 
-            fail _("No syncable repositories found for selected products and options.") if syncable_roots.empty?
-
-            plan_action(::Actions::BulkAction, ::Actions::Katello::Repository::Sync,
-                        syncable_roots.map(&:library_instance))
-
+            plan_action(::Actions::BulkAction, ::Actions::Katello::Repository::Sync, syncable_roots.map(&:library_instance)) unless syncable_roots.empty?
             plan_self(:sync_plan_name => sync_plan.name)
           end
         end

--- a/test/actions/katello/sync_plan/run_test.rb
+++ b/test/actions/katello/sync_plan/run_test.rb
@@ -7,8 +7,6 @@ describe ::Actions::Katello::SyncPlan::Run do
 
   before :all do
     @sync_plan = katello_sync_plans(:sync_plan_hourly)
-    @products = katello_products(:fedora, :redhat, :empty_product)
-    @sync_plan.products << @products
   end
 
   let(:action_class) { ::Actions::Katello::SyncPlan::Run }
@@ -23,11 +21,23 @@ describe ::Actions::Katello::SyncPlan::Run do
 
   it 'plans' do
     ForemanTasks::Task::DynflowTask.stubs(:where).returns(mock.tap { |m| m.stubs(:first! => task) })
-
+    products = katello_products(:fedora, :redhat, :empty_product)
+    @sync_plan.products << products
     action.stubs(:action_subject).with(@sync_plan)
     plan_action(action, @sync_plan)
     syncable_products = @sync_plan.products.syncable
     syncable_repositories = ::Katello::RootRepository.where(:product_id => syncable_products).has_url
     assert_action_planed_with(action, ::Actions::BulkAction, ::Actions::Katello::Repository::Sync, syncable_repositories.map(&:library_instance))
+  end
+
+  it 'does not plan without products' do
+    ForemanTasks::Task::DynflowTask.stubs(:where).returns(mock.tap { |m| m.stubs(:first! => task) })
+    action.stubs(:action_subject).with(@sync_plan)
+    plan_action(action, @sync_plan)
+    syncable_products = @sync_plan.products.syncable
+    syncable_repositories = ::Katello::RootRepository.where(:product_id => syncable_products).has_url
+    assert_empty syncable_products
+    assert_empty syncable_repositories
+    refute_action_planed action, ::Actions::BulkAction
   end
 end


### PR DESCRIPTION
Issue:

When a sync plan without products or repositories is run, it fails with the error: "No syncable repositories found for selected products and options."

As per the issue, we shouldn't fail the run in this case. Instead, we should let the job succeed without actually running the repository sync action.