### PR TITLE
Fixes #26810 - Don't run AutoAttach on every host update

### DIFF
--- a/app/lib/actions/katello/host/update.rb
+++ b/app/lib/actions/katello/host/update.rb
@@ -10,12 +10,14 @@ module Actions
           sequence do
             host.content_facet.save! if host.content_facet
 
+            auto_attach_enabled_via_checkin = consumer_params.try(:[], 'autoheal')
+
             if host.subscription_facet
               consumer_params ||= host.subscription_facet.consumer_attributes
               cp_update = plan_action(::Actions::Candlepin::Consumer::Update, host.subscription_facet.uuid, consumer_params)
             end
 
-            if consumer_params.present? && consumer_params['autoheal']
+            if auto_attach_enabled_via_checkin
               plan_action(::Actions::Candlepin::Consumer::AutoAttachSubscriptions, :uuid => host.subscription_facet.uuid)
             end
 

--- a/test/actions/katello/host/update_test.rb
+++ b/test/actions/katello/host/update_test.rb
@@ -82,5 +82,18 @@ module Katello::Host
         refute_action_planed action, ::Actions::Candlepin::Consumer::Update
       end
     end
+
+    describe 'Host update using facet params' do
+      it 'plans' do
+        @host.subscription_facet.stubs(:consumer_attributes).returns('autoheal' => true)
+        action.stubs(:action_subject).with(@host)
+
+        plan_action action, @host
+
+        # we shouldn't plan AutoAttach just because the facet has it enabled
+        refute_action_planed action, ::Actions::Candlepin::Consumer::AutoAttachSubscriptions
+        assert_action_planed_with action, ::Actions::Candlepin::Consumer::Update, @host.subscription_facet.uuid, @host.subscription_facet.consumer_attributes
+      end
+    end
   end
 end


### PR DESCRIPTION
A while back host update was changed to trigger auto-attach at the time it was being enabled(#4444). Since then the code has regressed such that any host UI update will trigger an auto-attach which is not intended. It's especially bad for use cases like System Purpose where the user will want to update 1-4 attributes before running auto-attach manually.

If the ::Update action isn't given a params hash (such as during a host checkin/fact update) the consumer params are taken from the subscription facet. If autoheal is true then an auto attach is performed. This PR prevents that from happening and will once again only trigger auto-attach on host update if the flag is being set to true.

**To test**

- check out this PR
- register a content host to your devel box (vagrant up katello-devel)
- from the details UI for the host, perform some updates and check Monitor->Tasks dynflow console for the relevant tasks. There should not be a planned action for AutoAttachSubscriptions.
- from the command line of your client, disable auto attach: `subscription-manager auto-attach --disable`. This should not trigger an auto attach (verify same as above)
- now, enable auto-attach `subscription-manager auto-attach --enable` - you should see that AutoAttachSubscriptions has ran during the host update