### PR TITLE
Fixes #26794 - Multi-entitlement missing on sub. details

### DIFF
--- a/app/models/katello/subscription.rb
+++ b/app/models/katello/subscription.rb
@@ -42,6 +42,10 @@ module Katello
       pools.any?(&:recently_expired?)
     end
 
+    def multi_entitlement?
+      pools.where("#{Katello::Pool.table_name}.multi_entitlement" => true).any?
+    end
+
     def virt_who_pools
       pools.where("#{Katello::Pool.table_name}.virt_who" => true)
     end

--- a/app/views/katello/api/v2/subscriptions/base.json.rabl
+++ b/app/views/katello/api/v2/subscriptions/base.json.rabl
@@ -10,7 +10,8 @@ attributes :account_number, :contract_number
 attributes :support_level
 attributes :product_id
 attributes :sockets, :cores, :ram
-attributes :instance_multiplier, :stacking_id, :multi_entitlement
+attributes :instance_multiplier, :stacking_id
+attributes :multi_entitlement? => :multi_entitlement
 attributes :type
 attributes :name => :product_name
 attributes :unmapped_guest

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -48,5 +48,11 @@ module Katello
                                :organization => @basic.organization, :provider => @basic.organization.anonymous_provider)
       refute @basic.redhat?
     end
+
+    def test_multi_entitlement
+      assert @basic.multi_entitlement?
+
+      refute @other.multi_entitlement?
+    end
   end
 end

--- a/webpack/scenes/Subscriptions/Details/SubscriptionAttributes.js
+++ b/webpack/scenes/Subscriptions/Details/SubscriptionAttributes.js
@@ -14,6 +14,6 @@ export default {
   support_type: __('Support Type'),
   arch: __('Architecture(s)'),
   type: __('Type'),
-  mutli_entitlement: __('Multi-entitlement'),
+  multi_entitlement: __('Multi-entitlement'),
   stacking_id: __('Stacking ID'),
 };

--- a/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetailInfo.test.js.snap
+++ b/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetailInfo.test.js.snap
@@ -146,7 +146,7 @@ exports[`subscriptions detail associations page renders correctly 1`] = `
           </b>
         </td>
         <td>
-          
+          true
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
This was missing due to backend changes and UI changes from several releases ago.

To test, just load up the details page for any subscription and it'll probably show 'false' for the Multi-entitlement field which would have been missing before.

To see a 'true' value - you'll need a subscription manifest with a variety of subscriptions and one of them is likely to have it. One example is "Red Hat Enterprise Linux Server, Premium (Physical or Virtual Nodes)"