### PR TITLE
Fixes #26774 - Don't fail repo destroy when Content is missing

### DIFF
--- a/app/lib/actions/katello/product/content_destroy.rb
+++ b/app/lib/actions/katello/product/content_destroy.rb
@@ -19,7 +19,7 @@ module Actions
                           owner: root_repository.product.organization.label,
                           content_id: root_repository.content_id)
 
-              ::Katello::Content.find(katello_content_id)&.destroy!
+              ::Katello::Content.find_by_id(katello_content_id)&.destroy!
             end
           end
         end

--- a/test/actions/katello/product_test.rb
+++ b/test/actions/katello/product_test.rb
@@ -33,7 +33,20 @@ module ::Actions::Katello::Product
         let(:candlepin_remove_class) { ::Actions::Candlepin::Product::ContentRemove }
 
         it 'plans' do
-          Katello::Content.expects(:find).returns(@content)
+          Katello::Content.expects(:find_by_id).returns(@content)
+
+          action = create_action action_class
+          action.stubs(:action_subject).with(@repository)
+          plan_action action, @repository.root
+          assert_action_planed_with action, candlepin_remove_class, product_id: @product.cp_id,
+                                                                    owner: @product.organization.label,
+                                                                    content_id: @repository.content_id
+          assert_action_planed_with action, candlepin_destroy_class, content_id: @repository.content_id,
+                                                                     owner: @product.organization.label
+        end
+
+        it 'plans when Content is missing' do
+          @repository.root.expects(:content).returns(nil)
 
           action = create_action action_class
           action.stubs(:action_subject).with(@repository)
@@ -46,7 +59,7 @@ module ::Actions::Katello::Product
         end
 
         it 'removes contents even if cp content_id is very large' do
-          Katello::Content.expects(:find).returns(@content)
+          Katello::Content.expects(:find_by_id).returns(@content)
 
           action = create_action action_class
           action.stubs(:action_subject).with(@repository)


### PR DESCRIPTION
The code in the ContentDestroy action was written to gracefully continue if it couldn't find the Katello::Content (notice the save navigation operator):

```
::Katello::Content.find(katello_content_id)&.destroy!
```

However, `find` will raise an error if the record doesn't exist. Using `find_by_id` will return nil in that case, so we can actually use safe navigation.


To test:
- create a custom product with a repository
- from the console, find the RootRepository:

```
root = Katello::RootRepository.find_by_name('your repo name')
```
- set its content_id to nil:

```
root.update_attributes(content_id: nil)
```

- Attempt to remove the repository. It should now succeed where it would have failed prior to this change
