### PR TITLE
Fixes #26811 - Select all host installable errata

### DIFF
--- a/app/controllers/katello/api/v2/host_errata_controller.rb
+++ b/app/controllers/katello/api/v2/host_errata_controller.rb
@@ -86,7 +86,7 @@ module Katello
         search_errata = @host.content_facet.installable_errata
         search_errata = search_errata.search_for(bulk_params[:included][:search])
         if @errata.any?
-          ::Katello::Erratum.where(errata_id: @errata).or(::Katello::Erratum.where(errata_id: search_errata))
+          @errata = ::Katello::Erratum.where(errata_id: @errata).or(::Katello::Erratum.where(errata_id: search_errata))
         else
           @errata = search_errata
         end

--- a/app/controllers/katello/api/v2/host_errata_controller.rb
+++ b/app/controllers/katello/api/v2/host_errata_controller.rb
@@ -86,13 +86,13 @@ module Katello
         search_errata = @host.content_facet.installable_errata
         search_errata = search_errata.search_for(bulk_params[:included][:search])
         if @errata.any?
-          ::Katello::Erratum.where("errata_id in (?) OR errata_id in (?)", @errata, search_errata)
+          ::Katello::Erratum.where(:errata_id: @errata).or(::Katello::Erratum.where(:errata_id: search_errata))
         else
           @errata = search_errata
         end
       end
 
-      @errata = @errata.where('errata_id not in (?)', bulk_params[:excluded][:ids]) unless bulk_params[:excluded][:ids].blank?
+      @errata = @errata.where.not(:errata_id: bulk_params[:excluded][:ids]) unless bulk_params[:excluded][:ids].blank?
 
       if bulk_params[:included][:ids].blank? && bulk_params[:included][:search].nil?
         fail HttpErrors::BadRequest, _("No errata have been specified.")

--- a/app/controllers/katello/api/v2/host_errata_controller.rb
+++ b/app/controllers/katello/api/v2/host_errata_controller.rb
@@ -50,7 +50,8 @@ module Katello
 
     api :PUT, "/hosts/:host_id/errata/apply", N_("Schedule errata for installation")
     param :host_id, :number, :desc => N_("Host ID"), :required => true
-    param :errata_ids, Array, :desc => N_("List of Errata ids to install"), :required => false
+    param :errata_ids, Array, :desc => N_("List of Errata ids to install"), :required => false, :deprecated => true
+
     param_group :bulk_errata_ids
     def apply
       task = async_task(::Actions::Katello::Host::Erratum::Install, @host, @errata_ids)

--- a/app/controllers/katello/api/v2/host_errata_controller.rb
+++ b/app/controllers/katello/api/v2/host_errata_controller.rb
@@ -93,7 +93,7 @@ module Katello
         end
       end
 
-      @errata = @errata.where.not(errata_id: bulk_params[:excluded][:ids]) unless bulk_params[:excluded][:ids].blank?
+      @errata = @errata.where.not(errata_id: bulk_params[:excluded][:ids]) unless @errata.empty? || bulk_params[:excluded][:ids].blank?
 
       if bulk_params[:included][:ids].blank? && bulk_params[:included][:search].nil?
         fail HttpErrors::BadRequest, _("No errata have been specified.")

--- a/app/controllers/katello/api/v2/host_errata_controller.rb
+++ b/app/controllers/katello/api/v2/host_errata_controller.rb
@@ -18,12 +18,13 @@ module Katello
     end
 
     def_param_group :bulk_errata_ids do
-      param :included, Hash, :required => true, :desc => N_("Search on errata based on included items."\
-                                                            " Note:This can be combined with excluded"), :action_aware => true do
+      param :included, Hash, :desc => N_("Errata to exclusively include in the action"), :required => true, :action_aware => true do
         param :search, String, :required => false, :desc => N_("Search string for erratum to perform an action on")
         param :ids, Array, :required => false, :desc => N_("List of errata ids to perform an action on, (ex: RHSA-2019:1168)")
       end
-      param :excluded, Hash, :required => true, :action_aware => true do
+      param :excluded, Hash, :desc => N_("Errata to explicitly exclude in the action."\
+                                         " All other applicable errata will be included in the action,"\
+                                         " unless an included parameter is passed as well."), :required => true, :action_aware => true do
         param :ids, Array, :required => false, :desc => N_("List of errata ids to exclude and not run an action on, (ex: RHSA-2019:1168)")
       end
     end
@@ -97,7 +98,7 @@ module Katello
       @errata = @errata.where.not(errata_id: bulk_params[:excluded][:ids]) unless @errata.empty? || bulk_params[:excluded][:ids].blank?
 
       if bulk_params[:included][:ids].blank? && bulk_params[:included][:search].nil?
