### PR TITLE
[CP] Fixes for 3.10

### DIFF
--- a/db/seeds.d/111-upgrade_tasks.rb
+++ b/db/seeds.d/111-upgrade_tasks.rb
@@ -6,7 +6,6 @@ UpgradeTask.define_tasks(:katello) do
     {:name => 'katello:upgrades:3.8:clear_checksum_type'},
     {:name => 'katello:upgrades:3.9:migrate_sync_plans'},
     {:name => 'katello:upgrades:3.10:clear_invalid_repo_credentials'},
-    {:name => 'katello:upgrades:3.11:import_yum_metadata'},
     {:name => 'katello:upgrades:3.11:update_puppet_repos'}
   ]
 end

--- a/engines/bastion_katello/lib/bastion_katello/engine.rb
+++ b/engines/bastion_katello/lib/bastion_katello/engine.rb
@@ -14,12 +14,7 @@ module BastionKatello
 
       Bastion.register_plugin(
         :name => 'bastion_katello',
-        :javascript => proc do
-          [
-            javascript_include_tag(*webpack_asset_paths('katello:common', :extension => 'js'), "data-turbolinks-track" => true),
-            javascript_include_tag('bastion_katello/bastion_katello')
-          ]
-        end,
+        :javascript => 'bastion_katello/bastion_katello',
         :stylesheet => 'bastion_katello/bastion_katello',
         :pages => %w(
           activation_keys

--- a/lib/katello/version.rb
+++ b/lib/katello/version.rb
@@ -1,3 +1,3 @@
 module Katello
-  VERSION = "3.10.1".freeze
+  VERSION = "3.10.1.1".freeze
 end


### PR DESCRIPTION

- the reverted commit is marked for 3.11 but somehow made it onto this branch (????) and breaks bastion pages:
```
Can't find entry point 'katello:common' in webpack manifest
```
- the change to db/seeds shows this in the logs during upgrade which doesn't look nice
```
Upgrade Step 7/8: katello:upgrades:3.11:import_yum_metadata. Failed upgrade task: katello:upgrades:3.11:import_yum_metadata, see logs for more information.       
```