### PR TITLE
Fixes #25823 - Unable to retrieve GPG keys through smart proxy

### DIFF
--- a/app/lib/katello/resources/candlepin/content.rb
+++ b/app/lib/katello/resources/candlepin/content.rb
@@ -12,8 +12,9 @@ module Katello
             JSON.parse(content_json).with_indifferent_access
           end
 
-          def all(owner_label)
-            content_json = Candlepin::CandlepinResource.get(path(owner_label), self.default_headers).body
+          def all(owner_label, include_only: nil)
+            includes = include_only ? "?#{included_list(include_only)}" : ""
+            content_json = Candlepin::CandlepinResource.get(path(owner_label) + includes, self.default_headers).body
             JSON.parse(content_json)
           end
 

--- a/db/seeds.d/111-upgrade_tasks.rb
+++ b/db/seeds.d/111-upgrade_tasks.rb
@@ -5,9 +5,9 @@ UpgradeTask.define_tasks(:katello) do
     {:name => 'katello:clean_backend_objects', :long_running => true, :skip_failure => true, :always_run => true},
     {:name => 'katello:upgrades:3.8:clear_checksum_type'},
     {:name => 'katello:upgrades:3.10:clear_invalid_repo_credentials'},
+    {:name => 'katello:upgrades:3.10:update_gpg_key_urls'},
     {:name => 'katello:upgrades:3.11:import_yum_metadata'},
     {:name => 'katello:upgrades:3.11:update_puppet_repos'},
     {:name => 'katello:upgrades:3.11:clear_checksum_type', :task_name => 'katello:upgrades:3.8:clear_checksum_type'}
-
   ]
 end

--- a/lib/katello/tasks/upgrades/3.10/update_gpg_key_urls.rake
+++ b/lib/katello/tasks/upgrades/3.10/update_gpg_key_urls.rake
@@ -1,0 +1,32 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '3.10' do
+      desc "Update repositories with API V1 GPG URLs"
+      task :update_gpg_key_urls => ["environment", "katello:check_ping"] do
+        User.current = User.anonymous_admin
+
+        ::Organization.all.each do |org|
+          org_contents = Katello::Resources::Candlepin::Content.all(org.label, include_only: [:id, :gpgUrl])
+
+          org_contents.each do |cp_content|
+            gpg_url = cp_content['gpgUrl']
+            if gpg_url && gpg_url.match(/katello\/api\/repositories/)
+              content = Katello::Content.where(cp_content_id: cp_content['id'], organization: org).first
+
+              if content.nil?
+                Rails.logger.warn("Candlepin Content id=#{cp_content['id']} isn't in our DB. Try running 'rake katello:reimport' first.")
+              else
+                root_repo = Katello::RootRepository.in_organization(org).where(content_id: content.cp_content_id).first
+                new_gpg_url = root_repo.library_instance.yum_gpg_key_url
+                cp_content['gpgUrl'] = new_gpg_url
+                Katello::Resources::Candlepin::Content.update(org.label, cp_content)
+                content.gpg_url = new_gpg_url
+                content.save!
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/lib/tasks/update_gpg_key_urls_test.rb
+++ b/test/lib/tasks/update_gpg_key_urls_test.rb
@@ -1,0 +1,49 @@
+require 'katello_test_helper'
+require 'rake'
+
+module Katello
+  class UpdateGpgKeyUrlTest < ActiveSupport::TestCase
+    def setup
+      Rake.application.rake_require 'katello/tasks/upgrades/3.10/update_gpg_key_urls'
+      Rake.application.rake_require 'katello/tasks/reimport'
+      Rake::Task['katello:upgrades:3.10:update_gpg_key_urls'].reenable
+      Rake::Task['katello:check_ping'].reenable
+      Rake::Task.define_task(:environment)
+    end
+
+    def test_update_gpg_key_urls
+      Katello::Ping.expects(:ping).returns(:status => 'ok')
+
+      contents = [
+        {
+          'id' => 123_456,
+          'gpgUrl' => '../../katello/api/repositories/100/gpg_key_content'
+        },
+        {
+          'id' => 654_321,
+          'gpgUrl' => '../../katello/api/v2/repositories/200/gpg_key_content'
+        }
+      ]
+
+      product = Organization.first.products.first
+      contents.each do |cp_content|
+        FactoryBot.create(:katello_root_repository, content_id: cp_content['id'], product: product)
+        content = FactoryBot.create(:katello_content, cp_content_id: cp_content['id'], organization: Organization.first)
+        FactoryBot.create(:katello_product_content, content: content, product: product)
+      end
+
+      library_instance = katello_repositories(:fedora_17_x86_64)
+      Katello::RootRepository.any_instance.stubs(:library_instance).returns(library_instance)
+
+      expected_gpg_url = "../../katello/api/v2/repositories/#{library_instance.id}/gpg_key_content"
+
+      Katello::Resources::Candlepin::Content.stubs(:all).returns(contents)
+      Katello::Resources::Candlepin::Content.expects(:update).once.with(Organization.first.label, 'id' => 123_456, 'gpgUrl' => expected_gpg_url)
+
+      Rake.application.invoke_task('katello:upgrades:3.10:update_gpg_key_urls')
+
+      assert_nil Katello::Content.where(cp_content_id: 654_321).first.gpg_url
+      assert_equal expected_gpg_url, Katello::Content.where(cp_content_id: 123_456).first.gpg_url
+    end
+  end
+end


### PR DESCRIPTION
Back in October we broke the ability for a Smart Proxy to fetch GPG keys for the v1 API: https://github.com/theforeman/puppet-foreman_proxy_content/pull/181. That's OK since we no longer support V1 as far as I know. However, repos still may be referring to the old GPG key URL and this PR adds an upgrade rake task that will clean up the data.

Here's how to test:

- Create a new custom product with a repository and add a GPG Key to it. Here's a sample one: https://paste.fedoraproject.org/paste/sAlHCYLtrAW9~uae4GjTTg
- There's now a Content object for this repo in Katello and Candlepin.
```
Katello::Content.last # this should look like the repo you just created, note the cp_content_id
```
Check the content in Candlepin. Be sure to use your own org. Note the gpg_url says something like "...katello/api/v2/repositories..."
```
Katello::Resources::Candlepin::Content.get(Organization.find(2).label, $CP_CONTENT_ID)
```

- update the content with the old v1 URL by taking /v2/ out of the current URL.

```
Katello::Resources::Candlepin::Content.update(Organization.find(2).label, {id: $CP_CONTENT_ID, gpgUrl: '../../katello/api/repositories/85/gpg_key_content'})
```

- register a content host using katello-client Forklift box, and assign your  custom product to it. From the command line run `subscription-manager refresh` and verify that /etc/yum.repos.d/redhat.repo has the repo with the v1 gpgkey URL.

- run the rake task
```
bundle exec rake katello:upgrades:3.10:update_gpg_key_urls
```

- on the client run `subscription-manager refresh` again and verify that the gpgkey now has a /v2/ url

