### PR TITLE
Fixes #26836 - remove pulp2 notifier on upgrade

### DIFF
--- a/db/seeds.d/111-upgrade_tasks.rb
+++ b/db/seeds.d/111-upgrade_tasks.rb
@@ -8,6 +8,7 @@ UpgradeTask.define_tasks(:katello) do
     {:name => 'katello:upgrades:3.10:update_gpg_key_urls'},
     {:name => 'katello:upgrades:3.11:import_yum_metadata'},
     {:name => 'katello:upgrades:3.11:update_puppet_repos'},
-    {:name => 'katello:upgrades:3.11:clear_checksum_type', :task_name => 'katello:upgrades:3.8:clear_checksum_type'}
+    {:name => 'katello:upgrades:3.11:clear_checksum_type', :task_name => 'katello:upgrades:3.8:clear_checksum_type'},
+    {:name => 'katello:upgrades:3.12:remove_pulp2_notifier'}
   ]
 end

--- a/lib/katello/tasks/upgrades/3.12/remove_pulp2_notifier.rake
+++ b/lib/katello/tasks/upgrades/3.12/remove_pulp2_notifier.rake
@@ -1,0 +1,13 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '3.12' do
+      desc "removes the unused pulp2 notifier"
+      task :remove_pulp2_notifier => %w(environment) do
+        SmartProxy.pulp_master!.pulp_api.resources.event_notifier.list.each do |notifier|
+          Rails.logger.info("Deleting notifier #{notifier['id']}")
+          SmartProxy.pulp_master!.pulp_api.resources.event_notifier.delete(notifier['id'])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
we no longer use the pulp2 post-sync notifier
but failed to remove it when we migrated sync plans to
dynflow