### PR TITLE
Fixes #26530 - Don't reset Add Ons on UI updates

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/content-host-details.controller.js
@@ -32,7 +32,6 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsController
         $scope.defaultRoles = ['Red Hat Enterprise Linux Server', 'Red Hat Enterprise Linux Workstation', 'Red Hat Enterprise Linux Compute Node'];
         $scope.defaultServiceLevels = ['Self-Support', 'Standard', 'Premium'];
 
-        $scope.purposeAddonsList = [];
         $scope.purposeAddonsCount = 0;
 
         $scope.panel = {
@@ -64,23 +63,23 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsController
 
         $scope.saveSubscriptionFacet = function (host) {
             var newHost = {id: host.id};
-            var addOns = [];
-
-            angular.forEach($scope.purposeAddonsList, function (addOn) {
-                if (addOn.selected) {
-                    addOns.push(addOn.name);
-                }
-            });
 
             newHost['subscription_facet_attributes'] = {
                 id: host.subscription_facet_attributes.id,
                 autoheal: host.subscription_facet_attributes.autoheal,
                 'purpose_role': host.subscription_facet_attributes.purpose_role,
                 'purpose_usage': host.subscription_facet_attributes.purpose_usage,
-                'purpose_addons': addOns,
                 'service_level': host.subscription_facet_attributes.service_level,
                 'release_version': host.subscription_facet_attributes.release_version
             };
+
+            if ($scope.purposeAddonsList) {
+                newHost['subscription_facet_attributes']['purpose_addons'] = _.chain($scope.purposeAddonsList).filter(function(addOn) {
+                    return addOn.selected;
+                }).map(function(addOn) {
+                    return addOn.name;
+                }).value();
+            }
 
             return $scope.save(newHost, true);
         };
@@ -186,7 +185,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostDetailsController
                 });
 
                 angular.forEach(addOns, function (addOn) {
-                    $scope.purposeAddonsList.push({"name": addOn, "selected": $scope.host.subscription_facet_attributes.purpose_addons.indexOf(addOn) > -1});
+                    $scope.purposeAddonsList.push({"name": addOn, "selected": purposeAddons.indexOf(addOn) > -1});
                 });
 
                 return $scope.purposeAddonsList;

--- a/engines/bastion_katello/test/content-hosts/details/content-host-details.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/details/content-host-details.controller.test.js
@@ -60,6 +60,10 @@ describe('Controller: ContentHostDetailsController', function() {
             },
             subscription: {uuid: 'abcd-1234'},
             subscription_facet_attributes: {
+              id: 101,
+              release_version: '7Server',
+              autoheal: true,
+              service_level: 'Premium',
               purpose_role: 'current-role',
               purpose_usage: 'current-usage',
               purpose_addons: ['current-addon']
@@ -113,6 +117,45 @@ describe('Controller: ContentHostDetailsController', function() {
             MenuExpander: MenuExpander
         });
     }));
+
+    describe("saveSubscriptionFacet()", function() {
+        var expectedHost;
+
+        beforeEach(function() {
+            expectedHost = {
+                id: 1,
+                subscription_facet_attributes: {
+                  id: 101,
+                  autoheal: true,
+                  purpose_role: 'current-role',
+                  purpose_usage: 'current-usage',
+                  service_level: 'Premium',
+                  release_version: '7Server',
+                }
+            };
+        });
+
+        it("sends purpose addons when they are set", function() {
+          spyOn($scope, 'save');
+          $scope.purposeAddonsList = [
+              {name: "Addon1", selected: true},
+              {name: "Addon2", selected: false},
+          ];
+          expectedHost['subscription_facet_attributes']['purpose_addons'] = ['Addon1'];
+
+          $scope.saveSubscriptionFacet(mockHost);
+
+          expect($scope.save).toHaveBeenCalledWith(expectedHost, true);
+        });
+
+        it ("doesn't send addons when they aren't set", function() {
+          spyOn($scope, 'save');
+
+          $scope.saveSubscriptionFacet(mockHost);
+
+          expect($scope.save).toHaveBeenCalledWith(expectedHost, true);
+        });
+    });
 
     it("sets the menu expander on the scope", function() {
         expect($scope.menuExpander).toBe(MenuExpander);


### PR DESCRIPTION
System Purpose Addons were being reset under certain conditions when updating a content host via the UI. The `scope.purposeAddonsList` was being initialized as an empty list until the addons selector was expanded which caused the empty list to be sent to the server if the addons list was never expanded or modified.

I've changed the code so that addons are only sent to the server if they've potentially (meaning the addons list was opened but not necessarily modified in any way) been updated.

**To test:**

**Old behavior:**
- Set up a custom product with some addons similar to #8111 
- From the details page of a content host, set one or more addons
-  **Refresh the page**
- Update the host in some way but don't modify or open the purpose addons selector
- Addons will be cleared out

**New behavior:**
- Apply this PR and repeat the above steps for the content host. The addons should be preserved.
- Extra credit: try to break things by unsetting some or all addons, updating the host in other ways, etc. Everything should work as expected.