-        fail HttpErrors::BadRequest, _("No errata have been specified.")
+        fail HttpErrors::BadRequest, _("No errata has been specified.")
       end
       @errata.pluck(:errata_id)
     end

--- a/app/controllers/katello/api/v2/host_errata_controller.rb
+++ b/app/controllers/katello/api/v2/host_errata_controller.rb
@@ -86,13 +86,13 @@ module Katello
         search_errata = @host.content_facet.installable_errata
         search_errata = search_errata.search_for(bulk_params[:included][:search])
         if @errata.any?
-          ::Katello::Erratum.where(:errata_id: @errata).or(::Katello::Erratum.where(:errata_id: search_errata))
+          ::Katello::Erratum.where(errata_id: @errata).or(::Katello::Erratum.where(errata_id: search_errata))
         else
           @errata = search_errata
         end
       end
 
-      @errata = @errata.where.not(:errata_id: bulk_params[:excluded][:ids]) unless bulk_params[:excluded][:ids].blank?
+      @errata = @errata.where.not(errata_id: bulk_params[:excluded][:ids]) unless bulk_params[:excluded][:ids].blank?
 
       if bulk_params[:included][:ids].blank? && bulk_params[:included][:search].nil?
         fail HttpErrors::BadRequest, _("No errata have been specified.")

--- a/app/controllers/katello/api/v2/host_errata_controller.rb
+++ b/app/controllers/katello/api/v2/host_errata_controller.rb
@@ -18,7 +18,8 @@ module Katello
     end
 
     def_param_group :bulk_errata_ids do
-      param :included, Hash, :required => true, :action_aware => true do
+      param :included, Hash, :required => true, :desc => N_("Search on errata based on included items."\
+                                                            " Note:This can be combined with excluded"), :action_aware => true do
         param :search, String, :required => false, :desc => N_("Search string for erratum to perform an action on")
         param :ids, Array, :required => false, :desc => N_("List of errata ids to perform an action on, (ex: RHSA-2019:1168)")
       end

--- a/app/controllers/katello/concerns/api/v2/bulk_hosts_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/bulk_hosts_extensions.rb
@@ -27,7 +27,7 @@ module Katello
         end
 
         @hosts = restrict_to.call(@hosts) if restrict_to
-        @hosts = @hosts.where('id not in (?)', bulk_params[:excluded][:ids]) unless bulk_params[:excluded][:ids].blank?
+        @hosts = @hosts.where.not(id: bulk_params[:excluded][:ids]) unless bulk_params[:excluded][:ids].blank?
 
         if bulk_params[:included][:ids].blank? && bulk_params[:included][:search].nil?
           fail HttpErrors::BadRequest, _("No hosts have been specified.")

--- a/app/controllers/katello/concerns/api/v2/bulk_hosts_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/bulk_hosts_extensions.rb
@@ -20,7 +20,7 @@ module Katello
           search_hosts = search_hosts.where(:organization_id => organization_id) if params[:organization_id]
           search_hosts = search_hosts.search_for(bulk_params[:included][:search])
           if @hosts.any?
-            ::Host.where("id in (?) OR id in (?)", @hosts, search_hosts)
+            @hosts = ::Host.where(id: @hosts).or(::Host.where(id: search_hosts))
           else
             @hosts = search_hosts
           end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
