### PR TITLE
Fixes #26301 - Fetch correct rpm counts in cv version details

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -79,6 +79,7 @@ module Katello
     param :file_id, String, :desc => N_("Id of a file to find repositories that contain the file")
     param :ostree_branch_id, String, :desc => N_("Id of an ostree branch to find repositories that contain that branch")
     param :library, :bool, :desc => N_("show repositories in Library and the default content view")
+    param :archived, :bool, :desc => N_("show archived repositories")
     param :content_type, RepositoryTypeManager.repository_types.keys, :desc => N_("limit to only repositories of this type")
     param :name, String, :desc => N_("name of the repository"), :required => false
     param :label, String, :desc => N_("label of the repository"), :required => false
@@ -132,6 +133,7 @@ module Katello
     def index_relation_content_view(query)
       if params[:content_view_version_id]
         query = query.where(:content_view_version_id => params[:content_view_version_id])
+        query = query.archived if ::Foreman::Cast.to_bool params[:archived]
         query = Katello::Repository.where(:id => query.select(:library_instance_id)) if params[:library]
       elsif params[:content_view_id]
         query = filter_by_content_view(query, params[:content_view_id], params[:environment_id], params[:available_for] == 'content_view')

--- a/app/views/katello/api/v2/repositories/base.json.rabl
+++ b/app/views/katello/api/v2/repositories/base.json.rabl
@@ -3,7 +3,7 @@ object @resource
 extends 'katello/api/v2/common/identifier'
 
 attributes :pulp_id => :backend_identifier
-attributes :relative_path, :container_repository_name, :full_path
+attributes :relative_path, :container_repository_name, :full_path, :library_instance_id
 
 glue(@object.root) do
   attributes :content_type, :url, :arch, :content_id

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/content-view-version-content.controller.js
@@ -32,7 +32,7 @@
                 params: {
                     'content_type': "yum",
                     'content_view_version_id': $scope.$stateParams.versionId,
-                    library: true
+                    archived: true
                 }
             },
             'packages': {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/views/content-view-version-yum.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/versions/views/content-view-version-yum.html
@@ -11,14 +11,14 @@
     <tbody>
       <tr bst-table-row ng-repeat="repository in table.rows">
         <td bst-table-cell>
-          <a ui-sref="product.repository.info({productId: repository.product.id, repositoryId: repository.id})">{{ repository.name }}</a>
+          <a ui-sref="product.repository.info({productId: repository.product.id, repositoryId: repository.library_instance_id })">{{ repository.name }}</a>
         </td>
         <td bst-table-cell>
           <a ui-sref="product.info({productId: repository.product.id})">{{ repository.product.name }}</a>
         </td>
         <td bst-table-cell>
           <div>
-            <a ui-sref="product.repository.manage-content.packages({productId: repository.product.id, repositoryId: repository.id})" translate>
+            <a ui-sref="product.repository.manage-content.packages({productId: repository.product.id, repositoryId: repository.library_instance_id})" translate>
               {{ repository.content_counts.rpm }} Packages
             </a>
           </div>
@@ -26,12 +26,12 @@
             {{ repository.content_counts.srpm }} Source RPMs
           </div>
           <div>
-            <a ui-sref="errata({repositoryId: repository.id})" translate>
+            <a ui-sref="errata({repositoryId: repository.library_instance_id})" translate>
               {{ repository.content_counts.erratum }} Errata
             </a>
           </div>
           <div>
-            <a ui-sref="product.repository.manage-content.module-streams({productId: repository.product.id, repositoryId: repository.id})">
+            <a ui-sref="product.repository.manage-content.module-streams({productId: repository.product.id, repositoryId: repository.library_instance_id})">
               {{ repository.content_counts.module_stream || 0 }} Module Streams
             </a>
           </div>

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -132,6 +132,17 @@ module Katello
       assert_response_ids response, ids
     end
 
+    def test_index_with_content_view_version_id_archived
+      version = @view.content_view_versions.first
+      ids = version.archived_repos.pluck :id
+
+      response = get :index, params: { :content_view_version_id => version.id, :organization_id => @organization.id, :archived => true }
+
+      assert_response :success
+      assert_template 'api/v2/repositories/index'
+      assert_response_ids response, ids
+    end
+
     def test_index_available_for_content_view
       ids = @view.organization.default_content_view.versions.first.repositories.pluck(:id) - @view.repositories.pluck(:id)
 


### PR DESCRIPTION
**To test:**

1. Create a repo with some content.
2. Add repo to cv and publish
3. Remove some content from repo
4. Re-publish repo
5. Go to CV > Version >  Yum Repositories
6. You should see the correct counts for the specific versions.

Most of the API changes come from the PR: https://github.com/Katello/katello/pull/6366 which tackles returning archived repo when environment is not specified.