### PR TITLE
Fixes #26776 - SUSE errata not correctly displayed

### DIFF
--- a/app/views/katello/api/v2/errata/_counts.json.rabl
+++ b/app/views/katello/api/v2/errata/_counts.json.rabl
@@ -5,11 +5,11 @@ node :security do |_presenter|
 end
 
 node :bugfix do |_presenter|
-  totals[:bugfix]
+  totals[:bugfix].to_i + totals[:recommended].to_i
 end
 
 node :enhancement do |_presenter|
-  totals[:enhancement]
+  totals[:enhancement].to_i + totals[:optional].to_i
 end
 
 node :total do |_presenter|

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
@@ -121,11 +121,11 @@
                   <i class="fa fa-warning inline-icon" title="{{ 'Security' | translate }}"></i>
                 </span>
 
-                <span ng-show="erratum.type == 'bugfix'">
+                <span ng-show="erratum.type == 'bugfix' || erratum.type == 'recommended'">
                   <i class="fa fa-bug inline-icon" title="{{ 'Bug Fix' | translate }}"></i>
                 </span>
 
-                <span ng-show="erratum.type == 'enhancement'">
+                <span ng-show="erratum.type == 'enhancement' || erratum.type == 'optional'">
                   <i class="fa fa-plus-square inline-icon" title="{{ 'Enhancement' | translate }}"></i>
                 </span>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -208,7 +208,7 @@
 
         <dt translate>Bug Fix</dt>
         <dd>
-          <a ui-sref="content-host.errata.index({getSearch: 'type=bugfix'})" ng-class="{black: !host.content_facet_attributes.errata_counts.bugfix, yellow: host.content_facet_attributes.errata_counts.bugfix > 0}">
+          <a ui-sref="content-host.errata.index({getSearch: 'type=bugfix or type=recommended'})" ng-class="{black: !host.content_facet_attributes.errata_counts.bugfix, yellow: host.content_facet_attributes.errata_counts.bugfix > 0}">
             <i class="fa fa-bug inline-icon" title="{{ 'Bug Fix' | translate }}"></i>
             {{ host.content_facet_attributes.errata_counts.bugfix || 0 }}
           </a>
@@ -216,7 +216,7 @@
 
         <dt translate>Enhancement</dt>
         <dd>
-          <a ui-sref="content-host.errata.index({getSearch: 'type=enhancement'})" ng-class="{black: !host.content_facet_attributes.errata_counts.enhancement, yellow: host.content_facet_attributes.errata_counts.enhancement > 0}">
+          <a ui-sref="content-host.errata.index({getSearch: 'type=enhancement or type=optional'})" ng-class="{black: !host.content_facet_attributes.errata_counts.enhancement, yellow: host.content_facet_attributes.errata_counts.enhancement > 0}">
             <i class="fa fa-plus-square inline-icon" title="{{ 'Enhancement' | translate }}"></i>
             {{ host.content_facet_attributes.errata_counts.enhancement || 0 }}
           </a>


### PR DESCRIPTION
* search-link in content-host for bugfix and enhancement did not add
  suse equivalent errata-types to search-string
* add icons to suse errata-types in errata-list