### PR TITLE
Fixes #26752 - remove react-router package

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "react-ellipsis-with-tooltip": "^1.0.7",
     "react-helmet": "^5.2.0",
     "react-redux": "^5.0.6",
-    "react-router": "^4.2.0",
     "react-router-bootstrap": "0.24.4",
     "react-router-dom": "^4.2.2",
     "redux": "^3.7.2",

--- a/webpack/components/SelectOrg/SetOrganization.js
+++ b/webpack/components/SelectOrg/SetOrganization.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { Form, Button } from 'patternfly-react';
-import { withRouter } from 'react-router';
+import { withRouter } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import Select from '../../move_to_pf/Select/Select';

--- a/webpack/scenes/ModuleStreams/Details/index.js
+++ b/webpack/scenes/ModuleStreams/Details/index.js
@@ -1,6 +1,6 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
+import { withRouter } from 'react-router-dom';
 import reducer from './ModuleStreamDetailsReducer';
 import * as moduleStreamDetailsActions from './ModuleStreamDetailsActions';
 import ModuleStreamDetails from './ModuleStreamDetails';

--- a/webpack/scenes/ModuleStreams/index.js
+++ b/webpack/scenes/ModuleStreams/index.js
@@ -1,6 +1,6 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
+import { withRouter } from 'react-router-dom';
 
 import ModuleStreamsPage from './ModuleStreamsPage';
 import reducer from './ModuleStreamsReducer';

--- a/webpack/scenes/Subscriptions/Details/index.js
+++ b/webpack/scenes/Subscriptions/Details/index.js
@@ -1,6 +1,6 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
+import { withRouter } from 'react-router-dom';
 import reducer from './SubscriptionDetailReducer';
 import { loadProducts } from '../../Products/ProductActions';
 import * as subscriptionDetailActions from './SubscriptionDetailActions';

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/index.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/index.js
@@ -1,6 +1,6 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
+import { withRouter } from 'react-router-dom';
 
 import * as actions from './UpstreamSubscriptionsActions';
 import reducer from './UpstreamSubscriptionsReducer';


### PR DESCRIPTION
adding `react-router-dom` to core broke nightlies, we think it may be related to `react-router` package. @sharvit 
`react-router` can be safely removed because react-router-dom uses all its exports