### PR TITLE
Fixes #26855 - don't define params that are in the group already

### DIFF
--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -70,9 +70,6 @@ module Katello
     end
 
     api :POST, '/organizations', N_('Create organization')
-    param :name, String, :desc => N_("name"), :required => true
-    param :label, String, :desc => N_("unique label")
-    param :description, String, :desc => N_("description")
     param_group :resource
     def create
       @organization = Organization.new(resource_params)


### PR DESCRIPTION
the resource group already lists name, label and description, no need to
add them explicitly to the endpoint