### PR TITLE
Fixes #26825 - Allow some DMI UUID duplicates on registration

### DIFF
--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -29,6 +29,8 @@ module Katello
 
       attr_accessor :facts
 
+      DMI_UUID_ALLOWED_DUPS = ['', 'Not Settable', 'Not Present'].freeze
+
       def host_type
         host_facts = self.host.facts
         host_facts["virt::host_type"] || host_facts["hypervisor::type"]
@@ -249,7 +251,7 @@ module Katello
 
         hosts = ::Host.unscoped.distinct.left_outer_joins(:fact_values)
                 .where("#{::Host.table_name}.name = ? OR (#{FactValue.table_name}.fact_name_id = ?
-               AND #{FactValue.table_name}.value = ?)", host_name, uuid_fact_id, host_uuid)
+               AND #{FactValue.table_name}.value = ? AND #{FactValue.table_name}.value NOT IN (?))", host_name, uuid_fact_id, host_uuid, DMI_UUID_ALLOWED_DUPS)
 
         return if hosts.empty?
 

--- a/test/models/host/subscription_facet_test.rb
+++ b/test/models/host/subscription_facet_test.rb
@@ -304,6 +304,18 @@ module Katello
       assert_equal host3, Katello::Host::SubscriptionFacet.find_host(facts, org)
     end
 
+    def test_find_host_multiple_existing_empty_uuid
+      allowed_dups = ['', 'Not Settable', 'Not Present']
+      allowed_dups.each do |dup|
+        host = FactoryBot.create(:host, organization: org)
+        FactValue.create(value: dup, host: host, fact_name: uuid_fact_name)
+
+        facts = {'network.hostname' => 'inexistent_hostname', 'dmi.system.uuid' => dup}
+
+        assert_nil Katello::Host::SubscriptionFacet.find_host(facts, org)
+      end
+    end
+
     def test_find_or_create_host_with_org
       created_host = FactoryBot.create(:host, :organization_id => org.id)
       host = Katello::Host::SubscriptionFacet.find_or_create_host(org, :facts => {'network.hostname' => created_host.name})


### PR DESCRIPTION
It turns out that when dmidecode can't determine a UUID there are some possible substitutions it will make -'Not Present' and 'Not Settable'

https://github.com/nima/python-dmidecode/blob/92f117b13b3ef2506bcf9c15ff1e151206c6faee/src/dmidecode.c#L456

This PR allows those possible values to exist as duplicates since it's an unavoidable situation. I also added a check for an empty string which shouldn't happen and may be unnecessary to look for.

**To test**

- register the katello-client forklift box to your env
- alter the hostname of the client so it doesnt conflict with the existing registration
```
hostnamectl set-hostname whatever.example.com
```
- override the dmi.system.uuid fact to check for these cases:
```
[root@katello-client-c vagrant]# cat /etc/rhsm/facts/uuid.facts 
{"dmi.system.uuid": ""}
```
- modify the local DB to match your overridden value from the rails console
```
fv = ::FactValue.where(host_id: ::Host.where(name: 'katello-client-a.jturel.example.com')).where(fact_name_id: Katello::RhsmFactName.find_by(name: 'dmi::system::uuid')).first
=> #<FactValue id: 26717, value: "Not Settable", fact_name_id: 71, host_id: 174, updated_at: "2019-04-17 21:13:58", created_at: "2019-04-05 02:56:10">

fv.update_attributes(value: "Not Present")
```

- clean and register the system with the new hostname and overridden fact
```
subscription-manager clean
subscription-manager register
```
- Registration should succeed and you can find the duplicate hosts with the query in the code here

