### PR TITLE
fixes #26466 - update product name in candlepin

### DIFF
--- a/app/lib/actions/candlepin/product/update.rb
+++ b/app/lib/actions/candlepin/product/update.rb
@@ -1,0 +1,17 @@
+module Actions
+  module Candlepin
+    module Product
+      class Update < Candlepin::Abstract
+        input_format do
+          param :owner
+          param :name
+          param :id
+        end
+
+        def run
+          output[:response] = ::Katello::Resources::Candlepin::Product.update(input[:owner], name: input[:name], id: input[:id])
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/product/update.rb
+++ b/app/lib/actions/katello/product/update.rb
@@ -13,6 +13,14 @@ module Actions
               product.previous_changes.key?('ssl_client_key_id'))
             plan_action(::Actions::Katello::Product::RepositoriesCertsReset, product)
           end
+
+          if product.previous_changes.key?('name')
+            plan_action(::Actions::Candlepin::Product::Update, owner: product.organization.label, name: product.name, id: product.cp_id)
+            product.subscriptions.each do |subscription|
+              plan_action(::Actions::Katello::Subscription::Update, subscription, name: product.name)
+            end
+          end
+
           product.reload
         end
       end

--- a/app/lib/actions/katello/subscription/update.rb
+++ b/app/lib/actions/katello/subscription/update.rb
@@ -1,0 +1,11 @@
+module Actions
+  module Katello
+    module Subscription
+      class Update < Actions::EntryAction
+        def plan(subscription, subscription_params)
+          subscription.update_attributes!(subscription_params)
+        end
+      end
+    end
+  end
+end

--- a/app/lib/katello/resources/candlepin/product.rb
+++ b/app/lib/katello/resources/candlepin/product.rb
@@ -110,6 +110,10 @@ module Katello
           def path(owner_label, id = nil)
             "/candlepin/owners/#{owner_label}/products/#{id}"
           end
+
+          def update(owner_label, attrs)
+            JSON.parse(self.put(path(owner_label, attrs[:id] || attrs['id']), JSON.generate(attrs), self.default_headers).body).with_indifferent_access
+          end
         end
       end
     end

--- a/test/actions/candlepin/product_test.rb
+++ b/test/actions/candlepin/product_test.rb
@@ -34,6 +34,23 @@ class Actions::Candlepin::Product::ContentUpdateTest < ActiveSupport::TestCase
   end
 end
 
+class Actions::Candlepin::Product::UpdateTest < ActiveSupport::TestCase
+  include Dynflow::Testing
+  include Support::Actions::RemoteAction
+
+  describe 'Update' do
+    let(:action_class) { ::Actions::Candlepin::Product::Update }
+    let(:planned_action) do
+      create_and_plan_action action_class, owner: 'Default_Organization', name: 'Animal Product', id: 123
+    end
+
+    it 'runs' do
+      ::Katello::Resources::Candlepin::Product.expects(:update).with('Default_Organization', :name => 'Animal Product', :id => 123)
+      run_action planned_action
+    end
+  end
+end
+
 class Actions::Candlepin::Product::DestroyTest < ActiveSupport::TestCase
   include Dynflow::Testing
   include Support::Actions::RemoteAction

--- a/test/actions/katello/product_test.rb
+++ b/test/actions/katello/product_test.rb
@@ -116,10 +116,15 @@ module ::Actions::Katello::Product
     it 'plans' do
       action.expects(:action_subject).with(product)
       product.expects(:reload)
-      plan_action action, product, :gpg_key_id => key.id
-      assert_action_planed_with(action,
-                                ::Actions::Katello::Product::RepositoriesGpgReset,
-                                product)
+      plan_action action, product, :gpg_key_id => key.id, :name => "Animal Product"
+      assert_action_planed_with(action, ::Actions::Katello::Product::RepositoriesGpgReset, product)
+
+      assert_action_planed_with(action, ::Actions::Candlepin::Product::Update, owner: product.organization.label, name: product.name, id: product.cp_id)
+
+      assert(product.subscriptions.length > 0)
+      product.subscriptions.each do |subscription|
+        assert_action_planed_with(action, ::Actions::Katello::Subscription::Update, subscription, name: product.name)
+      end
     end
 
     it 'raises error when validation fails' do

--- a/test/actions/katello/subscription_test.rb
+++ b/test/actions/katello/subscription_test.rb
@@ -1,0 +1,22 @@
+require 'katello_test_helper'
+
+module ::Actions::Katello::Subscription
+  class TestBase < ActiveSupport::TestCase
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include Support::Actions::RemoteAction
+    include FactoryBot::Syntax::Methods
+
+    let(:action) { create_action action_class }
+  end
+
+  class UpdateTest < TestBase
+    let(:action_class) { ::Actions::Katello::Subscription::Update }
+    let(:subscription) { katello_subscriptions(:basic_subscription) }
+
+    it 'plans' do
+      plan_action action, subscription, :name => "Animal Product"
+      assert_equal("Animal Product", subscription.name)
+    end
+  end
+end


### PR DESCRIPTION
This PR is created to display the name of the product within the "Subscriptions" tab under the "Activation Key" navigation item. Previously the label was being displayed. Displaying the name is more consistent because products are normally referenced with their name and not label. 
This is done by updating the Product name in Katellos' subscription model and the Candlepin db.

To check this PR:
1. Create a Product and add a new repository.
2. Create an Activation Key.
3. Add Subscription to this key.
4. The name of the product must be displayed within the "Subscriptions" tab under the "Activation Key" navigation item.
5. Update the product name and check under this tab, the updated product name must be displayed and not the label.