@@ -15,7 +15,7 @@
 angular.module('Bastion.content-hosts').controller('ContentHostErrataController',
     ['$scope', '$timeout', '$window', 'translate', 'HostErratum', 'Nutupane', 'Organization', 'Environment', 'BastionConfig',
     function ($scope, $timeout, $window, translate, HostErratum, Nutupane, Organization, Environment, BastionConfig) {
-        var errataNutupane, params = {
+        var params = {
             'sort_by': 'updated',
             'sort_order': 'DESC',
             'paged': true,
@@ -28,13 +28,11 @@ angular.module('Bastion.content-hosts').controller('ContentHostErrataController'
                 'errata_id': errataId});
         }
 
-        errataNutupane = new Nutupane(HostErratum, params, 'get');
+        $scope.nutupane = new Nutupane(HostErratum, params, 'get');
         $scope.controllerName = 'katello_errata';
-
-        errataNutupane.masterOnly = true;
-        $scope.table = errataNutupane.table;
+        $scope.nutupane.masterOnly = true;
+        $scope.table = $scope.nutupane.table;
         $scope.table.errataFilterTerm = "";
-        $scope.nutupane = errataNutupane;
 
         $scope.table.errataCompare = function (item) {
             var searchText = $scope.table.errataFilterTerm;
@@ -83,8 +81,8 @@ angular.module('Bastion.content-hosts').controller('ContentHostErrataController'
         $scope.host.$promise.then(function() {
             $scope.setupErrataOptions($scope.host);
             if ($scope.host['content_facet_attributes'] && $scope.host.id) {
-                errataNutupane.setParams({id: $scope.host.id});
-                errataNutupane.load();
+                $scope.nutupane.setParams({id: $scope.host.id});
+                $scope.nutupane.load();
             }
         });
 
@@ -111,8 +109,8 @@ angular.module('Bastion.content-hosts').controller('ContentHostErrataController'
                 errataParams['environment_id'] = option['environment_id'];
             }
 
-            errataNutupane.setParams(errataParams);
-            errataNutupane.refresh();
+            $scope.nutupane.setParams(errataParams);
+            $scope.nutupane.refresh();
         };
 
         $scope.transitionToErratum = function (erratum) {
@@ -152,7 +150,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostErrataController'
             }
         };
 
-        errataNutupane.enableSelectAllResults();
+        $scope.nutupane.enableSelectAllResults();
 
         if ($scope.$stateParams.errataId) {
             loadErratum($scope.$stateParams.errataId);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
@@ -5,7 +5,6 @@
  * @requires $scope
  * @resource $timeout
  * @resource $window
- * @resource $location
  * @requires HostErratum
  * @requires Nutupane
  * @requires BastionConfig
@@ -14,8 +13,8 @@
  *   Provides the functionality for the content host package list and actions.
  */
 angular.module('Bastion.content-hosts').controller('ContentHostErrataController',
-    ['$scope', '$timeout', '$window', '$location', 'translate', 'HostErratum', 'Nutupane', 'Organization', 'Environment', 'BastionConfig',
-    function ($scope, $timeout, $window, $location, translate, HostErratum, Nutupane, Organization, Environment, BastionConfig) {
+    ['$scope', '$timeout', '$window', 'translate', 'HostErratum', 'Nutupane', 'Organization', 'Environment', 'BastionConfig',
+    function ($scope, $timeout, $window, translate, HostErratum, Nutupane, Organization, Environment, BastionConfig) {
         var errataNutupane, params = {
             'sort_by': 'updated',
             'sort_order': 'DESC',
@@ -154,10 +153,6 @@ angular.module('Bastion.content-hosts').controller('ContentHostErrataController'
         };
 
         errataNutupane.enableSelectAllResults();
-        // if ($location.search()['select_all']) {
-        //     nutupane.table.selectAllResults(true);
-        // }
-
 
         if ($scope.$stateParams.errataId) {
             loadErratum($scope.$stateParams.errataId);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/views/content-host-errata.html
@@ -113,7 +113,7 @@
             <th bst-table-column="issued" translate>Issued</th>
           </tr>
         </thead>
-
+        <div data-extend-template="layouts/select-all-results.html"></div>
         <tbody>
           <tr bst-table-row ng-repeat="erratum in table.rows | filter:table.errataCompare" row-select="erratum">
             <td bst-table-cell>

--- a/engines/bastion_katello/test/content-hosts/content/content-host-errata.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content/content-host-errata.controller.test.js
@@ -37,6 +37,7 @@ describe('Controller: ContentHostErrataController', function() {
             $promise: {then: function(callback) {callback(host)}}
         };
         Nutupane = function() {
+
             this.table = {
                 showColumns: function() {},
                 getSelected: function() {return [mockErratum];},
@@ -47,6 +48,7 @@ describe('Controller: ContentHostErrataController', function() {
             this.refresh = function() {nutupaneMock.refresh()};
             this.load = function () {nutupaneMock.load()};
             this.enableSelectAllResults = function () {};
+            this.getAllSelectedResults = function() {return [mockErratum];}
         };
         HostErratum = {
             get: function() {return []},
@@ -97,7 +99,7 @@ describe('Controller: ContentHostErrataController', function() {
         spyOn($scope.table, "selectAll");
         spyOn($scope, "transitionTo");
         $scope.applySelected();
-        expect(HostErratum.apply).toHaveBeenCalledWith({id: host.id, errata_ids: [mockErratum.errata_id]},
+        expect(HostErratum.apply).toHaveBeenCalledWith({id: host.id, bulk_errata_ids: [{errata_id: mockErratum.errata_id}]},
                                                          jasmine.any(Function));
         expect($scope.transitionTo).toHaveBeenCalledWith('content-host.tasks.details', {taskId: mockTask.id});
         expect($scope.table.selectAll).toHaveBeenCalledWith(false);

--- a/test/controllers/api/v2/host_errata_controller_test.rb
+++ b/test/controllers/api/v2/host_errata_controller_test.rb
@@ -3,7 +3,7 @@
 require "katello_test_helper"
 
 module Katello
-  class Api::V2::HostErrataControllerTest < ActionController::TestCase
+  class HostErrataControllerTestBase < ActionController::TestCase
     include Support::ForemanTasks::Task
     tests ::Katello::Api::V2::HostErrataController
 
@@ -26,7 +26,73 @@ module Katello
       setup_foreman_routes
       permissions
     end
+  end
 
+  class HostErrataControllerBulkErrataTest < HostErrataControllerTestBase
+    def setup
+      super
+      @controller = ::Katello::Api::V2::HostErrataController.new
+      @controller.instance_variable_set(:@host, @host)
+      @errata = katello_errata(:security)
+      @host.content_facet.bound_repositories << @errata.repositories.first
+      @bugfix = katello_errata(:bugfix)
+    end
+
+    def test_search_bulk_errata
+      bulk_params = {
+        :included => {
+          :search => "errata_id = #{@errata.errata_id}"
+        }
+      }
+      result = @controller.find_bulk_errata_ids(bulk_params)
+
+      assert_includes result, @errata.errata_id
+    end
+
+    def test_search_bulk_errata_exclude
+      bulk_params = {
+        :included => {
+          :search => "issued <  Yesterday"
+        },
+        :excluded => {
+          :ids => [@bugfix.errata_id]
+        }
+      }
+      result = @controller.find_bulk_errata_ids(bulk_params)
+
+      refute_includes result, @bugfix.errata_id
+      assert_includes result, @errata.errata_id
+    end
+
+    def test_search_bulk_errata_ids
+      bulk_params = {
+        :included => {
+          :ids => [@bugfix.errata_id]
+        }
+      }
+      result = @controller.find_bulk_errata_ids(bulk_params)
+
+      refute_includes result, @errata.errata_id
+      assert_includes result, @bugfix.errata_id
+    end
+
+    def test_search_bulk_errata_ids_excluded
+      bulk_params = {
+        :included => {
+          :ids => [@bugfix.errata_id, @errata.errata_id]
+        },
+        :excluded => {
+          :ids => [@bugfix.errata_id]
+        }
+      }
+      result = @controller.find_bulk_errata_ids(bulk_params)
+
+      refute_includes result, @bugfix.errata_id
+      assert_includes result, @errata.errata_id
+    end
+  end
+
+  class Api::V2::HostErrataControllerTest < HostErrataControllerTestBase
     def test_index
       response = get :index, params: { :host_id => @host_dev.id }
 

--- a/test/controllers/api/v2/host_errata_controller_test.rb
+++ b/test/controllers/api/v2/host_errata_controller_test.rb
@@ -90,6 +90,19 @@ module Katello
       refute_includes result, @bugfix.errata_id
       assert_includes result, @errata.errata_id
     end
+
+    def test_excludes_only_case
+      bulk_params = {
+        :excluded => {
+          :ids => [@bugfix.errata_id]
+        }
+      }
+      exception = assert_raises(HttpErrors::BadRequest) do
+        @controller.find_bulk_errata_ids(bulk_params)
+      end
+      assert_match /No errata have been specified/, exception.message
+    end
+
   end
 
   class Api::V2::HostErrataControllerTest < HostErrataControllerTestBase

--- a/test/controllers/api/v2/host_errata_controller_test.rb
+++ b/test/controllers/api/v2/host_errata_controller_test.rb
@@ -100,9 +100,8 @@ module Katello
       exception = assert_raises(HttpErrors::BadRequest) do
         @controller.find_bulk_errata_ids(bulk_params)
       end
-      assert_match /No errata has been specified/, exception.message
+      assert_match(/No errata has been specified/, exception.message)
     end
-
   end
 
   class Api::V2::HostErrataControllerTest < HostErrataControllerTestBase

--- a/test/controllers/api/v2/host_errata_controller_test.rb
+++ b/test/controllers/api/v2/host_errata_controller_test.rb
@@ -100,7 +100,7 @@ module Katello
       exception = assert_raises(HttpErrors::BadRequest) do
         @controller.find_bulk_errata_ids(bulk_params)
       end
-      assert_match /No errata have been specified/, exception.message
+      assert_match /No errata has been specified/, exception.message
     end
 
   end


### PR DESCRIPTION
This commit lets you select "all" installable errata on content hosts
errata page. Prior to this one was able to only select the errata on the
first page. This commit tries to address that by facilitating bulk
params for errata apply.
In addition it provides functionality in the UI to facilitate the same.