### PR TITLE
Fixes #26870 - properly adapt repo update task

### DIFF
--- a/app/lib/actions/katello/repository/update.rb
+++ b/app/lib/actions/katello/repository/update.rb
@@ -31,7 +31,7 @@ module Actions
                                        gpg_url: repository.yum_gpg_key_url)
           end
           if root.pulp_update_needed?
-            plan_pulp_action([::Actions::Pulp::Repository::Refresh,
+            plan_pulp_action([::Actions::Pulp::Orchestration::Repository::Refresh,
                               ::Actions::Pulp3::Orchestration::Repository::Update],
                              repository,
                              SmartProxy.pulp_master)

--- a/app/lib/actions/pulp/orchestration/repository/refresh.rb
+++ b/app/lib/actions/pulp/orchestration/repository/refresh.rb
@@ -1,0 +1,14 @@
+module Actions
+  module Pulp
+    module Orchestration
+      module Repository
+        class Refresh < Pulp::Abstract
+          def plan(repository, smart_proxy, options = {})
+            options[:capsule_id] = smart_proxy.id
+            plan_action(Actions::Pulp::Repository::Refresh, repository, options)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -71,7 +71,7 @@ module ::Actions::Katello::Repository
 
   class UpdateTest < TestBase
     let(:action_class) { ::Actions::Katello::Repository::Update }
-    let(:pulp_action_class) { ::Actions::Pulp::Repository::Refresh }
+    let(:pulp_action_class) { ::Actions::Pulp::Orchestration::Repository::Refresh }
     let(:candlepin_action_class) { ::Actions::Candlepin::Product::ContentUpdate }
     let(:repository) { katello_repositories(:fedora_17_unpublished) }
     let(:pulp3_action_class) { ::Actions::Pulp3::Orchestration::Repository::Update }

--- a/test/fixtures/vcr_cassettes/scenarios/org_create.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/org_create.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://theta.partello.example.com:8443/candlepin/owners/
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/
     body:
       encoding: UTF-8
       base64_string: |
@@ -17,9 +17,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="jAxTjRjZQ7yDaaSwD6cYjZLXGgzg3ZSt",
-        oauth_nonce="FjmEo3RL9yNeKy0AL9N7kHXSLe5QkqgqYKSAEcDCdsM", oauth_signature="CM68J%2BQg2pwjyTdGij09pHXix6A%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1552949000", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD",
+        oauth_nonce="uZb5zi74fIILDsZVoocQOQbQKwNpaVJirUQPELGuk", oauth_signature="kdaD%2F9gzfZi4dXKOkjxmWFOLDso%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559211612", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -36,21 +36,21 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 985dead7-9b73-4cc9-978d-d1882c869e71
+      - bbee3147-a824-40d6-8abe-d6ed30df2f3b
       X-Version:
-      - 2.5.9-1
+      - 2.6.5-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 18 Mar 2019 22:43:20 GMT
+      - Thu, 30 May 2019 10:20:12 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wMy0xOFQyMjo0MzoyMCswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDMtMThUMjI6NDM6MjArMDAwMCIsImlkIjoiNDAyOGY5Zjg2
-        OTkxMGIzMDAxNjk5MmY5MzllNzAwMDAiLCJrZXkiOiJzY2VuYXJpb190ZXN0
+        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxMDoyMDoxMiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDUtMzBUMTA6MjA6MTIrMDAwMCIsImlkIjoiNDAyOGY5Zjc2
+        YjA0MzBhOTAxNmIwODQxMTlmNjAwOWMiLCJrZXkiOiJzY2VuYXJpb190ZXN0
         IiwiZGlzcGxheU5hbWUiOiJzY2VuYXJpb190ZXN0IiwicGFyZW50T3duZXIi
         Om51bGwsImNvbnRlbnRQcmVmaXgiOiIvc2NlbmFyaW9fdGVzdC8kZW52Iiwi
         ZGVmYXVsdFNlcnZpY2VMZXZlbCI6bnVsbCwidXBzdHJlYW1Db25zdW1lciI6
@@ -59,10 +59,10 @@ http_interactions:
         Y2Vzc01vZGVMaXN0IjoiZW50aXRsZW1lbnQiLCJsYXN0UmVmcmVzaGVkIjpu
         dWxsLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0=
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:20 GMT
+  recorded_at: Thu, 30 May 2019 10:20:12 GMT
 - request:
     method: post
-    uri: https://theta.partello.example.com:8443/candlepin/owners/scenario_test/environments
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/environments
     body:
       encoding: UTF-8
       base64_string: |
@@ -76,9 +76,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="jAxTjRjZQ7yDaaSwD6cYjZLXGgzg3ZSt",
-        oauth_nonce="BKz1Jt2DZaJYYwJyEqZOZaszKxxFIjKJkXEpb7BnY", oauth_signature="GcWzjwnU700RXDlAFYjA4TDpjb0%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1552949000", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD",
+        oauth_nonce="90nxvHMfNuD7my93ymX6b2kIcPVgdsDFh42ptGtIFM", oauth_signature="zuHXpKzZW8TZhjm6%2Bj7Z1kuV6Fg%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559211612", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -95,30 +95,30 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 71c7bb25-ac84-4e2e-9ed4-06592ac570d5
+      - 5dbc6e4c-9d44-4192-8022-06e590e2680e
       X-Version:
-      - 2.5.9-1
+      - 2.6.5-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 18 Mar 2019 22:43:20 GMT
+      - Thu, 30 May 2019 10:20:12 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wMy0xOFQyMjo0MzoyMCswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDMtMThUMjI6NDM6MjArMDAwMCIsImlkIjoiZDgwYTU3ODNj
+        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxMDoyMDoxMiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDUtMzBUMTA6MjA6MTIrMDAwMCIsImlkIjoiZDgwYTU3ODNj
         NTAyZjBmOTY5ZTIzMDg5NDM3YmI3Y2UiLCJuYW1lIjoiTGlicmFyeSIsImRl
-        c2NyaXB0aW9uIjpudWxsLCJvd25lciI6eyJpZCI6IjQwMjhmOWY4Njk5MTBi
-        MzAwMTY5OTJmOTM5ZTcwMDAwIiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRp
+        c2NyaXB0aW9uIjpudWxsLCJvd25lciI6eyJpZCI6IjQwMjhmOWY3NmIwNDMw
+        YTkwMTZiMDg0MTE5ZjYwMDljIiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRp
         c3BsYXlOYW1lIjoic2NlbmFyaW9fdGVzdCIsImhyZWYiOiIvb3duZXJzL3Nj
         ZW5hcmlvX3Rlc3QifSwiZW52aXJvbm1lbnRDb250ZW50IjpbXX0=
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:20 GMT
+  recorded_at: Thu, 30 May 2019 10:20:12 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com:8443/candlepin/owners/scenario_test/uebercert
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/uebercert
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -130,9 +130,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="jAxTjRjZQ7yDaaSwD6cYjZLXGgzg3ZSt", oauth_nonce="NhJFED3EK33ePRXeqLOrH1IjtXRneoJ1qPr4ZXb5GjE",
-        oauth_signature="ctIyD60W1b6szID7zHHWxEYpWNE%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1552949000", oauth_version="1.0"
+      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="5LzwqZ7Jyp9DjFnblsV03z7IEGjbv8oRl6SqIOQMc",
+        oauth_signature="SVwuV7TG6dZ0FLVxkHNXzvieCLw%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1559211612", oauth_version="1.0"
       Cp-User:
       - foreman_admin
   response:
@@ -143,28 +143,28 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 9804a8ed-68ea-4495-874b-e65acb55bfb9
+      - 7900a9b7-e9c0-458c-a059-9731998cc885
       X-Version:
-      - 2.5.9-1
-      - 2.5.9-1
+      - 2.6.5-1
+      - 2.6.5-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 18 Mar 2019 22:43:20 GMT
+      - Thu, 30 May 2019 10:20:12 GMT
     body:
       encoding: UTF-8
       base64_string: |
         eyJkaXNwbGF5TWVzc2FnZSI6InViZXIgY2VydGlmaWNhdGUgZm9yIG93bmVy
         IHNjZW5hcmlvX3Rlc3Qgd2FzIG5vdCBmb3VuZC4gUGxlYXNlIGdlbmVyYXRl
-        IG9uZS4iLCJyZXF1ZXN0VXVpZCI6Ijk4MDRhOGVkLTY4ZWEtNDQ5NS04NzRi
-        LWU2NWFjYjU1YmZiOSJ9
+        IG9uZS4iLCJyZXF1ZXN0VXVpZCI6Ijc5MDBhOWI3LWU5YzAtNDU4Yy1hMDU5
+        LTk3MzE5OThjYzg4NSJ9
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:20 GMT
+  recorded_at: Thu, 30 May 2019 10:20:12 GMT
 - request:
     method: post
-    uri: https://theta.partello.example.com:8443/candlepin/owners/scenario_test/uebercert
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/uebercert
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -178,9 +178,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="jAxTjRjZQ7yDaaSwD6cYjZLXGgzg3ZSt",
-        oauth_nonce="51y5X4E9DeFne5ZNiJQEbBD4NvwfcTg6wVllod5gcw", oauth_signature="lzuNSV0sjClPLthUTmBEyxX0Lh4%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1552949000", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD",
+        oauth_nonce="9fsW131MDUHqz0xk5hzZIb92WjH1qoSSSlBetLwIZw", oauth_signature="IYth8HujAU%2FLJgGXkYk2BzcY460%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559211612", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -197,118 +197,161 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 46e24905-c5f6-425b-b6a2-b6fececde604
+      - 2d8d496d-6d1e-4771-9c50-17171d941b32
       X-Version:
-      - 2.5.9-1
+      - 2.6.5-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 18 Mar 2019 22:43:20 GMT
+      - Thu, 30 May 2019 10:20:14 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wMy0xOFQyMjo0MzoyMCswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDMtMThUMjI6NDM6MjErMDAwMCIsImlkIjoiNDAyOGY5Zjg2
-        OTkxMGIzMDAxNjk5MmY5M2JhZDAwMDMiLCJrZXkiOiItLS0tLUJFR0lOIFJT
-        QSBQUklWQVRFIEtFWS0tLS0tXG5NSUlFcEFJQkFBS0NBUUVBaEpRSDVaUmZn
-        K2dRaVhsVGxaaGVpcEpIRzQ1MlFrQTFlUVo5N2NZNzNBTm1xeENZXG5HMEJ3
-        S1pjZ0RhbnJiVkQ3K3FNaElPVGtCYnVZRlBEWmZuZitQOWxRS3J3VEdweTFo
-        WHgwbzZOUFMrNzRwZGc5XG5rMElIcjJSM3p4TTJyVnVxNGxrSFRnTUdMREpm
-        dGJkMStZYy83UDl2eHZicnJMb1lIV0gyeStmWHVndERUSkxLXG5EdDRBc1Zp
-        WVpZdzJQZWZ1UWtmWmRQWDNPQmY2SWdMQlNnNHN3T0ZMY3hMeENvZ2QxM2tH
-        YTRkUXlSbWJ0bllVXG43bXdpOVBBSFd0cUxIQkVaMmE1eXhYUTQvbTNQVUhu
-        a2JmdW9kKzc0Y2ltVldtVkVOZHRjVk5uNTJ0Q2t3Q2hXXG4yRHY2VnBTVjl6
-        Y3FzS2RhSXE5UDRSRkp4MXFjMS9NdnlhNUF5d0lEQVFBQkFvSUJBR1pTS1ZZ
-        U2tUVW9vYnE0XG5ITDVUL29OTUtmMG1ramJIZjMyTWVSeE41bDBEY3ZXTHRS
-        a3pQbDJhK1c0U09sVUFMN2xjdFhEQnR3cUZvZlpuXG5mRFNUUDNMZnNYT0or
-        K1NLRmI2VU15RW9KVWNoaEYzYTZvc0FaeFlDb0VUOU96SElrYlpucDYrWnZl
-        WFdhdS9BXG5UQmp0UFhVWUg1aWJjWUM1ajJyOTlJK2l1MmdsdE1YOEo4czA2
-        dytXcTQxM0hJaTl4WkFhWnZIQmo2ZEh2aHVXXG5hNUtHT2RnWDVMcURLNlFZ
-        NWhNNU1lNjV3VmNzY2l1alNjYXpRem9zemxRNjFBeHVFY1JZb1RBUUZPZTdq
-        a25UXG5PNkF0R3NkNkttUWpHL0c0eCtjZG9ZSkZ3M25kci95bVc2eXlOVHpv
-        QktkSkVUOC9xNEJ1WnZVcmQ2MktYR3V1XG5YdFJuSVFFQ2dZRUF1YXZXRjNY
-        REZIN0k5d3l4Z05GcG9pYlc4YWd0QXdodThmVnBNS0hteER5SVZGSEoyWmxC
-        XG5BWnFuQkt5UzAvbDNDbWxDbldGZk0xbVJhNmdvQktZaXpGU2NhczJGMmJE
-        dHJIWXJQc2U2Z1NXVVhMWjBDMUdYXG5SblNpVVFHTFNCbGJKTUk4RGpxT25s
-        eDlkTTJUMEpNNjhKdTZSNEhMTURoVkJjVXlla21menlFQ2dZRUF0c3ZmXG45
-        S2xIQm41UFJuZEU4ZlVpOElJMG8vVW11T2R5Nk51ODhBYnBrK1AvUVVGdmNm
-        dUhlcG1Cb0xEb0RvTEJVQ3duXG5VQkFYbUd5SzEyQWh1d0FuY1pyTk5jZWVx
-        WVc5UHZ5TjUrVUN3Mml0OStzRHRKQzA2MlNYN2h5MXU3MEtKcGtDXG5YcFl5
-        ZTB6M3VLNVE3bWk3RjFvQTFyYUVwekJOLzBQRnZNRVM3bXNDZ1lBWmJyay9z
-        MmpLV09lTU41Zmt6a3FLXG41SWtTeHZlTGI4OUtvMVFLVGxMKzFFL1VSUFBD
-        TTZUYzVHTTJWN0V4Q2YzTlZrZkNxUURTVnRWOWlxWVlwTzBsXG5VZjJ1LzRI
-        ekpMSVpxb0lYOG1IUXFPWWVvUHRhUlkzVUg4dlFEc2NXVkNyUTZTNHl3TUNp
-        WG9ic3hmQVdaT1J3XG42dFBrVVpvVWU5TGhuSFppbTgwaElRS0JnUUNsYVVk
-        M2RkYTNvWVRMRnhKa2dKYmxYRzJXRURqQ0NXNktHSTJZXG5CaWxIa29GZzQz
-        MmRmeWJSWWlkUzZjS1RudTZmUmRVdE5lS2tJMVJnSUxWbEtuYUc3clhUZkpl
-        dWZ6OEl5REVCXG5MdEtaVVJoYngyYks5a2RBMnY1QWtlcEJ3SVoyOXU2VitR
-        UWxYemlxL2RKdWFvY2lVbWQvNUJtVjBMaER6V2daXG5yZjBia1FLQmdRQ2lt
-        REg1L1VNaGs3Q2x1R0F2dUxJS0k3NHJMVHJ3NWR5WDgvTnlhY3M4REhWeWdl
-        bnMwcFdwXG41ZnFuYlVyZU5JcERTcmhIc1VHVkhkZmkwaTlaaE91Q245MW1R
-        dGlBaFhDd2U3ZE9LckJwQVhyVCt1VHh5dlQ1XG54WE1pVFBESFMvNmZJc2ZB
-        UVdMSWtvVWQzRlN4ay9PczN2bnoyMklXMWdPbUZNWU9zem1GN2c9PVxuLS0t
-        LS1FTkQgUlNBIFBSSVZBVEUgS0VZLS0tLS1cbiIsImNlcnQiOiItLS0tLUJF
-        R0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUdZakNDQlVxZ0F3SUJBZ0lJUGdn
-        QjNoRjRsc1V3RFFZSktvWklodmNOQVFFTEJRQXdnWVV4Q3pBSkJnTlZcbkJB
-        WVRBbFZUTVJjd0ZRWURWUVFJREE1T2IzSjBhQ0JEWVhKdmJHbHVZVEVRTUE0
-        R0ExVUVCd3dIVW1Gc1pXbG5cbmFERVFNQTRHQTFVRUNnd0hTMkYwWld4c2J6
-        RVVNQklHQTFVRUN3d0xVMjl0WlU5eVoxVnVhWFF4SXpBaEJnTlZcbkJBTU1H
-        blJvWlhSaExuQmhjblJsYkd4dkxtVjRZVzF3YkdVdVkyOXRNQjRYRFRFNU1E
-        TXhPREl5TkRNeU1Gb1hcbkRUUTVNVEl3TVRFek1EQXdNRm93R0RFV01CUUdB
-        MVVFQ2d3TmMyTmxibUZ5YVc5ZmRHVnpkRENDQVNJd0RRWUpcbktvWklodmNO
-        QVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQUlTVUIrV1VYNFBvRUlsNVU1V1lY
-        b3FTUnh1T2RrSkFcbk5Ya0dmZTNHTzl3RFpxc1FtQnRBY0NtWElBMnA2MjFR
-        Ky9xaklTRGs1QVc3bUJUdzJYNTMvai9aVUNxOEV4cWNcbnRZVjhkS09qVDB2
-        dStLWFlQWk5DQjY5a2Q4OFROcTFicXVKWkIwNERCaXd5WDdXM2RmbUhQK3ov
-        YjhiMjY2eTZcbkdCMWg5c3ZuMTdvTFEweVN5ZzdlQUxGWW1HV01OajNuN2tK
-        SDJYVDE5emdYK2lJQ3dVb09MTURoUzNNUzhRcUlcbkhkZDVCbXVIVU1rWm03
-        WjJGTzVzSXZUd0IxcmFpeHdSR2RtdWNzVjBPUDV0ejFCNTVHMzdxSGZ1K0hJ
-        cGxWcGxcblJEWGJYRlRaK2RyUXBNQW9WdGc3K2xhVWxmYzNLckNuV2lLdlQr
-        RVJTY2Rhbk5mekw4bXVRTXNDQXdFQUFhT0NcbkEwQXdnZ004TUE0R0ExVWRE
-        d0VCL3dRRUF3SUVzREFUQmdOVkhTVUVEREFLQmdnckJnRUZCUWNEQWpBSkJn
-        TlZcbkhSTUVBakFBTUJFR0NXQ0dTQUdHK0VJQkFRUUVBd0lGb0RBZEJnTlZI
-        UTRFRmdRVWlvVC9VbjNBM05jak0vR0pcblcrNVkwc3BMSkhNd0h3WURWUjBq
-        QkJnd0ZvQVVnY3poNWR6SFVYZlZRUURVUEZkU2RxalRCTFF3TVFZUUt3WUJc
-        bkJBR1NDQWtCclptWDVQVjJBUVFkREJ0elkyVnVZWEpwYjE5MFpYTjBYM1Zs
-        WW1WeVgzQnliMlIxWTNRd0ZnWVFcbkt3WUJCQUdTQ0FrQnJabVg1UFYyQXdR
-        Q0RBQXdGZ1lRS3dZQkJBR1NDQWtCclptWDVQVjJBZ1FDREFBd0ZnWVFcbkt3
-        WUJCQUdTQ0FrQnJabVg1UFYyQlFRQ0RBQXdHUVlRS3dZQkJBR1NDQWtDclpt
-        WDVQVjNBUVFGREFONWRXMHdcbkpBWVJLd1lCQkFHU0NBa0NyWm1YNVBWM0FR
-        RUVEd3dOZFdWaVpYSmZZMjl1ZEdWdWREQXlCaEVyQmdFRUFaSUlcbkNRS3Rt
-        WmZrOVhjQkFnUWREQnN4TlRVeU9UUTVNREF3T1RVd1gzVmxZbVZ5WDJOdmJu
-        UmxiblF3SFFZUkt3WUJcbkJBR1NDQWtDclptWDVQVjNBUVVFQ0F3R1EzVnpk
-        Rzl0TUNVR0VTc0dBUVFCa2dnSkFxMlpsK1QxZHdFR0JCQU1cbkRpOXpZMlZ1
-        WVhKcGIxOTBaWE4wTUJjR0VTc0dBUVFCa2dnSkFxMlpsK1QxZHdFSEJBSU1B
-        REFZQmhFckJnRUVcbkFaSUlDUUt0bVpmazlYY0JDQVFEREFFeE1Dc0dDaXNH
-        QVFRQmtnZ0pCQUVFSFF3YmMyTmxibUZ5YVc5ZmRHVnpcbmRGOTFaV0psY2w5
-        d2NtOWtkV04wTUJBR0Npc0dBUVFCa2dnSkJBSUVBZ3dBTUIwR0Npc0dBUVFC
-        a2dnSkJBTUVcbkR3d05NVFUxTWprME9UQXdNRGsxTURBUkJnb3JCZ0VFQVpJ
-        SUNRUUZCQU1NQVRFd0pBWUtLd1lCQkFHU0NBa0VcbkJnUVdEQlF5TURFNUxU
-        QXpMVEU0VkRJeU9qUXpPakl3V2pBa0Jnb3JCZ0VFQVpJSUNRUUhCQllNRkRJ
-        d05Ea3Rcbk1USXRNREZVTVRNNk1EQTZNREJhTUJFR0Npc0dBUVFCa2dnSkJB
-        d0VBd3dCTURBUUJnb3JCZ0VFQVpJSUNRUUtcbkJBSU1BREFRQmdvckJnRUVB
-        WklJQ1FRTkJBSU1BREFSQmdvckJnRUVBWklJQ1FRT0JBTU1BVEF3RVFZS0t3
-        WUJcbkJBR1NDQWtFQ3dRRERBRXhNRFFHQ2lzR0FRUUJrZ2dKQlFFRUpnd2tO
-        MkpsTlRNeFlUSXRNekV4WWkwMFptUTFcbkxXRmlZVGN0T0RBM1pUVTFZMlU0
-        TURnNE1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQzRiNkdqYm1ZVnFJbWJc
-        bnJqWGdSL2tadEhpQ0JBM1dHc0RYeDFaSzJ0UmNMT1AraUMxVnk0bVF0WkFq
-        Nyt2QytjcTZTUTRLTWh1aXhnQkRcbmIrUDhFNndaTjhCNEJ3TWczRTFwQk10
-        VG5lMlRycUQ1dnpUWnErNUNESEFXdWxia2JPTEtHdjFyOGpzMFdEUVpcbmln
-        MzdQRnh6U1V0YXE0OXNuNC9YSjRlc0FqdFZWM3dYZVpQV3hockFPbVdPZjEy
-        dVpJUk8rRC9BRXh1TmVxNFhcbkZIcHl0UWRSbmo5aFBzSzZ4SU5OQzdwRWZC
-        MkNoYVdWWkp4NHhIQ0lsemtPRGZacjR0b2tFYlJQeHhxOVh0OCtcbk5EQ0V4
-        YXRyZmNCV291MHFESUw0Mjg4RTF3WWEzeFBwSGI2UVovd1hsZ1FjejZmd1Jy
-        dFZvbHlXQWdleWxlMUdcbkdNT2k1Y1ZHXG4tLS0tLUVORCBDRVJUSUZJQ0FU
-        RS0tLS0tXG4iLCJzZXJpYWwiOnsiY3JlYXRlZCI6IjIwMTktMDMtMThUMjI6
-        NDM6MjArMDAwMCIsInVwZGF0ZWQiOiIyMDE5LTAzLTE4VDIyOjQzOjIwKzAw
-        MDAiLCJpZCI6NDQ2OTgyNDY4MzQ1MjcwMDM1Nywic2VyaWFsIjo0NDY5ODI0
-        NjgzNDUyNzAwMzU3LCJleHBpcmF0aW9uIjoiMjA0OS0xMi0wMVQxMzowMDow
-        MCswMDAwIiwiY29sbGVjdGVkIjpmYWxzZSwicmV2b2tlZCI6ZmFsc2V9LCJv
-        d25lciI6eyJpZCI6IjQwMjhmOWY4Njk5MTBiMzAwMTY5OTJmOTM5ZTcwMDAw
-        Iiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRpc3BsYXlOYW1lIjoic2NlbmFy
-        aW9fdGVzdCIsImhyZWYiOiIvb3duZXJzL3NjZW5hcmlvX3Rlc3QifX0=
+        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxMDoyMDoxMiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDUtMzBUMTA6MjA6MTQrMDAwMCIsImlkIjoiNDAyOGY5Zjc2
+        YjA0MzBhOTAxNmIwODQxMjAyMzAwOWYiLCJrZXkiOiItLS0tLUJFR0lOIFJT
+        QSBQUklWQVRFIEtFWS0tLS0tXG5NSUlKS0FJQkFBS0NBZ0VBeEVGYkZvUEJk
+        dnpMcUV1NHBIZG92Qlp2N1VROXZ6Mm5Xc2JOSTdhYmZ1T1ZNU1EvXG5ZcU96
+        TXZ5VzgyRlh0aGV3VjZWZmttdzNiczRINGttVVAzaUlCdkd5dHJNNEl2TnVp
+        NHJYcHJvaFFUY3Vsa1JPXG44Ym1CU1FjZGdmRWVEWFgxTjlwcFNIcGRFMXhV
+        M3hxZnd5TCs3cGI4aURJcHdyRTZyMnVBK2tnVnVGK01VMTBsXG5XamkyZWhK
+        WkJUeENTSU5wZEUzcXFkQnN2VHQ1VGFaM3ZBdDh5TUxkaUVwVHNIcjRMVXdN
+        eFptTVFkcXRzRkdzXG5FcExieWxTT0JmaUhUcGJCeWF3SWR1aHVoalE2YVdT
+        RWZaUHJ6bU05ZlV3bjJHVEFQOVY3TzZhU0xVUzU2bXhqXG5yT3hGWjJPODBD
+        cjlhZ01jd2dhQnNlay9sTmd4SjZrUWJzZ1Rydjc3YnR6VzQvSkEvaU5DVU4y
+        KzM4cUxpTVdOXG51QnloR0lkSnk0T0NjOTA3bkNIL2djTlNodXRpMHdpbHpT
+        dFBXRUdjMjQxdnVqcjdBMzh5N2s4TUdYc2tYUUxnXG5zdVpjVW9sV3Z5NlBR
+        L1RCaXU0S1JWVTFIbkFZRC9XTXoxTi8vaWNkRDJFQ3FscXVPMytmM05RdTdD
+        ZlprZVV6XG5vNVJ5TXBLNzlHcnNmK3Ftck9TczRWRlN4V05EeEJmdGM2eUU3
+        TUV2MUx2VjM5UWtwUlF2RGZwS2p1ZVMvRkdyXG5UY21kZGwyMDR3SFdHWnNC
+        SHJyd2tVc0lBeklxSGk1RnVzRVNEaXg1aUxySWU1QkoxQU5QNGxMalRaMkhp
+        L1NXXG5HRHFpRm52emhsZ21mL1lhS0tnM0tSWnN2YkxhZjdSSWRaK0J2emho
+        WVdseFZrTVZDVGxwUW5UMTVLMENBd0VBXG5BUUtDQWdCK0JzNGNqaTFkWUli
+        VG94U0dJTndUOUlDWnA3blRKaDlqRHNqTEIwZWhXem9DSFpuS21QN0pYaVQ5
+        XG5VMlJFM2I5eStSSi9iNWpGUWU4VUpGWGIwR1hodDdJZzJzUFF4ZXdXRmVu
+        WCtpekN1VkhrVXljeTJRSXB5RFR0XG5yYzJ6clN6MFdnQkQ5N2Z2Wjlwa2px
+        OUxXeHpFVUJjSXl0WEFYWmttN3UwYlM5RU8zZVM1MzlYTnN4K1RFbGN5XG5J
+        bmthSWJGRmE0ZW0xdDROUXJUcDVWMThWeEFoeCtrRXpWNGl0VVRMcWN1RjFN
+        Mlp1SGpUQWc5eXVmWUVYdm40XG40WmphSWJ0OTYwaGdPM0JHSkNIaWJoY2Fv
+        VFBMRERWL1VibEFuNnBKRTZrWUxDWXdoYkt4MURySjM4dk4wZUY4XG4rQzVW
+        dG52d0tNZCtYUjlrVU5SMytIeEI5NStUSDdkNU5udUdOMUVLdVZZUFZZRlli
+        a2RraHVtZStIcFREV2FpXG5NdEZCRHlMemcxaWYwdjl6Z2VEdnlNbDFtemMy
+        NVVmRDhCQ2VOc0dMTDMzbGlUcWIvSk51akwyajQ3enhTYzZOXG41SGpRNXZU
+        SWE5VGM2T3NybkI3RVFOb3J5WkhlRGhNMkJydlNxR2FjbUtNaTFpalBHVkVt
+        ZE1tWEdFNUd2YjRXXG51T3BkMVQ5b2RYM3pFcHhmSjMyaCt0M2oxVzBPMmFq
+        SGdNeXRLem1NcDJ4Vmt6ZWV3MWY4NUdOekJHalJJelU3XG5JMmk4QmFseDZz
+        dEJIbGhSWkNEV2EzRlR4VGNHVjJNVktGemZhejAvSkd0bFpkV1RJVU9CU2Fn
+        eU5xc1R4UnoxXG5YUThRWHY0eDhhYzNJNTVTQ3ZPc2JPd1NsS0xXamp1azBL
+        elZBb2E2emZTMUZsWmo3UUtDQVFFQTZSWWFmWjM4XG5aendpNGFsVmR1Z25J
+        aTY3eTRPUElQM2xBZ1Rra1JZclVYblNwV1d6NHFsTjJza0Z0QjRiQVYxNnNs
+        MHNSRDRNXG54T1RxRzlhcDJ2YzFTaGhMd09PalpObzErbmJWZDZ4eTNyTGxx
+        WisrSU9OZ2gxd3Z4OVVFQ0l2ZTRaN3VpblgxXG5XU0dDTGRSbG5Cd2Z0eEpV
+        b3NkMnBodGJjM2J3UFZXbzNpTGJmeTNidlRaNFFDMkJFK2Ezc05FTnI3c1A2
+        eWZKXG5EUVo1Z0hLaFk0Z0tyQ1R0bUNDMmkxUndhTU96aVg1Y0R1NmpFY2Z3
+        aFNyT1VoajlsaWUvd3RpSnF0bmtwaEd2XG5wN25vZTdmSXZ4d0FpL3JUTDlo
+        T3VZYW1rczhtMFhBcE41OEMyVkJ1MXEwNk9USHAzTzlvZ0xHL1IzemVrMTZw
+        XG5qZ2hwZFo4TzZiRitKd0tDQVFFQTE0eGE0eFZnUEVGeXdWMWRnb01Pbjdh
+        eUEreHRiVzNWSHcyMVJXS2hha1U1XG5GcUF5UXFZejVIRXVyVTJGeER1Mkpy
+        OEMzMWtGTDkzUi9ocC9wVWtYLzY1L3dsbHJmdVpTVUlCVDRTdVNoazZ3XG52
+        NEl1SFhvNGNxc0dFa3NrbjBWcXEzRGhDTnM2cThLeW51WEQ4UEtxd0tWR0N5
+        aXNpZzlWMFRicHkrRHM4QWJ2XG43dkdLcUUyY1o0N0VqZ0dTWEtXYTcxNmh6
+        ZXhpYWR5NWlOZHh6Z0Q0VmxMMDVvUTJvcFp2OXIyTkt1aG9kbnkwXG5xQWEz
+        V3V4dkNBcmlCZ1RXb2RIMjdIZTNJdEgyMWNGOHpFOUlSTFo1MCtVMmU3L1dm
+        Z0RNSHVMcS90ZGxuZEdBXG5WZE5pbFRkdHFwRW16ay9LTy9pMG55clN4cTl1
+        Ly9UQXJuS2t0M05mQ3dLQ0FRRUFobjZ5bW5sbkEwcTM5ZTUzXG4yanpyRjla
+        UGxvYzdONVpKWm5qY1NydTRFek53VU8vMmRIdXM2T25GMk1EbVpFdEVXVmRh
+        QzZhaVI1cXZXNURxXG5RZWNUWU1YVU1HRXFEeSs2cGVPY0dZbndYb0JyOVF5
+        djhOcERBTmc0MmQ0WWpiWG56ZGlmWEZYa1ZLSDVNK2l6XG5HUGxCYzZtb0hL
+        VnIyVDAvNzhoWnA0cWQvayt1eUJ2MkI2QStrd211eVlUL3lZOVhqbWNxTUU2
+        c3ZFOVlITDRJXG5VaDVWeWk4a3lmdFdXZDlIWGF4UEZLOU0vM0REdDZiZktu
+        Z2d4VTZXUk9aNnlEdWFkSE4yZEQwUVZuLzNuaXZXXG5NakErUUlkakJPQ1R6
+        SW5kNUNpVUJaWHFzcVdXUno4YU5kV1BHeUdxQ0VvOHlzWEYwY0pEekZWN0VQ
+        SFpxSDAzXG5aYkY5VVFLQ0FRQnlOS2VqVWh3ZlVQNGdmZnVodnhic2dMeHBY
+        OGZMQnpxNHJXYXlVTVA5cnBmRTZUUTRKQit5XG5sbFdJOVY0K3p2U0FLd3ky
+        a2xBeFFIS1hGQ3MxeERpMi9Cb3RPM3U5VFFPb0s1WkY0L1JLdlQ3ZytYUzlv
+        Wmh2XG5DVGE2VXA0ZzFZTGpPM2ZBWFlnRW9iQktpS3I4NjFhVm8vd3N4V3hG
+        NmtJcUM5SnNkOHlTa05wbjNBci9pYitwXG5EdmdOMWI5YTMxUHNLRlBLNjho
+        cEZzNG5OeC9SYXFvcDh1SlhrUTN4cjR1N1RFdVR4SGcwNzNZNDRQWWRjdENS
+        XG5qbEticGN5akNNQ3dJZTRpd09UcjlRek9vK05DcFB4L3pSN0ZDcXYzTHl6
+        MzRIdHFjMjRmNUhUL0JIVmpZbTcwXG54TnV1ekkvMm5wdjFDWmVNTmorMTFs
+        U1JHYVUwbmlocEFvSUJBRS8ybHZLYUNVRkJtdXZFbGZiaHI4SDFsUmxYXG55
+        S05ad1l3RkpVV1FCMkNEMitIbGVIM2FHTEZENUxzLy9DaElZd3dWVDlrTll3
+        V0hsTzV3Qml5ejE3OTVxOTFUXG5KT2gzZWxkd0pqd1BPVDJnZGpaYlU1RWVK
+        di9HQzdDV1UyNHdYT284eHUxMmpWNkVUc0JMV0lBMHB1SGdhdmloXG5uVVZj
+        UEZ5dkRac25yM1hvK2RxYjhETEdCaVc1TlFHUXlVTVNhVlBPOWZndEN5bTVQ
+        NGsvUWN2TUQ3bm5ESkZyXG5nK2FXY1RUZzhjb01iMlMwc1NoYzc2SmtKbkhT
+        eGZCNS9uOFlzbW5pa29rNHZzR1dvUTF6TTRYR2tBTHVMMzllXG5WbDdEWS9I
+        bkJMaEJFY3g1VUtIcmJuRkVEd2tsODNhTmQwMWlWUURGZGFpOHorQ1I1OXhj
+        eGVGVkJqOD1cbi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tXG4iLCJj
+        ZXJ0IjoiLS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tXG5NSUlIWVRDQ0Jr
+        bWdBd0lCQWdJSU5jNTRxQ0xUdlRnd0RRWUpLb1pJaHZjTkFRRUxCUUF3Z1lR
+        eEN6QUpCZ05WXG5CQVlUQWxWVE1SY3dGUVlEVlFRSURBNU9iM0owYUNCRFlY
+        SnZiR2x1WVRFUU1BNEdBMVVFQnd3SFVtRnNaV2xuXG5hREVRTUE0R0ExVUVD
+        Z3dIUzJGMFpXeHNiekVVTUJJR0ExVUVDd3dMVTI5dFpVOXlaMVZ1YVhReElq
+        QWdCZ05WXG5CQU1NR1dSbGRtVnNMbUpoYkcxdmNtRXVaWGhoYlhCc1pTNWpi
+        MjB3SGhjTk1Ua3dOVE13TVRBeU1ERXlXaGNOXG5ORGt4TWpBeE1UTXdNREF3
+        V2pBWU1SWXdGQVlEVlFRS0RBMXpZMlZ1WVhKcGIxOTBaWE4wTUlJQ0lqQU5C
+        Z2txXG5oa2lHOXcwQkFRRUZBQU9DQWc4QU1JSUNDZ0tDQWdFQXhFRmJGb1BC
+        ZHZ6THFFdTRwSGRvdkJadjdVUTl2ejJuXG5Xc2JOSTdhYmZ1T1ZNU1EvWXFP
+        ek12eVc4MkZYdGhld1Y2VmZrbXczYnM0SDRrbVVQM2lJQnZHeXRyTTRJdk51
+        XG5pNHJYcHJvaFFUY3Vsa1JPOGJtQlNRY2RnZkVlRFhYMU45cHBTSHBkRTF4
+        VTN4cWZ3eUwrN3BiOGlESXB3ckU2XG5yMnVBK2tnVnVGK01VMTBsV2ppMmVo
+        SlpCVHhDU0lOcGRFM3FxZEJzdlR0NVRhWjN2QXQ4eU1MZGlFcFRzSHI0XG5M
+        VXdNeFptTVFkcXRzRkdzRXBMYnlsU09CZmlIVHBiQnlhd0lkdWh1aGpRNmFX
+        U0VmWlByem1NOWZVd24yR1RBXG5QOVY3TzZhU0xVUzU2bXhqck94RloyTzgw
+        Q3I5YWdNY3dnYUJzZWsvbE5neEo2a1Fic2dUcnY3N2J0elc0L0pBXG4vaU5D
+        VU4yKzM4cUxpTVdOdUJ5aEdJZEp5NE9DYzkwN25DSC9nY05TaHV0aTB3aWx6
+        U3RQV0VHYzI0MXZ1anI3XG5BMzh5N2s4TUdYc2tYUUxnc3VaY1VvbFd2eTZQ
+        US9UQml1NEtSVlUxSG5BWUQvV016MU4vL2ljZEQyRUNxbHF1XG5PMytmM05R
+        dTdDZlprZVV6bzVSeU1wSzc5R3JzZitxbXJPU3M0VkZTeFdORHhCZnRjNnlF
+        N01FdjFMdlYzOVFrXG5wUlF2RGZwS2p1ZVMvRkdyVGNtZGRsMjA0d0hXR1pz
+        QkhycndrVXNJQXpJcUhpNUZ1c0VTRGl4NWlMckllNUJKXG4xQU5QNGxMalRa
+        MkhpL1NXR0RxaUZudnpobGdtZi9ZYUtLZzNLUlpzdmJMYWY3UklkWitCdnpo
+        aFlXbHhWa01WXG5DVGxwUW5UMTVLMENBd0VBQWFPQ0EwQXdnZ004TUE0R0Ex
+        VWREd0VCL3dRRUF3SUVzREFUQmdOVkhTVUVEREFLXG5CZ2dyQmdFRkJRY0RB
+        akFKQmdOVkhSTUVBakFBTUJFR0NXQ0dTQUdHK0VJQkFRUUVBd0lGb0RBZEJn
+        TlZIUTRFXG5GZ1FVMit6Ny9oUG9maGl0UG9Zb3dXSG54aHdzSjJvd0h3WURW
+        UjBqQkJnd0ZvQVU4QUxEdlVVb0lIR2lQQVd6XG4xZnVKZ0YxRU9FTXdNUVlR
+        S3dZQkJBR1NDQWtCcmJEQ2hMUjRBUVFkREJ0elkyVnVZWEpwYjE5MFpYTjBY
+        M1ZsXG5ZbVZ5WDNCeWIyUjFZM1F3RmdZUUt3WUJCQUdTQ0FrQnJiRENoTFI0
+        QXdRQ0RBQXdGZ1lRS3dZQkJBR1NDQWtCXG5yYkRDaExSNEFnUUNEQUF3RmdZ
+        UUt3WUJCQUdTQ0FrQnJiRENoTFI0QlFRQ0RBQXdHUVlRS3dZQkJBR1NDQWtD
+        XG5yYkRDaExSNUFRUUZEQU41ZFcwd0pBWVJLd1lCQkFHU0NBa0NyYkRDaExS
+        NUFRRUVEd3dOZFdWaVpYSmZZMjl1XG5kR1Z1ZERBeUJoRXJCZ0VFQVpJSUNR
+        S3RzTUtFdEhrQkFnUWREQnN4TlRVNU1qRXhOakV5TnpreVgzVmxZbVZ5XG5Y
+        Mk52Ym5SbGJuUXdIUVlSS3dZQkJBR1NDQWtDcmJEQ2hMUjVBUVVFQ0F3R1Ez
+        VnpkRzl0TUNVR0VTc0dBUVFCXG5rZ2dKQXEyd3dvUzBlUUVHQkJBTURpOXpZ
+        MlZ1WVhKcGIxOTBaWE4wTUJjR0VTc0dBUVFCa2dnSkFxMnd3b1MwXG5lUUVI
+        QkFJTUFEQVlCaEVyQmdFRUFaSUlDUUt0c01LRXRIa0JDQVFEREFFeE1Dc0dD
+        aXNHQVFRQmtnZ0pCQUVFXG5IUXdiYzJObGJtRnlhVzlmZEdWemRGOTFaV0ps
+        Y2w5d2NtOWtkV04wTUJBR0Npc0dBUVFCa2dnSkJBSUVBZ3dBXG5NQjBHQ2lz
+        R0FRUUJrZ2dKQkFNRUR3d05NVFUxT1RJeE1UWXhNamM1TWpBUkJnb3JCZ0VF
+        QVpJSUNRUUZCQU1NXG5BVEV3SkFZS0t3WUJCQUdTQ0FrRUJnUVdEQlF5TURF
+        NUxUQTFMVE13VkRFd09qSXdPakV5V2pBa0Jnb3JCZ0VFXG5BWklJQ1FRSEJC
+        WU1GREl3TkRrdE1USXRNREZVTVRNNk1EQTZNREJhTUJFR0Npc0dBUVFCa2dn
+        SkJBd0VBd3dCXG5NREFRQmdvckJnRUVBWklJQ1FRS0JBSU1BREFRQmdvckJn
+        RUVBWklJQ1FRTkJBSU1BREFSQmdvckJnRUVBWklJXG5DUVFPQkFNTUFUQXdF
+        UVlLS3dZQkJBR1NDQWtFQ3dRRERBRXhNRFFHQ2lzR0FRUUJrZ2dKQlFFRUpn
+        d2tNbVUwXG5ObUppTUdRdFpXTXdaaTAwTkRoaExXRTRaVFF0TVdOaU5UazJN
+        ekUwWm1GaU1BMEdDU3FHU0liM0RRRUJDd1VBXG5BNElCQVFCOS9VQmJvdE1a
+        WktxeEwrTGw4TlVBMXd1eXJIS0hXckNoaDBqcmljYnpJQW81eFZEbGlQV1Bi
+        Y2FUXG4wcWIzVWtiTXN6UGRXVUROQXoyYjQ5Q3dKSHpyeisvL0dodEJLQUNI
+        ZHpiaDRvY1ZUNm9GUkRqS2EwQXRlU1BVXG44OHdtY1ZKOXBLZitJMWxYZ1RE
+        VmZzWmRWTDhoVEpKazVvNjc5NkRNc3ZCbmlmekQ2c2UvbkdiTnNVd1M3NWZF
+        XG52Z2F2SlpVMjBaeGNzM2lxRmNzNmVlVDJJTlpFa3NTa0pxaWsvQTRCZFlK
+        RjBjM2cxWEg2RytXSDc3N1BDejlTXG55eFp0bTVzbW9QOHJDMkNvQ3RQMGhz
+        UDlNZm53R1c2WXhFV0xjR202OFEyQ3c4d2JKNlZjb0tudDdHdGRjSWpHXG5G
+        WU5oVzFPbC9jczZLb0xuelF3cTBzOE5RaEZLXG4tLS0tLUVORCBDRVJUSUZJ
+        Q0FURS0tLS0tXG4iLCJzZXJpYWwiOnsiY3JlYXRlZCI6IjIwMTktMDUtMzBU
+        MTA6MjA6MTIrMDAwMCIsInVwZGF0ZWQiOiIyMDE5LTA1LTMwVDEwOjIwOjEy
+        KzAwMDAiLCJpZCI6Mzg3NzE2ODk5Mjc0NjcxNjQ3Miwic2VyaWFsIjozODc3
+        MTY4OTkyNzQ2NzE2NDcyLCJleHBpcmF0aW9uIjoiMjA0OS0xMi0wMVQxMzow
+        MDowMCswMDAwIiwiY29sbGVjdGVkIjpmYWxzZSwicmV2b2tlZCI6ZmFsc2V9
+        LCJvd25lciI6eyJpZCI6IjQwMjhmOWY3NmIwNDMwYTkwMTZiMDg0MTE5ZjYw
+        MDljIiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRpc3BsYXlOYW1lIjoic2Nl
+        bmFyaW9fdGVzdCIsImhyZWYiOiIvb3duZXJzL3NjZW5hcmlvX3Rlc3QifX0=
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:21 GMT
+  recorded_at: Thu, 30 May 2019 10:20:14 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/organization_destroy.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/organization_destroy.yml
@@ -1,208 +1,8 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/504c1a10-35c9-4742-8135-1fc36fbfec03/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:34:00 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"7a8171ef266c49d0725d95c1b62eb7be-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '684'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81MDRjMWExMC0zNWM5LTQ3NDItODEzNS0xZmMzNmZiZmVj
-        MDMvIiwgInRhc2tfaWQiOiAiNTA0YzFhMTAtMzVjOS00NzQyLTgxMzUtMWZj
-        MzZmYmZlYzAzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUi
-        OiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAi
-        MjAxOS0wMi0wNFQxODozNDowMFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
-        YXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVl
-        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZl
-        bDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmci
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
-        Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzU4ODU5
-        NzdhNzY4MjBjNTkyMDYxNGYifSwgImlkIjogIjVjNTg4NTk3N2E3NjgyMGM1
-        OTIwNjE0ZiJ9
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:34:00 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/504c1a10-35c9-4742-8135-1fc36fbfec03/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:34:00 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"7a8171ef266c49d0725d95c1b62eb7be-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '684'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81MDRjMWExMC0zNWM5LTQ3NDItODEzNS0xZmMzNmZiZmVj
-        MDMvIiwgInRhc2tfaWQiOiAiNTA0YzFhMTAtMzVjOS00NzQyLTgxMzUtMWZj
-        MzZmYmZlYzAzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUi
-        OiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAi
-        MjAxOS0wMi0wNFQxODozNDowMFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
-        YXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVl
-        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZl
-        bDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmci
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
-        Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzU4ODU5
-        NzdhNzY4MjBjNTkyMDYxNGYifSwgImlkIjogIjVjNTg4NTk3N2E3NjgyMGM1
-        OTIwNjE0ZiJ9
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:34:00 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/504c1a10-35c9-4742-8135-1fc36fbfec03/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:34:00 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"200b50987ffee98a5af65ba6f1518812-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '703'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81MDRjMWExMC0zNWM5LTQ3NDItODEzNS0xZmMzNmZiZmVj
-        MDMvIiwgInRhc2tfaWQiOiAiNTA0YzFhMTAtMzVjOS00NzQyLTgxMzUtMWZj
-        MzZmYmZlYzAzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUi
-        OiAiMjAxOS0wMi0wNFQxODozNDowMFoiLCAiX25zIjogInRhc2tfc3RhdHVz
-        IiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0wMi0wNFQxODozNDowMFoiLCAidHJh
-        Y2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNz
-        X3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwg
-        InN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVk
-        X3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQi
-        OiB7IiRvaWQiOiAiNWM1ODg1OTc3YTc2ODIwYzU5MjA2MTRmIn0sICJpZCI6
-        ICI1YzU4ODU5NzdhNzY4MjBjNTkyMDYxNGYifQ==
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:34:00 GMT
-- request:
     method: delete
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/content/1549305194264
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Authorization:
-      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="oEJaCIIiV0LKobgk3GefS9HGoekjhkHMBdUOQVdnIf0",
-        oauth_signature="hbdlGo%2FR50bKj%2F8OLiTOx8qGWL4%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1549305240", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-  response:
-    status:
-      code: 204
-      message: No Content
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - a9064663-9d2d-4f12-b2e6-e082db7172a7
-      X-Version:
-      - 2.5.9-1
-      Date:
-      - Mon, 04 Feb 2019 18:34:00 GMT
-    body:
-      encoding: UTF-8
-      base64_string: ''
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:34:00 GMT
-- request:
-    method: delete
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/scenario_test/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -221,9 +21,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:44:05 GMT
+      - Thu, 30 May 2019 10:21:19 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '172'
       Content-Type:
@@ -232,14 +32,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2UwNzA1Y2RiLTdiN2MtNDU5MS04NTQwLTYxYzFhZWM2OTlmZS8iLCAi
-        dGFza19pZCI6ICJlMDcwNWNkYi03YjdjLTQ1OTEtODU0MC02MWMxYWVjNjk5
-        ZmUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzkxMDdlNmJhLWU3MWItNGUzOS1iYmMyLTVmNzcwZDc5MmVhOC8iLCAi
+        dGFza19pZCI6ICI5MTA3ZTZiYS1lNzFiLTRlMzktYmJjMi01Zjc3MGQ3OTJl
+        YTgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:44:05 GMT
+  recorded_at: Thu, 30 May 2019 10:21:19 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/e0705cdb-7b7c-4591-8540-61c1aec699fe/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/9107e6ba-e71b-4e39-bbc2-5f770d792ea8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -258,15 +58,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:44:05 GMT
+      - Thu, 30 May 2019 10:21:19 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"1538c38be6eccd1650a59b244a36f7c0-gzip"'
+      - '"391b94627763dc985e8e9438d563e964-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '546'
+      - '652'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -274,22 +74,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lMDcwNWNkYi03YjdjLTQ1OTEtODU0MC02MWMxYWVjNjk5
-        ZmUvIiwgInRhc2tfaWQiOiAiZTA3MDVjZGItN2I3Yy00NTkxLTg1NDAtNjFj
-        MWFlYzY5OWZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy85MTA3ZTZiYS1lNzFiLTRlMzktYmJjMi01Zjc3MGQ3OTJl
+        YTgvIiwgInRhc2tfaWQiOiAiOTEwN2U2YmEtZTcxYi00ZTM5LWJiYzItNWY3
+        NzBkNzkyZWE4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUi
         OiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBu
         dWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwg
-        InByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiIiwgInN0YXRlIjog
-        IndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0IjogbnVs
-        bCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzkwMWYzNWJm
-        MWJhOWVjMDRjYjk4Y2IifSwgImlkIjogIjVjOTAxZjM1YmYxYmE5ZWMwNGNi
-        OThjYiJ9
+        InByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAid2FpdGluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
+        ZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRv
+        aWQiOiAiNWNlZmFlOWZjMzhlYjVjOGY5ZmY1ZmZhIn0sICJpZCI6ICI1Y2Vm
+        YWU5ZmMzOGViNWM4ZjlmZjVmZmEifQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:44:05 GMT
+  recorded_at: Thu, 30 May 2019 10:21:19 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/e0705cdb-7b7c-4591-8540-61c1aec699fe/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/9107e6ba-e71b-4e39-bbc2-5f770d792ea8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -308,15 +110,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:44:05 GMT
+      - Thu, 30 May 2019 10:21:19 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"ba37d72f4c1c26762abc1aba9d8d54e3-gzip"'
+      - '"f54a48b4810b2ee214bbe35dd51a76ab-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '672'
+      - '670'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -324,24 +126,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lMDcwNWNkYi03YjdjLTQ1OTEtODU0MC02MWMxYWVjNjk5
-        ZmUvIiwgInRhc2tfaWQiOiAiZTA3MDVjZGItN2I3Yy00NTkxLTg1NDAtNjFj
-        MWFlYzY5OWZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy85MTA3ZTZiYS1lNzFiLTRlMzktYmJjMi01Zjc3MGQ3OTJl
+        YTgvIiwgInRhc2tfaWQiOiAiOTEwN2U2YmEtZTcxYi00ZTM5LWJiYzItNWY3
+        NzBkNzkyZWE4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUi
         OiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAi
-        MjAxOS0wMy0xOFQyMjo0NDowNVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
+        MjAxOS0wNS0zMFQxMDoyMToxOVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
         YXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVl
-        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVs
-        bG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29y
-        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEu
-        cGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9y
-        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzkwMWYzNWJmMWJhOWVjMDRj
-        Yjk4Y2IifSwgImlkIjogIjVjOTAxZjM1YmYxYmE5ZWMwNGNiOThjYiJ9
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5i
+        YWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlOWZjMzhlYjVjOGY5ZmY1
+        ZmZhIn0sICJpZCI6ICI1Y2VmYWU5ZmMzOGViNWM4ZjlmZjVmZmEifQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:44:05 GMT
+  recorded_at: Thu, 30 May 2019 10:21:19 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/e0705cdb-7b7c-4591-8540-61c1aec699fe/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/9107e6ba-e71b-4e39-bbc2-5f770d792ea8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -360,15 +162,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:44:05 GMT
+      - Thu, 30 May 2019 10:21:19 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"ba37d72f4c1c26762abc1aba9d8d54e3-gzip"'
+      - '"0a687b5628ff5d87f28adfeb48a77d1f-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '672'
+      - '689'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -376,77 +178,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lMDcwNWNkYi03YjdjLTQ1OTEtODU0MC02MWMxYWVjNjk5
-        ZmUvIiwgInRhc2tfaWQiOiAiZTA3MDVjZGItN2I3Yy00NTkxLTg1NDAtNjFj
-        MWFlYzY5OWZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy85MTA3ZTZiYS1lNzFiLTRlMzktYmJjMi01Zjc3MGQ3OTJl
+        YTgvIiwgInRhc2tfaWQiOiAiOTEwN2U2YmEtZTcxYi00ZTM5LWJiYzItNWY3
+        NzBkNzkyZWE4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUi
-        OiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAi
-        MjAxOS0wMy0xOFQyMjo0NDowNVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
-        YXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVl
-        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVs
-        bG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29y
-        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEu
-        cGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9y
-        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzkwMWYzNWJmMWJhOWVjMDRj
-        Yjk4Y2IifSwgImlkIjogIjVjOTAxZjM1YmYxYmE5ZWMwNGNiOThjYiJ9
-    http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:44:05 GMT
-- request:
-    method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/e0705cdb-7b7c-4591-8540-61c1aec699fe/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 18 Mar 2019 22:44:05 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"22b3f1cd79f76189a0935fddcaabb2d8-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '691'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lMDcwNWNkYi03YjdjLTQ1OTEtODU0MC02MWMxYWVjNjk5
-        ZmUvIiwgInRhc2tfaWQiOiAiZTA3MDVjZGItN2I3Yy00NTkxLTg1NDAtNjFj
-        MWFlYzY5OWZlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUi
-        OiAiMjAxOS0wMy0xOFQyMjo0NDowNVoiLCAiX25zIjogInRhc2tfc3RhdHVz
-        IiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0wMy0xOFQyMjo0NDowNVoiLCAidHJh
+        OiAiMjAxOS0wNS0zMFQxMDoyMToxOVoiLCAiX25zIjogInRhc2tfc3RhdHVz
+        IiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0wNS0zMFQxMDoyMToxOVoiLCAidHJh
         Y2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNz
         X3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRl
-        IjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0wQHRoZXRhLnBhcnRlbGxvLmV4YW1wbGUuY29tIiwgInJl
-        c3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWM5MDFmMzViZjFiYTllYzA0Y2I5OGNiIn0sICJpZCI6ICI1YzkwMWYzNWJm
-        MWJhOWVjMDRjYjk4Y2IifQ==
+        a2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUi
+        OiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNvbSIsICJyZXN1
+        bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVj
+        ZWZhZTlmYzM4ZWI1YzhmOWZmNWZmYSJ9LCAiaWQiOiAiNWNlZmFlOWZjMzhl
+        YjVjOGY5ZmY1ZmZhIn0=
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:44:05 GMT
+  recorded_at: Thu, 30 May 2019 10:21:19 GMT
 - request:
     method: delete
-    uri: https://theta.partello.example.com:8443/candlepin/environments/d80a5783c502f0f969e23089437bb7ce
+    uri: https://devel.balmora.example.com:8443/candlepin/environments/d80a5783c502f0f969e23089437bb7ce
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -458,9 +208,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="jAxTjRjZQ7yDaaSwD6cYjZLXGgzg3ZSt", oauth_nonce="h7n05lWbe8K7HVuWz6uFQ5FDcA1zL4HQFzQOMMKVPk",
-        oauth_signature="5MLk%2BNtRKuCA3%2F03A1zHvX%2BImcA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1552949045", oauth_version="1.0"
+      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="8FUVhLGliBoQ0YuhBc6XvgsZdmySKtPzbfplFN9VUo",
+        oauth_signature="ZB0mRw7H0h0cEHiHioPbj3wA8Ic%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1559211679", oauth_version="1.0"
       Cp-User:
       - foreman_admin
   response:
@@ -471,19 +221,19 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - e90271b1-50cb-4dac-98d5-2e230e5f06d3
+      - 92c0dc29-96ae-4200-b423-56ab729844de
       X-Version:
-      - 2.5.9-1
+      - 2.6.5-1
       Date:
-      - Mon, 18 Mar 2019 22:44:05 GMT
+      - Thu, 30 May 2019 10:21:19 GMT
     body:
       encoding: UTF-8
       base64_string: ''
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:44:05 GMT
+  recorded_at: Thu, 30 May 2019 10:21:19 GMT
 - request:
     method: delete
-    uri: https://theta.partello.example.com:8443/candlepin/owners/scenario_test/content/1552949002184
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/content/1559211615167
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -495,9 +245,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="jAxTjRjZQ7yDaaSwD6cYjZLXGgzg3ZSt", oauth_nonce="EeLaOAbZdb3aUp8Casts7vRllHhqDGGAmznyfhHUnPA",
-        oauth_signature="xGPGB27llVEUv%2BQolfIrLmxeufY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1552949045", oauth_version="1.0"
+      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="odeL3TM1ELMPBhFj99oFhEFeVL4QSUtiddKootxZxg",
+        oauth_signature="qJopRU%2FXCDc7o8MBWWfoZ4%2FAECg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1559211679", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -512,19 +262,19 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - dd393129-d465-4f8a-807e-6c23cbf2c5be
+      - 51e90160-e03f-41f8-af01-7afe628545db
       X-Version:
-      - 2.5.9-1
+      - 2.6.5-1
       Date:
-      - Mon, 18 Mar 2019 22:44:05 GMT
+      - Thu, 30 May 2019 10:21:19 GMT
     body:
       encoding: UTF-8
       base64_string: ''
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:44:05 GMT
+  recorded_at: Thu, 30 May 2019 10:21:19 GMT
 - request:
     method: delete
-    uri: https://theta.partello.example.com:8443/candlepin/owners/scenario_test
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -536,9 +286,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="jAxTjRjZQ7yDaaSwD6cYjZLXGgzg3ZSt", oauth_nonce="Lxy5fvLAavS88XxWns9PVTnkR6R9kGVsWg3KJfg",
-        oauth_signature="VwoF9u%2B%2Bz%2BKJUCDLpai4pGq3qas%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1552949046", oauth_version="1.0"
+      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="ClypwnBCvr1oJKdn4F1nXUEu1T65llqIw5TFCbThQg",
+        oauth_signature="QdtKayS7gl3Aswa3u78BbmX8VXs%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1559211679", oauth_version="1.0"
       Cp-User:
       - foreman_admin
   response:
@@ -549,14 +299,14 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 2e4c6916-6cb3-4986-a63e-83f704b9c672
+      - 8698a1f2-146e-40c7-8043-7cba386b438f
       X-Version:
-      - 2.5.9-1
+      - 2.6.5-1
       Date:
-      - Mon, 18 Mar 2019 22:44:05 GMT
+      - Thu, 30 May 2019 10:21:19 GMT
     body:
       encoding: UTF-8
       base64_string: ''
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:44:06 GMT
+  recorded_at: Thu, 30 May 2019 10:21:19 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/product_create.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/product_create.yml
@@ -1,125 +1,8 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/pools/4028f96668b959e70168b9c9227e0005
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Authorization:
-      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="2KboibBHfmQ1xltl2hyTXK09uYmAXqd9wkKPdqwoCe4",
-        oauth_signature="4t6dgwhnbC8%2BAo6vGEnyiWK3wrs%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1549305193", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 3554c079-df23-4c00-8352-ca2d0ad63873
-      X-Version:
-      - 2.5.9-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Mon, 04 Feb 2019 18:33:12 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wMi0wNFQxODozMzoxMyswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDItMDRUMTg6MzM6MTMrMDAwMCIsImlkIjoiNDAyOGY5NjY2
-        OGI5NTllNzAxNjhiOWM5MjI3ZTAwMDUiLCJ0eXBlIjoiTk9STUFMIiwib3du
-        ZXIiOnsiaWQiOiI0MDI4Zjk2NjY4Yjk1OWU3MDE2OGI5YzkxY2JlMDAwMCIs
-        ImtleSI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5TmFtZSI6InNjZW5hcmlv
-        X3Rlc3QiLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0sImFjdGl2
-        ZVN1YnNjcmlwdGlvbiI6dHJ1ZSwic291cmNlRW50aXRsZW1lbnQiOm51bGws
-        InF1YW50aXR5IjotMSwic3RhcnREYXRlIjoiMjAxNy0wMS0wMVQyMDoxNTow
-        MSswMDAwIiwiZW5kRGF0ZSI6IjIwNDYtMTItMjVUMjA6MTU6MDErMDAwMCIs
-        ImF0dHJpYnV0ZXMiOltdLCJyZXN0cmljdGVkVG9Vc2VybmFtZSI6bnVsbCwi
-        Y29udHJhY3ROdW1iZXIiOm51bGwsImFjY291bnROdW1iZXIiOm51bGwsIm9y
-        ZGVyTnVtYmVyIjpudWxsLCJjb25zdW1lZCI6MCwiZXhwb3J0ZWQiOjAsImJy
-        YW5kaW5nIjpbXSwiY2FsY3VsYXRlZEF0dHJpYnV0ZXMiOnsiY29tcGxpYW5j
-        ZV90eXBlIjoiU3RhbmRhcmQifSwidXBzdHJlYW1Qb29sSWQiOm51bGwsInVw
-        c3RyZWFtRW50aXRsZW1lbnRJZCI6bnVsbCwidXBzdHJlYW1Db25zdW1lcklk
-        IjpudWxsLCJwcm9kdWN0TmFtZSI6IlNjZW5hcmlvIFByb2R1Y3QiLCJwcm9k
-        dWN0SWQiOiI3YzgyNTAxM2NhYjAxMzQ5YWU4Y2I4ZGIxODdkZTM5MSIsInBy
-        b2R1Y3RBdHRyaWJ1dGVzIjpbeyJuYW1lIjoiYXJjaCIsInZhbHVlIjoiQUxM
-        In1dLCJzdGFja0lkIjpudWxsLCJzdGFja2VkIjpmYWxzZSwic291cmNlU3Rh
-        Y2tJZCI6bnVsbCwiZGV2ZWxvcG1lbnRQb29sIjpmYWxzZSwiZGVyaXZlZFBy
-        b2R1Y3RBdHRyaWJ1dGVzIjpbXSwiZGVyaXZlZFByb2R1Y3RJZCI6bnVsbCwi
-        ZGVyaXZlZFByb2R1Y3ROYW1lIjpudWxsLCJwcm92aWRlZFByb2R1Y3RzIjpb
-        XSwiZGVyaXZlZFByb3ZpZGVkUHJvZHVjdHMiOltdLCJzdWJzY3JpcHRpb25T
-        dWJLZXkiOm51bGwsInN1YnNjcmlwdGlvbklkIjpudWxsLCJocmVmIjoiL3Bv
-        b2xzLzQwMjhmOTY2NjhiOTU5ZTcwMTY4YjljOTIyN2UwMDA1In0=
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:13 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/pools/4028f96668b959e70168b9c9227e0005/entitlements/consumer_uuids
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Authorization:
-      - OAuth oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk", oauth_nonce="e5AaTsU19uEkqNc7qNRB4XBuyPME3abrH0KJ9Q4bwM",
-        oauth_signature="mG7gv3aTkqBrQxLcHzbc1sjCAX8%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1549305193", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - eccdb83f-fd12-485b-a5d2-03e410606e82
-      X-Version:
-      - 2.5.9-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Mon, 04 Feb 2019 18:33:12 GMT
-    body:
-      encoding: UTF-8
-      base64_string: 'W10=
-
-'
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:13 GMT
-- request:
     method: post
-    uri: https://theta.partello.example.com:8443/candlepin/owners/scenario_test/products/
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/products/
     body:
       encoding: UTF-8
       base64_string: |
@@ -134,9 +17,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="jAxTjRjZQ7yDaaSwD6cYjZLXGgzg3ZSt",
-        oauth_nonce="P0GCtZa8oJvl3pln6njuGgmH0jlQ8s4vYW2jGui4", oauth_signature="Obf4DlbndUelLh85zpJN5s8oILQ%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1552949001", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD",
+        oauth_nonce="3qmGFAQ0IN3ZKr0NHwUrvFkiNSmCBHTtbKBLPycIkE", oauth_signature="WHzzNngKrOf7jsg0qhwU005kokI%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559211614", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -153,31 +36,31 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 133cd745-f67f-4198-8a6d-aeadcc90fff8
+      - 4f2ef085-11fb-430c-945f-354ac8754f09
       X-Version:
-      - 2.5.9-1
+      - 2.6.5-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 18 Mar 2019 22:43:21 GMT
+      - Thu, 30 May 2019 10:20:14 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wMy0xOFQyMjo0MzoyMSswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDMtMThUMjI6NDM6MjErMDAwMCIsInV1aWQiOiI0MDI4Zjlm
-        ODY5OTEwYjMwMDE2OTkyZjkzY2I0MDAwNCIsImlkIjoiN2M4MjUwMTNjYWIw
+        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxMDoyMDoxNCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDUtMzBUMTA6MjA6MTQrMDAwMCIsInV1aWQiOiI0MDI4Zjlm
+        NzZiMDQzMGE5MDE2YjA4NDEyMTQxMDBhMCIsImlkIjoiN2M4MjUwMTNjYWIw
         MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
         dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
         IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
-        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOWY4Njk5MTBiMzAwMTY5OTJmOTNjYjQw
-        MDA0IiwicHJvZHVjdENvbnRlbnQiOltdfQ==
+        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOWY3NmIwNDMwYTkwMTZiMDg0MTIxNDEw
+        MGEwIiwicHJvZHVjdENvbnRlbnQiOltdfQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:21 GMT
+  recorded_at: Thu, 30 May 2019 10:20:14 GMT
 - request:
     method: post
-    uri: https://theta.partello.example.com:8443/candlepin/owners/scenario_test/pools
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/pools
     body:
       encoding: UTF-8
       base64_string: |
@@ -194,9 +77,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="jAxTjRjZQ7yDaaSwD6cYjZLXGgzg3ZSt",
-        oauth_nonce="rbpPbwzwYh6nHKADZm6Ca0M2kPo7T52lRKPVXEjXuY", oauth_signature="yyi%2BtORpCV7LehH38UxdTHfO5j8%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1552949001", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD",
+        oauth_nonce="9bD0VxP4tvSztNqdWl8lfXdk1TFeCZxlsOkMoKGyoQ", oauth_signature="7JeR2ui5fDPVqBGeBpAgSuqz3bc%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559211614", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -213,22 +96,22 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 9cf18676-49cf-4a11-ae10-8766c632625d
+      - 40d16daa-035f-48ef-bbf0-0acc64c57af3
       X-Version:
-      - 2.5.9-1
+      - 2.6.5-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 18 Mar 2019 22:43:21 GMT
+      - Thu, 30 May 2019 10:20:14 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wMy0xOFQyMjo0MzoyMSswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDMtMThUMjI6NDM6MjErMDAwMCIsImlkIjoiNDAyOGY5Zjg2
-        OTkxMGIzMDAxNjk5MmY5M2QyNjAwMDUiLCJ0eXBlIjoiTk9STUFMIiwib3du
-        ZXIiOnsiaWQiOiI0MDI4ZjlmODY5OTEwYjMwMDE2OTkyZjkzOWU3MDAwMCIs
+        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxMDoyMDoxNCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDUtMzBUMTA6MjA6MTQrMDAwMCIsImlkIjoiNDAyOGY5Zjc2
+        YjA0MzBhOTAxNmIwODQxMjE2NTAwYTEiLCJ0eXBlIjoiTk9STUFMIiwib3du
+        ZXIiOnsiaWQiOiI0MDI4ZjlmNzZiMDQzMGE5MDE2YjA4NDExOWY2MDA5YyIs
         ImtleSI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5TmFtZSI6InNjZW5hcmlv
         X3Rlc3QiLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0sImFjdGl2
         ZVN1YnNjcmlwdGlvbiI6dHJ1ZSwic291cmNlRW50aXRsZW1lbnQiOm51bGws
@@ -248,13 +131,13 @@ http_interactions:
         ZWRQcm9kdWN0SWQiOm51bGwsImRlcml2ZWRQcm9kdWN0TmFtZSI6bnVsbCwi
         cHJvdmlkZWRQcm9kdWN0cyI6W10sImRlcml2ZWRQcm92aWRlZFByb2R1Y3Rz
         IjpbXSwic3Vic2NyaXB0aW9uU3ViS2V5IjpudWxsLCJzdWJzY3JpcHRpb25J
-        ZCI6bnVsbCwiaHJlZiI6Ii9wb29scy80MDI4ZjlmODY5OTEwYjMwMDE2OTky
-        ZjkzZDI2MDAwNSJ9
+        ZCI6bnVsbCwiaHJlZiI6Ii9wb29scy80MDI4ZjlmNzZiMDQzMGE5MDE2YjA4
+        NDEyMTY1MDBhMSJ9
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:21 GMT
+  recorded_at: Thu, 30 May 2019 10:20:14 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -266,9 +149,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="jAxTjRjZQ7yDaaSwD6cYjZLXGgzg3ZSt", oauth_nonce="g5kBJmw4gyBZW2V2sM1FiNynrTVxuJ9jlR5sDJAKyE",
-        oauth_signature="yZcXMpqDTux6Dmo8Bsj4LiHjNBU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1552949001", oauth_version="1.0"
+      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="T7wGqOq9oQmJjiNpCk2gRO43TawoA4Bu6P8SzfYBJ5o",
+        oauth_signature="XZfDKtFZ5ljdN8cgmGmE15L1zy0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1559211614", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -283,31 +166,31 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 920da473-ad65-4616-b2b4-ffafa4469e71
+      - 5964f107-557e-4ad7-ad7a-8fc96779add2
       X-Version:
-      - 2.5.9-1
+      - 2.6.5-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 18 Mar 2019 22:43:21 GMT
+      - Thu, 30 May 2019 10:20:14 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wMy0xOFQyMjo0MzoyMSswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDMtMThUMjI6NDM6MjErMDAwMCIsInV1aWQiOiI0MDI4Zjlm
-        ODY5OTEwYjMwMDE2OTkyZjkzY2I0MDAwNCIsImlkIjoiN2M4MjUwMTNjYWIw
+        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxMDoyMDoxNCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDUtMzBUMTA6MjA6MTQrMDAwMCIsInV1aWQiOiI0MDI4Zjlm
+        NzZiMDQzMGE5MDE2YjA4NDEyMTQxMDBhMCIsImlkIjoiN2M4MjUwMTNjYWIw
         MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
         dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
         IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
-        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOWY4Njk5MTBiMzAwMTY5OTJmOTNjYjQw
-        MDA0IiwicHJvZHVjdENvbnRlbnQiOltdfQ==
+        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOWY3NmIwNDMwYTkwMTZiMDg0MTIxNDEw
+        MGEwIiwicHJvZHVjdENvbnRlbnQiOltdfQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:21 GMT
+  recorded_at: Thu, 30 May 2019 10:20:14 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com:8443/candlepin/owners/scenario_test/pools?add_future=true
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/pools?add_future=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -319,9 +202,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="jAxTjRjZQ7yDaaSwD6cYjZLXGgzg3ZSt", oauth_nonce="JD0qEMq65KgxOueX1MpTTsvg5wlihvGrNLpjTM0FkBo",
-        oauth_signature="R7JWfX4RCaQ8KjLJqD8FWi0mGpU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1552949001", oauth_version="1.0"
+      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="WiqQKEHxrJVUwGzxlsxYaRCxgYm4GBIm0RxhC6m8",
+        oauth_signature="D4zG0L1aYXd6ia4T8XdmbOGvb6Q%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1559211614", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -336,22 +219,22 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 89f75474-947d-42ae-9f6a-00785a4838e0
+      - 3a29f09b-52a5-4646-9f52-4e89d00e5733
       X-Version:
-      - 2.5.9-1
+      - 2.6.5-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 18 Mar 2019 22:43:21 GMT
+      - Thu, 30 May 2019 10:20:14 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        W3siY3JlYXRlZCI6IjIwMTktMDMtMThUMjI6NDM6MjErMDAwMCIsInVwZGF0
-        ZWQiOiIyMDE5LTAzLTE4VDIyOjQzOjIxKzAwMDAiLCJpZCI6IjQwMjhmOWY4
-        Njk5MTBiMzAwMTY5OTJmOTNkMjYwMDA1IiwidHlwZSI6Ik5PUk1BTCIsIm93
-        bmVyIjp7ImlkIjoiNDAyOGY5Zjg2OTkxMGIzMDAxNjk5MmY5MzllNzAwMDAi
+        W3siY3JlYXRlZCI6IjIwMTktMDUtMzBUMTA6MjA6MTQrMDAwMCIsInVwZGF0
+        ZWQiOiIyMDE5LTA1LTMwVDEwOjIwOjE0KzAwMDAiLCJpZCI6IjQwMjhmOWY3
+        NmIwNDMwYTkwMTZiMDg0MTIxNjUwMGExIiwidHlwZSI6Ik5PUk1BTCIsIm93
+        bmVyIjp7ImlkIjoiNDAyOGY5Zjc2YjA0MzBhOTAxNmIwODQxMTlmNjAwOWMi
         LCJrZXkiOiJzY2VuYXJpb190ZXN0IiwiZGlzcGxheU5hbWUiOiJzY2VuYXJp
         b190ZXN0IiwiaHJlZiI6Ii9vd25lcnMvc2NlbmFyaW9fdGVzdCJ9LCJhY3Rp
         dmVTdWJzY3JpcHRpb24iOnRydWUsInNvdXJjZUVudGl0bGVtZW50IjpudWxs
@@ -372,12 +255,12 @@ http_interactions:
         ImRlcml2ZWRQcm9kdWN0TmFtZSI6bnVsbCwicHJvdmlkZWRQcm9kdWN0cyI6
         W10sImRlcml2ZWRQcm92aWRlZFByb2R1Y3RzIjpbXSwic3Vic2NyaXB0aW9u
         U3ViS2V5IjpudWxsLCJzdWJzY3JpcHRpb25JZCI6bnVsbCwiaHJlZiI6Ii9w
-        b29scy80MDI4ZjlmODY5OTEwYjMwMDE2OTkyZjkzZDI2MDAwNSJ9XQ==
+        b29scy80MDI4ZjlmNzZiMDQzMGE5MDE2YjA4NDEyMTY1MDBhMSJ9XQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:21 GMT
+  recorded_at: Thu, 30 May 2019 10:20:14 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com:8443/candlepin/pools/4028f9f869910b30016992f93d260005
+    uri: https://devel.balmora.example.com:8443/candlepin/pools/4028f9f76b0430a9016b0841216500a1
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -389,9 +272,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="jAxTjRjZQ7yDaaSwD6cYjZLXGgzg3ZSt", oauth_nonce="mAje2UgmjlFvogtIPEY17KowO1pQwzAOMzmu0K9CI",
-        oauth_signature="UGLrcELek2sIAGh9%2Bps5ZU2dH%2BU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1552949001", oauth_version="1.0"
+      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="k4RcwntFa4wM22qz9lWcmei2mvmMdUTV52x3mz1p4",
+        oauth_signature="Mj6RH2bAN5rr46EHefANtNqmAn0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1559211614", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -406,22 +289,22 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - e229c1f4-3f33-45b2-8b93-17752e06514a
+      - 7659db85-d5a4-4eae-b5ce-635a49766169
       X-Version:
-      - 2.5.9-1
+      - 2.6.5-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 18 Mar 2019 22:43:21 GMT
+      - Thu, 30 May 2019 10:20:14 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wMy0xOFQyMjo0MzoyMSswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDMtMThUMjI6NDM6MjErMDAwMCIsImlkIjoiNDAyOGY5Zjg2
-        OTkxMGIzMDAxNjk5MmY5M2QyNjAwMDUiLCJ0eXBlIjoiTk9STUFMIiwib3du
-        ZXIiOnsiaWQiOiI0MDI4ZjlmODY5OTEwYjMwMDE2OTkyZjkzOWU3MDAwMCIs
+        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxMDoyMDoxNCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDUtMzBUMTA6MjA6MTQrMDAwMCIsImlkIjoiNDAyOGY5Zjc2
+        YjA0MzBhOTAxNmIwODQxMjE2NTAwYTEiLCJ0eXBlIjoiTk9STUFMIiwib3du
+        ZXIiOnsiaWQiOiI0MDI4ZjlmNzZiMDQzMGE5MDE2YjA4NDExOWY2MDA5YyIs
         ImtleSI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5TmFtZSI6InNjZW5hcmlv
         X3Rlc3QiLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0sImFjdGl2
         ZVN1YnNjcmlwdGlvbiI6dHJ1ZSwic291cmNlRW50aXRsZW1lbnQiOm51bGws
@@ -442,12 +325,12 @@ http_interactions:
         ZGVyaXZlZFByb2R1Y3ROYW1lIjpudWxsLCJwcm92aWRlZFByb2R1Y3RzIjpb
         XSwiZGVyaXZlZFByb3ZpZGVkUHJvZHVjdHMiOltdLCJzdWJzY3JpcHRpb25T
         dWJLZXkiOm51bGwsInN1YnNjcmlwdGlvbklkIjpudWxsLCJocmVmIjoiL3Bv
-        b2xzLzQwMjhmOWY4Njk5MTBiMzAwMTY5OTJmOTNkMjYwMDA1In0=
+        b2xzLzQwMjhmOWY3NmIwNDMwYTkwMTZiMDg0MTIxNjUwMGExIn0=
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:21 GMT
+  recorded_at: Thu, 30 May 2019 10:20:14 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com:8443/candlepin/owners/scenario_test/activation_keys/?include=pools.pool.id
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/activation_keys/?include=pools.pool.id
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -459,9 +342,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="jAxTjRjZQ7yDaaSwD6cYjZLXGgzg3ZSt", oauth_nonce="78t7CpVc1aT6VT6VWaKnOCqM1fD26GKIijPu1Ozjs",
-        oauth_signature="OVCTdmcIkVehJltOItBHs2FEX40%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1552949001", oauth_version="1.0"
+      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="arLzcGwBwfapNKocTCsRdAUx3SBcoyG4Y55Mjdr6E",
+        oauth_signature="QDiaIAhownlj2TLWHC5jfPooZDM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1559211614", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -476,25 +359,25 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - a0aeeaeb-a28e-43ed-8ca3-6af23ab3d9a1
+      - 578e7e03-3131-476d-9bc0-cbf2c347a48d
       X-Version:
-      - 2.5.9-1
+      - 2.6.5-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 18 Mar 2019 22:43:21 GMT
+      - Thu, 30 May 2019 10:20:14 GMT
     body:
       encoding: UTF-8
       base64_string: 'W10=
 
 '
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:21 GMT
+  recorded_at: Thu, 30 May 2019 10:20:14 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com:8443/candlepin/pools/4028f9f869910b30016992f93d260005/entitlements/consumer_uuids
+    uri: https://devel.balmora.example.com:8443/candlepin/pools/4028f9f76b0430a9016b0841216500a1/entitlements/consumer_uuids
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -506,9 +389,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="jAxTjRjZQ7yDaaSwD6cYjZLXGgzg3ZSt", oauth_nonce="9VFKFryFmcDiaLJbYYYk6F3XcUPBkchkK10g0mNuR0",
-        oauth_signature="Op95gx9D023IX1eyzV80YDh2txM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1552949001", oauth_version="1.0"
+      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="kl2zIVhThssOadryNfZ3PdtYsu13X56bz6b7RkY6Jg",
+        oauth_signature="hBrPhbachz%2FxLJKlhNBgL8PC4TQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1559211614", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -523,20 +406,20 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 667ac491-87ae-458e-b428-979a6347660d
+      - f47df280-dd23-4c2e-bed5-2dc4179e3bd4
       X-Version:
-      - 2.5.9-1
+      - 2.6.5-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 18 Mar 2019 22:43:21 GMT
+      - Thu, 30 May 2019 10:20:14 GMT
     body:
       encoding: UTF-8
       base64_string: 'W10=
 
 '
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:21 GMT
+  recorded_at: Thu, 30 May 2019 10:20:14 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/repo_create.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/repo_create.yml
@@ -2,1124 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/content/1549305194264?enabled=true
-    body:
-      encoding: UTF-8
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk",
-        oauth_nonce="dULDXBRRQ0rJ97lpF3WvR3IJFHntMGq8Czuage8V5A", oauth_signature="GjXNhNzE9X25oUGGTLwmkZCjhWM%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1549305194", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - a8f06465-327f-40da-a054-45da8107c0e9
-      X-Version:
-      - 2.5.9-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Mon, 04 Feb 2019 18:33:14 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wMi0wNFQxODozMzoxMiswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDItMDRUMTg6MzM6MTQrMDAwMCIsInV1aWQiOiI0MDI4Zjk2
-        NjY4Yjk1OWU3MDE2OGI5YzkyODAwMDAwOCIsImlkIjoiN2M4MjUwMTNjYWIw
-        MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
-        dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
-        IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
-        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOTY2NjhiOTU5ZTcwMTY4YjljOTI4MDAw
-        MDA4IiwicHJvZHVjdENvbnRlbnQiOlt7ImNvbnRlbnQiOnsiY3JlYXRlZCI6
-        IjIwMTktMDItMDRUMTg6MzM6MTQrMDAwMCIsInVwZGF0ZWQiOiIyMDE5LTAy
-        LTA0VDE4OjMzOjE0KzAwMDAiLCJ1dWlkIjoiNDAyOGY5NjY2OGI5NTllNzAx
-        NjhiOWM5MjcyNTAwMDciLCJpZCI6IjE1NDkzMDUxOTQyNjQiLCJ0eXBlIjoi
-        eXVtIiwibGFiZWwiOiJzY2VuYXJpb190ZXN0X1NjZW5hcmlvX1Byb2R1Y3Rf
-        U2NlbmFyaW9feXVtX3Byb2R1Y3QiLCJuYW1lIjoiU2NlbmFyaW8geXVtIHBy
-        b2R1Y3QiLCJ2ZW5kb3IiOiJDdXN0b20iLCJjb250ZW50VXJsIjoiL2N1c3Rv
-        bS9TY2VuYXJpb19Qcm9kdWN0L1NjZW5hcmlvX3l1bV9wcm9kdWN0IiwicmVx
-        dWlyZWRUYWdzIjpudWxsLCJncGdVcmwiOm51bGwsIm1vZGlmaWVkUHJvZHVj
-        dElkcyI6W10sImFyY2hlcyI6bnVsbCwicmVxdWlyZWRQcm9kdWN0SWRzIjpb
-        XSwibWV0YWRhdGFFeHBpcmUiOjEsInJlbGVhc2VWZXIiOm51bGx9LCJlbmFi
-        bGVkIjp0cnVlfV19
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:14 GMT
-- request:
-    method: post
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/environments/d80a5783c502f0f969e23089437bb7ce/content
-    body:
-      encoding: UTF-8
-      base64_string: 'W3siY29udGVudElkIjoiMTU0OTMwNTE5NDI2NCJ9XQ==
-
-'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="zjp7BihWXTQRyEHyjMDCmiFfK3zaUYzk",
-        oauth_nonce="7B6uice56KoadgBr3Jk3rYQxhM1dPBPbrJL9iWHrsSI", oauth_signature="H5Z0HvuK0xm%2BDuhaWicCU%2BAL9Uw%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1549305194", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-      Content-Length:
-      - '31'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 4435f7ea-9e44-412b-b061-d3343f072eea
-      X-Version:
-      - 2.5.9-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Mon, 04 Feb 2019 18:33:14 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wMi0wNFQxODozMzoxNCswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDItMDRUMTg6MzM6MTQrMDAwMCIsImlkIjoicmVnZW5fZW50
-        aXRsZW1lbnRfY2VydF9vZl9lbnZmOWU3MjIyMi0zZDc4LTRmZDEtYjRjMi1l
-        MzMzMTljYWI0ZjMiLCJzdGF0ZSI6IkNSRUFURUQiLCJzdGFydFRpbWUiOm51
-        bGwsImZpbmlzaFRpbWUiOm51bGwsInJlc3VsdCI6bnVsbCwicHJpbmNpcGFs
-        TmFtZSI6ImZvcmVtYW5fYWRtaW4iLCJ0YXJnZXRUeXBlIjpudWxsLCJ0YXJn
-        ZXRJZCI6bnVsbCwib3duZXJJZCI6bnVsbCwiY29ycmVsYXRpb25JZCI6bnVs
-        bCwicmVzdWx0RGF0YSI6bnVsbCwiZG9uZSI6ZmFsc2UsInN0YXR1c1BhdGgi
-        OiIvam9icy9yZWdlbl9lbnRpdGxlbWVudF9jZXJ0X29mX2VudmY5ZTcyMjIy
-        LTNkNzgtNGZkMS1iNGMyLWUzMzMxOWNhYjRmMyIsImdyb3VwIjoiYXN5bmMg
-        Z3JvdXAifQ==
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:14 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/c6afee6c-70ce-4925-9749-196f1c85aa6c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"2ac4e93d3271fc30ff4705e9f6512c8b-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '553'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9jNmFmZWU2Yy03MGNlLTQ5MjUtOTc0OS0xOTZm
-        MWM4NWFhNmMvIiwgInRhc2tfaWQiOiAiYzZhZmVlNmMtNzBjZS00OTI1LTk3
-        NDktMTk2ZjFjODVhYTZjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
-        IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIiIsICJz
-        dGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM1
-        ODg1NmI3YTc2ODIwYzU5MjA1Y2RkIn0sICJpZCI6ICI1YzU4ODU2YjdhNzY4
-        MjBjNTkyMDVjZGQifQ==
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:15 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/c6afee6c-70ce-4925-9749-196f1c85aa6c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"a4b415e68598407d14f3f3409424adf9-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '691'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9jNmFmZWU2Yy03MGNlLTQ5MjUtOTc0OS0xOTZm
-        MWM4NWFhNmMvIiwgInRhc2tfaWQiOiAiYzZhZmVlNmMtNzBjZS00OTI1LTk3
-        NDktMTk2ZjFjODVhYTZjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDItMDRUMTg6MzM6MTVaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
-        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJy
-        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
-        cmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJl
-        c3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWM1ODg1NmI3YTc2ODIwYzU5MjA1Y2RkIn0sICJpZCI6ICI1YzU4ODU2Yjdh
-        NzY4MjBjNTkyMDVjZGQifQ==
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:15 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/c6afee6c-70ce-4925-9749-196f1c85aa6c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"5532f9e843a7904cc2de472a11d2e7f8-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4314'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9jNmFmZWU2Yy03MGNlLTQ5MjUtOTc0OS0xOTZm
-        MWM4NWFhNmMvIiwgInRhc2tfaWQiOiAiYzZhZmVlNmMtNzBjZS00OTI1LTk3
-        NDktMTk2ZjFjODVhYTZjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDItMDRUMTg6MzM6MTVaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogImViMjlkM2VhLTRjMTYtNGZhZC1iOWVkLTAxMWM2YWI1ODgzZiIs
-        ICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
-        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAi
-        c3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI3MmMzMWQ4Ny02OTNkLTQxN2UtYWJkOS1kM2MyOTE2YTFlMmEiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJiNWFjZDdlNC1mNmEzLTQ3NGItOTNmZC1j
-        NWYxZDhkYzBmNzYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBN
-        cyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        Y2NmZTliYzEtNThhMS00ZTU1LWFhYWYtNTRkNTYwNDNkNjhlIiwgIm51bV9w
-        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
-        biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
-        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjBjZmUzNGJjLTA5MmQtNDAyZC1hZDFh
-        LWQwOGU1MTRhYjRmZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
-        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVz
-        IiwgInN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjhiYTU1M2IxLTUyOWYtNDQ4Ni04ODdhLTNmZGUxYmQ1YTc1YSIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJj
-        b21wcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3Y2JjMjU5MC0wN2YwLTQ4MDQt
-        YTJjZS01MzQyNmU2OWJjNDgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0
-        YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI5YjczNjJjOS04NTY3LTQxZDktYTQzOS1jNGZlNjJhYWU3ZTYi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI0ZWQwYjU1Ny01NWRiLTRiNTYtYTNmYS1jOTU0OTIxOTIyYzciLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDhhMjgx
-        YzctZTFhMC00MTgzLThiMjQtMjFlZmY3NGU0YzY2IiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJS
-        ZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9v
-        bGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
-        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmQ1YjA4YTEtOWVh
-        OC00NjY4LWEwYzMtOTdkMjMxZGE0MTQ0IiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
-        aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjVjODUwN2RiLWE2NGItNDM3MC05MDU4LTQzNDVm
-        YTdiYjY2OCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIi
-        LCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3Rv
-        dGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjJkOTRiMTdlLTYxNTQtNDhmYS1hOTJmLTdmNmJjNTk0ODIw
-        ZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
-        ZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBf
-        dHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
-        ZXBfaWQiOiAiYTM3Yjc0NjctMWE2Yi00MTJhLTgwMTktZTk5MDJlZDE3MGEx
-        IiwgIm51bV9wcm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRf
-        cmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
-        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIu
-        c2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjog
-        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzU4ODU2YjdhNzY4MjBjNTkyMDVj
-        ZGQifSwgImlkIjogIjVjNTg4NTZiN2E3NjgyMGM1OTIwNWNkZCJ9
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:15 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/c6afee6c-70ce-4925-9749-196f1c85aa6c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"20238e64c78114fa767658f6e3587501-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4295'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9jNmFmZWU2Yy03MGNlLTQ5MjUtOTc0OS0xOTZm
-        MWM4NWFhNmMvIiwgInRhc2tfaWQiOiAiYzZhZmVlNmMtNzBjZS00OTI1LTk3
-        NDktMTk2ZjFjODVhYTZjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDItMDRUMTg6MzM6MTVaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImViMjlkM2VhLTRjMTYtNGZhZC1iOWVkLTAxMWM2YWI1ODgzZiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
-        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3MmMz
-        MWQ4Ny02OTNkLTQxN2UtYWJkOS1kM2MyOTE2YTFlMmEiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJiNWFjZDdlNC1mNmEzLTQ3NGItOTNmZC1jNWYxZDhkYzBm
-        NzYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
-        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjY2ZlOWJjMS01OGEx
-        LTRlNTUtYWFhZi01NGQ1NjA0M2Q2OGUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMGNmZTM0YmMtMDkyZC00MDJkLWFkMWEtZDA4ZTUxNGFiNGZmIiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
-        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOGJhNTUzYjEtNTI5Zi00NDg2
-        LTg4N2EtM2ZkZTFiZDVhNzVhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
-        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
-        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
-        IjogMCwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjdjYmMyNTkwLTA3ZjAtNDgwNC1hMmNlLTUzNDI2ZTY5YmM0OCIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
-        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBl
-        IjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
-        VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjliNzM2MmM5LTg1
-        NjctNDFkOS1hNDM5LWM0ZmU2MmFhZTdlNiIsICJudW1fcHJvY2Vzc2VkIjog
-        MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2lu
-        ZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFS
-        VEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRlZDBiNTU3LTU1ZGItNGI1
-        Ni1hM2ZhLWM5NTQ5MjE5MjJjNyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBz
-        cWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJkOGEyODFjNy1lMWEwLTQxODMtOGIyNC0y
-        MWVmZjc0ZTRjNjYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0
-        YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVt
-        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJmZDViMDhhMS05ZWE4LTQ2NjgtYTBjMy05N2QyMzFk
-        YTQxNDQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJz
-        dGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNWM4
-        NTA3ZGItYTY0Yi00MzcwLTkwNTgtNDM0NWZhN2JiNjY4IiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVi
-        bGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmQ5NGIxN2Ut
-        NjE1NC00OGZhLWE5MmYtN2Y2YmM1OTQ4MjBkIiwgIm51bV9wcm9jZXNzZWQi
-        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0
-        aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVf
-        cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJO
-        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMzdiNzQ2Ny0x
-        YTZiLTQxMmEtODAxOS1lOTkwMmVkMTcwYTEiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDB9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBj
-        ZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUi
-        OiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJj
-        ZV93b3JrZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIs
-        ICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVjNTg4NTZiN2E3NjgyMGM1OTIwNWNkZCJ9LCAiaWQiOiAiNWM1ODg1
-        NmI3YTc2ODIwYzU5MjA1Y2RkIn0=
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:15 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/c6afee6c-70ce-4925-9749-196f1c85aa6c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"50e2a971786287e5a5c83f2cafb9883e-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4282'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9jNmFmZWU2Yy03MGNlLTQ5MjUtOTc0OS0xOTZm
-        MWM4NWFhNmMvIiwgInRhc2tfaWQiOiAiYzZhZmVlNmMtNzBjZS00OTI1LTk3
-        NDktMTk2ZjFjODVhYTZjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDItMDRUMTg6MzM6MTVaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImViMjlkM2VhLTRjMTYtNGZhZC1iOWVkLTAxMWM2YWI1ODgzZiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
-        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3MmMz
-        MWQ4Ny02OTNkLTQxN2UtYWJkOS1kM2MyOTE2YTFlMmEiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJiNWFjZDdlNC1mNmEzLTQ3NGItOTNmZC1jNWYxZDhkYzBm
-        NzYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
-        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjY2ZlOWJjMS01OGEx
-        LTRlNTUtYWFhZi01NGQ1NjA0M2Q2OGUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMGNmZTM0YmMtMDkyZC00MDJkLWFkMWEtZDA4ZTUxNGFiNGZmIiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
-        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOGJhNTUzYjEtNTI5Zi00NDg2
-        LTg4N2EtM2ZkZTFiZDVhNzVhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
-        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
-        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
-        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjdjYmMyNTkwLTA3ZjAtNDgwNC1hMmNlLTUzNDI2ZTY5YmM0OCIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
-        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjliNzM2MmM5LTg1NjctNDFk
-        OS1hNDM5LWM0ZmU2MmFhZTdlNiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
-        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
-        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjRlZDBiNTU3LTU1ZGItNGI1Ni1hM2ZhLWM5
-        NTQ5MjE5MjJjNyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
-        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
-        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogImQ4YTI4MWM3LWUxYTAtNDE4My04YjI0LTIxZWZmNzRlNGM2NiIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
-        Y3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlw
-        ZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImZkNWIwOGExLTllYTgtNDY2OC1hMGMzLTk3ZDIzMWRhNDE0NCIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJy
-        ZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RB
-        UlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1Yzg1MDdkYi1hNjRiLTQz
-        NzAtOTA1OC00MzQ1ZmE3YmI2NjgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
-        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        ZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9y
-        eSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyZDk0YjE3ZS02MTU0LTQ4ZmEtYTky
-        Zi03ZjZiYzU5NDgyMGQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3Mg
-        RmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
-        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImEzN2I3NDY3LTFhNmItNDEyYS04MDE5
-        LWU5OTAyZWQxNzBhMSIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVl
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwy
-        LnNhbWlyLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNl
-        bnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM1ODg1NmI3
-        YTc2ODIwYzU5MjA1Y2RkIn0sICJpZCI6ICI1YzU4ODU2YjdhNzY4MjBjNTky
-        MDVjZGQifQ==
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:15 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/c6afee6c-70ce-4925-9749-196f1c85aa6c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"e70b90caa5bb56edf121d5816f1f5870-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4275'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9jNmFmZWU2Yy03MGNlLTQ5MjUtOTc0OS0xOTZm
-        MWM4NWFhNmMvIiwgInRhc2tfaWQiOiAiYzZhZmVlNmMtNzBjZS00OTI1LTk3
-        NDktMTk2ZjFjODVhYTZjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDItMDRUMTg6MzM6MTVaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImViMjlkM2VhLTRjMTYtNGZhZC1iOWVkLTAxMWM2YWI1ODgzZiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
-        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3MmMz
-        MWQ4Ny02OTNkLTQxN2UtYWJkOS1kM2MyOTE2YTFlMmEiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJiNWFjZDdlNC1mNmEzLTQ3NGItOTNmZC1jNWYxZDhkYzBm
-        NzYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
-        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjY2ZlOWJjMS01OGEx
-        LTRlNTUtYWFhZi01NGQ1NjA0M2Q2OGUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMGNmZTM0YmMtMDkyZC00MDJkLWFkMWEtZDA4ZTUxNGFiNGZmIiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
-        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOGJhNTUzYjEtNTI5Zi00NDg2
-        LTg4N2EtM2ZkZTFiZDVhNzVhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
-        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
-        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
-        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjdjYmMyNTkwLTA3ZjAtNDgwNC1hMmNlLTUzNDI2ZTY5YmM0OCIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
-        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjliNzM2MmM5LTg1NjctNDFk
-        OS1hNDM5LWM0ZmU2MmFhZTdlNiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
-        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
-        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjRlZDBiNTU3LTU1ZGItNGI1Ni1hM2ZhLWM5
-        NTQ5MjE5MjJjNyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
-        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
-        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogImQ4YTI4MWM3LWUxYTAtNDE4My04YjI0LTIxZWZmNzRlNGM2NiIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
-        Y3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlw
-        ZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZk
-        NWIwOGExLTllYTgtNDY2OC1hMGMzLTk3ZDIzMWRhNDE0NCIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBv
-        dmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjVjODUwN2RiLWE2NGItNDM3MC05MDU4
-        LTQzNDVmYTdiYjY2OCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0
-        byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjJkOTRiMTdlLTYxNTQtNDhmYS1hOTJmLTdmNmJj
-        NTk0ODIwZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiYTM3Yjc0NjctMWE2Yi00MTJhLTgwMTktZTk5MDJl
-        ZDE3MGExIiwgIm51bV9wcm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVz
-        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2Vy
-        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
-        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
-        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzU4ODU2YjdhNzY4MjBj
-        NTkyMDVjZGQifSwgImlkIjogIjVjNTg4NTZiN2E3NjgyMGM1OTIwNWNkZCJ9
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:15 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/c6afee6c-70ce-4925-9749-196f1c85aa6c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"725eba6f773ad3e4d4961292f8353a99-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4269'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9jNmFmZWU2Yy03MGNlLTQ5MjUtOTc0OS0xOTZm
-        MWM4NWFhNmMvIiwgInRhc2tfaWQiOiAiYzZhZmVlNmMtNzBjZS00OTI1LTk3
-        NDktMTk2ZjFjODVhYTZjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDItMDRUMTg6MzM6MTVaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImViMjlkM2VhLTRjMTYtNGZhZC1iOWVkLTAxMWM2YWI1ODgzZiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
-        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3MmMz
-        MWQ4Ny02OTNkLTQxN2UtYWJkOS1kM2MyOTE2YTFlMmEiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJiNWFjZDdlNC1mNmEzLTQ3NGItOTNmZC1jNWYxZDhkYzBm
-        NzYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
-        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjY2ZlOWJjMS01OGEx
-        LTRlNTUtYWFhZi01NGQ1NjA0M2Q2OGUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMGNmZTM0YmMtMDkyZC00MDJkLWFkMWEtZDA4ZTUxNGFiNGZmIiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
-        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOGJhNTUzYjEtNTI5Zi00NDg2
-        LTg4N2EtM2ZkZTFiZDVhNzVhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
-        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
-        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
-        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjdjYmMyNTkwLTA3ZjAtNDgwNC1hMmNlLTUzNDI2ZTY5YmM0OCIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
-        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjliNzM2MmM5LTg1NjctNDFk
-        OS1hNDM5LWM0ZmU2MmFhZTdlNiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
-        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
-        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjRlZDBiNTU3LTU1ZGItNGI1Ni1hM2ZhLWM5
-        NTQ5MjE5MjJjNyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
-        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
-        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogImQ4YTI4MWM3LWUxYTAtNDE4My04YjI0LTIxZWZmNzRlNGM2NiIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
-        Y3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlw
-        ZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZk
-        NWIwOGExLTllYTgtNDY2OC1hMGMzLTk3ZDIzMWRhNDE0NCIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBv
-        dmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjVjODUwN2RiLWE2NGItNDM3MC05MDU4
-        LTQzNDVmYTdiYjY2OCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0
-        byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjJkOTRiMTdlLTYxNTQtNDhmYS1hOTJmLTdmNmJjNTk0
-        ODIwZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0
-        ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
-        ZXBfaWQiOiAiYTM3Yjc0NjctMWE2Yi00MTJhLTgwMTktZTk5MDJlZDE3MGEx
-        IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAicXVldWUiOiAicmVzZXJ2ZWRf
-        cmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
-        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIu
-        c2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjog
-        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzU4ODU2YjdhNzY4MjBjNTkyMDVj
-        ZGQifSwgImlkIjogIjVjNTg4NTZiN2E3NjgyMGM1OTIwNWNkZCJ9
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:15 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/c6afee6c-70ce-4925-9749-196f1c85aa6c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:15 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"eb77a1486d5caefba4f028d31ca6cc19-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '8549'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9jNmFmZWU2Yy03MGNlLTQ5MjUtOTc0OS0xOTZm
-        MWM4NWFhNmMvIiwgInRhc2tfaWQiOiAiYzZhZmVlNmMtNzBjZS00OTI1LTk3
-        NDktMTk2ZjFjODVhYTZjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogIjIwMTktMDItMDRUMTg6MzM6MTVaIiwgIl9ucyI6ICJ0YXNr
-        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTktMDItMDRUMTg6MzM6MTVa
-        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
-        cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
-        ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImViMjlkM2VhLTRjMTYtNGZhZC1iOWVk
-        LTAxMWM2YWI1ODgzZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
-        dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
-        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI3MmMzMWQ4Ny02OTNkLTQxN2UtYWJkOS1kM2MyOTE2
-        YTFlMmEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
-        cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNWFjZDdlNC1mNmEzLTQ3
-        NGItOTNmZC1jNWYxZDhkYzBmNzYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
-        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICJjY2ZlOWJjMS01OGExLTRlNTUtYWFhZi01NGQ1NjA0M2Q2OGUiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
-        cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGNmZTM0YmMtMDkyZC00MDJkLWFk
-        MWEtZDA4ZTUxNGFiNGZmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVs
-        ZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        OGJhNTUzYjEtNTI5Zi00NDg2LTg4N2EtM2ZkZTFiZDVhNzVhIiwgIm51bV9w
-        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
-        biI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNv
-        bXBzIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjdjYmMyNTkwLTA3ZjAtNDgwNC1hMmNl
-        LTUzNDI2ZTY5YmM0OCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
-        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0
-        YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjog
-        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjliNzM2MmM5LTg1NjctNDFkOS1hNDM5LWM0ZmU2MmFhZTdlNiIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRp
-        b24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJj
-        bG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRlZDBiNTU3
-        LTU1ZGItNGI1Ni1hM2ZhLWM5NTQ5MjE5MjJjNyIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
-        ZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRl
-        IHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ4YTI4MWM3LWUxYTAtNDE4My04
-        YjI0LTIxZWZmNzRlNGM2NiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJl
-        cG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImZkNWIwOGExLTllYTgtNDY2OC1hMGMzLTk3ZDIz
-        MWRhNDE0NCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwg
-        InN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjVjODUw
-        N2RiLWE2NGItNDM3MC05MDU4LTQzNDVmYTdiYjY2OCIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        UHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxp
-        c2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
-        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJkOTRiMTdlLTYxNTQt
-        NDhmYS1hOTJmLTdmNmJjNTk0ODIwZCIsICJudW1fcHJvY2Vzc2VkIjogMX0s
-        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBM
-        aXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9f
-        bWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTM3Yjc0NjctMWE2Yi00MTJh
-        LTgwMTktZTk5MDJlZDE3MGExIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
-        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwg
-        InJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJzdGFydGVkIjogIjIwMTkt
-        MDItMDRUMTg6MzM6MTVaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVzdWx0
-        cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wMi0wNFQxODozMzoxNVoiLCAidHJh
-        Y2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Rp
-        c3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7ImdlbmVyYXRlIHNxbGl0ZSI6ICJT
-        S0lQUEVEIiwgInJwbXMiOiAiRklOSVNIRUQiLCAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIjogIkZJTklTSEVEIiwgInJlbW92ZV9vbGRfcmVwb2RhdGEi
-        OiAiRklOSVNIRUQiLCAibW9kdWxlcyI6ICJGSU5JU0hFRCIsICJjbG9zZV9y
-        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQi
-        LCAiY29tcHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklT
-        SEVEIiwgInJlcG92aWV3IjogIlNLSVBQRUQiLCAicHVibGlzaF9kaXJlY3Rv
-        cnkiOiAiRklOSVNIRUQiLCAiZXJyYXRhIjogIkZJTklTSEVEIiwgIm1ldGFk
-        YXRhIjogIkZJTklTSEVEIn0sICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImRp
-        c3RyaWJ1dG9yX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAiaWQiOiAiNWM1ODg1
-        NmIwNWY1ZWUwNjA0Y2IxMDkyIiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2Vz
-        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRh
-        ZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
-        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogImViMjlkM2VhLTRjMTYtNGZhZC1iOWVkLTAx
-        MWM2YWI1ODgzZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
-        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRp
-        b24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICI3MmMzMWQ4Ny02OTNkLTQxN2UtYWJkOS1kM2MyOTE2YTFl
-        MmEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUi
-        OiAicnBtcyIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNWFjZDdlNC1mNmEzLTQ3NGIt
-        OTNmZC1jNWYxZDhkYzBmNzYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVs
-        dGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwi
-        OiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJjY2ZlOWJjMS01OGExLTRlNTUtYWFhZi01NGQ1NjA0M2Q2OGUiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJh
-        dGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMGNmZTM0YmMtMDkyZC00MDJkLWFkMWEt
-        ZDA4ZTUxNGFiNGZmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMi
-        LCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAi
-        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOGJh
-        NTUzYjEtNTI5Zi00NDg2LTg4N2EtM2ZkZTFiZDVhNzVhIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBz
-        IiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjdjYmMyNTkwLTA3ZjAtNDgwNC1hMmNlLTUz
-        NDI2ZTY5YmM0OCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
-        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4i
-        LCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjli
-        NzM2MmM5LTg1NjctNDFkOS1hNDM5LWM0ZmU2MmFhZTdlNiIsICJudW1fcHJv
-        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24i
-        OiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9z
-        ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRlZDBiNTU3LTU1
-        ZGItNGI1Ni1hM2ZhLWM5NTQ5MjE5MjJjNyIsICJudW1fcHJvY2Vzc2VkIjog
-        MX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
-        dGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNx
-        bGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImQ4YTI4MWM3LWUxYTAtNDE4My04YjI0
-        LTIxZWZmNzRlNGM2NiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9k
-        YXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImZkNWIwOGExLTllYTgtNDY2OC1hMGMzLTk3ZDIzMWRh
-        NDE0NCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
-        LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0
-        ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjVjODUwN2Ri
-        LWE2NGItNDM3MC05MDU4LTQzNDVmYTdiYjY2OCIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hf
-        ZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJkOTRiMTdlLTYxNTQtNDhm
-        YS1hOTJmLTdmNmJjNTk0ODIwZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0
-        aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTM3Yjc0NjctMWE2Yi00MTJhLTgw
-        MTktZTk5MDJlZDE3MGExIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjNTg4NTZiN2E3NjgyMGM1
-        OTIwNWNkZCJ9LCAiaWQiOiAiNWM1ODg1NmI3YTc2ODIwYzU5MjA1Y2RkIn0=
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:15 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1163,9 +46,9 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:21 GMT
+      - Thu, 30 May 2019 10:20:14 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '332'
       Location:
@@ -1180,14 +63,14 @@ http_interactions:
         X2FkZGVkIjogbnVsbCwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
         ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
         aXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lkIjogeyIkb2lk
-        IjogIjVjOTAxZjA5ZGIyODRlMWI0ZWRkZGI1ZiJ9LCAiaWQiOiAic2NlbmFy
+        IjogIjVjZWZhZTVlYjAyZTUzMTFhMjhhMDk0OSJ9LCAiaWQiOiAic2NlbmFy
         aW9fdGVzdCIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVz
         L3NjZW5hcmlvX3Rlc3QvIn0=
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:22 GMT
+  recorded_at: Thu, 30 May 2019 10:20:15 GMT
 - request:
     method: post
-    uri: https://theta.partello.example.com:8443/candlepin/owners/scenario_test/content/
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/content/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1204,9 +87,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="jAxTjRjZQ7yDaaSwD6cYjZLXGgzg3ZSt",
-        oauth_nonce="OT9ImzdwFtmNYJQNYm5tDOG0Hu6q7UwfVnVpiJhc", oauth_signature="h5nib7eoCZ0WgYGPeDundkiaVVU%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1552949002", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD",
+        oauth_nonce="IEkMJXRkabWc8D62Ag13tjkmm4kHvJn3iwP6KY3kmA", oauth_signature="K%2Bkxcw5NWWTA9UybtOHNKyNO%2FSE%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559211615", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -1223,22 +106,22 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 036c1cb7-b4ec-4144-8d63-c2a88790b439
+      - '08851c4f-bd50-4a03-aa3f-4a3a7a83b9a5'
       X-Version:
-      - 2.5.9-1
+      - 2.6.5-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 18 Mar 2019 22:43:21 GMT
+      - Thu, 30 May 2019 10:20:14 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wMy0xOFQyMjo0MzoyMiswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDMtMThUMjI6NDM6MjIrMDAwMCIsInV1aWQiOiI0MDI4Zjlm
-        ODY5OTEwYjMwMDE2OTkyZjkzZmQwMDAwNyIsImlkIjoiMTU1Mjk0OTAwMjE4
-        NCIsInR5cGUiOiJ5dW0iLCJsYWJlbCI6InNjZW5hcmlvX3Rlc3RfU2NlbmFy
+        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxMDoyMDoxNSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDUtMzBUMTA6MjA6MTUrMDAwMCIsInV1aWQiOiI0MDI4Zjlm
+        NzZiMDQzMGE5MDE2YjA4NDEyM2FkMDBhMyIsImlkIjoiMTU1OTIxMTYxNTE2
+        NyIsInR5cGUiOiJ5dW0iLCJsYWJlbCI6InNjZW5hcmlvX3Rlc3RfU2NlbmFy
         aW9fUHJvZHVjdF9TY2VuYXJpb195dW1fcHJvZHVjdCIsIm5hbWUiOiJTY2Vu
         YXJpbyB5dW0gcHJvZHVjdCIsInZlbmRvciI6IkN1c3RvbSIsImNvbnRlbnRV
         cmwiOiIvY3VzdG9tL1NjZW5hcmlvX1Byb2R1Y3QvU2NlbmFyaW9feXVtX3By
@@ -1247,10 +130,10 @@ http_interactions:
         b2R1Y3RJZHMiOltdLCJtZXRhZGF0YUV4cGlyZSI6MSwicmVsZWFzZVZlciI6
         bnVsbH0=
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:22 GMT
+  recorded_at: Thu, 30 May 2019 10:20:15 GMT
 - request:
     method: post
-    uri: https://theta.partello.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/content/1552949002184?enabled=true
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/content/1559211615167?enabled=true
     body:
       encoding: UTF-8
       base64_string: ''
@@ -1262,9 +145,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="jAxTjRjZQ7yDaaSwD6cYjZLXGgzg3ZSt",
-        oauth_nonce="mvKSUglcl5DsHl8lZObpzm8lUdvI6RiKiUpbTVd20", oauth_signature="z8qkOkwUlqLdjWPjjq6IhR7db2c%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1552949002", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD",
+        oauth_nonce="ZdtkCi9I8eiWj5YAs2CXNW0RZQ056H2crQEYys", oauth_signature="H1FHcBXmDJr91qnYfag%2Fu5V6ff4%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559211615", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -1279,29 +162,29 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - f9748157-2ed4-4bb6-8647-f7a2a57ad7fa
+      - e9af32f7-360a-4c31-b931-52b69acedea0
       X-Version:
-      - 2.5.9-1
+      - 2.6.5-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 18 Mar 2019 22:43:21 GMT
+      - Thu, 30 May 2019 10:20:14 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wMy0xOFQyMjo0MzoyMSswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDMtMThUMjI6NDM6MjIrMDAwMCIsInV1aWQiOiI0MDI4Zjlm
-        ODY5OTEwYjMwMDE2OTkyZjk0MDQ2MDAwOCIsImlkIjoiN2M4MjUwMTNjYWIw
+        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxMDoyMDoxNCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDUtMzBUMTA6MjA6MTUrMDAwMCIsInV1aWQiOiI0MDI4Zjlm
+        NzZiMDQzMGE5MDE2YjA4NDEyM2RmMDBhNCIsImlkIjoiN2M4MjUwMTNjYWIw
         MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
         dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
         IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
-        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOWY4Njk5MTBiMzAwMTY5OTJmOTQwNDYw
-        MDA4IiwicHJvZHVjdENvbnRlbnQiOlt7ImNvbnRlbnQiOnsiY3JlYXRlZCI6
-        IjIwMTktMDMtMThUMjI6NDM6MjIrMDAwMCIsInVwZGF0ZWQiOiIyMDE5LTAz
-        LTE4VDIyOjQzOjIyKzAwMDAiLCJ1dWlkIjoiNDAyOGY5Zjg2OTkxMGIzMDAx
-        Njk5MmY5M2ZkMDAwMDciLCJpZCI6IjE1NTI5NDkwMDIxODQiLCJ0eXBlIjoi
+        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOWY3NmIwNDMwYTkwMTZiMDg0MTIzZGYw
+        MGE0IiwicHJvZHVjdENvbnRlbnQiOlt7ImNvbnRlbnQiOnsiY3JlYXRlZCI6
+        IjIwMTktMDUtMzBUMTA6MjA6MTUrMDAwMCIsInVwZGF0ZWQiOiIyMDE5LTA1
+        LTMwVDEwOjIwOjE1KzAwMDAiLCJ1dWlkIjoiNDAyOGY5Zjc2YjA0MzBhOTAx
+        NmIwODQxMjNhZDAwYTMiLCJpZCI6IjE1NTkyMTE2MTUxNjciLCJ0eXBlIjoi
         eXVtIiwibGFiZWwiOiJzY2VuYXJpb190ZXN0X1NjZW5hcmlvX1Byb2R1Y3Rf
         U2NlbmFyaW9feXVtX3Byb2R1Y3QiLCJuYW1lIjoiU2NlbmFyaW8geXVtIHBy
         b2R1Y3QiLCJ2ZW5kb3IiOiJDdXN0b20iLCJjb250ZW50VXJsIjoiL2N1c3Rv
@@ -1311,13 +194,13 @@ http_interactions:
         XSwibWV0YWRhdGFFeHBpcmUiOjEsInJlbGVhc2VWZXIiOm51bGx9LCJlbmFi
         bGVkIjp0cnVlfV19
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:22 GMT
+  recorded_at: Thu, 30 May 2019 10:20:15 GMT
 - request:
     method: post
-    uri: https://theta.partello.example.com:8443/candlepin/environments/d80a5783c502f0f969e23089437bb7ce/content
+    uri: https://devel.balmora.example.com:8443/candlepin/environments/d80a5783c502f0f969e23089437bb7ce/content
     body:
       encoding: UTF-8
-      base64_string: 'W3siY29udGVudElkIjoiMTU1Mjk0OTAwMjE4NCJ9XQ==
+      base64_string: 'W3siY29udGVudElkIjoiMTU1OTIxMTYxNTE2NyJ9XQ==
 
 '
     headers:
@@ -1328,9 +211,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="jAxTjRjZQ7yDaaSwD6cYjZLXGgzg3ZSt",
-        oauth_nonce="RzmVoTTZvnsfZF5JFSHiYJhtF5Iwx7yNh9Lhb0WT8Uc", oauth_signature="4O1F21G8UkMhVBheDErK0g1S3mk%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1552949002", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD",
+        oauth_nonce="VZxFlHb7Rh2lwug80l5NLwo7AvRRANQcbwmFfjBQ", oauth_signature="79gPgU4QLXWgZVkcODAzkVBS5kg%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559211615", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -1347,34 +230,34 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - f2928c56-fea4-4258-979f-af22745158e9
+      - b74a1af7-e4ec-4894-b11c-c4656fd5aac6
       X-Version:
-      - 2.5.9-1
+      - 2.6.5-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 18 Mar 2019 22:43:22 GMT
+      - Thu, 30 May 2019 10:20:15 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wMy0xOFQyMjo0MzoyMiswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDMtMThUMjI6NDM6MjIrMDAwMCIsImlkIjoicmVnZW5fZW50
-        aXRsZW1lbnRfY2VydF9vZl9lbnY1ZjZhNTZlNS0yM2FhLTRkMGMtOGVmZi1l
-        MTM2NjBhZDRlNTEiLCJzdGF0ZSI6IkNSRUFURUQiLCJzdGFydFRpbWUiOm51
+        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxMDoyMDoxNSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDUtMzBUMTA6MjA6MTUrMDAwMCIsImlkIjoicmVnZW5fZW50
+        aXRsZW1lbnRfY2VydF9vZl9lbnY4NDZmYTUyMC03MTBhLTRhMDktODBkZC1k
+        ZmQ2YWEyZTA3MDYiLCJzdGF0ZSI6IkNSRUFURUQiLCJzdGFydFRpbWUiOm51
         bGwsImZpbmlzaFRpbWUiOm51bGwsInJlc3VsdCI6bnVsbCwicHJpbmNpcGFs
         TmFtZSI6ImZvcmVtYW5fYWRtaW4iLCJ0YXJnZXRUeXBlIjpudWxsLCJ0YXJn
         ZXRJZCI6bnVsbCwib3duZXJJZCI6bnVsbCwiY29ycmVsYXRpb25JZCI6bnVs
         bCwicmVzdWx0RGF0YSI6bnVsbCwiZG9uZSI6ZmFsc2UsInN0YXR1c1BhdGgi
-        OiIvam9icy9yZWdlbl9lbnRpdGxlbWVudF9jZXJ0X29mX2VudjVmNmE1NmU1
-        LTIzYWEtNGQwYy04ZWZmLWUxMzY2MGFkNGU1MSIsImdyb3VwIjoiYXN5bmMg
+        OiIvam9icy9yZWdlbl9lbnRpdGxlbWVudF9jZXJ0X29mX2Vudjg0NmZhNTIw
+        LTcxMGEtNGEwOS04MGRkLWRmZDZhYTJlMDcwNiIsImdyb3VwIjoiYXN5bmMg
         Z3JvdXAifQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:22 GMT
+  recorded_at: Thu, 30 May 2019 10:20:15 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/scenario_test/?details=true
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1393,11 +276,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:22 GMT
+      - Thu, 30 May 2019 10:20:15 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"14d69f94ecd9d90f470acfc6af4f67c8-gzip"'
+      - '"fc357c55b1e506cee901a0185bab98e4-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -1410,59 +293,59 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiU2NlbmFyaW8g
         eXVtIHByb2R1Y3QiLCAiZGVzY3JpcHRpb24iOiBudWxsLCAiZGlzdHJpYnV0
         b3JzIjogW3sicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgImxhc3RfdXBk
-        YXRlZCI6ICIyMDE5LTAzLTE4VDIyOjQzOjIxWiIsICJfaHJlZiI6ICIvcHVs
+        YXRlZCI6ICIyMDE5LTA1LTMwVDEwOjIwOjE1WiIsICJfaHJlZiI6ICIvcHVs
         cC9hcGkvdjIvcmVwb3NpdG9yaWVzL3NjZW5hcmlvX3Rlc3QvZGlzdHJpYnV0
         b3JzL3NjZW5hcmlvX3Rlc3RfY2xvbmUvIiwgImxhc3Rfb3ZlcnJpZGVfY29u
         ZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3Jf
         dHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJs
         aXNoIjogZmFsc2UsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19k
-        aXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVjOTAxZjBhZGIyODRl
-        MWI0ZWRkZGI2MiJ9LCAiY29uZmlnIjogeyJkZXN0aW5hdGlvbl9kaXN0cmli
+        aXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVjZWZhZTVmYjAyZTUz
+        MTFhMjhhMDk0YyJ9LCAiY29uZmlnIjogeyJkZXN0aW5hdGlvbl9kaXN0cmli
         dXRvcl9pZCI6ICJzY2VuYXJpb190ZXN0In0sICJpZCI6ICJzY2VuYXJpb190
         ZXN0X2Nsb25lIn0sIHsicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgImxh
-        c3RfdXBkYXRlZCI6ICIyMDE5LTAzLTE4VDIyOjQzOjIxWiIsICJfaHJlZiI6
+        c3RfdXBkYXRlZCI6ICIyMDE5LTA1LTMwVDEwOjIwOjE1WiIsICJfaHJlZiI6
         ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL3NjZW5hcmlvX3Rlc3QvZGlz
         dHJpYnV0b3JzL3NjZW5hcmlvX3Rlc3QvIiwgImxhc3Rfb3ZlcnJpZGVfY29u
         ZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3Jf
         dHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjog
         dHJ1ZSwgInNjcmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1
-        dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAiNWM5MDFmMDlkYjI4NGUxYjRlZGRk
-        YjYxIn0sICJjb25maWciOiB7InByb3RlY3RlZCI6IHRydWUsICJodHRwIjog
+        dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlNWZiMDJlNTMxMWEyOGEw
+        OTRiIn0sICJjb25maWciOiB7InByb3RlY3RlZCI6IHRydWUsICJodHRwIjog
         ZmFsc2UsICJodHRwcyI6IHRydWUsICJyZWxhdGl2ZV91cmwiOiAic2NlbmFy
         aW9fdGVzdCJ9LCAiaWQiOiAic2NlbmFyaW9fdGVzdCJ9LCB7InJlcG9faWQi
-        OiAic2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wMy0x
-        OFQyMjo0MzoyMloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRv
+        OiAic2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNS0z
+        MFQxMDoyMDoxNVoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRv
         cmllcy9zY2VuYXJpb190ZXN0L2Rpc3RyaWJ1dG9ycy9leHBvcnRfZGlzdHJp
         YnV0b3IvIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1
         Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJleHBvcnRf
         ZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNo
         cGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjog
-        eyIkb2lkIjogIjVjOTAxZjBhZGIyODRlMWI0ZWRkZGI2MyJ9LCAiY29uZmln
+        eyIkb2lkIjogIjVjZWZhZTVmYjAyZTUzMTFhMjhhMDk0ZCJ9LCAiY29uZmln
         IjogeyJodHRwIjogZmFsc2UsICJyZWxhdGl2ZV91cmwiOiAic2NlbmFyaW9f
         dGVzdCIsICJodHRwcyI6IGZhbHNlfSwgImlkIjogImV4cG9ydF9kaXN0cmli
         dXRvciJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3RlcyI6IHsi
         X3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3JlbW92ZWQi
         OiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25zIjogInJl
         cG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAic2NlbmFyaW9fdGVz
-        dCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wMy0xOFQyMjo0MzoyMVoiLCAi
+        dCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNS0zMFQxMDoyMDoxNFoiLCAi
         X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJpb190
         ZXN0L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2lt
         cG9ydGVycyIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIs
         ICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjogbnVs
-        bCwgInNjcmF0Y2hwYWQiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOTAx
-        ZjA5ZGIyODRlMWI0ZWRkZGI2MCJ9LCAiY29uZmlnIjogeyJmZWVkIjogImZp
+        bCwgInNjcmF0Y2hwYWQiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjZWZh
+        ZTVlYjAyZTUzMTFhMjhhMDk0YSJ9LCAiY29uZmlnIjogeyJmZWVkIjogImZp
         bGU6Ly8vdmFyL3d3dy90ZXN0X3JlcG9zL3pvbyIsICJzc2xfdmFsaWRhdGlv
         biI6IHRydWUsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9w
         b2xpY3kiOiAiaW1tZWRpYXRlIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0s
         ICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQiOiAi
-        NWM5MDFmMDlkYjI4NGUxYjRlZGRkYjVmIn0sICJ0b3RhbF9yZXBvc2l0b3J5
+        NWNlZmFlNWViMDJlNTMxMWEyOGEwOTQ5In0sICJ0b3RhbF9yZXBvc2l0b3J5
         X3VuaXRzIjogMCwgImlkIjogInNjZW5hcmlvX3Rlc3QiLCAiX2hyZWYiOiAi
         L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJpb190ZXN0LyJ9
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:22 GMT
+  recorded_at: Thu, 30 May 2019 10:20:15 GMT
 - request:
     method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/scenario_test/actions/publish/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/actions/publish/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1485,9 +368,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:22 GMT
+      - Thu, 30 May 2019 10:20:15 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '172'
       Content-Type:
@@ -1496,14 +379,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2Q4NDgzMGYwLTZmNmQtNDk1ZC05OGUwLTZmNjk2ZTg1ZjcwZi8iLCAi
-        dGFza19pZCI6ICJkODQ4MzBmMC02ZjZkLTQ5NWQtOThlMC02ZjY5NmU4NWY3
-        MGYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2YxN2NiNzFkLTJiY2MtNDI2Yy1iMjI2LWMyNmFjMDBkNDUwYy8iLCAi
+        dGFza19pZCI6ICJmMTdjYjcxZC0yYmNjLTQyNmMtYjIyNi1jMjZhYzAwZDQ1
+        MGMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:22 GMT
+  recorded_at: Thu, 30 May 2019 10:20:15 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d84830f0-6f6d-495d-98e0-6f696e85f70f/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/f17cb71d-2bcc-426c-b226-c26ac00d450c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1522,15 +405,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:22 GMT
+      - Thu, 30 May 2019 10:20:15 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"6053f1e6fd98983c833f130c53f2a97b-gzip"'
+      - '"7ad215d4cb498891c5d738b0670109a1-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '4302'
+      - '677'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1538,105 +421,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9kODQ4MzBmMC02ZjZkLTQ5NWQtOThlMC02ZjY5
-        NmU4NWY3MGYvIiwgInRhc2tfaWQiOiAiZDg0ODMwZjAtNmY2ZC00OTVkLTk4
-        ZTAtNmY2OTZlODVmNzBmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy9mMTdjYjcxZC0yYmNjLTQyNmMtYjIyNi1jMjZh
+        YzAwZDQ1MGMvIiwgInRhc2tfaWQiOiAiZjE3Y2I3MWQtMmJjYy00MjZjLWIy
+        MjYtYzI2YWMwMGQ0NTBjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDMtMThUMjI6NDM6MjJaIiwgInRyYWNlYmFjayI6IG51
+        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6MTVaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjBkODU0OWNlLWI5NWYtNGU4YS1iZGU0LWJjNjMyNWVkZDY0ZCIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
-        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAi
-        c3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI4NTcxMzhmZi1hMDlhLTRhMTMtODJkZi01ZDkwYmQxZGNlMDAiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIzYTIyNDY3ZC1lZjEzLTRhNWMtODgyYi1h
-        MDhiNjRmODFjOWEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBN
-        cyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        Y2ZhZjYyM2UtZDhjZC00N2U2LWExN2YtNTc2OWU5MGJiOTM0IiwgIm51bV9w
-        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
-        biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
-        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImUxODYzNjA5LWI2ZDEtNGY1My04YWFi
-        LTYwYTMzNWU2OTBhMSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
-        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVz
-        IiwgInN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjQ2MDczMmM0LTFkOWQtNGU2ZS1iMjVjLTljNjZlYmRiY2MyYiIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJj
-        b21wcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmMDE0ODIzOC1hZTkyLTQ5OGYt
-        OTY1Zi1jYzM3OTgxNDY0N2UiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0
-        YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI2ZjFjOGVkOC05ZTE3LTRiZTQtOWFlMS02MDJiNDU2ZTMxOWUi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJkNjU4ZjNkMi00MTg0LTQ4Y2ItYjNmNi1kNDJiNjJiMGQyOWYiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiN2NhY2Y5
-        MmMtOGMyNS00OTZmLTg1OTctZGQyNjE1YWE4ZGZhIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJS
-        ZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9v
-        bGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
-        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2IxNWI3ZDctZjkw
-        YS00OTY2LWJhZDAtZDM5OGE5MDkxOTk0IiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
-        aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjc4NzQ0MDUzLWJmMGEtNDM2ZS1hNDg0LTgxMDI2
-        ZmMzN2M3NiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIi
-        LCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3Rv
-        dGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImEwNTAwMDA2LWEwMGYtNDY0MC05ODNlLTM4OTgyYzEyYmI3
-        NiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
-        ZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBf
-        dHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
-        ZXBfaWQiOiAiZWVkMjhlZWEtMjMwZi00OGE3LWEyMmYtYzU5OTI4ZDYwMzgz
-        IiwgIm51bV9wcm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRf
-        cmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20u
-        ZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVz
-        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBs
-        ZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6
-        IHsiJG9pZCI6ICI1YzkwMWYwYWJmMWJhOWVjMDRjYjk0YzQifSwgImlkIjog
-        IjVjOTAxZjBhYmYxYmE5ZWMwNGNiOTRjNCJ9
+        fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVs
+        LmJhbG1vcmEuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmci
+        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
+        ZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjZWZhZTVmYzM4ZWI1
+        YzhmOWZmNTlkMyJ9LCAiaWQiOiAiNWNlZmFlNWZjMzhlYjVjOGY5ZmY1OWQz
+        In0=
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:22 GMT
+  recorded_at: Thu, 30 May 2019 10:20:15 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/d84830f0-6f6d-495d-98e0-6f696e85f70f/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/f17cb71d-2bcc-426c-b226-c26ac00d450c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1655,15 +458,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:22 GMT
+      - Thu, 30 May 2019 10:20:15 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"a8fb323b216f635659904e095af53677-gzip"'
+      - '"a403e659bb349c0763765681685632bc-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '8534'
+      - '4297'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1671,194 +474,724 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9kODQ4MzBmMC02ZjZkLTQ5NWQtOThlMC02ZjY5
-        NmU4NWY3MGYvIiwgInRhc2tfaWQiOiAiZDg0ODMwZjAtNmY2ZC00OTVkLTk4
-        ZTAtNmY2OTZlODVmNzBmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy9mMTdjYjcxZC0yYmNjLTQyNmMtYjIyNi1jMjZh
+        YzAwZDQ1MGMvIiwgInRhc2tfaWQiOiAiZjE3Y2I3MWQtMmJjYy00MjZjLWIy
+        MjYtYzI2YWMwMGQ0NTBjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogIjIwMTktMDMtMThUMjI6NDM6MjJaIiwgIl9ucyI6ICJ0YXNr
-        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTktMDMtMThUMjI6NDM6MjJa
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6MTVaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjA1OTQ2MDcyLThiNjAtNGI5Zi04MjY4LTk1ZDkxYTMwYWRkZiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3
+        NmI0ODg4My0zNDUzLTRjZmItOWVjNS00OTYwMmY5MTc2MDgiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICIxNGRhM2E2OC01NDUzLTRmMjYtODYxZi0yMjI2
+        YmRhZmQyMGYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIs
+        ICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODAy
+        ZTdkNGQtMTEwNS00OWRkLTk4YmMtOGIwMWYyMzFiYmI4IiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogImIzMTQ0MzYwLTRiZGMtNDM2OS1hMTVkLWFj
+        ODc5ZThiODEzOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwg
+        InN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJm
+        ZjM1NmEyLWU4NTMtNGFjOS05NmU4LTIxOTEzMzk2NzJhMyIsICJudW1fcHJv
+        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
+        cyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMmIzMDc3NC1hZjg3LTRjZDAtYjI4
+        ZC02N2NmZDFjMmJjNDQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRh
+        dGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICIyMmVhNDlhYi05NzllLTQ5ODEtYmFlNC02YjU4ZmQ5NDQ2YzciLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUi
+        OiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2
+        MzkzNGMwYi0yM2JlLTRlMWEtYTYyZS04NDM2YjJiZGEwMGYiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJn
+        ZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmM0ZWNjNTct
+        MmVjMC00YTgwLWExYzMtY2MxYTdlYWExMWU4IiwgIm51bV9wcm9jZXNzZWQi
+        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJSZW1v
+        dmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRf
+        cmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
+        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDliMTEyNzAtMGViOC00
+        Y2JiLWEzNDQtZDU4NTkxNjQ0Njc0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
+        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5n
+        IEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjhkOGUwODRlLTRhYmQtNDRlNC04ZGY0LTVjN2UzNWQ2
+        NDM3MSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAi
+        c3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjBlOWYwNWJhLTA5YjUtNGI2Yy1hMDc0LTQ3OGVlN2ZkZTg3NCIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
+        Y3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlw
+        ZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiY2FlOGI4NDEtZGM0NC00NjY1LTllNjAtM2FhZGM4MmMxN2MwIiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNvbS5kcTIi
+        LCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
+        ZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRv
+        aWQiOiAiNWNlZmFlNWZjMzhlYjVjOGY5ZmY1OWQzIn0sICJpZCI6ICI1Y2Vm
+        YWU1ZmMzOGViNWM4ZjlmZjU5ZDMifQ==
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:15 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/f17cb71d-2bcc-426c-b226-c26ac00d450c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:15 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"049c2f0c098d9eee4444225b8a67e853-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4284'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9mMTdjYjcxZC0yYmNjLTQyNmMtYjIyNi1jMjZh
+        YzAwZDQ1MGMvIiwgInRhc2tfaWQiOiAiZjE3Y2I3MWQtMmJjYy00MjZjLWIy
+        MjYtYzI2YWMwMGQ0NTBjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6MTVaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjA1OTQ2MDcyLThiNjAtNGI5Zi04MjY4LTk1ZDkxYTMwYWRkZiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3NmI0
+        ODg4My0zNDUzLTRjZmItOWVjNS00OTYwMmY5MTc2MDgiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIxNGRhM2E2OC01NDUzLTRmMjYtODYxZi0yMjI2YmRhZmQy
+        MGYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4MDJlN2Q0ZC0xMTA1
+        LTQ5ZGQtOThiYy04YjAxZjIzMWJiYjgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiYjMxNDQzNjAtNGJkYy00MzY5LWExNWQtYWM4NzllOGI4MTM5Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiSU5fUFJP
+        R1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYmZmMzU2YTItZTg1My00
+        YWM5LTk2ZTgtMjE5MTMzOTY3MmEzIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
+        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
+        IENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3Rv
+        dGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImIyYjMwNzc0LWFmODctNGNkMC1iMjhkLTY3Y2ZkMWMyYmM0
+        NCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90
+        eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjIyZWE0OWFi
+        LTk3OWUtNDk4MS1iYWU0LTZiNThmZDk0NDZjNyIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xv
+        c2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjYzOTM0YzBiLTIzYmUt
+        NGUxYS1hNjJlLTg0MzZiMmJkYTAwZiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
+        ZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0
+        ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmYzRlY2M1Ny0yZWMwLTRhODAtYTFj
+        My1jYzFhN2VhYTExZTgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBv
+        ZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJkOWIxMTI3MC0wZWI4LTRjYmItYTM0NC1kNTg1
+        OTE2NDQ2NzQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIs
+        ICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        OGQ4ZTA4NGUtNGFiZC00NGU0LThkZjQtNWM3ZTM1ZDY0MzcxIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAi
+        cHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMGU5ZjA1
+        YmEtMDliNS00YjZjLWEwNzQtNDc4ZWU3ZmRlODc0IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJX
+        cml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxp
+        emVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjYWU4Yjg0
+        MS1kYzQ0LTQ2NjUtOWU2MC0zYWFkYzgyYzE3YzAiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmYWU1
+        ZmMzOGViNWM4ZjlmZjU5ZDMifSwgImlkIjogIjVjZWZhZTVmYzM4ZWI1Yzhm
+        OWZmNTlkMyJ9
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:15 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/f17cb71d-2bcc-426c-b226-c26ac00d450c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:15 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"0fe1206875268c758377fcaaaef519c9-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4268'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9mMTdjYjcxZC0yYmNjLTQyNmMtYjIyNi1jMjZh
+        YzAwZDQ1MGMvIiwgInRhc2tfaWQiOiAiZjE3Y2I3MWQtMmJjYy00MjZjLWIy
+        MjYtYzI2YWMwMGQ0NTBjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6MTVaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjA1OTQ2MDcyLThiNjAtNGI5Zi04MjY4LTk1ZDkxYTMwYWRkZiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3NmI0
+        ODg4My0zNDUzLTRjZmItOWVjNS00OTYwMmY5MTc2MDgiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIxNGRhM2E2OC01NDUzLTRmMjYtODYxZi0yMjI2YmRhZmQy
+        MGYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4MDJlN2Q0ZC0xMTA1
+        LTQ5ZGQtOThiYy04YjAxZjIzMWJiYjgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiYjMxNDQzNjAtNGJkYy00MzY5LWExNWQtYWM4NzllOGI4MTM5Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYmZmMzU2YTItZTg1My00YWM5
+        LTk2ZTgtMjE5MTMzOTY3MmEzIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
+        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImIyYjMwNzc0LWFmODctNGNkMC1iMjhkLTY3Y2ZkMWMyYmM0NCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
+        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjIyZWE0OWFiLTk3OWUtNDk4
+        MS1iYWU0LTZiNThmZDk0NDZjNyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
+        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjYzOTM0YzBiLTIzYmUtNGUxYS1hNjJlLTg0
+        MzZiMmJkYTAwZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogImZjNGVjYzU3LTJlYzAtNGE4MC1hMWMzLWNjMWE3ZWFhMTFlOCIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        ImQ5YjExMjcwLTBlYjgtNGNiYi1hMzQ0LWQ1ODU5MTY0NDY3NCIsICJudW1f
+        cHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJy
+        ZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RB
+        UlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4ZDhlMDg0ZS00YWJkLTQ0
+        ZTQtOGRmNC01YzdlMzVkNjQzNzEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
+        ZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9y
+        eSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwZTlmMDViYS0wOWI1LTRiNmMtYTA3
+        NC00NzhlZTdmZGU4NzQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3Mg
+        RmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImNhZThiODQxLWRjNDQtNDY2NS05ZTYw
+        LTNhYWRjODJjMTdjMCIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVl
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2Vy
+        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFs
+        bW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjZWZhZTVmYzM4ZWI1YzhmOWZmNTlk
+        MyJ9LCAiaWQiOiAiNWNlZmFlNWZjMzhlYjVjOGY5ZmY1OWQzIn0=
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:15 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/f17cb71d-2bcc-426c-b226-c26ac00d450c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:15 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"c074b21b3a801ee4474c85db4a9f02f9-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4255'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9mMTdjYjcxZC0yYmNjLTQyNmMtYjIyNi1jMjZh
+        YzAwZDQ1MGMvIiwgInRhc2tfaWQiOiAiZjE3Y2I3MWQtMmJjYy00MjZjLWIy
+        MjYtYzI2YWMwMGQ0NTBjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6MTVaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjA1OTQ2MDcyLThiNjAtNGI5Zi04MjY4LTk1ZDkxYTMwYWRkZiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3NmI0
+        ODg4My0zNDUzLTRjZmItOWVjNS00OTYwMmY5MTc2MDgiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIxNGRhM2E2OC01NDUzLTRmMjYtODYxZi0yMjI2YmRhZmQy
+        MGYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4MDJlN2Q0ZC0xMTA1
+        LTQ5ZGQtOThiYy04YjAxZjIzMWJiYjgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiYjMxNDQzNjAtNGJkYy00MzY5LWExNWQtYWM4NzllOGI4MTM5Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYmZmMzU2YTItZTg1My00YWM5
+        LTk2ZTgtMjE5MTMzOTY3MmEzIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
+        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImIyYjMwNzc0LWFmODctNGNkMC1iMjhkLTY3Y2ZkMWMyYmM0NCIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
+        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjIyZWE0OWFiLTk3OWUtNDk4
+        MS1iYWU0LTZiNThmZDk0NDZjNyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
+        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjYzOTM0YzBiLTIzYmUtNGUxYS1hNjJlLTg0
+        MzZiMmJkYTAwZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogImZjNGVjYzU3LTJlYzAtNGE4MC1hMWMzLWNjMWE3ZWFhMTFlOCIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ5
+        YjExMjcwLTBlYjgtNGNiYi1hMzQ0LWQ1ODU5MTY0NDY3NCIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBv
+        dmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjhkOGUwODRlLTRhYmQtNDRlNC04ZGY0
+        LTVjN2UzNWQ2NDM3MSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0
+        byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjBlOWYwNWJhLTA5YjUtNGI2Yy1hMDc0LTQ3OGVlN2Zk
+        ZTg3NCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0
+        ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiY2FlOGI4NDEtZGM0NC00NjY1LTllNjAtM2FhZGM4MmMxN2Mw
+        IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAicXVldWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNvbS5k
+        cTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNWNlZmFlNWZjMzhlYjVjOGY5ZmY1OWQzIn0sICJpZCI6ICI1
+        Y2VmYWU1ZmMzOGViNWM4ZjlmZjU5ZDMifQ==
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:15 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/f17cb71d-2bcc-426c-b226-c26ac00d450c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:15 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"7e75f200c696b40286f172e996ebfdb4-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '8535'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9mMTdjYjcxZC0yYmNjLTQyNmMtYjIyNi1jMjZh
+        YzAwZDQ1MGMvIiwgInRhc2tfaWQiOiAiZjE3Y2I3MWQtMmJjYy00MjZjLWIy
+        MjYtYzI2YWMwMGQ0NTBjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6MTVaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6MTVa
         IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
         cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
         Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
         ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
         YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjBkODU0OWNlLWI5NWYtNGU4YS1iZGU0
-        LWJjNjMyNWVkZDY0ZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjA1OTQ2MDcyLThiNjAtNGI5Zi04MjY4
+        LTk1ZDkxYTMwYWRkZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
         Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
         dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
         dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI4NTcxMzhmZi1hMDlhLTRhMTMtODJkZi01ZDkwYmQx
-        ZGNlMDAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICI3NmI0ODg4My0zNDUzLTRjZmItOWVjNS00OTYwMmY5
+        MTc2MDgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
         MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
         cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
         U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzYTIyNDY3ZC1lZjEzLTRh
-        NWMtODgyYi1hMDhiNjRmODFjOWEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNGRhM2E2OC01NDUzLTRm
+        MjYtODYxZi0yMjI2YmRhZmQyMGYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
         Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
         RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICJjZmFmNjIzZS1kOGNkLTQ3ZTYtYTE3Zi01NzY5ZTkwYmI5MzQiLCAi
+        ZCI6ICI4MDJlN2Q0ZC0xMTA1LTQ5ZGQtOThiYy04YjAxZjIzMWJiYjgiLCAi
         bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
         aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
         cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
         LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTE4NjM2MDktYjZkMS00ZjUzLThh
-        YWItNjBhMzM1ZTY5MGExIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjMxNDQzNjAtNGJkYy00MzY5LWEx
+        NWQtYWM4NzllOGI4MTM5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
         c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVs
-        ZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAx
-        LCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0
-        NjA3MzJjNC0xZDlkLTRlNmUtYjI1Yy05YzY2ZWJkYmNjMmIiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
-        cHMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZjAxNDgyMzgtYWU5Mi00OThmLTk2NWYt
-        Y2MzNzk4MTQ2NDdlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRh
-        LiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAw
+        ZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAw
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        NmYxYzhlZDgtOWUxNy00YmU0LTlhZTEtNjAyYjQ1NmUzMTllIiwgIm51bV9w
-        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
-        biI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNs
-        b3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDY1OGYzZDIt
-        NDE4NC00OGNiLWIzZjYtZDQyYjYyYjBkMjlmIiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5l
-        cmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUg
-        c3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiN2NhY2Y5MmMtOGMyNS00OTZmLTg1
-        OTctZGQyNjE1YWE4ZGZhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVw
-        b2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAi
-        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiY2IxNWI3ZDctZjkwYS00OTY2LWJhZDAtZDM5OGE5
-        MDkxOTk0IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAi
-        c3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzg3NDQw
-        NTMtYmYwYS00MzZlLWE0ODQtODEwMjZmYzM3Yzc2IiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
-        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklO
-        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTA1MDAwMDYtYTAwZi00
-        NjQwLTk4M2UtMzg5ODJjMTJiYjc2IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwg
-        eyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
-        c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlZWQyOGVlYS0yMzBmLTQ4YTct
-        YTIyZi1jNTk5MjhkNjAzODMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9XX0sICJx
-        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0
-        ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAi
-        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhl
-        dGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQi
-        OiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJz
-        Y2VuYXJpb190ZXN0IiwgInN0YXJ0ZWQiOiAiMjAxOS0wMy0xOFQyMjo0Mzoy
-        MloiLCAiX25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRl
-        ZCI6ICIyMDE5LTAzLTE4VDIyOjQzOjIyWiIsICJ0cmFjZWJhY2siOiBudWxs
-        LCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAi
-        c3VtbWFyeSI6IHsiZ2VuZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQiLCAicnBt
-        cyI6ICJGSU5JU0hFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAi
-        RklOSVNIRUQiLCAicmVtb3ZlX29sZF9yZXBvZGF0YSI6ICJGSU5JU0hFRCIs
-        ICJtb2R1bGVzIjogIlNLSVBQRUQiLCAiY2xvc2VfcmVwb19tZXRhZGF0YSI6
+        YmZmMzU2YTItZTg1My00YWM5LTk2ZTgtMjE5MTMzOTY3MmEzIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNv
+        bXBzIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImIyYjMwNzc0LWFmODctNGNkMC1iMjhk
+        LTY3Y2ZkMWMyYmM0NCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0
+        YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjIyZWE0OWFiLTk3OWUtNDk4MS1iYWU0LTZiNThmZDk0NDZjNyIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRp
+        b24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJj
+        bG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjYzOTM0YzBi
+        LTIzYmUtNGUxYS1hNjJlLTg0MzZiMmJkYTAwZiIsICJudW1fcHJvY2Vzc2Vk
+        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
+        ZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRl
+        IHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZjNGVjYzU3LTJlYzAtNGE4MC1h
+        MWMzLWNjMWE3ZWFhMTFlOCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJl
+        cG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImQ5YjExMjcwLTBlYjgtNGNiYi1hMzQ0LWQ1ODU5
+        MTY0NDY3NCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwg
+        InN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjhkOGUw
+        ODRlLTRhYmQtNDRlNC04ZGY0LTVjN2UzNWQ2NDM3MSIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        UHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxp
+        c2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBlOWYwNWJhLTA5YjUt
+        NGI2Yy1hMDc0LTQ3OGVlN2ZkZTg3NCIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBM
+        aXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9f
+        bWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2FlOGI4NDEtZGM0NC00NjY1
+        LTllNjAtM2FhZGM4MmMxN2MwIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFs
+        bW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAi
+        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2
+        ZWwuYmFsbW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6
+        ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNj
+        ZW5hcmlvX3Rlc3QiLCAic3RhcnRlZCI6ICIyMDE5LTA1LTMwVDEwOjIwOjE1
+        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTktMDUtMzBUMTA6MjA6MTVaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
+        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJycG1z
+        IjogIkZJTklTSEVEIiwgImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSI6ICJG
+        SU5JU0hFRCIsICJyZW1vdmVfb2xkX3JlcG9kYXRhIjogIkZJTklTSEVEIiwg
+        Im1vZHVsZXMiOiAiRklOSVNIRUQiLCAiY2xvc2VfcmVwb19tZXRhZGF0YSI6
         ICJGSU5JU0hFRCIsICJkcnBtcyI6ICJTS0lQUEVEIiwgImNvbXBzIjogIkZJ
         TklTSEVEIiwgImRpc3RyaWJ1dGlvbiI6ICJGSU5JU0hFRCIsICJyZXBvdmll
         dyI6ICJTS0lQUEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVE
         IiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hF
         RCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6
-        ICJzY2VuYXJpb190ZXN0IiwgImlkIjogIjVjOTAxZjBhZGIyODRlMGI0MzM1
-        ZTBiYiIsICJkZXRhaWxzIjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        ICJzY2VuYXJpb190ZXN0IiwgImlkIjogIjVjZWZhZTVmYjAyZTUzMzQzNGNm
+        OGI0ZSIsICJkZXRhaWxzIjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
         cHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90
         eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3Rh
         bCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICIwZDg1NDljZS1iOTVmLTRlOGEtYmRlNC1iYzYzMjVlZGQ2NGQiLCAi
+        ZCI6ICIwNTk0NjA3Mi04YjYwLTRiOWYtODI2OC05NWQ5MWEzMGFkZGYiLCAi
         bnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
         aXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0
         ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAwLCAi
         c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODU3
-        MTM4ZmYtYTA5YS00YTEzLTgyZGYtNWQ5MGJkMWRjZTAwIiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzZi
+        NDg4ODMtMzQ1My00Y2ZiLTllYzUtNDk2MDJmOTE3NjA4IiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRl
         bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
         YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiM2EyMjQ2N2QtZWYxMy00YTVjLTg4MmItYTA4YjY0Zjgx
-        YzlhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        InN0ZXBfaWQiOiAiMTRkYTNhNjgtNTQ1My00ZjI2LTg2MWYtMjIyNmJkYWZk
+        MjBmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
         ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3Rl
         cF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
         IlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2ZhZjYyM2UtZDhj
-        ZC00N2U2LWExN2YtNTc2OWU5MGJiOTM0IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODAyZTdkNGQtMTEw
+        NS00OWRkLTk4YmMtOGIwMWYyMzFiYmI4IiwgIm51bV9wcm9jZXNzZWQiOiAw
         fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
         aW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3Rv
         dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
         OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogImUxODYzNjA5LWI2ZDEtNGY1My04YWFiLTYwYTMzNWU2OTBhMSIs
+        X2lkIjogImIzMTQ0MzYwLTRiZGMtNDM2OS1hMTVkLWFjODc5ZThiODEzOSIs
         ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
         Y3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6
-        ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQ
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDYwNzMyYzQtMWQ5ZC00ZTZl
-        LWIyNWMtOWM2NmViZGJjYzJiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
-        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
-        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
-        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImYwMTQ4MjM4LWFlOTItNDk4Zi05NjVmLWNjMzc5ODE0NjQ3ZSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
-        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjZmMWM4ZWQ4LTllMTctNGJl
-        NC05YWUxLTYwMmI0NTZlMzE5ZSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
-        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
-        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogImQ2NThmM2QyLTQxODQtNDhjYi1iM2Y2LWQ0
-        MmI2MmIwZDI5ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
-        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
-        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjdjYWNmOTJjLThjMjUtNDk2Zi04NTk3LWRkMjYxNWFhOGRmYSIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
-        Y3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlw
-        ZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNi
-        MTViN2Q3LWY5MGEtNDk2Ni1iYWQwLWQzOThhOTA5MTk5NCIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBv
-        dmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjc4NzQ0MDUzLWJmMGEtNDM2ZS1hNDg0
-        LTgxMDI2ZmMzN2M3NiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
-        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0
-        byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImEwNTAwMDA2LWEwMGYtNDY0MC05ODNlLTM4OTgyYzEy
-        YmI3NiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAx
-        LCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0
-        ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
-        ZXBfaWQiOiAiZWVkMjhlZWEtMjMwZi00OGE3LWEyMmYtYzU5OTI4ZDYwMzgz
-        IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjVjOTAxZjBhYmYxYmE5ZWMwNGNiOTRjNCJ9LCAiaWQi
-        OiAiNWM5MDFmMGFiZjFiYTllYzA0Y2I5NGM0In0=
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJmZjM1NmEyLWU4NTMtNGFj
+        OS05NmU4LTIxOTEzMzk2NzJhMyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBD
+        b21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJiMmIzMDc3NC1hZjg3LTRjZDAtYjI4ZC02N2NmZDFjMmJjNDQiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6
+        ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyMmVhNDlhYi05NzllLTQ5
+        ODEtYmFlNC02YjU4ZmQ5NDQ2YzciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVw
+        byBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0
+        YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI2MzkzNGMwYi0yM2JlLTRlMWEtYTYyZS04
+        NDM2YjJiZGEwMGYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJmYzRlY2M1Ny0yZWMwLTRhODAtYTFjMy1jYzFhN2VhYTExZTgi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5
+        cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJk
+        OWIxMTI3MC0wZWI4LTRjYmItYTM0NC1kNTg1OTE2NDQ2NzQiLCAibnVtX3By
+        b2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVw
+        b3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4ZDhlMDg0ZS00YWJkLTQ0ZTQtOGRm
+        NC01YzdlMzVkNjQzNzEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
+        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMg
+        dG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIwZTlmMDViYS0wOWI1LTRiNmMtYTA3NC00NzhlZTdm
+        ZGU4NzQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJz
+        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImNhZThiODQxLWRjNDQtNDY2NS05ZTYwLTNhYWRjODJjMTdj
+        MCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1Y2VmYWU1ZmMzOGViNWM4ZjlmZjU5ZDMifSwgImlk
+        IjogIjVjZWZhZTVmYzM4ZWI1YzhmOWZmNTlkMyJ9
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:22 GMT
+  recorded_at: Thu, 30 May 2019 10:20:15 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/repo_sync.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/repo_sync.yml
@@ -1,2810 +1,8 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/07af1450-931f-4ad7-b508-be1646617590/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:36 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"fe6197c35b124779c8b1f9c163f9b644-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '544'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wN2FmMTQ1MC05MzFmLTRhZDctYjUwOC1iZTE2NDY2MTc1
-        OTAvIiwgInRhc2tfaWQiOiAiMDdhZjE0NTAtOTMxZi00YWQ3LWI1MDgtYmUx
-        NjQ2NjE3NTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogbnVs
-        bCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
-        cm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIiIsICJzdGF0ZSI6ICJ3
-        YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51bGws
-        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM1ODg1ODA3YTc2
-        ODIwYzU5MjA1ZGVhIn0sICJpZCI6ICI1YzU4ODU4MDdhNzY4MjBjNTkyMDVk
-        ZWEifQ==
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:36 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/07af1450-931f-4ad7-b508-be1646617590/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:36 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"8c8365d8cf40df0296210d0cb5a47f9c-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1191'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wN2FmMTQ1MC05MzFmLTRhZDctYjUwOC1iZTE2NDY2MTc1
-        OTAvIiwgInRhc2tfaWQiOiAiMDdhZjE0NTAtOTMxZi00YWQ3LWI1MDgtYmUx
-        NjQ2NjE3NTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDItMDRUMTg6MzM6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
-        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
-        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
-        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
-        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
-        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiSU5fUFJPR1JF
-        U1MifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
-        Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRl
-        IjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
-        Y2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1YzU4ODU4MDdhNzY4MjBjNTkyMDVkZWEifSwgImlkIjogIjVjNTg4
-        NTgwN2E3NjgyMGM1OTIwNWRlYSJ9
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:36 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/07af1450-931f-4ad7-b508-be1646617590/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:36 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"3870a14957f3377683531e626a224f06-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1188'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wN2FmMTQ1MC05MzFmLTRhZDctYjUwOC1iZTE2NDY2MTc1
-        OTAvIiwgInRhc2tfaWQiOiAiMDdhZjE0NTAtOTMxZi00YWQ3LWI1MDgtYmUx
-        NjQ2NjE3NTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDItMDRUMTg6MzM6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
-        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
-        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
-        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
-        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
-        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
-        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
-        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
-        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAi
-        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
-        ICI1YzU4ODU4MDdhNzY4MjBjNTkyMDVkZWEifSwgImlkIjogIjVjNTg4NTgw
-        N2E3NjgyMGM1OTIwNWRlYSJ9
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:36 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/07af1450-931f-4ad7-b508-be1646617590/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:36 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"3870a14957f3377683531e626a224f06-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1188'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wN2FmMTQ1MC05MzFmLTRhZDctYjUwOC1iZTE2NDY2MTc1
-        OTAvIiwgInRhc2tfaWQiOiAiMDdhZjE0NTAtOTMxZi00YWQ3LWI1MDgtYmUx
-        NjQ2NjE3NTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDItMDRUMTg6MzM6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
-        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
-        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
-        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
-        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
-        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
-        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
-        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
-        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAi
-        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
-        ICI1YzU4ODU4MDdhNzY4MjBjNTkyMDVkZWEifSwgImlkIjogIjVjNTg4NTgw
-        N2E3NjgyMGM1OTIwNWRlYSJ9
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:36 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/07af1450-931f-4ad7-b508-be1646617590/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:36 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"3870a14957f3377683531e626a224f06-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1188'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wN2FmMTQ1MC05MzFmLTRhZDctYjUwOC1iZTE2NDY2MTc1
-        OTAvIiwgInRhc2tfaWQiOiAiMDdhZjE0NTAtOTMxZi00YWQ3LWI1MDgtYmUx
-        NjQ2NjE3NTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDItMDRUMTg6MzM6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
-        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
-        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
-        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
-        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
-        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
-        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
-        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
-        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAi
-        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
-        ICI1YzU4ODU4MDdhNzY4MjBjNTkyMDVkZWEifSwgImlkIjogIjVjNTg4NTgw
-        N2E3NjgyMGM1OTIwNWRlYSJ9
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:36 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/07af1450-931f-4ad7-b508-be1646617590/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:36 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"3870a14957f3377683531e626a224f06-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1188'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wN2FmMTQ1MC05MzFmLTRhZDctYjUwOC1iZTE2NDY2MTc1
-        OTAvIiwgInRhc2tfaWQiOiAiMDdhZjE0NTAtOTMxZi00YWQ3LWI1MDgtYmUx
-        NjQ2NjE3NTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDItMDRUMTg6MzM6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
-        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
-        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
-        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
-        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
-        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
-        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
-        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
-        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAi
-        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
-        ICI1YzU4ODU4MDdhNzY4MjBjNTkyMDVkZWEifSwgImlkIjogIjVjNTg4NTgw
-        N2E3NjgyMGM1OTIwNWRlYSJ9
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:36 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/07af1450-931f-4ad7-b508-be1646617590/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:36 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"a16500955530426f20c983e2ab0b9eb7-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1185'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wN2FmMTQ1MC05MzFmLTRhZDctYjUwOC1iZTE2NDY2MTc1
-        OTAvIiwgInRhc2tfaWQiOiAiMDdhZjE0NTAtOTMxZi00YWQ3LWI1MDgtYmUx
-        NjQ2NjE3NTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDItMDRUMTg6MzM6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
-        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
-        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
-        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
-        OiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
-        dGFsIjogMCwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRl
-        IjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5PVF9T
-        VEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
-        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9z
-        Ny1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1
-        bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        YzU4ODU4MDdhNzY4MjBjNTkyMDVkZWEifSwgImlkIjogIjVjNTg4NTgwN2E3
-        NjgyMGM1OTIwNWRlYSJ9
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:36 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/07af1450-931f-4ad7-b508-be1646617590/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"ae123dcdea28f2ee7ba8e47ab402d1fc-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1185'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wN2FmMTQ1MC05MzFmLTRhZDctYjUwOC1iZTE2NDY2MTc1
-        OTAvIiwgInRhc2tfaWQiOiAiMDdhZjE0NTAtOTMxZi00YWQ3LWI1MDgtYmUx
-        NjQ2NjE3NTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDItMDRUMTg6MzM6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
-        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
-        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
-        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
-        OiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
-        dGFsIjogMywgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAxfSwgIm1vZHVsZXMiOiB7InN0YXRl
-        IjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5PVF9T
-        VEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
-        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9z
-        Ny1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1
-        bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        YzU4ODU4MDdhNzY4MjBjNTkyMDVkZWEifSwgImlkIjogIjVjNTg4NTgwN2E3
-        NjgyMGM1OTIwNWRlYSJ9
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:37 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/07af1450-931f-4ad7-b508-be1646617590/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"e4421d2ed6cdfd63fc0a713b76d40919-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1179'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wN2FmMTQ1MC05MzFmLTRhZDctYjUwOC1iZTE2NDY2MTc1
-        OTAvIiwgInRhc2tfaWQiOiAiMDdhZjE0NTAtOTMxZi00YWQ3LWI1MDgtYmUx
-        NjQ2NjE3NTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDItMDRUMTg6MzM6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
-        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
-        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
-        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
-        OiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
-        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIklOX1BST0dSRVNT
-        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVl
-        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZl
-        bDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmci
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
-        Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzU4ODU4
-        MDdhNzY4MjBjNTkyMDVkZWEifSwgImlkIjogIjVjNTg4NTgwN2E3NjgyMGM1
-        OTIwNWRlYSJ9
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:37 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/07af1450-931f-4ad7-b508-be1646617590/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"e4421d2ed6cdfd63fc0a713b76d40919-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1179'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wN2FmMTQ1MC05MzFmLTRhZDctYjUwOC1iZTE2NDY2MTc1
-        OTAvIiwgInRhc2tfaWQiOiAiMDdhZjE0NTAtOTMxZi00YWQ3LWI1MDgtYmUx
-        NjQ2NjE3NTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDItMDRUMTg6MzM6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
-        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
-        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
-        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
-        OiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
-        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIklOX1BST0dSRVNT
-        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVl
-        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZl
-        bDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmci
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
-        Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzU4ODU4
-        MDdhNzY4MjBjNTkyMDVkZWEifSwgImlkIjogIjVjNTg4NTgwN2E3NjgyMGM1
-        OTIwNWRlYSJ9
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:37 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/07af1450-931f-4ad7-b508-be1646617590/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"4d55e0596db98909517c67f7f6ffcdf9-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1176'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wN2FmMTQ1MC05MzFmLTRhZDctYjUwOC1iZTE2NDY2MTc1
-        OTAvIiwgInRhc2tfaWQiOiAiMDdhZjE0NTAtOTMxZi00YWQ3LWI1MDgtYmUx
-        NjQ2NjE3NTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDItMDRUMTg6MzM6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
-        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
-        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
-        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
-        OiAiSU5fUFJPR1JFU1MifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
-        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
-        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUi
-        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIu
-        c2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAi
-        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
-        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVs
-        bCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzU4ODU4MDdh
-        NzY4MjBjNTkyMDVkZWEifSwgImlkIjogIjVjNTg4NTgwN2E3NjgyMGM1OTIw
-        NWRlYSJ9
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:37 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/07af1450-931f-4ad7-b508-be1646617590/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"a2440ea4b9b131e1fe70435c0c530017-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1170'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wN2FmMTQ1MC05MzFmLTRhZDctYjUwOC1iZTE2NDY2MTc1
-        OTAvIiwgInRhc2tfaWQiOiAiMDdhZjE0NTAtOTMxZi00YWQ3LWI1MDgtYmUx
-        NjQ2NjE3NTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDItMDRUMTg6MzM6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
-        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
-        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
-        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
-        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        Iml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
-        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAicmVz
-        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2Vy
-        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
-        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
-        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzU4ODU4MDdhNzY4MjBj
-        NTkyMDVkZWEifSwgImlkIjogIjVjNTg4NTgwN2E3NjgyMGM1OTIwNWRlYSJ9
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:37 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/07af1450-931f-4ad7-b508-be1646617590/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"a2440ea4b9b131e1fe70435c0c530017-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1170'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wN2FmMTQ1MC05MzFmLTRhZDctYjUwOC1iZTE2NDY2MTc1
-        OTAvIiwgInRhc2tfaWQiOiAiMDdhZjE0NTAtOTMxZi00YWQ3LWI1MDgtYmUx
-        NjQ2NjE3NTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDItMDRUMTg6MzM6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
-        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
-        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
-        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
-        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        Iml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
-        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAicmVz
-        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2Vy
-        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
-        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
-        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzU4ODU4MDdhNzY4MjBj
-        NTkyMDVkZWEifSwgImlkIjogIjVjNTg4NTgwN2E3NjgyMGM1OTIwNWRlYSJ9
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:37 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/07af1450-931f-4ad7-b508-be1646617590/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"a2440ea4b9b131e1fe70435c0c530017-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1170'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wN2FmMTQ1MC05MzFmLTRhZDctYjUwOC1iZTE2NDY2MTc1
-        OTAvIiwgInRhc2tfaWQiOiAiMDdhZjE0NTAtOTMxZi00YWQ3LWI1MDgtYmUx
-        NjQ2NjE3NTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDItMDRUMTg6MzM6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
-        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
-        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
-        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
-        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
-        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        Iml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
-        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAicmVz
-        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2Vy
-        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
-        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
-        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzU4ODU4MDdhNzY4MjBj
-        NTkyMDVkZWEifSwgImlkIjogIjVjNTg4NTgwN2E3NjgyMGM1OTIwNWRlYSJ9
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:37 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/07af1450-931f-4ad7-b508-be1646617590/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"5f878fb967cb44d32466f1445045abe8-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2423'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wN2FmMTQ1MC05MzFmLTRhZDctYjUwOC1iZTE2NDY2MTc1
-        OTAvIiwgInRhc2tfaWQiOiAiMDdhZjE0NTAtOTMxZi00YWQ3LWI1MDgtYmUx
-        NjQ2NjE3NTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTktMDItMDRUMTg6MzM6MzdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTktMDItMDRUMTg6MzM6MzZaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzLzQzZTE4ZTNiLTljZDktNDRlZC1iODdiLTk4ZDUw
-        ZDE0Y2ZjNS8iLCAidGFza19pZCI6ICI0M2UxOGUzYi05Y2Q5LTQ0ZWQtYjg3
-        Yi05OGQ1MGQxNGNmYzUifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
-        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
-        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
-        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
-        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
-        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
-        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wMi0w
-        NFQxODozMzozNloiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDE5LTAyLTA0VDE4OjMzOjM3WiIsICJpbXBvcnRlcl90
-        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
-        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
-        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
-        b3VudCI6IDAsICJpZCI6ICI1YzU4ODU4MTA1ZjVlZTA2MDRjYjEwYTciLCAi
-        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
-        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
-        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
-        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
-        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjNTg4NTgwN2E3NjgyMGM1OTIwNWRl
-        YSJ9LCAiaWQiOiAiNWM1ODg1ODA3YTc2ODIwYzU5MjA1ZGVhIn0=
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:37 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/43e18e3b-9cd9-44ed-b87b-98d50d14cfc5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"3431ded4ac8f59b950c2de63500825e6-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4559'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80M2UxOGUzYi05Y2Q5LTQ0ZWQtYjg3Yi05OGQ1
-        MGQxNGNmYzUvIiwgInRhc2tfaWQiOiAiNDNlMThlM2ItOWNkOS00NGVkLWI4
-        N2ItOThkNTBkMTRjZmM1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDItMDRUMTg6MzM6MzdaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
-        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZDYwMTkxNy03MGE2LTRhNjMtYjUx
-        Ny1lOGZiYThlZTIwMjEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBv
-        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMWY2MzQ5NzMtMTQ3NC00NTNh
-        LWI0YTktNmIxNDU5N2M2ODhhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
-        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERp
-        c3RyaWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9u
-        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjIyZTk2MWVkLWJkOWItNGFkNy04YmIz
-        LWFlZWQ2OTE1NTNlNiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
-        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwg
-        InN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI2ZTdl
-        ZWMzLTE1YjgtNDIxNy05YTE0LTE0MjkzZDQ4M2RlOCIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
-        UHVibGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJiZmY4NWU4NC04YTlkLTQ2NTQtYjE1OC05
-        MWQyZTMxODg5YjkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwg
-        InN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzE4
-        YjU4OTQtMDBiZS00NDM1LWFjYjYtYzUzZWQ2NmQwYWEwIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMmM3OTIwYTEtZDk3NS00NWI5LWFkMzUt
-        ZjM5MmE0OWRkNjhmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZp
-        bGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImFiN2M0YWNjLWE5MTUtNGY2MS1iZjNjLTI5MWQxZmRjMDM0ZSIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFS
-        VEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZkZjYzODYzLTQ4MzItNDBi
-        Ni1hNDE0LWRjOWQ5YmYyY2RmZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
-        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
-        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjgyMDgyN2Q0LWYzOWItNDU1ZS1hMjk4
-        LTIzODY4Mjg4YzQ1ZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
-        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUg
-        ZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVt
-        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI4NzZjYjU4Yi0xMzg2LTQ0YWYtOTY1Zi04ODY2OGZj
-        NGQxZWMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJz
-        dGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIxNWJmMDQ4NC04YjYxLTQwNTMtYjAyNS04NWEyOTBkMGM4NjAi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5
-        cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTJmMmJhYjct
-        ZTEwNS00OTk1LWJmZWEtZmIyMzAzNDJmZGU2IiwgIm51bV9wcm9jZXNzZWQi
-        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
-        aXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9k
-        aXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
-        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTljNGU3NDAtZjg1Mi00
-        MmQ4LTlkMjQtYjVhYTkzYjAzMGViIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
-        c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RB
-        UlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjZWZhMTA4Yy1jYzhiLTQ5
-        MDktYmU5Ny1mMDVkYWEwMzcyYzEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0s
-        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3
-        LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVu
-        bmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVj
-        NTg4NTgxN2E3NjgyMGM1OTIwNWY4ZiJ9LCAiaWQiOiAiNWM1ODg1ODE3YTc2
-        ODIwYzU5MjA1ZjhmIn0=
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:37 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/07af1450-931f-4ad7-b508-be1646617590/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"5f878fb967cb44d32466f1445045abe8-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2423'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wN2FmMTQ1MC05MzFmLTRhZDctYjUwOC1iZTE2NDY2MTc1
-        OTAvIiwgInRhc2tfaWQiOiAiMDdhZjE0NTAtOTMxZi00YWQ3LWI1MDgtYmUx
-        NjQ2NjE3NTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTktMDItMDRUMTg6MzM6MzdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTktMDItMDRUMTg6MzM6MzZaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzLzQzZTE4ZTNiLTljZDktNDRlZC1iODdiLTk4ZDUw
-        ZDE0Y2ZjNS8iLCAidGFza19pZCI6ICI0M2UxOGUzYi05Y2Q5LTQ0ZWQtYjg3
-        Yi05OGQ1MGQxNGNmYzUifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
-        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
-        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
-        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
-        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
-        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
-        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wMi0w
-        NFQxODozMzozNloiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDE5LTAyLTA0VDE4OjMzOjM3WiIsICJpbXBvcnRlcl90
-        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
-        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
-        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
-        b3VudCI6IDAsICJpZCI6ICI1YzU4ODU4MTA1ZjVlZTA2MDRjYjEwYTciLCAi
-        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
-        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
-        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
-        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
-        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjNTg4NTgwN2E3NjgyMGM1OTIwNWRl
-        YSJ9LCAiaWQiOiAiNWM1ODg1ODA3YTc2ODIwYzU5MjA1ZGVhIn0=
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:37 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/43e18e3b-9cd9-44ed-b87b-98d50d14cfc5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"e6e02854ff94646654ec09000bcbc558-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4550'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80M2UxOGUzYi05Y2Q5LTQ0ZWQtYjg3Yi05OGQ1
-        MGQxNGNmYzUvIiwgInRhc2tfaWQiOiAiNDNlMThlM2ItOWNkOS00NGVkLWI4
-        N2ItOThkNTBkMTRjZmM1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDItMDRUMTg6MzM6MzdaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
-        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJhZDYwMTkxNy03MGE2LTRhNjMtYjUxNy1l
-        OGZiYThlZTIwMjEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
-        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMWY2MzQ5NzMtMTQ3NC00NTNhLWI0YTkt
-        NmIxNDU5N2M2ODhhIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
-        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjIyZTk2MWVkLWJkOWItNGFkNy04YmIzLWFlZWQ2OTE1
-        NTNlNiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAy
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
-        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIklOX1BS
-        T0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI2ZTdlZWMzLTE1Yjgt
-        NDIxNy05YTE0LTE0MjkzZDQ4M2RlOCIsICJudW1fcHJvY2Vzc2VkIjogMn0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJiZmY4NWU4NC04YTlkLTQ2NTQtYjE1OC05MWQyZTMxODg5
-        YjkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlw
-        ZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
-        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzE4YjU4OTQtMDBi
-        ZS00NDM1LWFjYjYtYzUzZWQ2NmQwYWEwIiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiMmM3OTIwYTEtZDk3NS00NWI5LWFkMzUtZjM5MmE0OWRk
-        NjhmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFiN2M0YWNj
-        LWE5MTUtNGY2MS1iZjNjLTI5MWQxZmRjMDM0ZSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogImZkZjYzODYzLTQ4MzItNDBiNi1hNDE0LWRj
-        OWQ5YmYyY2RmZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
-        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
-        IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjgyMDgyN2Q0LWYzOWItNDU1ZS1hMjk4LTIzODY4Mjg4
-        YzQ1ZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
-        LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAi
-        c3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI4NzZjYjU4Yi0xMzg2LTQ0YWYtOTY1Zi04ODY2OGZjNGQxZWMiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUi
-        OiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIx
-        NWJmMDQ4NC04YjYxLTQwNTMtYjAyNS04NWEyOTBkMGM4NjAiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVw
-        b3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTJmMmJhYjctZTEwNS00OTk1
-        LWJmZWEtZmIyMzAzNDJmZGU2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
-        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZp
-        bGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rvcnki
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZTljNGU3NDAtZjg1Mi00MmQ4LTlkMjQt
-        YjVhYTkzYjAzMGViIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZp
-        bGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJjZWZhMTA4Yy1jYzhiLTQ5MDktYmU5Ny1m
-        MDVkYWEwMzcyYzEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRldmVsMi5z
-        YW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50
-        b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjNTg4NTgxN2E3
-        NjgyMGM1OTIwNWY4ZiJ9LCAiaWQiOiAiNWM1ODg1ODE3YTc2ODIwYzU5MjA1
-        ZjhmIn0=
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:37 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/07af1450-931f-4ad7-b508-be1646617590/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"5f878fb967cb44d32466f1445045abe8-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2423'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wN2FmMTQ1MC05MzFmLTRhZDctYjUwOC1iZTE2NDY2MTc1
-        OTAvIiwgInRhc2tfaWQiOiAiMDdhZjE0NTAtOTMxZi00YWQ3LWI1MDgtYmUx
-        NjQ2NjE3NTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTktMDItMDRUMTg6MzM6MzdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTktMDItMDRUMTg6MzM6MzZaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzLzQzZTE4ZTNiLTljZDktNDRlZC1iODdiLTk4ZDUw
-        ZDE0Y2ZjNS8iLCAidGFza19pZCI6ICI0M2UxOGUzYi05Y2Q5LTQ0ZWQtYjg3
-        Yi05OGQ1MGQxNGNmYzUifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
-        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
-        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
-        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
-        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
-        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
-        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wMi0w
-        NFQxODozMzozNloiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDE5LTAyLTA0VDE4OjMzOjM3WiIsICJpbXBvcnRlcl90
-        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
-        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
-        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
-        b3VudCI6IDAsICJpZCI6ICI1YzU4ODU4MTA1ZjVlZTA2MDRjYjEwYTciLCAi
-        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
-        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
-        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
-        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
-        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjNTg4NTgwN2E3NjgyMGM1OTIwNWRl
-        YSJ9LCAiaWQiOiAiNWM1ODg1ODA3YTc2ODIwYzU5MjA1ZGVhIn0=
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:37 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/43e18e3b-9cd9-44ed-b87b-98d50d14cfc5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"68aa8bf8d03d1ffd1f5005df3c8e2662-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4543'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80M2UxOGUzYi05Y2Q5LTQ0ZWQtYjg3Yi05OGQ1
-        MGQxNGNmYzUvIiwgInRhc2tfaWQiOiAiNDNlMThlM2ItOWNkOS00NGVkLWI4
-        N2ItOThkNTBkMTRjZmM1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDItMDRUMTg6MzM6MzdaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
-        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJhZDYwMTkxNy03MGE2LTRhNjMtYjUxNy1l
-        OGZiYThlZTIwMjEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
-        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMWY2MzQ5NzMtMTQ3NC00NTNhLWI0YTkt
-        NmIxNDU5N2M2ODhhIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
-        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjIyZTk2MWVkLWJkOWItNGFkNy04YmIzLWFlZWQ2OTE1
-        NTNlNiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
-        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI2ZTdlZWMzLTE1YjgtNDIx
-        Ny05YTE0LTE0MjkzZDQ4M2RlOCIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
-        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImJmZjg1ZTg0LThhOWQtNDY1NC1iMTU4LTkxZDJlMzE4ODliOSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
-        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVT
-        UyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3MThiNTg5NC0wMGJlLTQ0MzUt
-        YWNiNi1jNTNlZDY2ZDBhYTAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
-        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9k
-        dWxlcyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICIyYzc5MjBhMS1kOTc1LTQ1YjktYWQzNS1mMzkyYTQ5ZGQ2OGYiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUi
-        OiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
-        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWI3YzRhY2MtYTkxNS00
-        ZjYxLWJmM2MtMjkxZDFmZGMwMzRlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
-        IE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiZmRmNjM4NjMtNDgzMi00MGI2LWE0MTQtZGM5ZDliZjJj
-        ZGZmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
-        ICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3Rl
-        cF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
-        OiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiODIwODI3ZDQtZjM5Yi00NTVlLWEyOTgtMjM4NjgyODhjNDVmIiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5
-        cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjg3
-        NmNiNThiLTEzODYtNDRhZi05NjVmLTg4NjY4ZmM0ZDFlYyIsICJudW1fcHJv
-        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1v
-        dmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE1YmYwNDg0
-        LThiNjEtNDA1My1iMDI1LTg1YTI5MGQwYzg2MCIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
-        ZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI5MmYyYmFiNy1lMTA1LTQ5OTUtYmZlYS1m
-        YjIzMDM0MmZkZTYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8g
-        d2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVt
-        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJlOWM0ZTc0MC1mODUyLTQyZDgtOWQyNC1iNWFhOTNi
-        MDMwZWIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImNlZmExMDhjLWNjOGItNDkwOS1iZTk3LWYwNWRhYTAz
-        NzJjMSIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4
-        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9u
-        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2
-        ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJv
-        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM1ODg1ODE3YTc2ODIwYzU5
-        MjA1ZjhmIn0sICJpZCI6ICI1YzU4ODU4MTdhNzY4MjBjNTkyMDVmOGYifQ==
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:37 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/07af1450-931f-4ad7-b508-be1646617590/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"5f878fb967cb44d32466f1445045abe8-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2423'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wN2FmMTQ1MC05MzFmLTRhZDctYjUwOC1iZTE2NDY2MTc1
-        OTAvIiwgInRhc2tfaWQiOiAiMDdhZjE0NTAtOTMxZi00YWQ3LWI1MDgtYmUx
-        NjQ2NjE3NTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTktMDItMDRUMTg6MzM6MzdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTktMDItMDRUMTg6MzM6MzZaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzLzQzZTE4ZTNiLTljZDktNDRlZC1iODdiLTk4ZDUw
-        ZDE0Y2ZjNS8iLCAidGFza19pZCI6ICI0M2UxOGUzYi05Y2Q5LTQ0ZWQtYjg3
-        Yi05OGQ1MGQxNGNmYzUifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
-        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
-        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
-        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
-        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
-        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
-        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wMi0w
-        NFQxODozMzozNloiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDE5LTAyLTA0VDE4OjMzOjM3WiIsICJpbXBvcnRlcl90
-        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
-        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
-        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
-        b3VudCI6IDAsICJpZCI6ICI1YzU4ODU4MTA1ZjVlZTA2MDRjYjEwYTciLCAi
-        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
-        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
-        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
-        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
-        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjNTg4NTgwN2E3NjgyMGM1OTIwNWRl
-        YSJ9LCAiaWQiOiAiNWM1ODg1ODA3YTc2ODIwYzU5MjA1ZGVhIn0=
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:37 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/43e18e3b-9cd9-44ed-b87b-98d50d14cfc5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"f436809047b6c48f8dd596140ccea069-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4531'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80M2UxOGUzYi05Y2Q5LTQ0ZWQtYjg3Yi05OGQ1
-        MGQxNGNmYzUvIiwgInRhc2tfaWQiOiAiNDNlMThlM2ItOWNkOS00NGVkLWI4
-        N2ItOThkNTBkMTRjZmM1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDItMDRUMTg6MzM6MzdaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
-        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJhZDYwMTkxNy03MGE2LTRhNjMtYjUxNy1l
-        OGZiYThlZTIwMjEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
-        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMWY2MzQ5NzMtMTQ3NC00NTNhLWI0YTkt
-        NmIxNDU5N2M2ODhhIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
-        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjIyZTk2MWVkLWJkOWItNGFkNy04YmIzLWFlZWQ2OTE1
-        NTNlNiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
-        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI2ZTdlZWMzLTE1YjgtNDIx
-        Ny05YTE0LTE0MjkzZDQ4M2RlOCIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
-        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImJmZjg1ZTg0LThhOWQtNDY1NC1iMTU4LTkxZDJlMzE4ODliOSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
-        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3MThiNTg5NC0wMGJlLTQ0MzUtYWNi
-        Ni1jNTNlZDY2ZDBhYTAiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
-        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIy
-        Yzc5MjBhMS1kOTc1LTQ1YjktYWQzNS1mMzkyYTQ5ZGQ2OGYiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
-        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYWI3YzRhY2MtYTkxNS00ZjYxLWJmM2Mt
-        MjkxZDFmZGMwMzRlIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRh
-        LiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        ZmRmNjM4NjMtNDgzMi00MGI2LWE0MTQtZGM5ZDliZjJjZGZmIiwgIm51bV9w
-        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
-        biI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNs
-        b3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODIwODI3
-        ZDQtZjM5Yi00NTVlLWEyOTgtMjM4NjgyODhjNDVmIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJH
-        ZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJh
-        dGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
-        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjg3NmNiNThiLTEzODYt
-        NDRhZi05NjVmLTg4NjY4ZmM0ZDFlYyIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcg
-        b2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9k
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE1YmYwNDg0LThiNjEtNDA1My1i
-        MDI1LTg1YTI5MGQwYzg2MCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1M
-        IGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI5MmYyYmFiNy1lMTA1LTQ5OTUtYmZlYS1mYjIzMDM0MmZkZTYi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBf
-        dHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJlOWM0ZTc0MC1mODUyLTQyZDgtOWQyNC1iNWFhOTNiMDMwZWIiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAi
-        aW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImNlZmExMDhjLWNjOGItNDkwOS1iZTk3LWYwNWRhYTAzNzJjMSIsICJudW1f
-        cHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNl
-        X3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tLmRx
-        MiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
-        aWQiOiB7IiRvaWQiOiAiNWM1ODg1ODE3YTc2ODIwYzU5MjA1ZjhmIn0sICJp
-        ZCI6ICI1YzU4ODU4MTdhNzY4MjBjNTkyMDVmOGYifQ==
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:37 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/07af1450-931f-4ad7-b508-be1646617590/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"5f878fb967cb44d32466f1445045abe8-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2423'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wN2FmMTQ1MC05MzFmLTRhZDctYjUwOC1iZTE2NDY2MTc1
-        OTAvIiwgInRhc2tfaWQiOiAiMDdhZjE0NTAtOTMxZi00YWQ3LWI1MDgtYmUx
-        NjQ2NjE3NTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTktMDItMDRUMTg6MzM6MzdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTktMDItMDRUMTg6MzM6MzZaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzLzQzZTE4ZTNiLTljZDktNDRlZC1iODdiLTk4ZDUw
-        ZDE0Y2ZjNS8iLCAidGFza19pZCI6ICI0M2UxOGUzYi05Y2Q5LTQ0ZWQtYjg3
-        Yi05OGQ1MGQxNGNmYzUifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
-        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
-        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
-        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
-        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
-        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
-        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wMi0w
-        NFQxODozMzozNloiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDE5LTAyLTA0VDE4OjMzOjM3WiIsICJpbXBvcnRlcl90
-        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
-        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
-        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
-        b3VudCI6IDAsICJpZCI6ICI1YzU4ODU4MTA1ZjVlZTA2MDRjYjEwYTciLCAi
-        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
-        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
-        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
-        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
-        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjNTg4NTgwN2E3NjgyMGM1OTIwNWRl
-        YSJ9LCAiaWQiOiAiNWM1ODg1ODA3YTc2ODIwYzU5MjA1ZGVhIn0=
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:37 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/43e18e3b-9cd9-44ed-b87b-98d50d14cfc5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"1d7e964bd782fdd662c716bcde96c5a6-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4511'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80M2UxOGUzYi05Y2Q5LTQ0ZWQtYjg3Yi05OGQ1
-        MGQxNGNmYzUvIiwgInRhc2tfaWQiOiAiNDNlMThlM2ItOWNkOS00NGVkLWI4
-        N2ItOThkNTBkMTRjZmM1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDItMDRUMTg6MzM6MzdaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
-        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJhZDYwMTkxNy03MGE2LTRhNjMtYjUxNy1l
-        OGZiYThlZTIwMjEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
-        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMWY2MzQ5NzMtMTQ3NC00NTNhLWI0YTkt
-        NmIxNDU5N2M2ODhhIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
-        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjIyZTk2MWVkLWJkOWItNGFkNy04YmIzLWFlZWQ2OTE1
-        NTNlNiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
-        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI2ZTdlZWMzLTE1YjgtNDIx
-        Ny05YTE0LTE0MjkzZDQ4M2RlOCIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
-        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImJmZjg1ZTg0LThhOWQtNDY1NC1iMTU4LTkxZDJlMzE4ODliOSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
-        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3MThiNTg5NC0wMGJlLTQ0MzUtYWNi
-        Ni1jNTNlZDY2ZDBhYTAiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
-        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIy
-        Yzc5MjBhMS1kOTc1LTQ1YjktYWQzNS1mMzkyYTQ5ZGQ2OGYiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
-        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYWI3YzRhY2MtYTkxNS00ZjYxLWJmM2Mt
-        MjkxZDFmZGMwMzRlIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRh
-        LiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        ZmRmNjM4NjMtNDgzMi00MGI2LWE0MTQtZGM5ZDliZjJjZGZmIiwgIm51bV9w
-        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
-        biI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNs
-        b3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODIwODI3ZDQt
-        ZjM5Yi00NTVlLWEyOTgtMjM4NjgyODhjNDVmIiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5l
-        cmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUg
-        c3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODc2Y2I1OGItMTM4Ni00NGFmLTk2
-        NWYtODg2NjhmYzRkMWVjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVw
-        b2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAi
-        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiMTViZjA0ODQtOGI2MS00MDUzLWIwMjUtODVhMjkw
-        ZDBjODYwIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAi
-        c3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTJmMmJh
-        YjctZTEwNS00OTk1LWJmZWEtZmIyMzAzNDJmZGU2IiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
-        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklO
-        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTljNGU3NDAtZjg1Mi00
-        MmQ4LTlkMjQtYjVhYTkzYjAzMGViIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwg
-        eyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
-        c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjZWZhMTA4Yy1jYzhiLTQ5MDkt
-        YmU5Ny1mMDVkYWEwMzcyYzEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9XX0sICJx
-        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRl
-        dmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmlu
-        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJyZXN1bHQi
-        OiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjNTg4
-        NTgxN2E3NjgyMGM1OTIwNWY4ZiJ9LCAiaWQiOiAiNWM1ODg1ODE3YTc2ODIw
-        YzU5MjA1ZjhmIn0=
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:37 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/07af1450-931f-4ad7-b508-be1646617590/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"5f878fb967cb44d32466f1445045abe8-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2423'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8wN2FmMTQ1MC05MzFmLTRhZDctYjUwOC1iZTE2NDY2MTc1
-        OTAvIiwgInRhc2tfaWQiOiAiMDdhZjE0NTAtOTMxZi00YWQ3LWI1MDgtYmUx
-        NjQ2NjE3NTkwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTktMDItMDRUMTg6MzM6MzdaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTktMDItMDRUMTg6MzM6MzZaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzLzQzZTE4ZTNiLTljZDktNDRlZC1iODdiLTk4ZDUw
-        ZDE0Y2ZjNS8iLCAidGFza19pZCI6ICI0M2UxOGUzYi05Y2Q5LTQ0ZWQtYjg3
-        Yi05OGQ1MGQxNGNmYzUifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
-        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
-        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
-        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
-        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
-        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
-        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wMi0w
-        NFQxODozMzozNloiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDE5LTAyLTA0VDE4OjMzOjM3WiIsICJpbXBvcnRlcl90
-        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
-        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
-        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
-        b3VudCI6IDAsICJpZCI6ICI1YzU4ODU4MTA1ZjVlZTA2MDRjYjEwYTciLCAi
-        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
-        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
-        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
-        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
-        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjNTg4NTgwN2E3NjgyMGM1OTIwNWRl
-        YSJ9LCAiaWQiOiAiNWM1ODg1ODA3YTc2ODIwYzU5MjA1ZGVhIn0=
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:37 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/43e18e3b-9cd9-44ed-b87b-98d50d14cfc5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:37 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"0b94847f6d3814dc356a51ef4d16e11c-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '9057'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80M2UxOGUzYi05Y2Q5LTQ0ZWQtYjg3Yi05OGQ1
-        MGQxNGNmYzUvIiwgInRhc2tfaWQiOiAiNDNlMThlM2ItOWNkOS00NGVkLWI4
-        N2ItOThkNTBkMTRjZmM1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogIjIwMTktMDItMDRUMTg6MzM6MzdaIiwgIl9ucyI6ICJ0YXNr
-        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTktMDItMDRUMTg6MzM6Mzda
-        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
-        cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0
-        ZXBfdHlwZSI6ICJzYXZlX3RhciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZDYwMTkx
-        Ny03MGE2LTRhNjMtYjUxNy1lOGZiYThlZTIwMjEiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIklu
-        aXRpYWxpemluZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMWY2MzQ5
-        NzMtMTQ3NC00NTNhLWI0YTktNmIxNDU5N2M2ODhhIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIERpc3RyaWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
-        ZGlzdHJpYnV0aW9uIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
-        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjIyZTk2MWVkLWJkOWIt
-        NGFkNy04YmIzLWFlZWQ2OTE1NTNlNiIsICJudW1fcHJvY2Vzc2VkIjogMX0s
-        IHsibnVtX3N1Y2Nlc3MiOiA4LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjog
-        OCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjI2ZTdlZWMzLTE1YjgtNDIxNy05YTE0LTE0MjkzZDQ4M2RlOCIsICJudW1f
-        cHJvY2Vzc2VkIjogOH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJk
-        cnBtcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImJmZjg1ZTg0LThhOWQtNDY1NC1iMTU4
-        LTkxZDJlMzE4ODliOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
-        Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEi
-        LCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3MThi
-        NTg5NC0wMGJlLTQ0MzUtYWNiNi1jNTNlZDY2ZDBhYTAiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgTW9kdWxlcyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIyYzc5MjBhMS1kOTc1LTQ1YjktYWQzNS1mMzky
-        YTQ5ZGQ2OGYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIs
-        ICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWI3YzRh
-        Y2MtYTkxNS00ZjYxLWJmM2MtMjkxZDFmZGMwMzRlIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiZmRmNjM4NjMtNDgzMi00MGI2LWE0MTQtZGM5
-        ZDliZjJjZGZmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
-        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
-        ZXBfaWQiOiAiODIwODI3ZDQtZjM5Yi00NTVlLWEyOTgtMjM4NjgyODhjNDVm
-        IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
-        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
-        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODc2
-        Y2I1OGItMTM4Ni00NGFmLTk2NWYtODg2NjhmYzRkMWVjIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
-        ICJSZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92
-        ZV9vbGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTViZjA0ODQtOGI2
-        MS00MDUzLWIwMjUtODVhMjkwZDBjODYwIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
-        aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiOTJmMmJhYjctZTEwNS00OTk1LWJmZWEtZmIyMzAzNDJm
-        ZGU2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJz
-        dGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwi
-        OiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiZTljNGU3NDAtZjg1Mi00MmQ4LTlkMjQtYjVhYTkzYjAzMGViIiwgIm51
-        bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjog
-        ImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJj
-        ZWZhMTA4Yy1jYzhiLTQ5MDktYmU5Ny1mMDVkYWEwMzcyYzEiLCAibnVtX3By
-        b2Nlc3NlZCI6IDF9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
-        b3JrZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIi
-        LCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
-        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhh
-        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJl
-        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0Iiwg
-        InN0YXJ0ZWQiOiAiMjAxOS0wMi0wNFQxODozMzozN1oiLCAiX25zIjogInJl
-        cG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTAyLTA0
-        VDE4OjMzOjM3WiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3Jf
-        dHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6IHsiZ2Vu
-        ZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQiLCAicnBtcyI6ICJGSU5JU0hFRCIs
-        ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicmVt
-        b3ZlX29sZF9yZXBvZGF0YSI6ICJGSU5JU0hFRCIsICJtb2R1bGVzIjogIkZJ
-        TklTSEVEIiwgInNhdmVfdGFyIjogIkZJTklTSEVEIiwgImNsb3NlX3JlcG9f
-        bWV0YWRhdGEiOiAiRklOSVNIRUQiLCAiZHJwbXMiOiAiU0tJUFBFRCIsICJj
-        b21wcyI6ICJGSU5JU0hFRCIsICJkaXN0cmlidXRpb24iOiAiRklOSVNIRUQi
-        LCAicmVwb3ZpZXciOiAiU0tJUFBFRCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6
-        ICJGSU5JU0hFRCIsICJlcnJhdGEiOiAiRklOSVNIRUQiLCAibWV0YWRhdGEi
-        OiAiRklOSVNIRUQifSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJp
-        YnV0b3JfaWQiOiAic2NlbmFyaW9fdGVzdCIsICJpZCI6ICI1YzU4ODU4MTA1
-        ZjVlZTA2MDRjYjEwYTgiLCAiZGV0YWlscyI6IFt7Im51bV9zdWNjZXNzIjog
-        MSwgImRlc2NyaXB0aW9uIjogIkNvcHlpbmcgZmlsZXMiLCAic3RlcF90eXBl
-        IjogInNhdmVfdGFyIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
-        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFkNjAxOTE3LTcwYTYt
-        NGE2My1iNTE3LWU4ZmJhOGVlMjAyMSIsICJudW1fcHJvY2Vzc2VkIjogMX0s
-        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6
-        aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVf
-        cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxZjYzNDk3My0xNDc0
-        LTQ1M2EtYjRhOS02YjE0NTk3YzY4OGEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmli
-        dXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjJlOTYxZWQtYmQ5Yi00YWQ3LThi
-        YjMtYWVlZDY5MTU1M2U2IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1f
-        c3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMi
-        LCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiA4LCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjZlN2Vl
-        YzMtMTViOC00MjE3LTlhMTQtMTQyOTNkNDgzZGU4IiwgIm51bV9wcm9jZXNz
-        ZWQiOiA4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiYmZmODVlODQtOGE5ZC00NjU0LWIxNTgtOTFkMmUz
-        MTg4OWI5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
-        IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVw
-        X3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjcxOGI1ODk0LTAw
-        YmUtNDQzNS1hY2I2LWM1M2VkNjZkMGFhMCIsICJudW1fcHJvY2Vzc2VkIjog
-        M30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1z
-        X3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjJjNzkyMGExLWQ5NzUtNDViOS1hZDM1LWYzOTJhNDlkZDY4
-        ZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBf
-        dHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhYjdjNGFjYy1hOTE1
-        LTRmNjEtYmYzYy0yOTFkMWZkYzAzNGUiLCAibnVtX3Byb2Nlc3NlZCI6IDN9
-        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJmZGY2Mzg2My00ODMyLTQwYjYtYTQxNC1kYzlkOWJmMmNk
-        ZmYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwg
-        ImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVw
-        X3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI4MjA4MjdkNC1mMzliLTQ1NWUtYTI5OC0yMzg2ODI4OGM0NWYiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4NzZjYjU4Yi0x
-        Mzg2LTQ0YWYtOTY1Zi04ODY2OGZjNGQxZWMiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92
-        aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9y
-        ZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNWJmMDQ4NC04YjYxLTQwNTMt
-        YjAyNS04NWEyOTBkMGM4NjAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
-        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRN
-        TCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90
-        YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI5MmYyYmFiNy1lMTA1LTQ5OTUtYmZlYS1mYjIzMDM0MmZkZTYiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlw
-        ZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlOWM0
-        ZTc0MC1mODUyLTQyZDgtOWQyNC1iNWFhOTNiMDMwZWIiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlh
-        bGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNlZmExMDhj
-        LWNjOGItNDkwOS1iZTk3LWYwNWRhYTAzNzJjMSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzU4
-        ODU4MTdhNzY4MjBjNTkyMDVmOGYifSwgImlkIjogIjVjNTg4NTgxN2E3Njgy
-        MGM1OTIwNWY4ZiJ9
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:37 GMT
-- request:
     method: post
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/content/units/rpm/search/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJsaW1pdCI6OCwic2tpcCI6MCwiZmllbGRzIjpbIm5h
-        bWUiLCJ2ZXJzaW9uIiwicmVsZWFzZSIsImFyY2giLCJlcG9jaCIsInN1bW1h
-        cnkiLCJzb3VyY2VycG0iLCJjaGVja3N1bSIsImZpbGVuYW1lIiwiX2lkIl0s
-        ImZpbHRlcnMiOnsiX2lkIjp7IiRpbiI6WyIwZmJjZWU2My1kZmI4LTQxZjYt
-        YWU5Yi0xMGJlMjkzNmNmZGUiLCIxN2VlOWRkMy0zMWFmLTRmMzMtOGE4Ni05
-        NDFlMDZkZDE4NWQiLCI1OWY1MDFiZS1jYzgzLTRmN2YtYTlhZS0yMDgxYmZj
-        ZjdkZjgiLCI3NjZmNmRjYy1jMjg3LTRmZjgtYjVmMC00MTRjODg1ZjA4YmEi
-        LCI5NDk2NzQ0Yi1kNTM5LTQyNTAtYWNkMS0zM2ZmNmZmYzQ5ZTgiLCJhZTZl
-        OGEyMC1jZTYwLTQ1YTctYTZkMS1kNWYyNDIzODlmOGUiLCJjOTUxYjM3MS1k
-        NjU2LTRhMmItYjZiMi04ZWU1NjRiNmJmZjQiLCJkMWE3MzM1NC00MWU4LTQ3
-        MzUtYTMzNi05YWUwODk0YjUyOTEiXX19fSwiaW5jbHVkZV9yZXBvcyI6dHJ1
-        ZX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '497'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '6021'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVzdCIs
-        ICIzMWQ2NDU1Mi1iZjFjLTQ3ZDMtODYwOS04NjhhZDFhMmI0MDIiLCAiMi1U
-        ZXN0Q1YtdjJfMC1kZjI2ZjZkMS02ODBmLTRlMmItYWI4Yy00Mzk2OWY3M2E4
-        YzUiLCAiMi16b28yLXYxXzAtZGYyNmY2ZDEtNjgwZi00ZTJiLWFiOGMtNDM5
-        NjlmNzNhOGM1IiwgIjItem9vLXYxXzAtZGYyNmY2ZDEtNjgwZi00ZTJiLWFi
-        OGMtNDM5NjlmNzNhOGM1IiwgIjItVGVzdENWLXYxXzAtZGYyNmY2ZDEtNjgw
-        Zi00ZTJiLWFiOGMtNDM5NjlmNzNhOGM1IiwgImRmMjZmNmQxLTY4MGYtNGUy
-        Yi1hYjhjLTQzOTY5ZjczYThjNSJdLCAic291cmNlcnBtIjogIndhbHJ1cy0w
-        LjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJ3YWxydXMiLCAiY2hlY2tzdW0i
-        OiAiNmU4ZDZkYzA1N2UzZTJjOTgxOWYwZGM3ZTZjN2I3Zjg2YmYyZTg1NzFi
-        YmE0MTRhZGVjN2ZiNjIxYTQ2MWRmZCIsICJzdW1tYXJ5IjogIkEgZHVtbXkg
-        cGFja2FnZSBvZiB3YWxydXMiLCAiZmlsZW5hbWUiOiAid2FscnVzLTAuMy0w
-        Ljgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4z
-        IiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICIwZmJjZWU2My1kZmI4LTQx
-        ZjYtYWU5Yi0xMGJlMjkzNmNmZGUiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hp
-        bGRyZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3Vu
-        aXRzL3JwbS8wZmJjZWU2My1kZmI4LTQxZjYtYWU5Yi0xMGJlMjkzNmNmZGUv
-        In0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiMzFkNjQ1NTItYmYx
-        Yy00N2QzLTg2MDktODY4YWQxYTJiNDAyIiwgIjItVGVzdENWLXYyXzAtZGYy
-        NmY2ZDEtNjgwZi00ZTJiLWFiOGMtNDM5NjlmNzNhOGM1IiwgInNjZW5hcmlv
-        X3Rlc3QiLCAiMi1UZXN0Q1YtdjFfMC1kZjI2ZjZkMS02ODBmLTRlMmItYWI4
-        Yy00Mzk2OWY3M2E4YzUiLCAiZGYyNmY2ZDEtNjgwZi00ZTJiLWFiOGMtNDM5
-        NjlmNzNhOGM1Il0sICJzb3VyY2VycG0iOiAiY2hlZXRhaC0wLjMtMC44LnNy
-        Yy5ycG0iLCAibmFtZSI6ICJjaGVldGFoIiwgImNoZWNrc3VtIjogIjQyMmQw
-        YmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIzZTE3ZjU3OGY5MjRmNzQ4ODBkZWJk
-        YmI3ZDY1ZmIzNjhkYWUiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ug
-        b2YgY2hlZXRhaCIsICJmaWxlbmFtZSI6ICJjaGVldGFoLTAuMy0wLjgubm9h
-        cmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJl
-        bGVhc2UiOiAiMC44IiwgIl9pZCI6ICIxN2VlOWRkMy0zMWFmLTRmMzMtOGE4
-        Ni05NDFlMDZkZDE4NWQiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4i
-        OiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3Jw
-        bS8xN2VlOWRkMy0zMWFmLTRmMzMtOGE4Ni05NDFlMDZkZDE4NWQvIn0sIHsi
-        cmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVzdCIsICIz
-        MWQ2NDU1Mi1iZjFjLTQ3ZDMtODYwOS04NjhhZDFhMmI0MDIiLCAiMi1UZXN0
-        Q1YtdjJfMC1kZjI2ZjZkMS02ODBmLTRlMmItYWI4Yy00Mzk2OWY3M2E4YzUi
-        LCAiMi16b28yLXYxXzAtZGYyNmY2ZDEtNjgwZi00ZTJiLWFiOGMtNDM5Njlm
-        NzNhOGM1IiwgIjItem9vLXYxXzAtZGYyNmY2ZDEtNjgwZi00ZTJiLWFiOGMt
-        NDM5NjlmNzNhOGM1IiwgIjItVGVzdENWLXYxXzAtZGYyNmY2ZDEtNjgwZi00
-        ZTJiLWFiOGMtNDM5NjlmNzNhOGM1IiwgImRmMjZmNmQxLTY4MGYtNGUyYi1h
-        YjhjLTQzOTY5ZjczYThjNSJdLCAic291cmNlcnBtIjogInBlbmd1aW4tMC4z
-        LTAuOC5zcmMucnBtIiwgIm5hbWUiOiAicGVuZ3VpbiIsICJjaGVja3N1bSI6
-        ICIzZmNiMmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1
-        NjRmYzIxMGZkNmU0ODYzNWJlNjk0IiwgInN1bW1hcnkiOiAiQSBkdW1teSBw
-        YWNrYWdlIG9mIHBlbmd1aW4iLCAiZmlsZW5hbWUiOiAicGVuZ3Vpbi0wLjMt
-        MC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAu
-        MyIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiNTlmNTAxYmUtY2M4My00
-        ZjdmLWE5YWUtMjA4MWJmY2Y3ZGY4IiwgImFyY2giOiAibm9hcmNoIiwgImNo
-        aWxkcmVuIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91
-        bml0cy9ycG0vNTlmNTAxYmUtY2M4My00ZjdmLWE5YWUtMjA4MWJmY2Y3ZGY4
-        LyJ9LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbInNjZW5hcmlvX3Rl
-        c3QiLCAiMzFkNjQ1NTItYmYxYy00N2QzLTg2MDktODY4YWQxYTJiNDAyIiwg
-        IjItVGVzdENWLXYyXzAtZGYyNmY2ZDEtNjgwZi00ZTJiLWFiOGMtNDM5Njlm
-        NzNhOGM1IiwgIjItem9vMi12MV8wLWRmMjZmNmQxLTY4MGYtNGUyYi1hYjhj
-        LTQzOTY5ZjczYThjNSIsICIyLXpvby12MV8wLWRmMjZmNmQxLTY4MGYtNGUy
-        Yi1hYjhjLTQzOTY5ZjczYThjNSIsICIyLVRlc3RDVi12MV8wLWRmMjZmNmQx
-        LTY4MGYtNGUyYi1hYjhjLTQzOTY5ZjczYThjNSIsICJkZjI2ZjZkMS02ODBm
-        LTRlMmItYWI4Yy00Mzk2OWY3M2E4YzUiXSwgInNvdXJjZXJwbSI6ICJnaXJh
-        ZmZlLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogImdpcmFmZmUiLCAiY2hl
-        Y2tzdW0iOiAiZjI1ZDY3ZDFkOWRhMDRmMTJlNTdjYTMyMzI0N2I0Mzg5MWFj
-        NDY1MzNlMzU1YjgyZGU2ZDE5MjIwMDlmOWYxNCIsICJzdW1tYXJ5IjogIkEg
-        ZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZlIiwgImZpbGVuYW1lIjogImdpcmFm
-        ZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lv
-        biI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjc2NmY2ZGNj
-        LWMyODctNGZmOC1iNWYwLTQxNGM4ODVmMDhiYSIsICJhcmNoIjogIm5vYXJj
-        aCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2Nv
-        bnRlbnQvdW5pdHMvcnBtLzc2NmY2ZGNjLWMyODctNGZmOC1iNWYwLTQxNGM4
-        ODVmMDhiYS8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJzY2Vu
-        YXJpb190ZXN0IiwgIjMxZDY0NTUyLWJmMWMtNDdkMy04NjA5LTg2OGFkMWEy
-        YjQwMiIsICIyLVRlc3RDVi12Ml8wLWRmMjZmNmQxLTY4MGYtNGUyYi1hYjhj
-        LTQzOTY5ZjczYThjNSIsICIyLXpvbzItdjFfMC1kZjI2ZjZkMS02ODBmLTRl
-        MmItYWI4Yy00Mzk2OWY3M2E4YzUiLCAiMi16b28tdjFfMC1kZjI2ZjZkMS02
-        ODBmLTRlMmItYWI4Yy00Mzk2OWY3M2E4YzUiLCAiMi1UZXN0Q1YtdjFfMC1k
-        ZjI2ZjZkMS02ODBmLTRlMmItYWI4Yy00Mzk2OWY3M2E4YzUiLCAiZGYyNmY2
-        ZDEtNjgwZi00ZTJiLWFiOGMtNDM5NjlmNzNhOGM1Il0sICJzb3VyY2VycG0i
-        OiAibGlvbi0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJsaW9uIiwgImNo
-        ZWNrc3VtIjogIjEyNDAwZGM5NWMyM2E0YzE2MDcyNWE5MDg3MTZjZDNmY2Rk
-        N2E4OTgxNTg1NDM3YWI2NGNkNjJlZmEzZTRhZTQiLCAic3VtbWFyeSI6ICJB
-        IGR1bW15IHBhY2thZ2Ugb2YgbGlvbiIsICJmaWxlbmFtZSI6ICJsaW9uLTAu
-        My0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAi
-        MC4zIiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICI5NDk2NzQ0Yi1kNTM5
-        LTQyNTAtYWNkMS0zM2ZmNmZmYzQ5ZTgiLCAiYXJjaCI6ICJub2FyY2giLCAi
-        Y2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50
-        L3VuaXRzL3JwbS85NDk2NzQ0Yi1kNTM5LTQyNTAtYWNkMS0zM2ZmNmZmYzQ5
-        ZTgvIn0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9f
-        dGVzdCIsICIyLVRlc3RDVi12Ml8wLWRmMjZmNmQxLTY4MGYtNGUyYi1hYjhj
-        LTQzOTY5ZjczYThjNSIsICIyLXpvbzItdjFfMC1kZjI2ZjZkMS02ODBmLTRl
-        MmItYWI4Yy00Mzk2OWY3M2E4YzUiLCAiMi16b28tdjFfMC1kZjI2ZjZkMS02
-        ODBmLTRlMmItYWI4Yy00Mzk2OWY3M2E4YzUiLCAiMi1UZXN0Q1YtdjFfMC1k
-        ZjI2ZjZkMS02ODBmLTRlMmItYWI4Yy00Mzk2OWY3M2E4YzUiLCAiZGYyNmY2
-        ZDEtNjgwZi00ZTJiLWFiOGMtNDM5NjlmNzNhOGM1Il0sICJzb3VyY2VycG0i
-        OiAibW9ua2V5LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogIm1vbmtleSIs
-        ICJjaGVja3N1bSI6ICIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1
-        ZDM5YjAyODAxNjlmNjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwgInN1bW1hcnki
-        OiAiQSBkdW1teSBwYWNrYWdlIG9mIG1vbmtleSIsICJmaWxlbmFtZSI6ICJt
-        b25rZXktMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVy
-        c2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogImFlNmU4
-        YTIwLWNlNjAtNDVhNy1hNmQxLWQ1ZjI0MjM4OWY4ZSIsICJhcmNoIjogIm5v
-        YXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
-        L2NvbnRlbnQvdW5pdHMvcnBtL2FlNmU4YTIwLWNlNjAtNDVhNy1hNmQxLWQ1
-        ZjI0MjM4OWY4ZS8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJz
-        Y2VuYXJpb190ZXN0IiwgIjMxZDY0NTUyLWJmMWMtNDdkMy04NjA5LTg2OGFk
-        MWEyYjQwMiIsICIyLVRlc3RDVi12Ml8wLWRmMjZmNmQxLTY4MGYtNGUyYi1h
-        YjhjLTQzOTY5ZjczYThjNSIsICIyLXpvbzItdjFfMC1kZjI2ZjZkMS02ODBm
-        LTRlMmItYWI4Yy00Mzk2OWY3M2E4YzUiLCAiMi16b28tdjFfMC1kZjI2ZjZk
-        MS02ODBmLTRlMmItYWI4Yy00Mzk2OWY3M2E4YzUiLCAiMi1UZXN0Q1YtdjFf
-        MC1kZjI2ZjZkMS02ODBmLTRlMmItYWI4Yy00Mzk2OWY3M2E4YzUiLCAiZGYy
-        NmY2ZDEtNjgwZi00ZTJiLWFiOGMtNDM5NjlmNzNhOGM1Il0sICJzb3VyY2Vy
-        cG0iOiAiZWxlcGhhbnQtMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAiZWxl
-        cGhhbnQiLCAiY2hlY2tzdW0iOiAiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3
-        Y2IzZDE2MTQ1MzA2YmI5NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsICJz
-        dW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBlbGVwaGFudCIsICJmaWxl
-        bmFtZSI6ICJlbGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2gi
-        OiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJf
-        aWQiOiAiYzk1MWIzNzEtZDY1Ni00YTJiLWI2YjItOGVlNTY0YjZiZmY0Iiwg
-        ImFyY2giOiAibm9hcmNoIiwgImNoaWxkcmVuIjoge30sICJfaHJlZiI6ICIv
-        cHVscC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vYzk1MWIzNzEtZDY1Ni00
-        YTJiLWI2YjItOGVlNTY0YjZiZmY0LyJ9LCB7InJlcG9zaXRvcnlfbWVtYmVy
-        c2hpcHMiOiBbInNjZW5hcmlvX3Rlc3QiLCAiMzFkNjQ1NTItYmYxYy00N2Qz
-        LTg2MDktODY4YWQxYTJiNDAyIiwgIjItVGVzdENWLXYyXzAtZGYyNmY2ZDEt
-        NjgwZi00ZTJiLWFiOGMtNDM5NjlmNzNhOGM1IiwgIjItem9vMi12MV8wLWRm
-        MjZmNmQxLTY4MGYtNGUyYi1hYjhjLTQzOTY5ZjczYThjNSIsICIyLXpvby12
-        MV8wLWRmMjZmNmQxLTY4MGYtNGUyYi1hYjhjLTQzOTY5ZjczYThjNSIsICIy
-        LVRlc3RDVi12MV8wLWRmMjZmNmQxLTY4MGYtNGUyYi1hYjhjLTQzOTY5Zjcz
-        YThjNSIsICJkZjI2ZjZkMS02ODBmLTRlMmItYWI4Yy00Mzk2OWY3M2E4YzUi
-        XSwgInNvdXJjZXJwbSI6ICJzcXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCAi
-        bmFtZSI6ICJzcXVpcnJlbCIsICJjaGVja3N1bSI6ICIyNTE3NjhiZGQxNWYx
-        M2Q3ODQ4N2MyNzYzOGFhNmFlY2QwMTU1MWUyNTM3NTYwOTNjZGUxYzBhZTg3
-        OGExN2QyIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHNxdWly
-        cmVsIiwgImZpbGVuYW1lIjogInNxdWlycmVsLTAuMy0wLjgubm9hcmNoLnJw
-        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2Ui
-        OiAiMC44IiwgIl9pZCI6ICJkMWE3MzM1NC00MWU4LTQ3MzUtYTMzNi05YWUw
-        ODk0YjUyOTEiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwg
-        Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9kMWE3
-        MzM1NC00MWU4LTQ3MzUtYTMzNi05YWUwODk0YjUyOTEvIn1d
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:38 GMT
-- request:
-    method: post
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/content/units/erratum/search/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJsaW1pdCI6Mywic2tpcCI6MCwiZmlsdGVycyI6eyJf
-        aWQiOnsiJGluIjpbIjBmMGQ5NGViLWI4NjctNDUyZi05NTJmLTA5OTAzMzIy
-        MTc5MyIsIjEwOWQ4NTNmLTM4ZTUtNDNiZi1iYjQxLWRjMmRlNjJiODYyMiIs
-        IjM4ZDE5NGU1LTMyNjYtNGMyYy04MmEwLWQ2NjI2M2ZhNzMxYSJdfX19LCJp
-        bmNsdWRlX3JlcG9zIjp0cnVlfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '199'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4988'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiMzFkNjQ1NTItYmYxYy00
-        N2QzLTg2MDktODY4YWQxYTJiNDAyIiwgInNjZW5hcmlvX3Rlc3QiXSwgIl9o
-        cmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL2VycmF0dW0vMGYw
-        ZDk0ZWItYjg2Ny00NTJmLTk1MmYtMDk5MDMzMjIxNzkzLyIsICJpc3N1ZWQi
-        OiAiMjAxMC0wMS0wMSAwMTowMTowMSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6
-        IGZhbHNlLCAicmVmZXJlbmNlcyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRh
-        Ijoge30sICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAi
-        UkhFQS0yMDEwOjAwMDEiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29t
-        IiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6ICJFbXB0eSBlcnJhdGEiLCAi
-        Y2hpbGRyZW4iOiB7fSwgInZlcnNpb24iOiAiMSIsICJyZWJvb3Rfc3VnZ2Vz
-        dGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3QiOiBb
-        XSwgInN0YXR1cyI6ICJzdGFibGUiLCAidXBkYXRlZCI6ICIiLCAiZGVzY3Jp
-        cHRpb24iOiAiRW1wdHkgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAiMjAx
-        OS0wMi0wNFQxODozMzozN1oiLCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxz
-        ZSwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6
-        ICIiLCAic3VtbWFyeSI6ICIiLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICIw
-        ZjBkOTRlYi1iODY3LTQ1MmYtOTUyZi0wOTkwMzMyMjE3OTMifSwgeyJyZXBv
-        c2l0b3J5X21lbWJlcnNoaXBzIjogWyJzY2VuYXJpb190ZXN0Il0sICJfaHJl
-        ZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9lcnJhdHVtLzEwOWQ4
-        NTNmLTM4ZTUtNDNiZi1iYjQxLWRjMmRlNjJiODYyMi8iLCAiaXNzdWVkIjog
-        IjIwMTAtMTEtMTAgMDA6MDA6MDAiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBm
-        YWxzZSwgInJlZmVyZW5jZXMiOiBbeyJocmVmIjogImh0dHBzOi8vcmhuLnJl
-        ZGhhdC5jb20vZXJyYXRhL1JIU0EtMjAxMC0wODU4Lmh0bWwiLCAidHlwZSI6
-        ICJzZWxmIiwgImlkIjogbnVsbCwgInRpdGxlIjogIlJIU0EtMjAxMDowODU4
-        In0sIHsiaHJlZiI6ICJodHRwczovL2J1Z3ppbGxhLnJlZGhhdC5jb20vYnVn
-        emlsbGEvc2hvd19idWcuY2dpP2lkPTYyNzg4MiIsICJ0eXBlIjogImJ1Z3pp
-        bGxhIiwgImlkIjogIjYyNzg4MiIsICJ0aXRsZSI6ICJDVkUtMjAxMC0wNDA1
-        IGJ6aXAyOiBpbnRlZ2VyIG92ZXJmbG93IGZsYXcgaW4gQloyX2RlY29tcHJl
-        c3MifSwgeyJocmVmIjogImh0dHBzOi8vd3d3LnJlZGhhdC5jb20vc2VjdXJp
-        dHkvZGF0YS9jdmUvQ1ZFLTIwMTAtMDQwNS5odG1sIiwgInR5cGUiOiAiY3Zl
-        IiwgImlkIjogIkNWRS0yMDEwLTA0MDUiLCAidGl0bGUiOiAiQ1ZFLTIwMTAt
-        MDQwNSJ9LCB7ImhyZWYiOiAiaHR0cDovL3d3dy5yZWRoYXQuY29tL3NlY3Vy
-        aXR5L3VwZGF0ZXMvY2xhc3NpZmljYXRpb24vI2ltcG9ydGFudCIsICJ0eXBl
-        IjogIm90aGVyIiwgImlkIjogbnVsbCwgInRpdGxlIjogbnVsbH1dLCAicHVs
-        cF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lkIjogImVy
-        cmF0dW0iLCAiaWQiOiAiUkhTQS0yMDEwOjA4NTgiLCAiZnJvbSI6ICJzZWN1
-        cml0eUByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIkltcG9ydGFudCIsICJ0
-        aXRsZSI6ICJJbXBvcnRhbnQ6IGJ6aXAyIHNlY3VyaXR5IHVwZGF0ZSIsICJj
-        aGlsZHJlbiI6IHt9LCAidmVyc2lvbiI6ICIzIiwgInJlYm9vdF9zdWdnZXN0
-        ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFt7
-        InBhY2thZ2VzIjogW3sic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3Jj
-        LnJwbSIsICJuYW1lIjogImJ6aXAyLWRldmVsIiwgInN1bSI6IFsic2hhMjU2
-        IiwgImVhNjdjNjY0ZGExZmY5NmE2ZGM5NGQzMzAwOWI3M2Q4ZmFiMzFiNTk4
-        MjQxODNmYjQ1ZTliYTJlYmY4MmQ1ODMiXSwgImZpbGVuYW1lIjogImJ6aXAy
-        LWRldmVsLTEuMC41LTcuZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIs
-        ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
-        cmNoIjogImk2ODYifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5z
-        cmMucnBtIiwgIm5hbWUiOiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1
-        NiIsICJjOWYwNjRhNjg2MjU3M2ZiOWYyYTZhZmY3YzM2MjFmMTk0MGI0OTJk
-        ZjJlZGZjMmViYmRjMGI4MzA1ZjUxMTQ3Il0sICJmaWxlbmFtZSI6ICJiemlw
-        Mi1saWJzLTEuMC41LTcuZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIs
-        ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
-        cmNoIjogImk2ODYifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5z
-        cmMucnBtIiwgIm5hbWUiOiAiYnppcDIiLCAic3VtIjogWyJzaGEyNTYiLCAi
-        YjhhM2Y3MmJjMmIwZDg5YmE3MzcwOTlhYzk4YmY4ZDJhZjRiZWEwMmQzMTg4
-        NGMwMmRiOTdmN2Y2NmMzZDVjMiJdLCAiZmlsZW5hbWUiOiAiYnppcDItMS4w
-        LjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lv
-        biI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJ4
-        ODZfNjQifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBt
-        IiwgIm5hbWUiOiAiYnppcDItZGV2ZWwiLCAic3VtIjogWyJzaGEyNTYiLCAi
-        N2Y2MzEyNGU0NjU1YjdjOTJkMjNlYzRjMzgyMjZmNWQzNzQ2NTY4ODUzZGZm
-        NzUwZmM4NWUwNThlNzRiNWNmNiJdLCAiZmlsZW5hbWUiOiAiYnppcDItZGV2
-        ZWwtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjogIjAiLCAi
-        dmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJj
-        aCI6ICJ4ODZfNjQifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5z
-        cmMucnBtIiwgIm5hbWUiOiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1
-        NiIsICI4MDJmNDM5OWRiZGQwMTQ3NmUyNTRjM2IzMmM0MGFmZjU5Y2Y1ZDIz
-        YTQ1ZmE0ODhjNjkxN2NlODkwNGQ2YjRkIl0sICJmaWxlbmFtZSI6ICJiemlw
-        Mi1saWJzLTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6ICIw
-        IiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwg
-        ImFyY2giOiAieDg2XzY0In1dLCAibmFtZSI6ICJjb2xsZWN0aW9uLTAiLCAi
-        c2hvcnQiOiAiIn1dLCAic3RhdHVzIjogImZpbmFsIiwgInVwZGF0ZWQiOiAi
-        MjAxMC0xMS0xMCAwMDowMDowMCIsICJkZXNjcmlwdGlvbiI6ICJiemlwMiBp
-        cyBhIGZyZWVseSBhdmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNvbXBy
-        ZXNzb3IuIEl0IHByb3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11c3Qg
-        YmUgcmVzdGFydGVkIGZvciB0aGUgdXBkYXRlIHRvIHRha2UgZWZmZWN0LiIs
-        ICJfbGFzdF91cGRhdGVkIjogIjIwMTktMDItMDRUMTg6MzM6MzdaIiwgInJl
-        c3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJp
-        Z2h0cyI6ICJDb3B5cmlnaHQgMjAxMCBSZWQgSGF0IEluYyIsICJzb2x1dGlv
-        biI6ICJCZWZvcmUgYXBwbHlpbmcgdGhpcyB1cGRhdGUsIG1ha2Ugc3VyZSBh
-        bGwgcHJldmlvdXNseS1yZWxlYXNlZCBlcnJhdGFcbnJlbGV2YW50IHRvIHlv
-        dXIgc3lzdGVtIGhhdmUgYmVlbiBhcHBsaWVkLlxuXG5UaGlzIHVwZGF0ZSBp
-        cyBhdmFpbGFibGUgdmlhIHRoZSBSZWQgSGF0IE5ldHdvcmsuIERldGFpbHMg
-        b24gaG93IHRvXG51c2UgdGhlIFJlZCBIYXQgTmV0d29yayB0byBhcHBseSB0
-        aGlzIHVwZGF0ZSBhcmUgYXZhaWxhYmxlIGF0XG5odHRwOi8va2Jhc2UucmVk
-        aGF0LmNvbS9mYXEvZG9jcy9ET0MtMTEyNTkiLCAic3VtbWFyeSI6ICJVcGRh
-        dGVkIGJ6aXAyIHBhY2thZ2VzIHRoYXQgZml4IG9uZSBzZWN1cml0eSBpc3N1
-        ZSIsICJyZWxlYXNlIjogIiIsICJfaWQiOiAiMTA5ZDg1M2YtMzhlNS00M2Jm
-        LWJiNDEtZGMyZGU2MmI4NjIyIn0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlw
-        cyI6IFsiMzFkNjQ1NTItYmYxYy00N2QzLTg2MDktODY4YWQxYTJiNDAyIiwg
-        InNjZW5hcmlvX3Rlc3QiXSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250
-        ZW50L3VuaXRzL2VycmF0dW0vMzhkMTk0ZTUtMzI2Ni00YzJjLTgyYTAtZDY2
-        MjYzZmE3MzFhLyIsICJpc3N1ZWQiOiAiMjAxMC0wMS0wMSAwMTowMTowMSIs
-        ICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVmZXJlbmNlcyI6IFtd
-        LCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lk
-        IjogImVycmF0dW0iLCAiaWQiOiAiUkhFQS0yMDEwOjAwMDIiLCAiZnJvbSI6
-        ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRs
-        ZSI6ICJPbmUgcGFja2FnZSBlcnJhdGEiLCAiY2hpbGRyZW4iOiB7fSwgInZl
-        cnNpb24iOiAiMSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBl
-        IjogInNlY3VyaXR5IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNy
-        YyI6ICJodHRwOi8vd3d3LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAi
-        ZWxlcGhhbnQiLCAic3VtIjogbnVsbCwgImZpbGVuYW1lIjogImVsZXBoYW50
-        LTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6IG51bGwsICJ2ZXJzaW9u
-        IjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJhcmNoIjogIm5vYXJjaCJ9
-        XSwgIm5hbWUiOiAiY29sbGVjdGlvbi0wIiwgInNob3J0IjogIiJ9XSwgInN0
-        YXR1cyI6ICJzdGFibGUiLCAidXBkYXRlZCI6ICIiLCAiZGVzY3JpcHRpb24i
-        OiAiT25lIHBhY2thZ2UgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAiMjAx
-        OS0wMi0wNFQxODozMzozN1oiLCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxz
-        ZSwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6
-        ICIiLCAic3VtbWFyeSI6ICIiLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICIz
-        OGQxOTRlNS0zMjY2LTRjMmMtODJhMC1kNjYyNjNmYTczMWEifV0=
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:38 GMT
-- request:
-    method: post
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/content/units/package_group/search/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJsaW1pdCI6Miwic2tpcCI6MCwiZmlsdGVycyI6eyJf
-        aWQiOnsiJGluIjpbIjRiMjZjZDY5LWI2YzctNGEzZS1iZjY3LTAyMzdhMmE1
-        OWQ1MyIsImU2ZDhhOWNjLThkMzItNDZlYy04MTg5LTg4NzU3OWEwZTllYiJd
-        fX19LCJpbmNsdWRlX3JlcG9zIjp0cnVlfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '160'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1288'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVzdCJd
-        LCAibWFuZGF0b3J5X3BhY2thZ2VfbmFtZXMiOiBbImVsZXBoYW50LGdpcmFm
-        ZmUsY2hlZXRhaCxsaW9uLG1vbmtleSxwZW5ndWluLHNxdWlycmVsLHdhbHJ1
-        cyIsICJwZW5ndWluIl0sICJyZXBvX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAi
-        bmFtZSI6ICJtYW1tYWwiLCAidXNlcl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1
-        bHQiOiB0cnVlLCAiX2xhc3RfdXBkYXRlZCI6ICIyMDE5LTAyLTA0VDE4OjMz
-        OjM3WiIsICJjaGlsZHJlbiI6IHt9LCAib3B0aW9uYWxfcGFja2FnZV9uYW1l
-        cyI6IFtdLCAidHJhbnNsYXRlZF9uYW1lIjoge30sICJfaHJlZiI6ICIvcHVs
-        cC9hcGkvdjIvY29udGVudC91bml0cy9wYWNrYWdlX2dyb3VwLzRiMjZjZDY5
-        LWI2YzctNGEzZS1iZjY3LTAyMzdhMmE1OWQ1My8iLCAidHJhbnNsYXRlZF9k
-        ZXNjcmlwdGlvbiI6IHt9LCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJk
-        ZWZhdWx0X3BhY2thZ2VfbmFtZXMiOiBbXSwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAicGFja2FnZV9ncm91cCIsICJpZCI6ICJtYW1tYWwiLCAiX2lkIjogIjRi
-        MjZjZDY5LWI2YzctNGEzZS1iZjY3LTAyMzdhMmE1OWQ1MyIsICJkaXNwbGF5
-        X29yZGVyIjogMTAyNCwgImNvbmRpdGlvbmFsX3BhY2thZ2VfbmFtZXMiOiBb
-        XX0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVz
-        dCJdLCAibWFuZGF0b3J5X3BhY2thZ2VfbmFtZXMiOiBbInBlbmd1aW4iXSwg
-        InJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJuYW1lIjogImJpcmQiLCAi
-        dXNlcl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAiX2xhc3Rf
-        dXBkYXRlZCI6ICIyMDE5LTAyLTA0VDE4OjMzOjM3WiIsICJjaGlsZHJlbiI6
-        IHt9LCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdLCAidHJhbnNsYXRl
-        ZF9uYW1lIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91
-        bml0cy9wYWNrYWdlX2dyb3VwL2U2ZDhhOWNjLThkMzItNDZlYy04MTg5LTg4
-        NzU3OWEwZTllYi8iLCAidHJhbnNsYXRlZF9kZXNjcmlwdGlvbiI6IHt9LCAi
-        cHVscF91c2VyX21ldGFkYXRhIjoge30sICJkZWZhdWx0X3BhY2thZ2VfbmFt
-        ZXMiOiBbXSwgIl9jb250ZW50X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIs
-        ICJpZCI6ICJiaXJkIiwgIl9pZCI6ICJlNmQ4YTljYy04ZDMyLTQ2ZWMtODE4
-        OS04ODc1NzlhMGU5ZWIiLCAiZGlzcGxheV9vcmRlciI6IDEwMjQsICJjb25k
-        aXRpb25hbF9wYWNrYWdlX25hbWVzIjogW119XQ==
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:38 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/task_groups/bf8fe592-c18b-431d-9e81-359a598025d8/state_summary/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 04 Feb 2019 18:33:38 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"f488fb4a2bc756aee3f1e9f5b238fe1f-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '127'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJhY2NlcHRlZCI6IDAsICJmaW5pc2hlZCI6IDAsICJydW5uaW5nIjogMCwg
-        ImNhbmNlbGVkIjogMCwgIndhaXRpbmciOiAwLCAic2tpcHBlZCI6IDAsICJz
-        dXNwZW5kZWQiOiAwLCAiZXJyb3IiOiAwLCAidG90YWwiOiAwfQ==
-    http_version: 
-  recorded_at: Mon, 04 Feb 2019 18:33:38 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/scenario_test/actions/sync/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2827,9 +25,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:43 GMT
+      - Thu, 30 May 2019 10:20:36 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '172'
       Content-Type:
@@ -2838,14 +36,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzI0Yzc1NTczLTc1YTktNDA2ZC05MjY0LTY3ZDBkZDFlZTFlMi8iLCAi
-        dGFza19pZCI6ICIyNGM3NTU3My03NWE5LTQwNmQtOTI2NC02N2QwZGQxZWUx
-        ZTIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzY2YzdmN2E0LTY5YmMtNDU2ZS1iZGQzLTk5YWI0NDUyNzNhMy8iLCAi
+        dGFza19pZCI6ICI2NmM3ZjdhNC02OWJjLTQ1NmUtYmRkMy05OWFiNDQ1Mjcz
+        YTMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:43 GMT
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/24c75573-75a9-406d-9264-67d0dd1ee1e2/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/66c7f7a4-69bc-456e-bdd3-99ab445273a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2864,11 +62,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:43 GMT
+      - Thu, 30 May 2019 10:20:36 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"9ded66cabbc0b757255e7c1e6faaebdb-gzip"'
+      - '"054522b3ea00ede125c053ee7fe1f8ab-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -2880,22 +78,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yNGM3NTU3My03NWE5LTQwNmQtOTI2NC02N2QwZGQxZWUx
-        ZTIvIiwgInRhc2tfaWQiOiAiMjRjNzU1NzMtNzVhOS00MDZkLTkyNjQtNjdk
-        MGRkMWVlMWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy82NmM3ZjdhNC02OWJjLTQ1NmUtYmRkMy05OWFiNDQ1Mjcz
+        YTMvIiwgInRhc2tfaWQiOiAiNjZjN2Y3YTQtNjliYy00NTZlLWJkZDMtOTlh
+        YjQ0NTI3M2EzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogbnVs
         bCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
         cm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIiIsICJzdGF0ZSI6ICJ3
         YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51bGws
-        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM5MDFmMWZiZjFi
-        YTllYzA0Y2I5NWE1In0sICJpZCI6ICI1YzkwMWYxZmJmMWJhOWVjMDRjYjk1
-        YTUifQ==
+        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlNzRjMzhl
+        YjVjOGY5ZmY1YWJjIn0sICJpZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjVh
+        YmMifQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:43 GMT
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/24c75573-75a9-406d-9264-67d0dd1ee1e2/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/66c7f7a4-69bc-456e-bdd3-99ab445273a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2914,15 +112,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:43 GMT
+      - Thu, 30 May 2019 10:20:36 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"b74d828525ccc786784965af67503fab-gzip"'
+      - '"d57d6b210bc6f2f296cc0220a847b20d-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1179'
+      - '1177'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2930,12 +128,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yNGM3NTU3My03NWE5LTQwNmQtOTI2NC02N2QwZGQxZWUx
-        ZTIvIiwgInRhc2tfaWQiOiAiMjRjNzU1NzMtNzVhOS00MDZkLTkyNjQtNjdk
-        MGRkMWVlMWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy82NmM3ZjdhNC02OWJjLTQ1NmUtYmRkMy05OWFiNDQ1Mjcz
+        YTMvIiwgInRhc2tfaWQiOiAiNjZjN2Y3YTQtNjliYy00NTZlLWJkZDMtOTlh
+        YjQ0NTI3M2EzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDMtMThUMjI6NDM6NDNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTktMDUtMzBUMTA6MjA6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
@@ -2949,17 +147,17 @@ http_interactions:
         YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
         VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiSU5fUFJPR1JF
         U1MifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
-        dGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1
-        bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzkwMWYx
-        ZmJmMWJhOWVjMDRjYjk1YTUifSwgImlkIjogIjVjOTAxZjFmYmYxYmE5ZWMw
-        NGNiOTVhNSJ9
+        ZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVu
+        bmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlNzRj
+        MzhlYjVjOGY5ZmY1YWJjIn0sICJpZCI6ICI1Y2VmYWU3NGMzOGViNWM4Zjlm
+        ZjVhYmMifQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:43 GMT
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/24c75573-75a9-406d-9264-67d0dd1ee1e2/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/66c7f7a4-69bc-456e-bdd3-99ab445273a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2978,15 +176,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:43 GMT
+      - Thu, 30 May 2019 10:20:36 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"7be4388e355cc8a53688056a2d9214eb-gzip"'
+      - '"faaab20f0a5595273e93e8ba1f33c4b6-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1176'
+      - '1174'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2994,12 +192,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yNGM3NTU3My03NWE5LTQwNmQtOTI2NC02N2QwZGQxZWUx
-        ZTIvIiwgInRhc2tfaWQiOiAiMjRjNzU1NzMtNzVhOS00MDZkLTkyNjQtNjdk
-        MGRkMWVlMWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy82NmM3ZjdhNC02OWJjLTQ1NmUtYmRkMy05OWFiNDQ1Mjcz
+        YTMvIiwgInRhc2tfaWQiOiAiNjZjN2Y3YTQtNjliYy00NTZlLWJkZDMtOTlh
+        YjQ0NTI3M2EzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDMtMThUMjI6NDM6NDNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTktMDUtMzBUMTA6MjA6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
@@ -3012,18 +210,18 @@ http_interactions:
         dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
         YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
         VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhl
-        dGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5p
-        bmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVs
-        bCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzkwMWYxZmJm
-        MWJhOWVjMDRjYjk1YTUifSwgImlkIjogIjVjOTAxZjFmYmYxYmE5ZWMwNGNi
-        OTVhNSJ9
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2
+        ZWwuYmFsbW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGws
+        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlNzRjMzhl
+        YjVjOGY5ZmY1YWJjIn0sICJpZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjVh
+        YmMifQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:43 GMT
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/24c75573-75a9-406d-9264-67d0dd1ee1e2/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/66c7f7a4-69bc-456e-bdd3-99ab445273a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3042,15 +240,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:43 GMT
+      - Thu, 30 May 2019 10:20:36 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"7be4388e355cc8a53688056a2d9214eb-gzip"'
+      - '"faaab20f0a5595273e93e8ba1f33c4b6-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1176'
+      - '1174'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3058,12 +256,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yNGM3NTU3My03NWE5LTQwNmQtOTI2NC02N2QwZGQxZWUx
-        ZTIvIiwgInRhc2tfaWQiOiAiMjRjNzU1NzMtNzVhOS00MDZkLTkyNjQtNjdk
-        MGRkMWVlMWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy82NmM3ZjdhNC02OWJjLTQ1NmUtYmRkMy05OWFiNDQ1Mjcz
+        YTMvIiwgInRhc2tfaWQiOiAiNjZjN2Y3YTQtNjliYy00NTZlLWJkZDMtOTlh
+        YjQ0NTI3M2EzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDMtMThUMjI6NDM6NDNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTktMDUtMzBUMTA6MjA6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
@@ -3076,18 +274,18 @@ http_interactions:
         dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
         YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
         VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhl
-        dGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5p
-        bmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVs
-        bCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzkwMWYxZmJm
-        MWJhOWVjMDRjYjk1YTUifSwgImlkIjogIjVjOTAxZjFmYmYxYmE5ZWMwNGNi
-        OTVhNSJ9
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2
+        ZWwuYmFsbW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGws
+        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlNzRjMzhl
+        YjVjOGY5ZmY1YWJjIn0sICJpZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjVh
+        YmMifQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:43 GMT
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/24c75573-75a9-406d-9264-67d0dd1ee1e2/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/66c7f7a4-69bc-456e-bdd3-99ab445273a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3106,15 +304,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:43 GMT
+      - Thu, 30 May 2019 10:20:36 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"7be4388e355cc8a53688056a2d9214eb-gzip"'
+      - '"faaab20f0a5595273e93e8ba1f33c4b6-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1176'
+      - '1174'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3122,12 +320,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yNGM3NTU3My03NWE5LTQwNmQtOTI2NC02N2QwZGQxZWUx
-        ZTIvIiwgInRhc2tfaWQiOiAiMjRjNzU1NzMtNzVhOS00MDZkLTkyNjQtNjdk
-        MGRkMWVlMWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy82NmM3ZjdhNC02OWJjLTQ1NmUtYmRkMy05OWFiNDQ1Mjcz
+        YTMvIiwgInRhc2tfaWQiOiAiNjZjN2Y3YTQtNjliYy00NTZlLWJkZDMtOTlh
+        YjQ0NTI3M2EzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDMtMThUMjI6NDM6NDNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTktMDUtMzBUMTA6MjA6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
@@ -3140,18 +338,18 @@ http_interactions:
         dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
         YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
         VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhl
-        dGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5p
-        bmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVs
-        bCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzkwMWYxZmJm
-        MWJhOWVjMDRjYjk1YTUifSwgImlkIjogIjVjOTAxZjFmYmYxYmE5ZWMwNGNi
-        OTVhNSJ9
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2
+        ZWwuYmFsbW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGws
+        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlNzRjMzhl
+        YjVjOGY5ZmY1YWJjIn0sICJpZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjVh
+        YmMifQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:43 GMT
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/24c75573-75a9-406d-9264-67d0dd1ee1e2/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/66c7f7a4-69bc-456e-bdd3-99ab445273a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3170,15 +368,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:43 GMT
+      - Thu, 30 May 2019 10:20:36 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"29220afab21c9109debac63e2db59b4f-gzip"'
+      - '"faaab20f0a5595273e93e8ba1f33c4b6-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1173'
+      - '1174'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3186,12 +384,76 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yNGM3NTU3My03NWE5LTQwNmQtOTI2NC02N2QwZGQxZWUx
-        ZTIvIiwgInRhc2tfaWQiOiAiMjRjNzU1NzMtNzVhOS00MDZkLTkyNjQtNjdk
-        MGRkMWVlMWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy82NmM3ZjdhNC02OWJjLTQ1NmUtYmRkMy05OWFiNDQ1Mjcz
+        YTMvIiwgInRhc2tfaWQiOiAiNjZjN2Y3YTQtNjliYy00NTZlLWJkZDMtOTlh
+        YjQ0NTI3M2EzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDMtMThUMjI6NDM6NDNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTktMDUtMzBUMTA6MjA6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
+        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2
+        ZWwuYmFsbW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGws
+        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlNzRjMzhl
+        YjVjOGY5ZmY1YWJjIn0sICJpZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjVh
+        YmMifQ==
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/66c7f7a4-69bc-456e-bdd3-99ab445273a3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:36 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"7dac04d8fc74a56bc901c1ad97273e3c-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1171'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82NmM3ZjdhNC02OWJjLTQ1NmUtYmRkMy05OWFiNDQ1Mjcz
+        YTMvIiwgInRhc2tfaWQiOiAiNjZjN2Y3YTQtNjliYy00NTZlLWJkZDMtOTlh
+        YjQ0NTI3M2EzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTktMDUtMzBUMTA6MjA6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
@@ -3204,18 +466,18 @@ http_interactions:
         bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRl
         IjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5PVF9T
         VEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
-        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEu
-        cGFydGVsbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmci
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
-        dGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwg
-        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzkwMWYxZmJmMWJh
-        OWVjMDRjYjk1YTUifSwgImlkIjogIjVjOTAxZjFmYmYxYmE5ZWMwNGNiOTVh
-        NSJ9
+        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwu
+        YmFsbW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBk
+        ZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlNzRjMzhlYjVj
+        OGY5ZmY1YWJjIn0sICJpZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjVhYmMi
+        fQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:43 GMT
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/24c75573-75a9-406d-9264-67d0dd1ee1e2/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/66c7f7a4-69bc-456e-bdd3-99ab445273a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3234,15 +496,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:43 GMT
+      - Thu, 30 May 2019 10:20:36 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"bdde9f1d8bc926b37321d5b5194c0b98-gzip"'
+      - '"796c8750d48870fa7fde64d490430100-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1167'
+      - '1165'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3250,12 +512,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yNGM3NTU3My03NWE5LTQwNmQtOTI2NC02N2QwZGQxZWUx
-        ZTIvIiwgInRhc2tfaWQiOiAiMjRjNzU1NzMtNzVhOS00MDZkLTkyNjQtNjdk
-        MGRkMWVlMWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy82NmM3ZjdhNC02OWJjLTQ1NmUtYmRkMy05OWFiNDQ1Mjcz
+        YTMvIiwgInRhc2tfaWQiOiAiNjZjN2Y3YTQtNjliYy00NTZlLWJkZDMtOTlh
+        YjQ0NTI3M2EzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDMtMThUMjI6NDM6NDNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTktMDUtMzBUMTA6MjA6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
@@ -3268,17 +530,17 @@ http_interactions:
         OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
         IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIklOX1BST0dSRVNT
         In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVl
-        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVs
-        bG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29y
-        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEu
-        cGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9y
-        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzkwMWYxZmJmMWJhOWVjMDRj
-        Yjk1YTUifSwgImlkIjogIjVjOTAxZjFmYmYxYmE5ZWMwNGNiOTVhNSJ9
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5i
+        YWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlNzRjMzhlYjVjOGY5ZmY1
+        YWJjIn0sICJpZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjVhYmMifQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:43 GMT
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/24c75573-75a9-406d-9264-67d0dd1ee1e2/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/66c7f7a4-69bc-456e-bdd3-99ab445273a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3297,15 +559,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:43 GMT
+      - Thu, 30 May 2019 10:20:36 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"bdde9f1d8bc926b37321d5b5194c0b98-gzip"'
+      - '"796c8750d48870fa7fde64d490430100-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1167'
+      - '1165'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3313,12 +575,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yNGM3NTU3My03NWE5LTQwNmQtOTI2NC02N2QwZGQxZWUx
-        ZTIvIiwgInRhc2tfaWQiOiAiMjRjNzU1NzMtNzVhOS00MDZkLTkyNjQtNjdk
-        MGRkMWVlMWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy82NmM3ZjdhNC02OWJjLTQ1NmUtYmRkMy05OWFiNDQ1Mjcz
+        YTMvIiwgInRhc2tfaWQiOiAiNjZjN2Y3YTQtNjliYy00NTZlLWJkZDMtOTlh
+        YjQ0NTI3M2EzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDMtMThUMjI6NDM6NDNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTktMDUtMzBUMTA6MjA6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
@@ -3331,17 +593,17 @@ http_interactions:
         OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
         IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIklOX1BST0dSRVNT
         In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVl
-        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVs
-        bG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29y
-        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEu
-        cGFydGVsbG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9y
-        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzkwMWYxZmJmMWJhOWVjMDRj
-        Yjk1YTUifSwgImlkIjogIjVjOTAxZjFmYmYxYmE5ZWMwNGNiOTVhNSJ9
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5i
+        YWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlNzRjMzhlYjVjOGY5ZmY1
+        YWJjIn0sICJpZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjVhYmMifQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:43 GMT
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/24c75573-75a9-406d-9264-67d0dd1ee1e2/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/66c7f7a4-69bc-456e-bdd3-99ab445273a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3360,15 +622,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:43 GMT
+      - Thu, 30 May 2019 10:20:36 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"d583548570bc63410c8d2e7c4e67b0d7-gzip"'
+      - '"28fbdd80bad421f7f5738588b4f0bb1c-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1161'
+      - '1162'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3376,35 +638,35 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yNGM3NTU3My03NWE5LTQwNmQtOTI2NC02N2QwZGQxZWUx
-        ZTIvIiwgInRhc2tfaWQiOiAiMjRjNzU1NzMtNzVhOS00MDZkLTkyNjQtNjdk
-        MGRkMWVlMWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy82NmM3ZjdhNC02OWJjLTQ1NmUtYmRkMy05OWFiNDQ1Mjcz
+        YTMvIiwgInRhc2tfaWQiOiAiNjZjN2Y3YTQtNjliYy00NTZlLWJkZDMtOTlh
+        YjQ0NTI3M2EzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDMtMThUMjI6NDM6NDNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTktMDUtMzBUMTA6MjA6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
         IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
         OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
         bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
-        IklOX1BST0dSRVNTIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhh
-        bXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25h
-        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVs
-        bG8uZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVs
-        bCwgIl9pZCI6IHsiJG9pZCI6ICI1YzkwMWYxZmJmMWJhOWVjMDRjYjk1YTUi
-        fSwgImlkIjogIjVjOTAxZjFmYmYxYmE5ZWMwNGNiOTVhNSJ9
+        OiAiSU5fUFJPR1JFU1MifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5l
+        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxt
+        b3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51
+        bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlNzRjMzhlYjVjOGY5ZmY1YWJj
+        In0sICJpZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjVhYmMifQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:43 GMT
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/24c75573-75a9-406d-9264-67d0dd1ee1e2/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/66c7f7a4-69bc-456e-bdd3-99ab445273a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3423,15 +685,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:43 GMT
+      - Thu, 30 May 2019 10:20:36 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"c55faa9286ab896755f614570c0e1cd5-gzip"'
+      - '"db62225374a434e23dbd6033652daf9f-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1158'
+      - '1156'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3439,12 +701,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yNGM3NTU3My03NWE5LTQwNmQtOTI2NC02N2QwZGQxZWUx
-        ZTIvIiwgInRhc2tfaWQiOiAiMjRjNzU1NzMtNzVhOS00MDZkLTkyNjQtNjdk
-        MGRkMWVlMWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy82NmM3ZjdhNC02OWJjLTQ1NmUtYmRkMy05OWFiNDQ1Mjcz
+        YTMvIiwgInRhc2tfaWQiOiAiNjZjN2Y3YTQtNjliYy00NTZlLWJkZDMtOTlh
+        YjQ0NTI3M2EzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDMtMThUMjI6NDM6NDNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTktMDUtMzBUMTA6MjA6MzZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
@@ -3457,17 +719,17 @@ http_interactions:
         Iml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklT
         SEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
         ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAicmVz
-        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUi
-        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8u
-        ZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwg
-        Il9pZCI6IHsiJG9pZCI6ICI1YzkwMWYxZmJmMWJhOWVjMDRjYjk1YTUifSwg
-        ImlkIjogIjVjOTAxZjFmYmYxYmE5ZWMwNGNiOTVhNSJ9
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNWNlZmFlNzRjMzhlYjVjOGY5ZmY1YWJjIn0sICJp
+        ZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjVhYmMifQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:43 GMT
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/24c75573-75a9-406d-9264-67d0dd1ee1e2/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/66c7f7a4-69bc-456e-bdd3-99ab445273a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3486,15 +748,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:43 GMT
+      - Thu, 30 May 2019 10:20:36 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"f1c765603fffd9fd9267fe44c494bcc3-gzip"'
+      - '"cd95f98c09da6f7269130ce527fdb1b9-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2411'
+      - '2409'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3502,16 +764,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yNGM3NTU3My03NWE5LTQwNmQtOTI2NC02N2QwZGQxZWUx
-        ZTIvIiwgInRhc2tfaWQiOiAiMjRjNzU1NzMtNzVhOS00MDZkLTkyNjQtNjdk
-        MGRkMWVlMWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy82NmM3ZjdhNC02OWJjLTQ1NmUtYmRkMy05OWFiNDQ1Mjcz
+        YTMvIiwgInRhc2tfaWQiOiAiNjZjN2Y3YTQtNjliYy00NTZlLWJkZDMtOTlh
+        YjQ0NTI3M2EzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTktMDMtMThUMjI6NDM6NDNaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTktMDMtMThUMjI6NDM6NDNaIiwgInRyYWNl
+        IjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgInRyYWNl
         YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzL2ViZWRlZjMxLTUzMWYtNGU3OC04MjJlLWY3NDYz
-        YzdiYzI5Ny8iLCAidGFza19pZCI6ICJlYmVkZWYzMS01MzFmLTRlNzgtODIy
-        ZS1mNzQ2M2M3YmMyOTcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bHAvYXBpL3YyL3Rhc2tzL2ZiMzVkM2U5LTRmYjItNDc3Yi1iNWQ4LWRlNjQ3
+        OGE1YWZkNC8iLCAidGFza19pZCI6ICJmYjM1ZDNlOS00ZmIyLTQ3N2ItYjVk
+        OC1kZTY0NzhhNWFmZDQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
         bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
         dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
         cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
@@ -3523,42 +785,42 @@ http_interactions:
         XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
         ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhh
-        bXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9u
-        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQHRoZXRhLnBhcnRl
-        bGxvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlv
-        biI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wMy0xOFQyMjo0Mzo0M1oi
-        LCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIy
-        MDE5LTAzLTE4VDIyOjQzOjQzWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1
-        bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnki
-        OiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAx
-        NSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJp
-        ZCI6ICI1YzkwMWYxZmRiMjg0ZTBiNDMzNWUwZDAiLCAiZGV0YWlscyI6IHsi
-        bW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7
-        InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3Rh
-        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAi
-        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
-        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxz
-        IjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJn
-        ZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
-        YnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJl
-        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjVjOTAxZjFmYmYxYmE5ZWMwNGNiOTVhNSJ9LCAiaWQiOiAi
-        NWM5MDFmMWZiZjFiYTllYzA0Y2I5NWE1In0=
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFt
+        cGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
+        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
+        OiBudWxsLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzdGFydGVkIjogIjIwMTktMDUtMzBUMTA6MjA6MzZaIiwg
+        Il9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAx
+        OS0wNS0zMFQxMDoyMDozNloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
+        aW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5Ijog
+        eyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUs
+        ICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQi
+        OiAiNWNlZmFlNzRiMDJlNTMzNDM0Y2Y4YjYzIiwgImRldGFpbHMiOiB7Im1v
+        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
+        aXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRl
+        dGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBt
+        X3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6
+        IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJy
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjVhYmMifSwgImlkIjogIjVj
+        ZWZhZTc0YzM4ZWI1YzhmOWZmNWFiYyJ9
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:43 GMT
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/ebedef31-531f-4e78-822e-f7463c7bc297/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/fb35d3e9-4fb2-477b-b5d8-de6478a5afd4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3577,15 +839,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:43 GMT
+      - Thu, 30 May 2019 10:20:36 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"f7fffc758b3bc1f3b16c4ccbaedf301d-gzip"'
+      - '"dcb207ba6ae36c31941d38ce7fb70e56-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '4544'
+      - '677'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3593,110 +855,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9lYmVkZWYzMS01MzFmLTRlNzgtODIyZS1mNzQ2
-        M2M3YmMyOTcvIiwgInRhc2tfaWQiOiAiZWJlZGVmMzEtNTMxZi00ZTc4LTgy
-        MmUtZjc0NjNjN2JjMjk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy9mYjM1ZDNlOS00ZmIyLTQ3N2ItYjVkOC1kZTY0
+        NzhhNWFmZDQvIiwgInRhc2tfaWQiOiAiZmIzNWQzZTktNGZiMi00NzdiLWI1
+        ZDgtZGU2NDc4YTVhZmQ0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDMtMThUMjI6NDM6NDNaIiwgInRyYWNlYmFjayI6IG51
+        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
-        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI0NGNhNDQ5ZS1iYzFmLTRiOTUtODVmZC1i
-        NjZiNDQzOTMwZTciLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiSU5fUFJPR1JFU1Mi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzk4MWJlNzktNDE4Yi00ODkzLTg0
-        NzItMTFkOThlN2FjMmRmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3Ry
-        aWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjNjMDc2MWNhLTlmZWUtNDNhZC05NmU2LTg0
-        Nzg0YTEwNGRhMiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
-        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0
-        ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA1YzgxNjQ5
-        LTkxNjUtNDI3MS1hYmM0LWMyMTg4OGQ4NDc2YyIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI5MGRjYWIzYS03MTQ3LTRlZmQtOGE1ZC04N2Ew
-        NjNlM2U1M2IiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0
-        ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWU1YzFk
-        OWYtZGU4Ny00YWJlLTlmOGUtYmYyNTI4ZmI3NjdkIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAi
-        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiNGE5NGU5ZmMtMWFlZi00NGM4LWFiNDEtMjRm
-        MzUyODNiODAzIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
-        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUi
-        LCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjAz
-        OTc3NDJkLTE5ZTEtNDMxZi1iNjFjLTQ2NGI5ODdlYjg2MyIsICJudW1fcHJv
-        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFk
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQwYThjOWNmLWQ2NjItNDVmNS04
-        MjUzLWNmY2I4NjQzYmE2ZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjI3NGMzYmE5LTE0MzktNDkwNy04M2M5LTY3
-        OTk3ODllOTM0MCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
-        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
-        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICIyOTUwYjVmYy1iMmExLTRjM2UtYjdhMi04NzZiNTg1ZmMy
-        NzgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVw
-        X3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI3ODRjMDhmZC00ZjM5LTQ1MGQtYmJmNS1kMzQ3YWQzY2JjN2QiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUi
-        OiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
-        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTAxYTNhOGYtYjg3
-        OS00ODJkLWFjNDMtNDFmNDE1MzVlYjRjIiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJl
-        Y3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODg5MWYzZTctZmI5MC00MGFm
-        LTk0YTYtNzYxMTU3MzZhN2U2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
-        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3Rp
-        bmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRh
-        ZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5YzgzZWFmYi0yZmNjLTRkMTYt
-        YjQ2Yy0xYjI5NTJhZWMzZjIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJx
-        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0
-        ZWxsby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0
-        YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOTAxZjFmYmYxYmE5ZWMw
-        NGNiOTcxYiJ9LCAiaWQiOiAiNWM5MDFmMWZiZjFiYTllYzA0Y2I5NzFiIn0=
+        fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVs
+        LmJhbG1vcmEuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmci
+        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
+        ZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjZWZhZTc0YzM4ZWI1
+        YzhmOWZmNWMzZCJ9LCAiaWQiOiAiNWNlZmFlNzRjMzhlYjVjOGY5ZmY1YzNk
+        In0=
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:43 GMT
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/24c75573-75a9-406d-9264-67d0dd1ee1e2/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/66c7f7a4-69bc-456e-bdd3-99ab445273a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3715,15 +892,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:43 GMT
+      - Thu, 30 May 2019 10:20:36 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"f1c765603fffd9fd9267fe44c494bcc3-gzip"'
+      - '"cd95f98c09da6f7269130ce527fdb1b9-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2411'
+      - '2409'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3731,16 +908,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yNGM3NTU3My03NWE5LTQwNmQtOTI2NC02N2QwZGQxZWUx
-        ZTIvIiwgInRhc2tfaWQiOiAiMjRjNzU1NzMtNzVhOS00MDZkLTkyNjQtNjdk
-        MGRkMWVlMWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy82NmM3ZjdhNC02OWJjLTQ1NmUtYmRkMy05OWFiNDQ1Mjcz
+        YTMvIiwgInRhc2tfaWQiOiAiNjZjN2Y3YTQtNjliYy00NTZlLWJkZDMtOTlh
+        YjQ0NTI3M2EzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTktMDMtMThUMjI6NDM6NDNaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTktMDMtMThUMjI6NDM6NDNaIiwgInRyYWNl
+        IjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgInRyYWNl
         YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzL2ViZWRlZjMxLTUzMWYtNGU3OC04MjJlLWY3NDYz
-        YzdiYzI5Ny8iLCAidGFza19pZCI6ICJlYmVkZWYzMS01MzFmLTRlNzgtODIy
-        ZS1mNzQ2M2M3YmMyOTcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bHAvYXBpL3YyL3Rhc2tzL2ZiMzVkM2U5LTRmYjItNDc3Yi1iNWQ4LWRlNjQ3
+        OGE1YWZkNC8iLCAidGFza19pZCI6ICJmYjM1ZDNlOS00ZmIyLTQ3N2ItYjVk
+        OC1kZTY0NzhhNWFmZDQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
         bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
         dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
         cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
@@ -3752,42 +929,42 @@ http_interactions:
         XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
         ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhh
-        bXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9u
-        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQHRoZXRhLnBhcnRl
-        bGxvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlv
-        biI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wMy0xOFQyMjo0Mzo0M1oi
-        LCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIy
-        MDE5LTAzLTE4VDIyOjQzOjQzWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1
-        bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnki
-        OiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAx
-        NSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJp
-        ZCI6ICI1YzkwMWYxZmRiMjg0ZTBiNDMzNWUwZDAiLCAiZGV0YWlscyI6IHsi
-        bW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7
-        InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3Rh
-        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAi
-        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
-        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxz
-        IjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJn
-        ZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
-        YnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJl
-        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjVjOTAxZjFmYmYxYmE5ZWMwNGNiOTVhNSJ9LCAiaWQiOiAi
-        NWM5MDFmMWZiZjFiYTllYzA0Y2I5NWE1In0=
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFt
+        cGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
+        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
+        OiBudWxsLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzdGFydGVkIjogIjIwMTktMDUtMzBUMTA6MjA6MzZaIiwg
+        Il9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAx
+        OS0wNS0zMFQxMDoyMDozNloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
+        aW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5Ijog
+        eyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUs
+        ICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQi
+        OiAiNWNlZmFlNzRiMDJlNTMzNDM0Y2Y4YjYzIiwgImRldGFpbHMiOiB7Im1v
+        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
+        aXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRl
+        dGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBt
+        X3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6
+        IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJy
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjVhYmMifSwgImlkIjogIjVj
+        ZWZhZTc0YzM4ZWI1YzhmOWZmNWFiYyJ9
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:43 GMT
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/ebedef31-531f-4e78-822e-f7463c7bc297/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/fb35d3e9-4fb2-477b-b5d8-de6478a5afd4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3806,15 +983,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:43 GMT
+      - Thu, 30 May 2019 10:20:36 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"a51516bb0e55ef54c499c827f7bd6068-gzip"'
+      - '"5d307e0c3b2abce1f5e0e0eb9d6c7b38-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '4538'
+      - '4539'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3822,110 +999,339 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9lYmVkZWYzMS01MzFmLTRlNzgtODIyZS1mNzQ2
-        M2M3YmMyOTcvIiwgInRhc2tfaWQiOiAiZWJlZGVmMzEtNTMxZi00ZTc4LTgy
-        MmUtZjc0NjNjN2JjMjk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy9mYjM1ZDNlOS00ZmIyLTQ3N2ItYjVkOC1kZTY0
+        NzhhNWFmZDQvIiwgInRhc2tfaWQiOiAiZmIzNWQzZTktNGZiMi00NzdiLWI1
+        ZDgtZGU2NDc4YTVhZmQ0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDMtMThUMjI6NDM6NDNaIiwgInRyYWNlYmFjayI6IG51
+        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
         InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
         ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI0NGNhNDQ5ZS1iYzFmLTRiOTUtODVmZC1i
-        NjZiNDQzOTMwZTciLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI1OWEyY2U2OC00N2M4LTQ4OWYtYjYzYS1m
+        ZTQ2NzllNTc3NTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
         dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
         dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYzk4MWJlNzktNDE4Yi00ODkzLTg0NzIt
-        MTFkOThlN2FjMmRmIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiOGNmNjFmOTQtZmFkMC00YThiLTk4M2Ut
+        NmVhNDAyOWRkMzJiIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImIwOTA5MGMwLWEyMTgtNDYzOS1iOGMzLThkODY0
+        OTIzNDJhMSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBf
+        dHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
+        VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc5MDFjZjlmLTU5
+        YzItNDBlOC05YzEyLTY3NTFhMDc5NGQ2OCIsICJudW1fcHJvY2Vzc2VkIjog
+        MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVt
+        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIwODdjNTdlYS0wMDU3LTQ0ZTgtYjY2Ny0zOTBkY2Q0
+        ZGEyOWIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBf
+        dHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDViY2JlMjIt
+        ZGY4Mi00ZjdjLWFhZDgtNWI4ZmQ1ZjFlNjk5IiwgIm51bV9wcm9jZXNzZWQi
+        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
+        aXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiOWY1ZmQwYjktYjYwOC00OWZhLTgxZDgtNjhlMTU3
+        M2JlM2JkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAi
+        c3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE0ODZh
+        ZWRjLWE2MDItNDYyMS1iNDVlLWYyNmQ4YzY5YmQ3OCIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        UHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjA2MTE2ZjU4LTk5YzktNDhlYi05NGYw
+        LTQwZjcxYWVlOWQyMiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFk
+        YXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjMyMGI2YTZjLTU5NzktNGU0Zi1hNjgzLWNiYmI3
+        YTNhMDBjOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
+        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI1NzI4MGM4MS1lNGU5LTQ1YzAtOTAyYi0yYjEyY2M4MWM0ZWQi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5
+        cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICI0MWI3NTYxMi1jZjY3LTRmZDktYWU3Zi04MGVlNzc1OTYwMWQiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
+        cmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
+        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzU3NWEzZjAtYzY5OC00
+        Yjg3LTgyZTYtYjUxY2EyZjg0ODdhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
+        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
+        IGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rv
+        cnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzczMWY4MDQtZDIwZi00MmIyLWI4
+        NDEtMzM0MmMzYzA1NGY2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3Rpbmdz
+        IEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0
+        YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3NjY3ZWQ0Yi1mMjNmLTRlYTgtODYy
+        ZS04M2I4ZTRiNzFiN2YiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3Jh
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJh
+        bG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjVj
+        M2QifSwgImlkIjogIjVjZWZhZTc0YzM4ZWI1YzhmOWZmNWMzZCJ9
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/66c7f7a4-69bc-456e-bdd3-99ab445273a3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:36 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"cd95f98c09da6f7269130ce527fdb1b9-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2409'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy82NmM3ZjdhNC02OWJjLTQ1NmUtYmRkMy05OWFiNDQ1Mjcz
+        YTMvIiwgInRhc2tfaWQiOiAiNjZjN2Y3YTQtNjliYy00NTZlLWJkZDMtOTlh
+        YjQ0NTI3M2EzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzL2ZiMzVkM2U5LTRmYjItNDc3Yi1iNWQ4LWRlNjQ3
+        OGE1YWZkNC8iLCAidGFza19pZCI6ICJmYjM1ZDNlOS00ZmIyLTQ3N2ItYjVk
+        OC1kZTY0NzhhNWFmZDQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFt
+        cGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
+        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
+        OiBudWxsLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzdGFydGVkIjogIjIwMTktMDUtMzBUMTA6MjA6MzZaIiwg
+        Il9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAx
+        OS0wNS0zMFQxMDoyMDozNloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
+        aW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5Ijog
+        eyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUs
+        ICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQi
+        OiAiNWNlZmFlNzRiMDJlNTMzNDM0Y2Y4YjYzIiwgImRldGFpbHMiOiB7Im1v
+        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
+        aXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRl
+        dGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBt
+        X3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6
+        IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJy
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjVhYmMifSwgImlkIjogIjVj
+        ZWZhZTc0YzM4ZWI1YzhmOWZmNWFiYyJ9
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/fb35d3e9-4fb2-477b-b5d8-de6478a5afd4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:36 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"4d2140e666629c5506287e54fef92740-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4536'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9mYjM1ZDNlOS00ZmIyLTQ3N2ItYjVkOC1kZTY0
+        NzhhNWFmZDQvIiwgInRhc2tfaWQiOiAiZmIzNWQzZTktNGZiMi00NzdiLWI1
+        ZDgtZGU2NDc4YTVhZmQ0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI1OWEyY2U2OC00N2M4LTQ4OWYtYjYzYS1m
+        ZTQ2NzllNTc3NTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiOGNmNjFmOTQtZmFkMC00YThiLTk4M2Ut
+        NmVhNDAyOWRkMzJiIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
         Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
         dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
         ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjNjMDc2MWNhLTlmZWUtNDNhZC05NmU2LTg0Nzg0YTEw
-        NGRhMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAz
+        ICJzdGVwX2lkIjogImIwOTA5MGMwLWEyMTgtNDYzOS1iOGMzLThkODY0OTIz
+        NDJhMSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA2
         LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
         ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIklOX1BS
         T0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA1YzgxNjQ5LTkxNjUt
-        NDI3MS1hYmM0LWMyMTg4OGQ4NDc2YyIsICJudW1fcHJvY2Vzc2VkIjogM30s
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc5MDFjZjlmLTU5YzIt
+        NDBlOC05YzEyLTY3NTFhMDc5NGQ2OCIsICJudW1fcHJvY2Vzc2VkIjogNn0s
         IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
         ZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICI5MGRjYWIzYS03MTQ3LTRlZmQtOGE1ZC04N2EwNjNlM2U1
-        M2IiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICIwODdjNTdlYS0wMDU3LTQ0ZTgtYjY2Ny0zOTBkY2Q0ZGEy
+        OWIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlw
         ZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
         X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWU1YzFkOWYtZGU4
-        Ny00YWJlLTlmOGUtYmYyNTI4ZmI3NjdkIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDViY2JlMjItZGY4
+        Mi00ZjdjLWFhZDgtNWI4ZmQ1ZjFlNjk5IiwgIm51bV9wcm9jZXNzZWQiOiAw
         fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
         aW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNf
         dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
         YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiNGE5NGU5ZmMtMWFlZi00NGM4LWFiNDEtMjRmMzUyODNi
-        ODAzIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        InN0ZXBfaWQiOiAiOWY1ZmQwYjktYjYwOC00OWZhLTgxZDgtNjhlMTU3M2Jl
+        M2JkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
         ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
         cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
         Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjAzOTc3NDJk
-        LTE5ZTEtNDMxZi1iNjFjLTQ2NGI5ODdlYjg2MyIsICJudW1fcHJvY2Vzc2Vk
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE0ODZhZWRj
+        LWE2MDItNDYyMS1iNDVlLWYyNmQ4YzY5YmQ3OCIsICJudW1fcHJvY2Vzc2Vk
         IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
         bGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
         cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjQwYThjOWNmLWQ2NjItNDVmNS04MjUzLWNm
-        Y2I4NjQzYmE2ZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        cyI6IDAsICJzdGVwX2lkIjogIjA2MTE2ZjU4LTk5YzktNDhlYi05NGYwLTQw
+        ZjcxYWVlOWQyMiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
         c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
         IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
         X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjI3NGMzYmE5LTE0MzktNDkwNy04M2M5LTY3OTk3ODll
-        OTM0MCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        ICJzdGVwX2lkIjogIjMyMGI2YTZjLTU5NzktNGU0Zi1hNjgzLWNiYmI3YTNh
+        MDBjOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
         LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAi
         c3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6
         IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICIyOTUwYjVmYy1iMmExLTRjM2UtYjdhMi04NzZiNTg1ZmMyNzgiLCAi
+        ZCI6ICI1NzI4MGM4MS1lNGU5LTQ1YzAtOTAyYi0yYjEyY2M4MWM0ZWQiLCAi
         bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
         aXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUi
         OiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3
-        ODRjMDhmZC00ZjM5LTQ1MGQtYmJmNS1kMzQ3YWQzY2JjN2QiLCAibnVtX3By
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0
+        MWI3NTYxMi1jZjY3LTRmZDktYWU3Zi04MGVlNzc1OTYwMWQiLCAibnVtX3By
         b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
         IjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVw
         b3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
         RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTAxYTNhOGYtYjg3OS00ODJk
-        LWFjNDMtNDFmNDE1MzVlYjRjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzU3NWEzZjAtYzY5OC00Yjg3
+        LTgyZTYtYjUxY2EyZjg0ODdhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
         dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZp
         bGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rvcnki
         LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiODg5MWYzZTctZmI5MC00MGFmLTk0YTYt
-        NzYxMTU3MzZhN2U2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNzczMWY4MDQtZDIwZi00MmIyLWI4NDEt
+        MzM0MmMzYzA1NGY2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZp
         bGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI5YzgzZWFmYi0yZmNjLTRkMTYtYjQ2Yy0x
-        YjI5NTJhZWMzZjIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5l
-        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0
-        ZWxsby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjOTAxZjFmYmYxYmE5ZWMwNGNiOTcx
-        YiJ9LCAiaWQiOiAiNWM5MDFmMWZiZjFiYTllYzA0Y2I5NzFiIn0=
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI3NjY3ZWQ0Yi1mMjNmLTRlYTgtODYyZS04
+        M2I4ZTRiNzFiN2YiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9u
+        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1v
+        cmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjVjM2Qi
+        fSwgImlkIjogIjVjZWZhZTc0YzM4ZWI1YzhmOWZmNWMzZCJ9
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:43 GMT
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/24c75573-75a9-406d-9264-67d0dd1ee1e2/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/66c7f7a4-69bc-456e-bdd3-99ab445273a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3944,15 +1350,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:43 GMT
+      - Thu, 30 May 2019 10:20:36 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"f1c765603fffd9fd9267fe44c494bcc3-gzip"'
+      - '"cd95f98c09da6f7269130ce527fdb1b9-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2411'
+      - '2409'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3960,16 +1366,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yNGM3NTU3My03NWE5LTQwNmQtOTI2NC02N2QwZGQxZWUx
-        ZTIvIiwgInRhc2tfaWQiOiAiMjRjNzU1NzMtNzVhOS00MDZkLTkyNjQtNjdk
-        MGRkMWVlMWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy82NmM3ZjdhNC02OWJjLTQ1NmUtYmRkMy05OWFiNDQ1Mjcz
+        YTMvIiwgInRhc2tfaWQiOiAiNjZjN2Y3YTQtNjliYy00NTZlLWJkZDMtOTlh
+        YjQ0NTI3M2EzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTktMDMtMThUMjI6NDM6NDNaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTktMDMtMThUMjI6NDM6NDNaIiwgInRyYWNl
+        IjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgInRyYWNl
         YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzL2ViZWRlZjMxLTUzMWYtNGU3OC04MjJlLWY3NDYz
-        YzdiYzI5Ny8iLCAidGFza19pZCI6ICJlYmVkZWYzMS01MzFmLTRlNzgtODIy
-        ZS1mNzQ2M2M3YmMyOTcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bHAvYXBpL3YyL3Rhc2tzL2ZiMzVkM2U5LTRmYjItNDc3Yi1iNWQ4LWRlNjQ3
+        OGE1YWZkNC8iLCAidGFza19pZCI6ICJmYjM1ZDNlOS00ZmIyLTQ3N2ItYjVk
+        OC1kZTY0NzhhNWFmZDQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
         bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
         dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
         cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
@@ -3981,42 +1387,42 @@ http_interactions:
         XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
         ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhh
-        bXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9u
-        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQHRoZXRhLnBhcnRl
-        bGxvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlv
-        biI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wMy0xOFQyMjo0Mzo0M1oi
-        LCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIy
-        MDE5LTAzLTE4VDIyOjQzOjQzWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1
-        bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnki
-        OiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAx
-        NSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJp
-        ZCI6ICI1YzkwMWYxZmRiMjg0ZTBiNDMzNWUwZDAiLCAiZGV0YWlscyI6IHsi
-        bW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7
-        InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3Rh
-        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAi
-        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
-        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxz
-        IjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJn
-        ZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
-        YnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJl
-        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjVjOTAxZjFmYmYxYmE5ZWMwNGNiOTVhNSJ9LCAiaWQiOiAi
-        NWM5MDFmMWZiZjFiYTllYzA0Y2I5NWE1In0=
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFt
+        cGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
+        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
+        OiBudWxsLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzdGFydGVkIjogIjIwMTktMDUtMzBUMTA6MjA6MzZaIiwg
+        Il9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAx
+        OS0wNS0zMFQxMDoyMDozNloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
+        aW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5Ijog
+        eyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUs
+        ICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQi
+        OiAiNWNlZmFlNzRiMDJlNTMzNDM0Y2Y4YjYzIiwgImRldGFpbHMiOiB7Im1v
+        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
+        aXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRl
+        dGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBt
+        X3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6
+        IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJy
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjVhYmMifSwgImlkIjogIjVj
+        ZWZhZTc0YzM4ZWI1YzhmOWZmNWFiYyJ9
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:43 GMT
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/ebedef31-531f-4e78-822e-f7463c7bc297/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/fb35d3e9-4fb2-477b-b5d8-de6478a5afd4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4035,15 +1441,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:43 GMT
+      - Thu, 30 May 2019 10:20:36 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"ecfb91d9a059208294d1eef676abeaa5-gzip"'
+      - '"68975af539894f4417dd85aa6a8a1833-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '4531'
+      - '4526'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -4051,339 +1457,110 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9lYmVkZWYzMS01MzFmLTRlNzgtODIyZS1mNzQ2
-        M2M3YmMyOTcvIiwgInRhc2tfaWQiOiAiZWJlZGVmMzEtNTMxZi00ZTc4LTgy
-        MmUtZjc0NjNjN2JjMjk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy9mYjM1ZDNlOS00ZmIyLTQ3N2ItYjVkOC1kZTY0
+        NzhhNWFmZDQvIiwgInRhc2tfaWQiOiAiZmIzNWQzZTktNGZiMi00NzdiLWI1
+        ZDgtZGU2NDc4YTVhZmQ0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDMtMThUMjI6NDM6NDNaIiwgInRyYWNlYmFjayI6IG51
+        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
         InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
         ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI0NGNhNDQ5ZS1iYzFmLTRiOTUtODVmZC1i
-        NjZiNDQzOTMwZTciLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI1OWEyY2U2OC00N2M4LTQ4OWYtYjYzYS1m
+        ZTQ2NzllNTc3NTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
         dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
         dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYzk4MWJlNzktNDE4Yi00ODkzLTg0NzIt
-        MTFkOThlN2FjMmRmIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiOGNmNjFmOTQtZmFkMC00YThiLTk4M2Ut
+        NmVhNDAyOWRkMzJiIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
         Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
         dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
         ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjNjMDc2MWNhLTlmZWUtNDNhZC05NmU2LTg0Nzg0YTEw
-        NGRhMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        ICJzdGVwX2lkIjogImIwOTA5MGMwLWEyMTgtNDYzOS1iOGMzLThkODY0OTIz
+        NDJhMSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
         LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
         ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA1YzgxNjQ5LTkxNjUtNDI3
-        MS1hYmM0LWMyMTg4OGQ4NDc2YyIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc5MDFjZjlmLTU5YzItNDBl
+        OC05YzEyLTY3NTFhMDc5NGQ2OCIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
         bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
         ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
         bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjkwZGNhYjNhLTcxNDctNGVmZC04YTVkLTg3YTA2M2UzZTUzYiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
-        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVT
-        UyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZTVjMWQ5Zi1kZTg3LTRhYmUt
-        OWY4ZS1iZjI1MjhmYjc2N2QiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9k
-        dWxlcyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI0YTk0ZTlmYy0xYWVmLTQ0YzgtYWI0MS0yNGYzNTI4M2I4MDMiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUi
-        OiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
-        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDM5Nzc0MmQtMTllMS00
-        MzFmLWI2MWMtNDY0Yjk4N2ViODYzIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
-        IE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiNDBhOGM5Y2YtZDY2Mi00NWY1LTgyNTMtY2ZjYjg2NDNi
-        YTZkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
-        ICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3Rl
-        cF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
-        OiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMjc0YzNiYTktMTQzOS00OTA3LTgzYzktNjc5OTc4OWU5MzQwIiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5
-        cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI5
-        NTBiNWZjLWIyYTEtNGMzZS1iN2EyLTg3NmI1ODVmYzI3OCIsICJudW1fcHJv
-        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1v
-        dmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc4NGMwOGZk
-        LTRmMzktNDUwZC1iYmY1LWQzNDdhZDNjYmM3ZCIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
-        ZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJhMDFhM2E4Zi1iODc5LTQ4MmQtYWM0My00
-        MWY0MTUzNWViNGMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8g
-        d2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVt
-        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI4ODkxZjNlNy1mYjkwLTQwYWYtOTRhNi03NjExNTcz
-        NmE3ZTYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjljODNlYWZiLTJmY2MtNGQxNi1iNDZjLTFiMjk1MmFl
-        YzNmMiIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQHRoZXRhLnBhcnRlbGxvLmV4YW1wbGUu
-        Y29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjog
-        InJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQHRoZXRhLnBhcnRlbGxvLmV4
-        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
-        aWQiOiB7IiRvaWQiOiAiNWM5MDFmMWZiZjFiYTllYzA0Y2I5NzFiIn0sICJp
-        ZCI6ICI1YzkwMWYxZmJmMWJhOWVjMDRjYjk3MWIifQ==
-    http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:43 GMT
-- request:
-    method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/24c75573-75a9-406d-9264-67d0dd1ee1e2/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 18 Mar 2019 22:43:43 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"f1c765603fffd9fd9267fe44c494bcc3-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2411'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yNGM3NTU3My03NWE5LTQwNmQtOTI2NC02N2QwZGQxZWUx
-        ZTIvIiwgInRhc2tfaWQiOiAiMjRjNzU1NzMtNzVhOS00MDZkLTkyNjQtNjdk
-        MGRkMWVlMWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTktMDMtMThUMjI6NDM6NDNaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTktMDMtMThUMjI6NDM6NDNaIiwgInRyYWNl
-        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzL2ViZWRlZjMxLTUzMWYtNGU3OC04MjJlLWY3NDYz
-        YzdiYzI5Ny8iLCAidGFza19pZCI6ICJlYmVkZWYzMS01MzFmLTRlNzgtODIy
-        ZS1mNzQ2M2M3YmMyOTcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
-        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
-        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
-        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
-        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhh
-        bXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9u
-        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQHRoZXRhLnBhcnRl
-        bGxvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlv
-        biI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wMy0xOFQyMjo0Mzo0M1oi
-        LCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIy
-        MDE5LTAzLTE4VDIyOjQzOjQzWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1
-        bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnki
-        OiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAx
-        NSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJp
-        ZCI6ICI1YzkwMWYxZmRiMjg0ZTBiNDMzNWUwZDAiLCAiZGV0YWlscyI6IHsi
-        bW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7
-        InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3Rh
-        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAi
-        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
-        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxz
-        IjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJn
-        ZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
-        YnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJl
-        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjVjOTAxZjFmYmYxYmE5ZWMwNGNiOTVhNSJ9LCAiaWQiOiAi
-        NWM5MDFmMWZiZjFiYTllYzA0Y2I5NWE1In0=
-    http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:44 GMT
-- request:
-    method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/ebedef31-531f-4e78-822e-f7463c7bc297/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 18 Mar 2019 22:43:44 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"99788691716a4119c459f8005680aebb-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4524'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9lYmVkZWYzMS01MzFmLTRlNzgtODIyZS1mNzQ2
-        M2M3YmMyOTcvIiwgInRhc2tfaWQiOiAiZWJlZGVmMzEtNTMxZi00ZTc4LTgy
-        MmUtZjc0NjNjN2JjMjk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDMtMThUMjI6NDM6NDNaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
-        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI0NGNhNDQ5ZS1iYzFmLTRiOTUtODVmZC1i
-        NjZiNDQzOTMwZTciLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
-        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYzk4MWJlNzktNDE4Yi00ODkzLTg0NzIt
-        MTFkOThlN2FjMmRmIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
-        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjNjMDc2MWNhLTlmZWUtNDNhZC05NmU2LTg0Nzg0YTEw
-        NGRhMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
-        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA1YzgxNjQ5LTkxNjUtNDI3
-        MS1hYmM0LWMyMTg4OGQ4NDc2YyIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
-        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjkwZGNhYjNhLTcxNDctNGVmZC04YTVkLTg3YTA2M2UzZTUzYiIsICJu
+        IjogIjA4N2M1N2VhLTAwNTctNDRlOC1iNjY3LTM5MGRjZDRkYTI5YiIsICJu
         dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
         cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
         cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZTVjMWQ5Zi1kZTg3LTRhYmUtOWY4
-        ZS1iZjI1MjhmYjc2N2QiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNWJjYmUyMi1kZjgyLTRmN2MtYWFk
+        OC01YjhmZDVmMWU2OTkiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
         dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
-        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRh
-        OTRlOWZjLTFhZWYtNDRjOC1hYjQxLTI0ZjM1MjgzYjgwMyIsICJudW1fcHJv
-        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwMzk3NzQyZC0xOWUxLTQzMWYtYjYx
-        Yy00NjRiOTg3ZWI4NjMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRh
-        dGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI0MGE4YzljZi1kNjYyLTQ1ZjUtODI1My1jZmNiODY0M2JhNmQiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUi
-        OiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIy
-        NzRjM2JhOS0xNDM5LTQ5MDctODNjOS02Nzk5Nzg5ZTkzNDAiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJn
-        ZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjk1MGI1ZmMt
-        YjJhMS00YzNlLWI3YTItODc2YjU4NWZjMjc4IiwgIm51bV9wcm9jZXNzZWQi
-        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJSZW1v
-        dmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRf
-        cmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
-        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzg0YzA4ZmQtNGYzOS00
-        NTBkLWJiZjUtZDM0N2FkM2NiYzdkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5n
-        IEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImEwMWEzYThmLWI4NzktNDgyZC1hYzQzLTQxZjQxNTM1
-        ZWI0YyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAi
-        c3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjg4OTFmM2U3LWZiOTAtNDBhZi05NGE2LTc2MTE1NzM2YTdlNiIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
-        Y3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlw
-        ZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
-        OiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiOWM4M2VhZmItMmZjYy00ZDE2LWI0NmMtMWIyOTUyYWVjM2YyIiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
-        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhhbXBsZS5j
-        b20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
-        JG9pZCI6ICI1YzkwMWYxZmJmMWJhOWVjMDRjYjk3MWIifSwgImlkIjogIjVj
-        OTAxZjFmYmYxYmE5ZWMwNGNiOTcxYiJ9
+        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICI5ZjVmZDBiOS1iNjA4LTQ5ZmEtODFkOC02OGUxNTczYmUzYmQiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAi
+        Y29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTQ4NmFlZGMtYTYwMi00NjIx
+        LWI0NWUtZjI2ZDhjNjliZDc4IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1l
+        dGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiMDYxMTZmNTgtOTljOS00OGViLTk0ZjAtNDBmNzFhZWU5ZDIy
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90
+        eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAx
+        LCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiMzIwYjZhNmMtNTk3OS00ZTRmLWE2ODMtY2JiYjdhM2EwMGM5IiwgIm51
+        bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUi
+        OiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjU3Mjgw
+        YzgxLWU0ZTktNDVjMC05MDJiLTJiMTJjYzgxYzRlZCIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        UmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVf
+        b2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
+        VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQxYjc1NjEyLWNm
+        NjctNGZkOS1hZTdmLTgwZWU3NzU5NjAxZCIsICJudW1fcHJvY2Vzc2VkIjog
+        MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
+        dGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI3NTc1YTNmMC1jNjk4LTRiODctODJlNi1iNTFj
+        YTJmODQ4N2EiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2Vi
+        IiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI3NzMxZjgwNC1kMjBmLTQyYjItYjg0MS0zMzQyYzNjMDU0
+        ZjYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVw
+        X3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3Rv
+        dGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjc2NjdlZDRiLWYyM2YtNGVhOC04NjJlLTgzYjhlNGI3MWI3
+        ZiIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2VydmVk
+        X3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5jb20u
+        ZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFtcGxl
+        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
+        eyIkb2lkIjogIjVjZWZhZTc0YzM4ZWI1YzhmOWZmNWMzZCJ9LCAiaWQiOiAi
+        NWNlZmFlNzRjMzhlYjVjOGY5ZmY1YzNkIn0=
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:44 GMT
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/24c75573-75a9-406d-9264-67d0dd1ee1e2/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/66c7f7a4-69bc-456e-bdd3-99ab445273a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4402,15 +1579,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:44 GMT
+      - Thu, 30 May 2019 10:20:36 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"f1c765603fffd9fd9267fe44c494bcc3-gzip"'
+      - '"cd95f98c09da6f7269130ce527fdb1b9-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2411'
+      - '2409'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -4418,16 +1595,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yNGM3NTU3My03NWE5LTQwNmQtOTI2NC02N2QwZGQxZWUx
-        ZTIvIiwgInRhc2tfaWQiOiAiMjRjNzU1NzMtNzVhOS00MDZkLTkyNjQtNjdk
-        MGRkMWVlMWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy82NmM3ZjdhNC02OWJjLTQ1NmUtYmRkMy05OWFiNDQ1Mjcz
+        YTMvIiwgInRhc2tfaWQiOiAiNjZjN2Y3YTQtNjliYy00NTZlLWJkZDMtOTlh
+        YjQ0NTI3M2EzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTktMDMtMThUMjI6NDM6NDNaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTktMDMtMThUMjI6NDM6NDNaIiwgInRyYWNl
+        IjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgInRyYWNl
         YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzL2ViZWRlZjMxLTUzMWYtNGU3OC04MjJlLWY3NDYz
-        YzdiYzI5Ny8iLCAidGFza19pZCI6ICJlYmVkZWYzMS01MzFmLTRlNzgtODIy
-        ZS1mNzQ2M2M3YmMyOTcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bHAvYXBpL3YyL3Rhc2tzL2ZiMzVkM2U5LTRmYjItNDc3Yi1iNWQ4LWRlNjQ3
+        OGE1YWZkNC8iLCAidGFza19pZCI6ICJmYjM1ZDNlOS00ZmIyLTQ3N2ItYjVk
+        OC1kZTY0NzhhNWFmZDQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
         bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
         dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
         cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
@@ -4439,42 +1616,42 @@ http_interactions:
         XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
         ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhh
-        bXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9u
-        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQHRoZXRhLnBhcnRl
-        bGxvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlv
-        biI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wMy0xOFQyMjo0Mzo0M1oi
-        LCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIy
-        MDE5LTAzLTE4VDIyOjQzOjQzWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1
-        bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnki
-        OiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAx
-        NSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJp
-        ZCI6ICI1YzkwMWYxZmRiMjg0ZTBiNDMzNWUwZDAiLCAiZGV0YWlscyI6IHsi
-        bW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7
-        InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3Rh
-        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAi
-        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
-        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxz
-        IjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJn
-        ZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
-        YnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJl
-        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjVjOTAxZjFmYmYxYmE5ZWMwNGNiOTVhNSJ9LCAiaWQiOiAi
-        NWM5MDFmMWZiZjFiYTllYzA0Y2I5NWE1In0=
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFt
+        cGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
+        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
+        OiBudWxsLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzdGFydGVkIjogIjIwMTktMDUtMzBUMTA6MjA6MzZaIiwg
+        Il9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAx
+        OS0wNS0zMFQxMDoyMDozNloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
+        aW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5Ijog
+        eyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUs
+        ICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQi
+        OiAiNWNlZmFlNzRiMDJlNTMzNDM0Y2Y4YjYzIiwgImRldGFpbHMiOiB7Im1v
+        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
+        aXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRl
+        dGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBt
+        X3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6
+        IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJy
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjVhYmMifSwgImlkIjogIjVj
+        ZWZhZTc0YzM4ZWI1YzhmOWZmNWFiYyJ9
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:44 GMT
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/ebedef31-531f-4e78-822e-f7463c7bc297/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/fb35d3e9-4fb2-477b-b5d8-de6478a5afd4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4493,15 +1670,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:44 GMT
+      - Thu, 30 May 2019 10:20:36 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"7bd20124509cf1dc594d64f6c5c17a9e-gzip"'
+      - '"80f5ad459933dd336f1360d182aff661-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '4504'
+      - '4503'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -4509,110 +1686,110 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9lYmVkZWYzMS01MzFmLTRlNzgtODIyZS1mNzQ2
-        M2M3YmMyOTcvIiwgInRhc2tfaWQiOiAiZWJlZGVmMzEtNTMxZi00ZTc4LTgy
-        MmUtZjc0NjNjN2JjMjk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy9mYjM1ZDNlOS00ZmIyLTQ3N2ItYjVkOC1kZTY0
+        NzhhNWFmZDQvIiwgInRhc2tfaWQiOiAiZmIzNWQzZTktNGZiMi00NzdiLWI1
+        ZDgtZGU2NDc4YTVhZmQ0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDMtMThUMjI6NDM6NDNaIiwgInRyYWNlYmFjayI6IG51
+        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
         InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
         ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI0NGNhNDQ5ZS1iYzFmLTRiOTUtODVmZC1i
-        NjZiNDQzOTMwZTciLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI1OWEyY2U2OC00N2M4LTQ4OWYtYjYzYS1m
+        ZTQ2NzllNTc3NTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
         dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
         dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYzk4MWJlNzktNDE4Yi00ODkzLTg0NzIt
-        MTFkOThlN2FjMmRmIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiOGNmNjFmOTQtZmFkMC00YThiLTk4M2Ut
+        NmVhNDAyOWRkMzJiIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
         Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
         dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
         ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjNjMDc2MWNhLTlmZWUtNDNhZC05NmU2LTg0Nzg0YTEw
-        NGRhMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        ICJzdGVwX2lkIjogImIwOTA5MGMwLWEyMTgtNDYzOS1iOGMzLThkODY0OTIz
+        NDJhMSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
         LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
         ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA1YzgxNjQ5LTkxNjUtNDI3
-        MS1hYmM0LWMyMTg4OGQ4NDc2YyIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc5MDFjZjlmLTU5YzItNDBl
+        OC05YzEyLTY3NTFhMDc5NGQ2OCIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
         bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
         ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
         bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjkwZGNhYjNhLTcxNDctNGVmZC04YTVkLTg3YTA2M2UzZTUzYiIsICJu
+        IjogIjA4N2M1N2VhLTAwNTctNDRlOC1iNjY3LTM5MGRjZDRkYTI5YiIsICJu
         dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
         cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
         cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZTVjMWQ5Zi1kZTg3LTRhYmUtOWY4
-        ZS1iZjI1MjhmYjc2N2QiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNWJjYmUyMi1kZjgyLTRmN2MtYWFk
+        OC01YjhmZDVmMWU2OTkiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
         dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
-        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRh
-        OTRlOWZjLTFhZWYtNDRjOC1hYjQxLTI0ZjM1MjgzYjgwMyIsICJudW1fcHJv
-        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIwMzk3NzQyZC0xOWUxLTQzMWYtYjYxYy00
-        NjRiOTg3ZWI4NjMiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEu
-        IiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAs
+        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
         ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0
-        MGE4YzljZi1kNjYyLTQ1ZjUtODI1My1jZmNiODY0M2JhNmQiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9u
-        IjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xv
-        c2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyNzRjM2JhOS0x
-        NDM5LTQ5MDctODNjOS02Nzk5Nzg5ZTkzNDAiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVy
-        YXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBz
-        cWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyOTUwYjVmYy1iMmExLTRjM2UtYjdh
-        Mi04NzZiNTg1ZmMyNzgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBv
-        ZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI3ODRjMDhmZC00ZjM5LTQ1MGQtYmJmNS1kMzQ3YWQz
-        Y2JjN2QiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJz
-        dGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMDFhM2E4
-        Zi1iODc5LTQ4MmQtYWM0My00MWY0MTUzNWViNGMiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNo
-        X2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJJTl9Q
-        Uk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4ODkxZjNlNy1mYjkw
-        LTQwYWYtOTRhNi03NjExNTczNmE3ZTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcg
-        TGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
-        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
-        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjljODNlYWZiLTJmY2Mt
-        NGQxNi1iNDZjLTFiMjk1MmFlYzNmMiIsICJudW1fcHJvY2Vzc2VkIjogMH1d
-        fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQHRoZXRh
-        LnBhcnRlbGxvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5n
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5
+        ZjVmZDBiOS1iNjA4LTQ5ZmEtODFkOC02OGUxNTczYmUzYmQiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
+        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiYTQ4NmFlZGMtYTYwMi00NjIxLWI0NWUt
+        ZjI2ZDhjNjliZDc4IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRh
+        LiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        MDYxMTZmNTgtOTljOS00OGViLTk0ZjAtNDBmNzFhZWU5ZDIyIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
+        biI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNs
+        b3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzIwYjZhNmMt
+        NTk3OS00ZTRmLWE2ODMtY2JiYjdhM2EwMGM5IiwgIm51bV9wcm9jZXNzZWQi
+        OiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5l
+        cmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUg
+        c3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTcyODBjODEtZTRlOS00NWMwLTkw
+        MmItMmIxMmNjODFjNGVkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVw
+        b2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAi
+        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiNDFiNzU2MTItY2Y2Ny00ZmQ5LWFlN2YtODBlZTc3
+        NTk2MDFkIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAi
+        c3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzU3NWEz
+        ZjAtYzY5OC00Yjg3LTgyZTYtYjUxY2EyZjg0ODdhIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
+        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiSU5f
+        UFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzczMWY4MDQtZDIw
+        Zi00MmIyLWI4NDEtMzM0MmMzYzA1NGY2IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5n
+        IExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVw
+        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
+        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3NjY3ZWQ0Yi1mMjNm
+        LTRlYTgtODYyZS04M2I4ZTRiNzFiN2YiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZl
+        bC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5n
         IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0w
-        QHRoZXRhLnBhcnRlbGxvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGws
-        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWM5MDFmMWZiZjFi
-        YTllYzA0Y2I5NzFiIn0sICJpZCI6ICI1YzkwMWYxZmJmMWJhOWVjMDRjYjk3
-        MWIifQ==
+        QGRldmVsLmJhbG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwg
+        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmYWU3NGMzOGVi
+        NWM4ZjlmZjVjM2QifSwgImlkIjogIjVjZWZhZTc0YzM4ZWI1YzhmOWZmNWMz
+        ZCJ9
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:44 GMT
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/24c75573-75a9-406d-9264-67d0dd1ee1e2/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/66c7f7a4-69bc-456e-bdd3-99ab445273a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4631,15 +1808,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:44 GMT
+      - Thu, 30 May 2019 10:20:36 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"f1c765603fffd9fd9267fe44c494bcc3-gzip"'
+      - '"cd95f98c09da6f7269130ce527fdb1b9-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2411'
+      - '2409'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -4647,16 +1824,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8yNGM3NTU3My03NWE5LTQwNmQtOTI2NC02N2QwZGQxZWUx
-        ZTIvIiwgInRhc2tfaWQiOiAiMjRjNzU1NzMtNzVhOS00MDZkLTkyNjQtNjdk
-        MGRkMWVlMWUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy82NmM3ZjdhNC02OWJjLTQ1NmUtYmRkMy05OWFiNDQ1Mjcz
+        YTMvIiwgInRhc2tfaWQiOiAiNjZjN2Y3YTQtNjliYy00NTZlLWJkZDMtOTlh
+        YjQ0NTI3M2EzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTktMDMtMThUMjI6NDM6NDNaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTktMDMtMThUMjI6NDM6NDNaIiwgInRyYWNl
+        IjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgInRyYWNl
         YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzL2ViZWRlZjMxLTUzMWYtNGU3OC04MjJlLWY3NDYz
-        YzdiYzI5Ny8iLCAidGFza19pZCI6ICJlYmVkZWYzMS01MzFmLTRlNzgtODIy
-        ZS1mNzQ2M2M3YmMyOTcifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bHAvYXBpL3YyL3Rhc2tzL2ZiMzVkM2U5LTRmYjItNDc3Yi1iNWQ4LWRlNjQ3
+        OGE1YWZkNC8iLCAidGFza19pZCI6ICJmYjM1ZDNlOS00ZmIyLTQ3N2ItYjVk
+        OC1kZTY0NzhhNWFmZDQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
         bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
         dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
         cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
@@ -4668,42 +1845,42 @@ http_interactions:
         XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
         ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAdGhldGEucGFydGVsbG8uZXhh
-        bXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9u
-        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQHRoZXRhLnBhcnRl
-        bGxvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nl
-        c3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlv
-        biI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAidHJhY2Vi
-        YWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wMy0xOFQyMjo0Mzo0M1oi
-        LCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIy
-        MDE5LTAzLTE4VDIyOjQzOjQzWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1
-        bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnki
-        OiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50
-        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjog
-        IkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJG
-        SU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRh
-        dGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAx
-        NSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJp
-        ZCI6ICI1YzkwMWYxZmRiMjg0ZTBiNDMzNWUwZDAiLCAiZGV0YWlscyI6IHsi
-        bW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7
-        InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3Rh
-        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAi
-        ZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRy
-        cG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxz
-        IjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJn
-        ZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJp
-        YnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJl
-        cnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsi
-        c3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjVjOTAxZjFmYmYxYmE5ZWMwNGNiOTVhNSJ9LCAiaWQiOiAi
-        NWM5MDFmMWZiZjFiYTllYzA0Y2I5NWE1In0=
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFt
+        cGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
+        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
+        OiBudWxsLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzdGFydGVkIjogIjIwMTktMDUtMzBUMTA6MjA6MzZaIiwg
+        Il9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAx
+        OS0wNS0zMFQxMDoyMDozNloiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
+        aW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5Ijog
+        eyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUs
+        ICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQi
+        OiAiNWNlZmFlNzRiMDJlNTMzNDM0Y2Y4YjYzIiwgImRldGFpbHMiOiB7Im1v
+        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
+        aXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRl
+        dGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBt
+        X3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6
+        IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJy
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjVhYmMifSwgImlkIjogIjVj
+        ZWZhZTc0YzM4ZWI1YzhmOWZmNWFiYyJ9
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:44 GMT
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/tasks/ebedef31-531f-4e78-822e-f7463c7bc297/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/fb35d3e9-4fb2-477b-b5d8-de6478a5afd4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4722,15 +1899,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:44 GMT
+      - Thu, 30 May 2019 10:20:36 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"20a27ebf9a3f938037c3bf9b51ebd90d-gzip"'
+      - '"34c415f95728946c32264c8dacc6f0c0-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '9042'
+      - '9043'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -4738,210 +1915,210 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9lYmVkZWYzMS01MzFmLTRlNzgtODIyZS1mNzQ2
-        M2M3YmMyOTcvIiwgInRhc2tfaWQiOiAiZWJlZGVmMzEtNTMxZi00ZTc4LTgy
-        MmUtZjc0NjNjN2JjMjk3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy9mYjM1ZDNlOS00ZmIyLTQ3N2ItYjVkOC1kZTY0
+        NzhhNWFmZDQvIiwgInRhc2tfaWQiOiAiZmIzNWQzZTktNGZiMi00NzdiLWI1
+        ZDgtZGU2NDc4YTVhZmQ0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogIjIwMTktMDMtMThUMjI6NDM6NDRaIiwgIl9ucyI6ICJ0YXNr
-        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTktMDMtMThUMjI6NDM6NDNa
+        aF90aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6MzZa
         IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
         cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
         Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0
         ZXBfdHlwZSI6ICJzYXZlX3RhciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NGNhNDQ5
-        ZS1iYzFmLTRiOTUtODVmZC1iNjZiNDQzOTMwZTciLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1OWEyY2U2
+        OC00N2M4LTQ4OWYtYjYzYS1mZTQ2NzllNTc3NTYiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIklu
         aXRpYWxpemluZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0
         aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
         dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzk4MWJl
-        NzktNDE4Yi00ODkzLTg0NzItMTFkOThlN2FjMmRmIiwgIm51bV9wcm9jZXNz
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOGNmNjFm
+        OTQtZmFkMC00YThiLTk4M2UtNmVhNDAyOWRkMzJiIiwgIm51bV9wcm9jZXNz
         ZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
         dWJsaXNoaW5nIERpc3RyaWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
         ZGlzdHJpYnV0aW9uIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
         TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNjMDc2MWNhLTlmZWUt
-        NDNhZC05NmU2LTg0Nzg0YTEwNGRhMiIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImIwOTA5MGMwLWEyMTgt
+        NDYzOS1iOGMzLThkODY0OTIzNDJhMSIsICJudW1fcHJvY2Vzc2VkIjogMX0s
         IHsibnVtX3N1Y2Nlc3MiOiA4LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
         ZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjog
         OCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
         ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjA1YzgxNjQ5LTkxNjUtNDI3MS1hYmM0LWMyMTg4OGQ4NDc2YyIsICJudW1f
+        Ijc5MDFjZjlmLTU5YzItNDBlOC05YzEyLTY3NTFhMDc5NGQ2OCIsICJudW1f
         cHJvY2Vzc2VkIjogOH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
         b24iOiAiUHVibGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJk
         cnBtcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjkwZGNhYjNhLTcxNDctNGVmZC04YTVk
-        LTg3YTA2M2UzZTUzYiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjA4N2M1N2VhLTAwNTctNDRlOC1iNjY3
+        LTM5MGRjZDRkYTI5YiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
         Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEi
         LCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZTVj
-        MWQ5Zi1kZTg3LTRhYmUtOWY4ZS1iZjI1MjhmYjc2N2QiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNWJj
+        YmUyMi1kZjgyLTRmN2MtYWFkOC01YjhmZDVmMWU2OTkiLCAibnVtX3Byb2Nl
         c3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgTW9kdWxlcyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjRhOTRlOWZjLTFhZWYtNDRjOC1hYjQxLTI0ZjM1
-        MjgzYjgwMyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwMzk3NzQy
-        ZC0xOWUxLTQzMWYtYjYxYy00NjRiOTg3ZWI4NjMiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI0MGE4YzljZi1kNjYyLTQ1ZjUtODI1My1jZmNi
-        ODY0M2JhNmQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIyNzRjM2JhOS0xNDM5LTQ5MDctODNjOS02Nzk5Nzg5ZTkzNDAi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyOTUw
-        YjVmYy1iMmExLTRjM2UtYjdhMi04NzZiNTg1ZmMyNzgiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3Zl
-        X29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3ODRjMDhmZC00ZjM5
-        LTQ1MGQtYmJmNS1kMzQ3YWQzY2JjN2QiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRp
-        bmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJhMDFhM2E4Zi1iODc5LTQ4MmQtYWM0My00MWY0MTUzNWVi
-        NGMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0
-        ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI4ODkxZjNlNy1mYjkwLTQwYWYtOTRhNi03NjExNTczNmE3ZTYiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0
-        aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAi
-        aW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjlj
-        ODNlYWZiLTJmY2MtNGQxNi1iNDZjLTFiMjk1MmFlYzNmMiIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX1dfSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dv
-        cmtlci0wQHRoZXRhLnBhcnRlbGxvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0
+        OiAwLCAic3RlcF9pZCI6ICI5ZjVmZDBiOS1iNjA4LTQ5ZmEtODFkOC02OGUx
+        NTczYmUzYmQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIs
+        ICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTQ4NmFl
+        ZGMtYTYwMi00NjIxLWI0NWUtZjI2ZDhjNjliZDc4IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiMDYxMTZmNTgtOTljOS00OGViLTk0ZjAtNDBm
+        NzFhZWU5ZDIyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiMzIwYjZhNmMtNTk3OS00ZTRmLWE2ODMtY2JiYjdhM2EwMGM5
+        IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
+        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTcy
+        ODBjODEtZTRlOS00NWMwLTkwMmItMmIxMmNjODFjNGVkIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
+        ICJSZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92
+        ZV9vbGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDFiNzU2MTItY2Y2
+        Ny00ZmQ5LWFlN2YtODBlZTc3NTk2MDFkIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
+        aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiNzU3NWEzZjAtYzY5OC00Yjg3LTgyZTYtYjUxY2EyZjg0
+        ODdhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJz
+        dGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiNzczMWY4MDQtZDIwZi00MmIyLWI4NDEtMzM0MmMzYzA1NGY2IiwgIm51
+        bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjog
+        ImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3
+        NjY3ZWQ0Yi1mMjNmLTRlYTgtODYyZS04M2I4ZTRiNzFiN2YiLCAibnVtX3By
+        b2Nlc3NlZCI6IDF9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0
         ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEB0aGV0YS5wYXJ0ZWxsby5leGFtcGxlLmNvbSIsICJy
-        ZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51
-        bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAic3RhcnRlZCI6ICIy
-        MDE5LTAzLTE4VDIyOjQzOjQzWiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jl
-        c3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTktMDMtMThUMjI6NDM6NDRaIiwg
-        InRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1
-        bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUi
-        OiAiU0tJUFBFRCIsICJycG1zIjogIkZJTklTSEVEIiwgImluaXRpYWxpemVf
-        cmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJyZW1vdmVfb2xkX3JlcG9k
-        YXRhIjogIkZJTklTSEVEIiwgIm1vZHVsZXMiOiAiU0tJUFBFRCIsICJzYXZl
+        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVs
+        bCwgInJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJzdGFydGVkIjogIjIw
+        MTktMDUtMzBUMTA6MjA6MzZaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVz
+        dWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wNS0zMFQxMDoyMDozNloiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVt
+        X2Rpc3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7ImdlbmVyYXRlIHNxbGl0ZSI6
+        ICJTS0lQUEVEIiwgInJwbXMiOiAiRklOSVNIRUQiLCAiaW5pdGlhbGl6ZV9y
+        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgInJlbW92ZV9vbGRfcmVwb2Rh
+        dGEiOiAiRklOSVNIRUQiLCAibW9kdWxlcyI6ICJGSU5JU0hFRCIsICJzYXZl
         X3RhciI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJ
         TklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNI
         RUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInJlcG92aWV3Ijog
         IlNLSVBQRUQiLCAicHVibGlzaF9kaXJlY3RvcnkiOiAiRklOSVNIRUQiLCAi
         ZXJyYXRhIjogIkZJTklTSEVEIiwgIm1ldGFkYXRhIjogIkZJTklTSEVEIn0s
         ICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogInNj
-        ZW5hcmlvX3Rlc3QiLCAiaWQiOiAiNWM5MDFmMjBkYjI4NGUwYjQzMzVlMGQx
+        ZW5hcmlvX3Rlc3QiLCAiaWQiOiAiNWNlZmFlNzRiMDJlNTMzNDM0Y2Y4YjY0
         IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
         biI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3RhciIs
         ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI0NGNhNDQ5ZS1iYzFmLTRiOTUtODVmZC1iNjZi
-        NDQzOTMwZTciLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICI1OWEyY2U2OC00N2M4LTQ4OWYtYjYzYS1mZTQ2
+        NzllNTc3NTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
         IjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1ldGFk
         YXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
         LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
         b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiYzk4MWJlNzktNDE4Yi00ODkzLTg0NzItMTFk
-        OThlN2FjMmRmIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2Vz
+        IjogMCwgInN0ZXBfaWQiOiAiOGNmNjFmOTQtZmFkMC00YThiLTk4M2UtNmVh
+        NDAyOWRkMzJiIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2Vz
         cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1dGlv
         biBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0ZW1z
         X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
         bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjNjMDc2MWNhLTlmZWUtNDNhZC05NmU2LTg0Nzg0YTEwNGRh
-        MiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4LCAi
+        dGVwX2lkIjogImIwOTA5MGMwLWEyMTgtNDYzOS1iOGMzLThkODY0OTIzNDJh
+        MSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4LCAi
         ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6
         ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklTSEVE
         IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA1YzgxNjQ5LTkxNjUtNDI3MS1h
-        YmM0LWMyMTg4OGQ4NDc2YyIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsibnVt
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjc5MDFjZjlmLTU5YzItNDBlOC05
+        YzEyLTY3NTFhMDc5NGQ2OCIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsibnVt
         X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEZWx0
         YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3RhbCI6
         IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
         ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjkwZGNhYjNhLTcxNDctNGVmZC04YTVkLTg3YTA2M2UzZTUzYiIsICJudW1f
+        IjA4N2M1N2VhLTAwNTctNDRlOC1iNjY3LTM5MGRjZDRkYTI5YiIsICJudW1f
         cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRp
         b24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0
         YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJhZTVjMWQ5Zi1kZTg3LTRhYmUtOWY4ZS1i
-        ZjI1MjhmYjc2N2QiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJkNWJjYmUyMi1kZjgyLTRmN2MtYWFkOC01
+        YjhmZDVmMWU2OTkiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
         ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxlcyIs
-        ICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRhOTRl
-        OWZjLTFhZWYtNDRjOC1hYjQxLTI0ZjM1MjgzYjgwMyIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAi
-        UHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIs
-        ICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIwMzk3NzQyZC0xOWUxLTQzMWYtYjYxYy00NjRi
-        OTg3ZWI4NjMiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwg
-        InN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJz
+        ICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0MGE4
-        YzljZi1kNjYyLTQ1ZjUtODI1My1jZmNiODY0M2JhNmQiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2Vf
-        cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyNzRjM2JhOS0xNDM5
-        LTQ5MDctODNjOS02Nzk5Nzg5ZTkzNDAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRp
-        bmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxp
-        dGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIyOTUwYjVmYy1iMmExLTRjM2UtYjdhMi04
-        NzZiNTg1ZmMyNzgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0
-        YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICI3ODRjMDhmZC00ZjM5LTQ1MGQtYmJmNS1kMzQ3YWQzY2Jj
-        N2QiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVw
-        X3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMDFhM2E4Zi1i
-        ODc5LTQ4MmQtYWM0My00MWY0MTUzNWViNGMiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
-        c2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2Rp
-        cmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4ODkxZjNlNy1mYjkwLTQwYWYt
-        OTRhNi03NjExNTczNmE3ZTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
-        bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGlu
-        Z3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
-        YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjljODNlYWZiLTJmY2MtNGQxNi1iNDZj
-        LTFiMjk1MmFlYzNmMiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9y
-        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1YzkwMWYxZmJmMWJhOWVjMDRj
-        Yjk3MWIifSwgImlkIjogIjVjOTAxZjFmYmYxYmE5ZWMwNGNiOTcxYiJ9
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5ZjVm
+        ZDBiOS1iNjA4LTQ5ZmEtODFkOC02OGUxNTczYmUzYmQiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29tcHMi
+        LCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiYTQ4NmFlZGMtYTYwMi00NjIxLWI0NWUtZjI2
+        ZDhjNjliZDc4IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2Vz
+        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIs
+        ICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDYx
+        MTZmNTgtOTljOS00OGViLTk0ZjAtNDBmNzFhZWU5ZDIyIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
+        ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNsb3Nl
+        X3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzIwYjZhNmMtNTk3
+        OS00ZTRmLWE2ODMtY2JiYjdhM2EwMGM5IiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
+        aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3Fs
+        aXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNTcyODBjODEtZTRlOS00NWMwLTkwMmIt
+        MmIxMmNjODFjNGVkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVwb2Rh
+        dGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiNDFiNzU2MTItY2Y2Ny00ZmQ5LWFlN2YtODBlZTc3NTk2
+        MDFkIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAic3Rl
+        cF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzU3NWEzZjAt
+        YzY5OC00Yjg3LTgyZTYtYjUxY2EyZjg0ODdhIiwgIm51bV9wcm9jZXNzZWQi
+        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJs
+        aXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9k
+        aXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzczMWY4MDQtZDIwZi00MmIy
+        LWI4NDEtMzM0MmMzYzA1NGY2IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJu
+        dW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3Rp
+        bmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRh
+        ZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3NjY3ZWQ0Yi1mMjNmLTRlYTgtODYy
+        ZS04M2I4ZTRiNzFiN2YiLCAibnVtX3Byb2Nlc3NlZCI6IDF9XX0sICJlcnJv
+        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlNzRjMzhlYjVjOGY5
+        ZmY1YzNkIn0sICJpZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjVjM2QifQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:44 GMT
+  recorded_at: Thu, 30 May 2019 10:20:36 GMT
 - request:
     method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -4964,9 +2141,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:44 GMT
+      - Thu, 30 May 2019 10:20:37 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -4976,63 +2153,63 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIxN2ViMDMyMi1kMGU1LTQ3ZGEtYmZj
-        ZS05NjRjNjBhMzY3MWQiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
-        Il9pZCI6IHsiJG9pZCI6ICI1YzkwMWYxZmJmMWJhOWVjMDRjYjk2MmQifSwg
-        InVuaXRfaWQiOiAiMTdlYjAzMjItZDBlNS00N2RhLWJmY2UtOTY0YzYwYTM2
-        NzFkIiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogIjNlNDYyYzEwLTk1ZGQtNGNiYi1hYmE3LWFhNzdiZDIzYTkxNiIs
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIzMDkxN2Q0OS04YWE3LTQxOTctODg3
+        Yi04MDJlNmZmZTlmOTgiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjViMzMifSwg
+        InVuaXRfaWQiOiAiMzA5MTdkNDktOGFhNy00MTk3LTg4N2ItODAyZTZmZmU5
+        Zjk4IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsi
+        X2lkIjogIjNkNWNkYTBmLTRkOTctNDg3My05OTJmLTAzNDc3ZDE1NGRlMyIs
         ICJfY29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjog
-        IjVjOTAxZjFmYmYxYmE5ZWMwNGNiOTYxYiJ9LCAidW5pdF9pZCI6ICIzZTQ2
-        MmMxMC05NWRkLTRjYmItYWJhNy1hYTc3YmQyM2E5MTYiLCAidW5pdF90eXBl
-        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNDhlN2VmOTct
-        ZmNhMC00MDY3LTg1YWYtZjEyYjg4ODQ5ZDg4IiwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNWM5MDFmMWZiZjFiYTll
-        YzA0Y2I5NjI0In0sICJ1bml0X2lkIjogIjQ4ZTdlZjk3LWZjYTAtNDA2Ny04
-        NWFmLWYxMmI4ODg0OWQ4OCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
-        bWV0YWRhdGEiOiB7Il9pZCI6ICI1ODczOWM0OS0xNjg5LTRjNDMtYTg3Mi0x
-        NmMzM2RhN2Y2ZjYiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1YzkwMWYxZmJmMWJhOWVjMDRjYjk1ZTkifSwgInVu
-        aXRfaWQiOiAiNTg3MzljNDktMTY4OS00YzQzLWE4NzItMTZjMzNkYTdmNmY2
+        IjVjZWZhZTc0YzM4ZWI1YzhmOWZmNWI0MSJ9LCAidW5pdF9pZCI6ICIzZDVj
+        ZGEwZi00ZDk3LTQ4NzMtOTkyZi0wMzQ3N2QxNTRkZTMiLCAidW5pdF90eXBl
+        X2lkIjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiNTI5ZjNhMTkt
+        NDBiMC00YTc2LThmZjItNDNlZGMyNzQ3YjRmIiwgIl9jb250ZW50X3R5cGVf
+        aWQiOiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlNzRjMzhlYjVj
+        OGY5ZmY1YjE4In0sICJ1bml0X2lkIjogIjUyOWYzYTE5LTQwYjAtNGE3Ni04
+        ZmYyLTQzZWRjMjc0N2I0ZiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsi
+        bWV0YWRhdGEiOiB7Il9pZCI6ICI4ZjY1ZmE5ZS1mODFmLTQ0YzktYTRiMS0y
+        M2E3OThhOTY2OWUiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjViMmEifSwgInVu
+        aXRfaWQiOiAiOGY2NWZhOWUtZjgxZi00NGM5LWE0YjEtMjNhNzk4YTk2Njll
         IiwgInVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lk
-        IjogImMzNjc2NDk0LTI3ZmEtNGRhZC04MThiLTFiZjM4OWE2YzdhOCIsICJf
+        IjogImFjNWE1MmM4LWZhNDYtNGY5MC05MDMxLWI4NWFjNTI0Njc4NSIsICJf
         Y29udGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjVj
-        OTAxZjFmYmYxYmE5ZWMwNGNiOTVmYiJ9LCAidW5pdF9pZCI6ICJjMzY3NjQ5
-        NC0yN2ZhLTRkYWQtODE4Yi0xYmYzODlhNmM3YTgiLCAidW5pdF90eXBlX2lk
-        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiZGEyNDE0ODUtYjA2
-        Ni00YmQ0LTkzOWUtNjZkYTdiMDFlMzJkIiwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNWM5MDFmMWZiZjFiYTllYzA0
-        Y2I5NjBlIn0sICJ1bml0X2lkIjogImRhMjQxNDg1LWIwNjYtNGJkNC05Mzll
-        LTY2ZGE3YjAxZTMyZCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
-        YWRhdGEiOiB7Il9pZCI6ICJkYzFiZjkxMi1hYjI4LTQ3MDUtYWU0Yi0xZDRk
-        YmM4NjgyNjkiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1YzkwMWYxZmJmMWJhOWVjMDRjYjk1ZjIifSwgInVuaXRf
-        aWQiOiAiZGMxYmY5MTItYWIyOC00NzA1LWFlNGItMWQ0ZGJjODY4MjY5Iiwg
+        ZWZhZTc0YzM4ZWI1YzhmOWZmNWIwMSJ9LCAidW5pdF9pZCI6ICJhYzVhNTJj
+        OC1mYTQ2LTRmOTAtOTAzMS1iODVhYzUyNDY3ODUiLCAidW5pdF90eXBlX2lk
+        IjogInJwbSJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYWU1MTBiODAtN2Yz
+        My00NzE0LTk1NmQtZDU2YjNjZjkwODgwIiwgIl9jb250ZW50X3R5cGVfaWQi
+        OiAicnBtIn0sICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlNzRjMzhlYjVjOGY5
+        ZmY1YjBmIn0sICJ1bml0X2lkIjogImFlNTEwYjgwLTdmMzMtNDcxNC05NTZk
+        LWQ1NmIzY2Y5MDg4MCIsICJ1bml0X3R5cGVfaWQiOiAicnBtIn0sIHsibWV0
+        YWRhdGEiOiB7Il9pZCI6ICJiNmVmNDBjYS01NWU4LTQ1YTMtOTRhOS0yYTM3
+        YjAwN2JiM2UiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0ifSwgIl9pZCI6
+        IHsiJG9pZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjVhZjgifSwgInVuaXRf
+        aWQiOiAiYjZlZjQwY2EtNTVlOC00NWEzLTk0YTktMmEzN2IwMDdiYjNlIiwg
         InVuaXRfdHlwZV9pZCI6ICJycG0ifSwgeyJtZXRhZGF0YSI6IHsiX2lkIjog
-        ImRmMzhmNjY5LWJhODMtNDlkZi1iN2VhLTM4OGEwZTNiY2IwZCIsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjVjOTAx
-        ZjFmYmYxYmE5ZWMwNGNiOTYwNCJ9LCAidW5pdF9pZCI6ICJkZjM4ZjY2OS1i
-        YTgzLTQ5ZGYtYjdlYS0zODhhMGUzYmNiMGQiLCAidW5pdF90eXBlX2lkIjog
+        ImNmOTFiMTYzLTRiMDYtNGE4NC05Yjk2LTdhMjNmYWQyOTM0MSIsICJfY29u
+        dGVudF90eXBlX2lkIjogInJwbSJ9LCAiX2lkIjogeyIkb2lkIjogIjVjZWZh
+        ZTc0YzM4ZWI1YzhmOWZmNWIyMSJ9LCAidW5pdF9pZCI6ICJjZjkxYjE2My00
+        YjA2LTRhODQtOWI5Ni03YTIzZmFkMjkzNDEiLCAidW5pdF90eXBlX2lkIjog
         InJwbSJ9XQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:44 GMT
+  recorded_at: Thu, 30 May 2019 10:20:37 GMT
 - request:
     method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/content/units/rpm/search/
+    uri: https://devel.balmora.example.com/pulp/api/v2/content/units/rpm/search/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjcml0ZXJpYSI6eyJsaW1pdCI6OCwic2tpcCI6MCwiZmllbGRzIjpbIm5h
         bWUiLCJ2ZXJzaW9uIiwicmVsZWFzZSIsImFyY2giLCJlcG9jaCIsInN1bW1h
         cnkiLCJzb3VyY2VycG0iLCJjaGVja3N1bSIsImZpbGVuYW1lIiwiX2lkIiwi
-        aXNfbW9kdWxhciJdLCJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMTdlYjAz
-        MjItZDBlNS00N2RhLWJmY2UtOTY0YzYwYTM2NzFkIiwiM2U0NjJjMTAtOTVk
-        ZC00Y2JiLWFiYTctYWE3N2JkMjNhOTE2IiwiNDhlN2VmOTctZmNhMC00MDY3
-        LTg1YWYtZjEyYjg4ODQ5ZDg4IiwiNTg3MzljNDktMTY4OS00YzQzLWE4NzIt
-        MTZjMzNkYTdmNmY2IiwiYzM2NzY0OTQtMjdmYS00ZGFkLTgxOGItMWJmMzg5
-        YTZjN2E4IiwiZGEyNDE0ODUtYjA2Ni00YmQ0LTkzOWUtNjZkYTdiMDFlMzJk
-        IiwiZGMxYmY5MTItYWIyOC00NzA1LWFlNGItMWQ0ZGJjODY4MjY5IiwiZGYz
-        OGY2NjktYmE4My00OWRmLWI3ZWEtMzg4YTBlM2JjYjBkIl19fX0sImluY2x1
+        aXNfbW9kdWxhciJdLCJmaWx0ZXJzIjp7Il9pZCI6eyIkaW4iOlsiMzA5MTdk
+        NDktOGFhNy00MTk3LTg4N2ItODAyZTZmZmU5Zjk4IiwiM2Q1Y2RhMGYtNGQ5
+        Ny00ODczLTk5MmYtMDM0NzdkMTU0ZGUzIiwiNTI5ZjNhMTktNDBiMC00YTc2
+        LThmZjItNDNlZGMyNzQ3YjRmIiwiOGY2NWZhOWUtZjgxZi00NGM5LWE0YjEt
+        MjNhNzk4YTk2NjllIiwiYWM1YTUyYzgtZmE0Ni00ZjkwLTkwMzEtYjg1YWM1
+        MjQ2Nzg1IiwiYWU1MTBiODAtN2YzMy00NzE0LTk1NmQtZDU2YjNjZjkwODgw
+        IiwiYjZlZjQwY2EtNTVlOC00NWEzLTk0YTktMmEzN2IwMDdiYjNlIiwiY2Y5
+        MWIxNjMtNGIwNi00YTg0LTliOTYtN2EyM2ZhZDI5MzQxIl19fX0sImluY2x1
         ZGVfcmVwb3MiOnRydWV9
     headers:
       Accept:
@@ -5051,328 +2228,112 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:44 GMT
+      - Thu, 30 May 2019 10:20:37 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '4374'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiZmM1MzVkOTEtNmM0NS00
-        MjkxLTg2NzctZDNiM2E3ZDRjNmZlIiwgInNjZW5hcmlvX3Rlc3QiXSwgInNv
-        dXJjZXJwbSI6ICJzcXVpcnJlbC0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6
-        ICJzcXVpcnJlbCIsICJjaGVja3N1bSI6ICIyNTE3NjhiZGQxNWYxM2Q3ODQ4
-        N2MyNzYzOGFhNmFlY2QwMTU1MWUyNTM3NTYwOTNjZGUxYzBhZTg3OGExN2Qy
-        IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHNxdWlycmVsIiwg
-        ImZpbGVuYW1lIjogInNxdWlycmVsLTAuMy0wLjgubm9hcmNoLnJwbSIsICJl
-        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIiOiBm
-        YWxzZSwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICIxN2ViMDMyMi1kMGU1
-        LTQ3ZGEtYmZjZS05NjRjNjBhMzY3MWQiLCAiYXJjaCI6ICJub2FyY2giLCAi
-        Y2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50
-        L3VuaXRzL3JwbS8xN2ViMDMyMi1kMGU1LTQ3ZGEtYmZjZS05NjRjNjBhMzY3
-        MWQvIn0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiZmM1MzVkOTEt
-        NmM0NS00MjkxLTg2NzctZDNiM2E3ZDRjNmZlIiwgInNjZW5hcmlvX3Rlc3Qi
-        XSwgInNvdXJjZXJwbSI6ICJjaGVldGFoLTAuMy0wLjguc3JjLnJwbSIsICJu
-        YW1lIjogImNoZWV0YWgiLCAiY2hlY2tzdW0iOiAiNDIyZDBiYWEwY2Q5ZDc3
-        MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdkNjVmYjM2
-        OGRhZSIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBjaGVldGFo
-        IiwgImZpbGVuYW1lIjogImNoZWV0YWgtMC4zLTAuOC5ub2FyY2gucnBtIiwg
-        ImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6
-        IGZhbHNlLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjNlNDYyYzEwLTk1
-        ZGQtNGNiYi1hYmE3LWFhNzdiZDIzYTkxNiIsICJhcmNoIjogIm5vYXJjaCIs
-        ICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRl
-        bnQvdW5pdHMvcnBtLzNlNDYyYzEwLTk1ZGQtNGNiYi1hYmE3LWFhNzdiZDIz
-        YTkxNi8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJmYzUzNWQ5
-        MS02YzQ1LTQyOTEtODY3Ny1kM2IzYTdkNGM2ZmUiLCAic2NlbmFyaW9fdGVz
-        dCJdLCAic291cmNlcnBtIjogIndhbHJ1cy0wLjMtMC44LnNyYy5ycG0iLCAi
-        bmFtZSI6ICJ3YWxydXMiLCAiY2hlY2tzdW0iOiAiNmU4ZDZkYzA1N2UzZTJj
-        OTgxOWYwZGM3ZTZjN2I3Zjg2YmYyZTg1NzFiYmE0MTRhZGVjN2ZiNjIxYTQ2
-        MWRmZCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMi
-        LCAiZmlsZW5hbWUiOiAid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIsICJl
-        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIiOiBm
-        YWxzZSwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICI0OGU3ZWY5Ny1mY2Ew
-        LTQwNjctODVhZi1mMTJiODg4NDlkODgiLCAiYXJjaCI6ICJub2FyY2giLCAi
-        Y2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50
-        L3VuaXRzL3JwbS80OGU3ZWY5Ny1mY2EwLTQwNjctODVhZi1mMTJiODg4NDlk
-        ODgvIn0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiZmM1MzVkOTEt
-        NmM0NS00MjkxLTg2NzctZDNiM2E3ZDRjNmZlIiwgInNjZW5hcmlvX3Rlc3Qi
-        XSwgInNvdXJjZXJwbSI6ICJnaXJhZmZlLTAuMy0wLjguc3JjLnJwbSIsICJu
-        YW1lIjogImdpcmFmZmUiLCAiY2hlY2tzdW0iOiAiZjI1ZDY3ZDFkOWRhMDRm
-        MTJlNTdjYTMyMzI0N2I0Mzg5MWFjNDY1MzNlMzU1YjgyZGU2ZDE5MjIwMDlm
-        OWYxNCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZl
-        IiwgImZpbGVuYW1lIjogImdpcmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwg
-        ImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6
-        IGZhbHNlLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjU4NzM5YzQ5LTE2
-        ODktNGM0My1hODcyLTE2YzMzZGE3ZjZmNiIsICJhcmNoIjogIm5vYXJjaCIs
-        ICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRl
-        bnQvdW5pdHMvcnBtLzU4NzM5YzQ5LTE2ODktNGM0My1hODcyLTE2YzMzZGE3
-        ZjZmNi8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJmYzUzNWQ5
-        MS02YzQ1LTQyOTEtODY3Ny1kM2IzYTdkNGM2ZmUiLCAic2NlbmFyaW9fdGVz
-        dCJdLCAic291cmNlcnBtIjogImxpb24tMC4zLTAuOC5zcmMucnBtIiwgIm5h
-        bWUiOiAibGlvbiIsICJjaGVja3N1bSI6ICIxMjQwMGRjOTVjMjNhNGMxNjA3
-        MjVhOTA4NzE2Y2QzZmNkZDdhODk4MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0
-        IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGxpb24iLCAiZmls
-        ZW5hbWUiOiAibGlvbi0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
-        MCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFyIjogZmFsc2UsICJy
-        ZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiYzM2NzY0OTQtMjdmYS00ZGFkLTgx
-        OGItMWJmMzg5YTZjN2E4IiwgImFyY2giOiAibm9hcmNoIiwgImNoaWxkcmVu
-        Ijoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9y
-        cG0vYzM2NzY0OTQtMjdmYS00ZGFkLTgxOGItMWJmMzg5YTZjN2E4LyJ9LCB7
-        InJlcG9zaXRvcnlfbWVtYmVyc2hpcHMiOiBbImZjNTM1ZDkxLTZjNDUtNDI5
-        MS04Njc3LWQzYjNhN2Q0YzZmZSIsICJzY2VuYXJpb190ZXN0IiwgIjItb2st
-        djFfMC1mYzUzNWQ5MS02YzQ1LTQyOTEtODY3Ny1kM2IzYTdkNGM2ZmUiXSwg
-        InNvdXJjZXJwbSI6ICJwZW5ndWluLTAuMy0wLjguc3JjLnJwbSIsICJuYW1l
-        IjogInBlbmd1aW4iLCAiY2hlY2tzdW0iOiAiM2ZjYjJjOTI3ZGU5ZTEzYmY2
-        ODQ2OTAzMmEyOGIxMzlkM2U1YWQyZTU4NTY0ZmMyMTBmZDZlNDg2MzViZTY5
-        NCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBwZW5ndWluIiwg
-        ImZpbGVuYW1lIjogInBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBtIiwgImVw
-        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZh
-        bHNlLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogImRhMjQxNDg1LWIwNjYt
-        NGJkNC05MzllLTY2ZGE3YjAxZTMyZCIsICJhcmNoIjogIm5vYXJjaCIsICJj
-        aGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQv
-        dW5pdHMvcnBtL2RhMjQxNDg1LWIwNjYtNGJkNC05MzllLTY2ZGE3YjAxZTMy
-        ZC8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJmYzUzNWQ5MS02
-        YzQ1LTQyOTEtODY3Ny1kM2IzYTdkNGM2ZmUiLCAic2NlbmFyaW9fdGVzdCJd
-        LCAic291cmNlcnBtIjogImVsZXBoYW50LTAuMy0wLjguc3JjLnJwbSIsICJu
-        YW1lIjogImVsZXBoYW50IiwgImNoZWNrc3VtIjogIjNlMWM3MGNkMWI0MjEz
-        MjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBh
-        NzAxZjMiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgZWxlcGhh
-        bnQiLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBt
-        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxh
-        ciI6IGZhbHNlLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogImRjMWJmOTEy
-        LWFiMjgtNDcwNS1hZTRiLTFkNGRiYzg2ODI2OSIsICJhcmNoIjogIm5vYXJj
-        aCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2Nv
-        bnRlbnQvdW5pdHMvcnBtL2RjMWJmOTEyLWFiMjgtNDcwNS1hZTRiLTFkNGRi
-        Yzg2ODI2OS8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJmYzUz
-        NWQ5MS02YzQ1LTQyOTEtODY3Ny1kM2IzYTdkNGM2ZmUiLCAic2NlbmFyaW9f
-        dGVzdCJdLCAic291cmNlcnBtIjogIm1vbmtleS0wLjMtMC44LnNyYy5ycG0i
-        LCAibmFtZSI6ICJtb25rZXkiLCAiY2hlY2tzdW0iOiAiMGU4ZmE1MGQwMTI4
-        ZmJhYmM3Y2NjNTYzMmUzZmEyNWQzOWIwMjgwMTY5ZjYxNjZjYjhlMmM4NGRl
-        ODUwMWRiMSIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBtb25r
-        ZXkiLCAiZmlsZW5hbWUiOiAibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIs
-        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIi
-        OiBmYWxzZSwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICJkZjM4ZjY2OS1i
-        YTgzLTQ5ZGYtYjdlYS0zODhhMGUzYmNiMGQiLCAiYXJjaCI6ICJub2FyY2gi
-        LCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250
-        ZW50L3VuaXRzL3JwbS9kZjM4ZjY2OS1iYTgzLTQ5ZGYtYjdlYS0zODhhMGUz
-        YmNiMGQvIn1d
-    http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:44 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/scenario_test/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImZpZWxkcyI6
-        eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '84'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 18 Mar 2019 22:43:44 GMT
-      Server:
-      - Apache
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '651'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIwOTEzN2JlYy03MzQyLTRlM2UtOTdh
-        OS05MmQwOGVhYTZlNGMiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
-        In0sICJfaWQiOiB7IiRvaWQiOiAiNWM5MDFmMWZiZjFiYTllYzA0Y2I5NmFl
-        In0sICJ1bml0X2lkIjogIjA5MTM3YmVjLTczNDItNGUzZS05N2E5LTkyZDA4
-        ZWFhNmU0YyIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
-        YXRhIjogeyJfaWQiOiAiYTVkM2VkNjItMGNlYy00NDVkLTg2OTctY2Y0NWMx
-        ZGFhMTJkIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
-        IjogeyIkb2lkIjogIjVjOTAxZjFmYmYxYmE5ZWMwNGNiOTZjYyJ9LCAidW5p
-        dF9pZCI6ICJhNWQzZWQ2Mi0wY2VjLTQ0NWQtODY5Ny1jZjQ1YzFkYWExMmQi
-        LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0ifSwgeyJtZXRhZGF0YSI6IHsi
-        X2lkIjogImI4ODBhOTk4LWEzNzMtNGQ2OC05MjdlLWFiNzdkMGI1MzBhOSIs
-        ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0ifSwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1YzkwMWYxZmJmMWJhOWVjMDRjYjk2OTUifSwgInVuaXRfaWQiOiAi
-        Yjg4MGE5OTgtYTM3My00ZDY4LTkyN2UtYWI3N2QwYjUzMGE5IiwgInVuaXRf
-        dHlwZV9pZCI6ICJlcnJhdHVtIn1d
-    http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:44 GMT
-- request:
-    method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/content/units/erratum/search/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJsaW1pdCI6Mywic2tpcCI6MCwiZmlsdGVycyI6eyJf
-        aWQiOnsiJGluIjpbIjA5MTM3YmVjLTczNDItNGUzZS05N2E5LTkyZDA4ZWFh
-        NmU0YyIsImE1ZDNlZDYyLTBjZWMtNDQ1ZC04Njk3LWNmNDVjMWRhYTEyZCIs
-        ImI4ODBhOTk4LWEzNzMtNGQ2OC05MjdlLWFiNzdkMGI1MzBhOSJdfX19LCJp
-        bmNsdWRlX3JlcG9zIjp0cnVlfQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '199'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 18 Mar 2019 22:43:44 GMT
-      Server:
-      - Apache
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4988'
+      - '4004'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
         W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVzdCJd
-        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvZXJyYXR1
-        bS8wOTEzN2JlYy03MzQyLTRlM2UtOTdhOS05MmQwOGVhYTZlNGMvIiwgImlz
-        c3VlZCI6ICIyMDEwLTExLTEwIDAwOjAwOjAwIiwgInJlbG9naW5fc3VnZ2Vz
-        dGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjogW3siaHJlZiI6ICJodHRwczov
-        L3Jobi5yZWRoYXQuY29tL2VycmF0YS9SSFNBLTIwMTAtMDg1OC5odG1sIiwg
-        InR5cGUiOiAic2VsZiIsICJpZCI6IG51bGwsICJ0aXRsZSI6ICJSSFNBLTIw
-        MTA6MDg1OCJ9LCB7ImhyZWYiOiAiaHR0cHM6Ly9idWd6aWxsYS5yZWRoYXQu
-        Y29tL2J1Z3ppbGxhL3Nob3dfYnVnLmNnaT9pZD02Mjc4ODIiLCAidHlwZSI6
-        ICJidWd6aWxsYSIsICJpZCI6ICI2Mjc4ODIiLCAidGl0bGUiOiAiQ1ZFLTIw
-        MTAtMDQwNSBiemlwMjogaW50ZWdlciBvdmVyZmxvdyBmbGF3IGluIEJaMl9k
-        ZWNvbXByZXNzIn0sIHsiaHJlZiI6ICJodHRwczovL3d3dy5yZWRoYXQuY29t
-        L3NlY3VyaXR5L2RhdGEvY3ZlL0NWRS0yMDEwLTA0MDUuaHRtbCIsICJ0eXBl
-        IjogImN2ZSIsICJpZCI6ICJDVkUtMjAxMC0wNDA1IiwgInRpdGxlIjogIkNW
-        RS0yMDEwLTA0MDUifSwgeyJocmVmIjogImh0dHA6Ly93d3cucmVkaGF0LmNv
-        bS9zZWN1cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQi
-        LCAidHlwZSI6ICJvdGhlciIsICJpZCI6IG51bGwsICJ0aXRsZSI6IG51bGx9
-        XSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9p
-        ZCI6ICJlcnJhdHVtIiwgImlkIjogIlJIU0EtMjAxMDowODU4IiwgImZyb20i
-        OiAic2VjdXJpdHlAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6ICJJbXBvcnRh
-        bnQiLCAidGl0bGUiOiAiSW1wb3J0YW50OiBiemlwMiBzZWN1cml0eSB1cGRh
-        dGUiLCAiY2hpbGRyZW4iOiB7fSwgInZlcnNpb24iOiAiMyIsICJyZWJvb3Rf
-        c3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xp
-        c3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJiemlwMi0xLjAuNS03LmVs
-        Nl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1kZXZlbCIsICJzdW0iOiBb
-        InNoYTI1NiIsICJlYTY3YzY2NGRhMWZmOTZhNmRjOTRkMzMwMDliNzNkOGZh
-        YjMxYjU5ODI0MTgzZmI0NWU5YmEyZWJmODJkNTgzIl0sICJmaWxlbmFtZSI6
-        ICJiemlwMi1kZXZlbC0xLjAuNS03LmVsNl8wLmk2ODYucnBtIiwgImVwb2No
-        IjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2
-        XzAiLCAiYXJjaCI6ICJpNjg2In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcu
-        ZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6aXAyLWxpYnMiLCAic3VtIjog
-        WyJzaGEyNTYiLCAiYzlmMDY0YTY4NjI1NzNmYjlmMmE2YWZmN2MzNjIxZjE5
-        NDBiNDkyZGYyZWRmYzJlYmJkYzBiODMwNWY1MTE0NyJdLCAiZmlsZW5hbWUi
-        OiAiYnppcDItbGlicy0xLjAuNS03LmVsNl8wLmk2ODYucnBtIiwgImVwb2No
-        IjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2
-        XzAiLCAiYXJjaCI6ICJpNjg2In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcu
-        ZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6aXAyIiwgInN1bSI6IFsic2hh
-        MjU2IiwgImI4YTNmNzJiYzJiMGQ4OWJhNzM3MDk5YWM5OGJmOGQyYWY0YmVh
-        MDJkMzE4ODRjMDJkYjk3ZjdmNjZjM2Q1YzIiXSwgImZpbGVuYW1lIjogImJ6
-        aXAyLTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6ICIwIiwg
-        InZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFy
-        Y2giOiAieDg2XzY0In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAu
-        c3JjLnJwbSIsICJuYW1lIjogImJ6aXAyLWRldmVsIiwgInN1bSI6IFsic2hh
-        MjU2IiwgIjdmNjMxMjRlNDY1NWI3YzkyZDIzZWM0YzM4MjI2ZjVkMzc0NjU2
-        ODg1M2RmZjc1MGZjODVlMDU4ZTc0YjVjZjYiXSwgImZpbGVuYW1lIjogImJ6
-        aXAyLWRldmVsLTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6
-        ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8w
-        IiwgImFyY2giOiAieDg2XzY0In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcu
-        ZWw2XzAuc3JjLnJwbSIsICJuYW1lIjogImJ6aXAyLWxpYnMiLCAic3VtIjog
-        WyJzaGEyNTYiLCAiODAyZjQzOTlkYmRkMDE0NzZlMjU0YzNiMzJjNDBhZmY1
-        OWNmNWQyM2E0NWZhNDg4YzY5MTdjZTg5MDRkNmI0ZCJdLCAiZmlsZW5hbWUi
-        OiAiYnppcDItbGlicy0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0iLCAiZXBv
-        Y2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5l
-        bDZfMCIsICJhcmNoIjogIng4Nl82NCJ9XSwgIm5hbWUiOiAiY29sbGVjdGlv
-        bi0wIiwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6ICJmaW5hbCIsICJ1cGRh
-        dGVkIjogIjIwMTAtMTEtMTAgMDA6MDA6MDAiLCAiZGVzY3JpcHRpb24iOiAi
-        YnppcDIgaXMgYSBmcmVlbHkgYXZhaWxhYmxlLCBoaWdoLXF1YWxpdHkgZGF0
-        YSBjb21wcmVzc29yLiBJdCBwcm92aWRlcyBib3RoXG5saWJiejIgbGlicmFy
-        eSBtdXN0IGJlIHJlc3RhcnRlZCBmb3IgdGhlIHVwZGF0ZSB0byB0YWtlIGVm
-        ZmVjdC4iLCAiX2xhc3RfdXBkYXRlZCI6ICIyMDE5LTAzLTE4VDIyOjQzOjQz
-        WiIsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50Ijog
-        IiIsICJyaWdodHMiOiAiQ29weXJpZ2h0IDIwMTAgUmVkIEhhdCBJbmMiLCAi
-        c29sdXRpb24iOiAiQmVmb3JlIGFwcGx5aW5nIHRoaXMgdXBkYXRlLCBtYWtl
-        IHN1cmUgYWxsIHByZXZpb3VzbHktcmVsZWFzZWQgZXJyYXRhXG5yZWxldmFu
-        dCB0byB5b3VyIHN5c3RlbSBoYXZlIGJlZW4gYXBwbGllZC5cblxuVGhpcyB1
-        cGRhdGUgaXMgYXZhaWxhYmxlIHZpYSB0aGUgUmVkIEhhdCBOZXR3b3JrLiBE
-        ZXRhaWxzIG9uIGhvdyB0b1xudXNlIHRoZSBSZWQgSGF0IE5ldHdvcmsgdG8g
-        YXBwbHkgdGhpcyB1cGRhdGUgYXJlIGF2YWlsYWJsZSBhdFxuaHR0cDovL2ti
-        YXNlLnJlZGhhdC5jb20vZmFxL2RvY3MvRE9DLTExMjU5IiwgInN1bW1hcnki
-        OiAiVXBkYXRlZCBiemlwMiBwYWNrYWdlcyB0aGF0IGZpeCBvbmUgc2VjdXJp
-        dHkgaXNzdWUiLCAicmVsZWFzZSI6ICIiLCAiX2lkIjogIjA5MTM3YmVjLTcz
-        NDItNGUzZS05N2E5LTkyZDA4ZWFhNmU0YyJ9LCB7InJlcG9zaXRvcnlfbWVt
-        YmVyc2hpcHMiOiBbImZjNTM1ZDkxLTZjNDUtNDI5MS04Njc3LWQzYjNhN2Q0
-        YzZmZSIsICJzY2VuYXJpb190ZXN0Il0sICJfaHJlZiI6ICIvcHVscC9hcGkv
-        djIvY29udGVudC91bml0cy9lcnJhdHVtL2E1ZDNlZDYyLTBjZWMtNDQ1ZC04
-        Njk3LWNmNDVjMWRhYTEyZC8iLCAiaXNzdWVkIjogIjIwMTAtMDEtMDEgMDE6
-        MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVyZW5j
-        ZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRf
-        dHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIlJIRUEtMjAxMDowMDAyIiwg
-        ImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6ICIi
-        LCAidGl0bGUiOiAiT25lIHBhY2thZ2UgZXJyYXRhIiwgImNoaWxkcmVuIjog
-        e30sICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNl
-        LCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFja2FnZXMi
-        OiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIsICJu
-        YW1lIjogImVsZXBoYW50IiwgInN1bSI6IG51bGwsICJmaWxlbmFtZSI6ICJl
-        bGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiBudWxsLCAi
-        dmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJu
-        b2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIi
-        fV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2Ny
-        aXB0aW9uIjogIk9uZSBwYWNrYWdlIGVycmF0YSIsICJfbGFzdF91cGRhdGVk
-        IjogIjIwMTktMDMtMThUMjI6NDM6NDNaIiwgInJlc3RhcnRfc3VnZ2VzdGVk
-        IjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAic29s
-        dXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJf
-        aWQiOiAiYTVkM2VkNjItMGNlYy00NDVkLTg2OTctY2Y0NWMxZGFhMTJkIn0s
-        IHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsiZmM1MzVkOTEtNmM0NS00
-        MjkxLTg2NzctZDNiM2E3ZDRjNmZlIiwgInNjZW5hcmlvX3Rlc3QiXSwgIl9o
-        cmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL2VycmF0dW0vYjg4
-        MGE5OTgtYTM3My00ZDY4LTkyN2UtYWI3N2QwYjUzMGE5LyIsICJpc3N1ZWQi
-        OiAiMjAxMC0wMS0wMSAwMTowMTowMSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6
-        IGZhbHNlLCAicmVmZXJlbmNlcyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRh
-        Ijoge30sICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAi
-        UkhFQS0yMDEwOjAwMDEiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29t
-        IiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6ICJFbXB0eSBlcnJhdGEiLCAi
-        Y2hpbGRyZW4iOiB7fSwgInZlcnNpb24iOiAiMSIsICJyZWJvb3Rfc3VnZ2Vz
-        dGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3QiOiBb
-        XSwgInN0YXR1cyI6ICJzdGFibGUiLCAidXBkYXRlZCI6ICIiLCAiZGVzY3Jp
-        cHRpb24iOiAiRW1wdHkgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAiMjAx
-        OS0wMy0xOFQyMjo0Mzo0M1oiLCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxz
-        ZSwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6
-        ICIiLCAic3VtbWFyeSI6ICIiLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJi
-        ODgwYTk5OC1hMzczLTRkNjgtOTI3ZS1hYjc3ZDBiNTMwYTkifV0=
+        LCAic291cmNlcnBtIjogIndhbHJ1cy0wLjMtMC44LnNyYy5ycG0iLCAibmFt
+        ZSI6ICJ3YWxydXMiLCAiY2hlY2tzdW0iOiAiNmU4ZDZkYzA1N2UzZTJjOTgx
+        OWYwZGM3ZTZjN2I3Zjg2YmYyZTg1NzFiYmE0MTRhZGVjN2ZiNjIxYTQ2MWRm
+        ZCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMiLCAi
+        ZmlsZW5hbWUiOiAid2FscnVzLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9j
+        aCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIiOiBmYWxz
+        ZSwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICIzMDkxN2Q0OS04YWE3LTQx
+        OTctODg3Yi04MDJlNmZmZTlmOTgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hp
+        bGRyZW4iOiB7fSwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3Vu
+        aXRzL3JwbS8zMDkxN2Q0OS04YWE3LTQxOTctODg3Yi04MDJlNmZmZTlmOTgv
+        In0sIHsicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVz
+        dCJdLCAic291cmNlcnBtIjogInNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIs
+        ICJuYW1lIjogInNxdWlycmVsIiwgImNoZWNrc3VtIjogIjI1MTc2OGJkZDE1
+        ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFl
+        ODc4YTE3ZDIiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1
+        aXJyZWwiLCAiZmlsZW5hbWUiOiAic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gu
+        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9k
+        dWxhciI6IGZhbHNlLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjNkNWNk
+        YTBmLTRkOTctNDg3My05OTJmLTAzNDc3ZDE1NGRlMyIsICJhcmNoIjogIm5v
+        YXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L2NvbnRlbnQvdW5pdHMvcnBtLzNkNWNkYTBmLTRkOTctNDg3My05OTJmLTAz
+        NDc3ZDE1NGRlMy8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJz
+        Y2VuYXJpb190ZXN0Il0sICJzb3VyY2VycG0iOiAibW9ua2V5LTAuMy0wLjgu
+        c3JjLnJwbSIsICJuYW1lIjogIm1vbmtleSIsICJjaGVja3N1bSI6ICIwZThm
+        YTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1ZDM5YjAyODAxNjlmNjE2NmNi
+        OGUyYzg0ZGU4NTAxZGIxIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdl
+        IG9mIG1vbmtleSIsICJmaWxlbmFtZSI6ICJtb25rZXktMC4zLTAuOC5ub2Fy
+        Y2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNf
+        bW9kdWxhciI6IGZhbHNlLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjUy
+        OWYzYTE5LTQwYjAtNGE3Ni04ZmYyLTQzZWRjMjc0N2I0ZiIsICJhcmNoIjog
+        Im5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBp
+        L3YyL2NvbnRlbnQvdW5pdHMvcnBtLzUyOWYzYTE5LTQwYjAtNGE3Ni04ZmYy
+        LTQzZWRjMjc0N2I0Zi8ifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjog
+        WyJzY2VuYXJpb190ZXN0Il0sICJzb3VyY2VycG0iOiAiY2hlZXRhaC0wLjMt
+        MC44LnNyYy5ycG0iLCAibmFtZSI6ICJjaGVldGFoIiwgImNoZWNrc3VtIjog
+        IjQyMmQwYmFhMGNkOWQ3NzEzYWU3OTZlODg2YTIzZTE3ZjU3OGY5MjRmNzQ4
+        ODBkZWJkYmI3ZDY1ZmIzNjhkYWUiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBh
+        Y2thZ2Ugb2YgY2hlZXRhaCIsICJmaWxlbmFtZSI6ICJjaGVldGFoLTAuMy0w
+        Ljgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4z
+        IiwgImlzX21vZHVsYXIiOiBmYWxzZSwgInJlbGVhc2UiOiAiMC44IiwgIl9p
+        ZCI6ICI4ZjY1ZmE5ZS1mODFmLTQ0YzktYTRiMS0yM2E3OThhOTY2OWUiLCAi
+        YXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS84ZjY1ZmE5ZS1mODFmLTQ0
+        YzktYTRiMS0yM2E3OThhOTY2OWUvIn0sIHsicmVwb3NpdG9yeV9tZW1iZXJz
+        aGlwcyI6IFsic2NlbmFyaW9fdGVzdCJdLCAic291cmNlcnBtIjogImVsZXBo
+        YW50LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogImVsZXBoYW50IiwgImNo
+        ZWNrc3VtIjogIjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMw
+        NmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCAic3VtbWFyeSI6ICJB
+        IGR1bW15IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCAiZmlsZW5hbWUiOiAiZWxl
+        cGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVy
+        c2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAicmVsZWFzZSI6
+        ICIwLjgiLCAiX2lkIjogImFjNWE1MmM4LWZhNDYtNGY5MC05MDMxLWI4NWFj
+        NTI0Njc4NSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJlbiI6IHt9LCAi
+        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvcnBtL2FjNWE1
+        MmM4LWZhNDYtNGY5MC05MDMxLWI4NWFjNTI0Njc4NS8ifSwgeyJyZXBvc2l0
+        b3J5X21lbWJlcnNoaXBzIjogWyJzY2VuYXJpb190ZXN0Il0sICJzb3VyY2Vy
+        cG0iOiAibGlvbi0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJsaW9uIiwg
+        ImNoZWNrc3VtIjogIjEyNDAwZGM5NWMyM2E0YzE2MDcyNWE5MDg3MTZjZDNm
+        Y2RkN2E4OTgxNTg1NDM3YWI2NGNkNjJlZmEzZTRhZTQiLCAic3VtbWFyeSI6
+        ICJBIGR1bW15IHBhY2thZ2Ugb2YgbGlvbiIsICJmaWxlbmFtZSI6ICJsaW9u
+        LTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24i
+        OiAiMC4zIiwgImlzX21vZHVsYXIiOiBmYWxzZSwgInJlbGVhc2UiOiAiMC44
+        IiwgIl9pZCI6ICJhZTUxMGI4MC03ZjMzLTQ3MTQtOTU2ZC1kNTZiM2NmOTA4
+        ODAiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hpbGRyZW4iOiB7fSwgIl9ocmVm
+        IjogIi9wdWxwL2FwaS92Mi9jb250ZW50L3VuaXRzL3JwbS9hZTUxMGI4MC03
+        ZjMzLTQ3MTQtOTU2ZC1kNTZiM2NmOTA4ODAvIn0sIHsicmVwb3NpdG9yeV9t
+        ZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVzdCJdLCAic291cmNlcnBtIjog
+        ImdpcmFmZmUtMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAiZ2lyYWZmZSIs
+        ICJjaGVja3N1bSI6ICJmMjVkNjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQz
+        ODkxYWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0IiwgInN1bW1hcnki
+        OiAiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCAiZmlsZW5hbWUiOiAi
+        Z2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2
+        ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFyIjogZmFsc2UsICJyZWxlYXNl
+        IjogIjAuOCIsICJfaWQiOiAiYjZlZjQwY2EtNTVlOC00NWEzLTk0YTktMmEz
+        N2IwMDdiYjNlIiwgImFyY2giOiAibm9hcmNoIiwgImNoaWxkcmVuIjoge30s
+        ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9ycG0vYjZl
+        ZjQwY2EtNTVlOC00NWEzLTk0YTktMmEzN2IwMDdiYjNlLyJ9LCB7InJlcG9z
+        aXRvcnlfbWVtYmVyc2hpcHMiOiBbInNjZW5hcmlvX3Rlc3QiXSwgInNvdXJj
+        ZXJwbSI6ICJwZW5ndWluLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogInBl
+        bmd1aW4iLCAiY2hlY2tzdW0iOiAiM2ZjYjJjOTI3ZGU5ZTEzYmY2ODQ2OTAz
+        MmEyOGIxMzlkM2U1YWQyZTU4NTY0ZmMyMTBmZDZlNDg2MzViZTY5NCIsICJz
+        dW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBwZW5ndWluIiwgImZpbGVu
+        YW1lIjogInBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjog
+        IjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAi
+        cmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogImNmOTFiMTYzLTRiMDYtNGE4NC05
+        Yjk2LTdhMjNmYWQyOTM0MSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGlsZHJl
+        biI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMv
+        cnBtL2NmOTFiMTYzLTRiMDYtNGE4NC05Yjk2LTdhMjNmYWQyOTM0MS8ifV0=
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:44 GMT
+  recorded_at: Thu, 30 May 2019 10:20:37 GMT
 - request:
     method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -5395,9 +2356,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:44 GMT
+      - Thu, 30 May 2019 10:20:37 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '2'
       Content-Type:
@@ -5408,10 +2369,216 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:44 GMT
+  recorded_at: Thu, 30 May 2019 10:20:37 GMT
 - request:
     method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImZpZWxkcyI6
+        eyJ1bml0IjpbXSwiYXNzb2NpYXRpb24iOlsidW5pdF9pZCJdfX19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '84'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:37 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '651'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICIxMWZjZjVmYS01YTY4LTRkNWQtOTEy
+        Yy03MWUyZDJjMGIyOTIiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
+        In0sICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlNzRjMzhlYjVjOGY5ZmY1YmUy
+        In0sICJ1bml0X2lkIjogIjExZmNmNWZhLTVhNjgtNGQ1ZC05MTJjLTcxZTJk
+        MmMwYjI5MiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7Im1ldGFk
+        YXRhIjogeyJfaWQiOiAiMzM0NDdmYjEtZWJjMy00YjBlLWFiMGQtYmZmMzY2
+        OTVhYzNiIiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSJ9LCAiX2lk
+        IjogeyIkb2lkIjogIjVjZWZhZTc0YzM4ZWI1YzhmOWZmNWJjMyJ9LCAidW5p
+        dF9pZCI6ICIzMzQ0N2ZiMS1lYmMzLTRiMGUtYWIwZC1iZmYzNjY5NWFjM2Ii
+        LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0ifSwgeyJtZXRhZGF0YSI6IHsi
+        X2lkIjogImI4ODM0MzUyLWJiNGItNDhhMi05MWFiLWMwYWM5YzEzYjgxMSIs
+        ICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0ifSwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1Y2VmYWU3NGMzOGViNWM4ZjlmZjViYTkifSwgInVuaXRfaWQiOiAi
+        Yjg4MzQzNTItYmI0Yi00OGEyLTkxYWItYzBhYzljMTNiODExIiwgInVuaXRf
+        dHlwZV9pZCI6ICJlcnJhdHVtIn1d
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:37 GMT
+- request:
+    method: post
+    uri: https://devel.balmora.example.com/pulp/api/v2/content/units/erratum/search/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJsaW1pdCI6Mywic2tpcCI6MCwiZmlsdGVycyI6eyJf
+        aWQiOnsiJGluIjpbIjExZmNmNWZhLTVhNjgtNGQ1ZC05MTJjLTcxZTJkMmMw
+        YjI5MiIsIjMzNDQ3ZmIxLWViYzMtNGIwZS1hYjBkLWJmZjM2Njk1YWMzYiIs
+        ImI4ODM0MzUyLWJiNGItNDhhMi05MWFiLWMwYWM5YzEzYjgxMSJdfX19LCJp
+        bmNsdWRlX3JlcG9zIjp0cnVlfQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '199'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:37 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4908'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sicmVwb3NpdG9yeV9tZW1iZXJzaGlwcyI6IFsic2NlbmFyaW9fdGVzdCJd
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5pdHMvZXJyYXR1
+        bS8xMWZjZjVmYS01YTY4LTRkNWQtOTEyYy03MWUyZDJjMGIyOTIvIiwgImlz
+        c3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAxIiwgInJlbG9naW5fc3VnZ2Vz
+        dGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjogW10sICJwdWxwX3VzZXJfbWV0
+        YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJp
+        ZCI6ICJSSEVBLTIwMTA6MDAwMiIsICJmcm9tIjogImx6YXArcHViQHJlZGhh
+        dC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIk9uZSBwYWNrYWdl
+        IGVycmF0YSIsICJjaGlsZHJlbiI6IHt9LCAidmVyc2lvbiI6ICIxIiwgInJl
+        Ym9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAi
+        cGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogImh0dHA6Ly93d3cu
+        ZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJlbGVwaGFudCIsICJzdW0i
+        OiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gu
+        cnBtIiwgImVwb2NoIjogbnVsbCwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVh
+        c2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJjb2xs
+        ZWN0aW9uLTAiLCAic2hvcnQiOiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIs
+        ICJ1cGRhdGVkIjogIiIsICJkZXNjcmlwdGlvbiI6ICJPbmUgcGFja2FnZSBl
+        cnJhdGEiLCAiX2xhc3RfdXBkYXRlZCI6ICIyMDE5LTA1LTMwVDEwOjIwOjM2
+        WiIsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50Ijog
+        IiIsICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5Ijog
+        IiIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjExZmNmNWZhLTVhNjgtNGQ1
+        ZC05MTJjLTcxZTJkMmMwYjI5MiJ9LCB7InJlcG9zaXRvcnlfbWVtYmVyc2hp
+        cHMiOiBbInNjZW5hcmlvX3Rlc3QiXSwgIl9ocmVmIjogIi9wdWxwL2FwaS92
+        Mi9jb250ZW50L3VuaXRzL2VycmF0dW0vMzM0NDdmYjEtZWJjMy00YjBlLWFi
+        MGQtYmZmMzY2OTVhYzNiLyIsICJpc3N1ZWQiOiAiMjAxMC0xMS0xMCAwMDow
+        MDowMCIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVmZXJlbmNl
+        cyI6IFt7ImhyZWYiOiAiaHR0cHM6Ly9yaG4ucmVkaGF0LmNvbS9lcnJhdGEv
+        UkhTQS0yMDEwLTA4NTguaHRtbCIsICJ0eXBlIjogInNlbGYiLCAiaWQiOiBu
+        dWxsLCAidGl0bGUiOiAiUkhTQS0yMDEwOjA4NTgifSwgeyJocmVmIjogImh0
+        dHBzOi8vYnVnemlsbGEucmVkaGF0LmNvbS9idWd6aWxsYS9zaG93X2J1Zy5j
+        Z2k/aWQ9NjI3ODgyIiwgInR5cGUiOiAiYnVnemlsbGEiLCAiaWQiOiAiNjI3
+        ODgyIiwgInRpdGxlIjogIkNWRS0yMDEwLTA0MDUgYnppcDI6IGludGVnZXIg
+        b3ZlcmZsb3cgZmxhdyBpbiBCWjJfZGVjb21wcmVzcyJ9LCB7ImhyZWYiOiAi
+        aHR0cHM6Ly93d3cucmVkaGF0LmNvbS9zZWN1cml0eS9kYXRhL2N2ZS9DVkUt
+        MjAxMC0wNDA1Lmh0bWwiLCAidHlwZSI6ICJjdmUiLCAiaWQiOiAiQ1ZFLTIw
+        MTAtMDQwNSIsICJ0aXRsZSI6ICJDVkUtMjAxMC0wNDA1In0sIHsiaHJlZiI6
+        ICJodHRwOi8vd3d3LnJlZGhhdC5jb20vc2VjdXJpdHkvdXBkYXRlcy9jbGFz
+        c2lmaWNhdGlvbi8jaW1wb3J0YW50IiwgInR5cGUiOiAib3RoZXIiLCAiaWQi
+        OiBudWxsLCAidGl0bGUiOiBudWxsfV0sICJwdWxwX3VzZXJfbWV0YWRhdGEi
+        OiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJS
+        SFNBLTIwMTA6MDg1OCIsICJmcm9tIjogInNlY3VyaXR5QHJlZGhhdC5jb20i
+        LCAic2V2ZXJpdHkiOiAiSW1wb3J0YW50IiwgInRpdGxlIjogIkltcG9ydGFu
+        dDogYnppcDIgc2VjdXJpdHkgdXBkYXRlIiwgImNoaWxkcmVuIjoge30sICJ2
+        ZXJzaW9uIjogIjMiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlw
+        ZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJz
+        cmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAi
+        YnppcDItZGV2ZWwiLCAic3VtIjogWyJzaGEyNTYiLCAiZWE2N2M2NjRkYTFm
+        Zjk2YTZkYzk0ZDMzMDA5YjczZDhmYWIzMWI1OTgyNDE4M2ZiNDVlOWJhMmVi
+        ZjgyZDU4MyJdLCAiZmlsZW5hbWUiOiAiYnppcDItZGV2ZWwtMS4wLjUtNy5l
+        bDZfMC5pNjg2LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4w
+        LjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7
+        InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6
+        ICJiemlwMi1saWJzIiwgInN1bSI6IFsic2hhMjU2IiwgImM5ZjA2NGE2ODYy
+        NTczZmI5ZjJhNmFmZjdjMzYyMWYxOTQwYjQ5MmRmMmVkZmMyZWJiZGMwYjgz
+        MDVmNTExNDciXSwgImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5l
+        bDZfMC5pNjg2LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4w
+        LjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7
+        InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6
+        ICJiemlwMiIsICJzdW0iOiBbInNoYTI1NiIsICJiOGEzZjcyYmMyYjBkODli
+        YTczNzA5OWFjOThiZjhkMmFmNGJlYTAyZDMxODg0YzAyZGI5N2Y3ZjY2YzNk
+        NWMyIl0sICJmaWxlbmFtZSI6ICJiemlwMi0xLjAuNS03LmVsNl8wLng4Nl82
+        NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJl
+        bGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6
+        ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlw
+        Mi1kZXZlbCIsICJzdW0iOiBbInNoYTI1NiIsICI3ZjYzMTI0ZTQ2NTViN2M5
+        MmQyM2VjNGMzODIyNmY1ZDM3NDY1Njg4NTNkZmY3NTBmYzg1ZTA1OGU3NGI1
+        Y2Y2Il0sICJmaWxlbmFtZSI6ICJiemlwMi1kZXZlbC0xLjAuNS03LmVsNl8w
+        Lng4Nl82NC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41
+        IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9LCB7
+        InNyYyI6ICJiemlwMi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6
+        ICJiemlwMi1saWJzIiwgInN1bSI6IFsic2hhMjU2IiwgIjgwMmY0Mzk5ZGJk
+        ZDAxNDc2ZTI1NGMzYjMyYzQwYWZmNTljZjVkMjNhNDVmYTQ4OGM2OTE3Y2U4
+        OTA0ZDZiNGQiXSwgImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5l
+        bDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIx
+        LjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQi
+        fV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJz
+        dGF0dXMiOiAiZmluYWwiLCAidXBkYXRlZCI6ICIyMDEwLTExLTEwIDAwOjAw
+        OjAwIiwgImRlc2NyaXB0aW9uIjogImJ6aXAyIGlzIGEgZnJlZWx5IGF2YWls
+        YWJsZSwgaGlnaC1xdWFsaXR5IGRhdGEgY29tcHJlc3Nvci4gSXQgcHJvdmlk
+        ZXMgYm90aFxubGliYnoyIGxpYnJhcnkgbXVzdCBiZSByZXN0YXJ0ZWQgZm9y
+        IHRoZSB1cGRhdGUgdG8gdGFrZSBlZmZlY3QuIiwgIl9sYXN0X3VwZGF0ZWQi
+        OiAiMjAxOS0wNS0zMFQxMDoyMDozNloiLCAicmVzdGFydF9zdWdnZXN0ZWQi
+        OiBmYWxzZSwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIkNvcHlyaWdo
+        dCAyMDEwIFJlZCBIYXQgSW5jIiwgInNvbHV0aW9uIjogIkJlZm9yZSBhcHBs
+        eWluZyB0aGlzIHVwZGF0ZSwgbWFrZSBzdXJlIGFsbCBwcmV2aW91c2x5LXJl
+        bGVhc2VkIGVycmF0YVxucmVsZXZhbnQgdG8geW91ciBzeXN0ZW0gaGF2ZSBi
+        ZWVuIGFwcGxpZWQuXG5cblRoaXMgdXBkYXRlIGlzIGF2YWlsYWJsZSB2aWEg
+        dGhlIFJlZCBIYXQgTmV0d29yay4gRGV0YWlscyBvbiBob3cgdG9cbnVzZSB0
+        aGUgUmVkIEhhdCBOZXR3b3JrIHRvIGFwcGx5IHRoaXMgdXBkYXRlIGFyZSBh
+        dmFpbGFibGUgYXRcbmh0dHA6Ly9rYmFzZS5yZWRoYXQuY29tL2ZhcS9kb2Nz
+        L0RPQy0xMTI1OSIsICJzdW1tYXJ5IjogIlVwZGF0ZWQgYnppcDIgcGFja2Fn
+        ZXMgdGhhdCBmaXggb25lIHNlY3VyaXR5IGlzc3VlIiwgInJlbGVhc2UiOiAi
+        IiwgIl9pZCI6ICIzMzQ0N2ZiMS1lYmMzLTRiMGUtYWIwZC1iZmYzNjY5NWFj
+        M2IifSwgeyJyZXBvc2l0b3J5X21lbWJlcnNoaXBzIjogWyJzY2VuYXJpb190
+        ZXN0Il0sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0cy9l
+        cnJhdHVtL2I4ODM0MzUyLWJiNGItNDhhMi05MWFiLWMwYWM5YzEzYjgxMS8i
+        LCAiaXNzdWVkIjogIjIwMTAtMDEtMDEgMDE6MDE6MDEiLCAicmVsb2dpbl9z
+        dWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNl
+        cl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
+        IiwgImlkIjogIlJIRUEtMjAxMDowMDAxIiwgImZyb20iOiAibHphcCtwdWJA
+        cmVkaGF0LmNvbSIsICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAiRW1wdHkg
+        ZXJyYXRhIiwgImNoaWxkcmVuIjoge30sICJ2ZXJzaW9uIjogIjEiLCAicmVi
+        b290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJw
+        a2dsaXN0IjogW10sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAi
+        IiwgImRlc2NyaXB0aW9uIjogIkVtcHR5IGVycmF0YSIsICJfbGFzdF91cGRh
+        dGVkIjogIjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgInJlc3RhcnRfc3VnZ2Vz
+        dGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAi
+        c29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVhc2UiOiAiMSIs
+        ICJfaWQiOiAiYjg4MzQzNTItYmI0Yi00OGEyLTkxYWItYzBhYzljMTNiODEx
+        In1d
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:37 GMT
+- request:
+    method: post
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -5434,9 +2601,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:44 GMT
+      - Thu, 30 May 2019 10:20:37 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -5446,28 +2613,28 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI5MWJlZDljOC0yMGE0LTRjYWItOWM5
-        OS02NzQ3ZWJiZjY1NzEiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNrYWdl
-        X2dyb3VwIn0sICJfaWQiOiB7IiRvaWQiOiAiNWM5MDFmMWZiZjFiYTllYzA0
-        Y2I5NmRiIn0sICJ1bml0X2lkIjogIjkxYmVkOWM4LTIwYTQtNGNhYi05Yzk5
-        LTY3NDdlYmJmNjU3MSIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91
-        cCJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiYmM5N2RlYTgtYWRjMC00YjRl
-        LWJlMjAtNjYwZTBiYjMxMmIwIiwgIl9jb250ZW50X3R5cGVfaWQiOiAicGFj
-        a2FnZV9ncm91cCJ9LCAiX2lkIjogeyIkb2lkIjogIjVjOTAxZjFmYmYxYmE5
-        ZWMwNGNiOTZlNiJ9LCAidW5pdF9pZCI6ICJiYzk3ZGVhOC1hZGMwLTRiNGUt
-        YmUyMC02NjBlMGJiMzEyYjAiLCAidW5pdF90eXBlX2lkIjogInBhY2thZ2Vf
+        W3sibWV0YWRhdGEiOiB7Il9pZCI6ICI1NzNmMDQzZC1hNzY4LTRmZjgtOGQz
+        Ni0zODIyMjY1NTExM2MiLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNrYWdl
+        X2dyb3VwIn0sICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlNzRjMzhlYjVjOGY5
+        ZmY1YmYyIn0sICJ1bml0X2lkIjogIjU3M2YwNDNkLWE3NjgtNGZmOC04ZDM2
+        LTM4MjIyNjU1MTEzYyIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91
+        cCJ9LCB7Im1ldGFkYXRhIjogeyJfaWQiOiAiZGJhY2NlNmEtNzQ0YS00Yzdk
+        LWEzN2ItNDE5YzhmZDllZjBlIiwgIl9jb250ZW50X3R5cGVfaWQiOiAicGFj
+        a2FnZV9ncm91cCJ9LCAiX2lkIjogeyIkb2lkIjogIjVjZWZhZTc0YzM4ZWI1
+        YzhmOWZmNWJmZSJ9LCAidW5pdF9pZCI6ICJkYmFjY2U2YS03NDRhLTRjN2Qt
+        YTM3Yi00MTljOGZkOWVmMGUiLCAidW5pdF90eXBlX2lkIjogInBhY2thZ2Vf
         Z3JvdXAifV0=
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:44 GMT
+  recorded_at: Thu, 30 May 2019 10:20:37 GMT
 - request:
     method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/content/units/package_group/search/
+    uri: https://devel.balmora.example.com/pulp/api/v2/content/units/package_group/search/
     body:
       encoding: UTF-8
       base64_string: |
         eyJjcml0ZXJpYSI6eyJsaW1pdCI6Miwic2tpcCI6MCwiZmlsdGVycyI6eyJf
-        aWQiOnsiJGluIjpbIjkxYmVkOWM4LTIwYTQtNGNhYi05Yzk5LTY3NDdlYmJm
-        NjU3MSIsImJjOTdkZWE4LWFkYzAtNGI0ZS1iZTIwLTY2MGUwYmIzMTJiMCJd
+        aWQiOnsiJGluIjpbIjU3M2YwNDNkLWE3NjgtNGZmOC04ZDM2LTM4MjIyNjU1
+        MTEzYyIsImRiYWNjZTZhLTc0NGEtNGM3ZC1hMzdiLTQxOWM4ZmQ5ZWYwZSJd
         fX19LCJpbmNsdWRlX3JlcG9zIjp0cnVlfQ==
     headers:
       Accept:
@@ -5486,9 +2653,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:44 GMT
+      - Thu, 30 May 2019 10:20:37 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -5502,36 +2669,36 @@ http_interactions:
         LCAibWFuZGF0b3J5X3BhY2thZ2VfbmFtZXMiOiBbInBlbmd1aW4iXSwgInJl
         cG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJuYW1lIjogImJpcmQiLCAidXNl
         cl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAiX2xhc3RfdXBk
-        YXRlZCI6ICIyMDE5LTAzLTE4VDIyOjQzOjQzWiIsICJjaGlsZHJlbiI6IHt9
+        YXRlZCI6ICIyMDE5LTA1LTMwVDEwOjAzOjA5WiIsICJjaGlsZHJlbiI6IHt9
         LCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdLCAidHJhbnNsYXRlZF9u
         YW1lIjoge30sICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvY29udGVudC91bml0
-        cy9wYWNrYWdlX2dyb3VwLzkxYmVkOWM4LTIwYTQtNGNhYi05Yzk5LTY3NDdl
-        YmJmNjU3MS8iLCAidHJhbnNsYXRlZF9kZXNjcmlwdGlvbiI6IHt9LCAicHVs
+        cy9wYWNrYWdlX2dyb3VwLzU3M2YwNDNkLWE3NjgtNGZmOC04ZDM2LTM4MjIy
+        NjU1MTEzYy8iLCAidHJhbnNsYXRlZF9kZXNjcmlwdGlvbiI6IHt9LCAicHVs
         cF91c2VyX21ldGFkYXRhIjoge30sICJkZWZhdWx0X3BhY2thZ2VfbmFtZXMi
         OiBbXSwgIl9jb250ZW50X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJp
-        ZCI6ICJiaXJkIiwgIl9pZCI6ICI5MWJlZDljOC0yMGE0LTRjYWItOWM5OS02
-        NzQ3ZWJiZjY1NzEiLCAiZGlzcGxheV9vcmRlciI6IDEwMjQsICJjb25kaXRp
+        ZCI6ICJiaXJkIiwgIl9pZCI6ICI1NzNmMDQzZC1hNzY4LTRmZjgtOGQzNi0z
+        ODIyMjY1NTExM2MiLCAiZGlzcGxheV9vcmRlciI6IDEwMjQsICJjb25kaXRp
         b25hbF9wYWNrYWdlX25hbWVzIjogW119LCB7InJlcG9zaXRvcnlfbWVtYmVy
         c2hpcHMiOiBbInNjZW5hcmlvX3Rlc3QiXSwgIm1hbmRhdG9yeV9wYWNrYWdl
         X25hbWVzIjogWyJlbGVwaGFudCxnaXJhZmZlLGNoZWV0YWgsbGlvbixtb25r
         ZXkscGVuZ3VpbixzcXVpcnJlbCx3YWxydXMiLCAicGVuZ3VpbiJdLCAicmVw
         b19pZCI6ICJzY2VuYXJpb190ZXN0IiwgIm5hbWUiOiAibWFtbWFsIiwgInVz
         ZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9sYXN0X3Vw
-        ZGF0ZWQiOiAiMjAxOS0wMy0xOFQyMjo0Mzo0M1oiLCAiY2hpbGRyZW4iOiB7
+        ZGF0ZWQiOiAiMjAxOS0wNS0zMFQxMDowMzowOVoiLCAiY2hpbGRyZW4iOiB7
         fSwgIm9wdGlvbmFsX3BhY2thZ2VfbmFtZXMiOiBbXSwgInRyYW5zbGF0ZWRf
         bmFtZSI6IHt9LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL2NvbnRlbnQvdW5p
-        dHMvcGFja2FnZV9ncm91cC9iYzk3ZGVhOC1hZGMwLTRiNGUtYmUyMC02NjBl
-        MGJiMzEyYjAvIiwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgInB1
+        dHMvcGFja2FnZV9ncm91cC9kYmFjY2U2YS03NDRhLTRjN2QtYTM3Yi00MTlj
+        OGZkOWVmMGUvIiwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24iOiB7fSwgInB1
         bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNrYWdlX25hbWVz
         IjogW10sICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAi
-        aWQiOiAibWFtbWFsIiwgIl9pZCI6ICJiYzk3ZGVhOC1hZGMwLTRiNGUtYmUy
-        MC02NjBlMGJiMzEyYjAiLCAiZGlzcGxheV9vcmRlciI6IDEwMjQsICJjb25k
+        aWQiOiAibWFtbWFsIiwgIl9pZCI6ICJkYmFjY2U2YS03NDRhLTRjN2QtYTM3
+        Yi00MTljOGZkOWVmMGUiLCAiZGlzcGxheV9vcmRlciI6IDEwMjQsICJjb25k
         aXRpb25hbF9wYWNrYWdlX25hbWVzIjogW119XQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:44 GMT
+  recorded_at: Thu, 30 May 2019 10:20:37 GMT
 - request:
     method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -5555,9 +2722,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:44 GMT
+      - Thu, 30 May 2019 10:20:37 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '2'
       Content-Type:
@@ -5568,10 +2735,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:44 GMT
+  recorded_at: Thu, 30 May 2019 10:20:37 GMT
 - request:
     method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -5594,9 +2761,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:44 GMT
+      - Thu, 30 May 2019 10:20:37 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '2'
       Content-Type:
@@ -5607,10 +2774,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:44 GMT
+  recorded_at: Thu, 30 May 2019 10:20:37 GMT
 - request:
     method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: 'eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkaXN0cmlidXRpb24iXX19
@@ -5633,9 +2800,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:44 GMT
+      - Thu, 30 May 2019 10:20:37 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -5659,24 +2826,24 @@ http_interactions:
         cy9kaXN0cmlidXRpb24vOWIvODMxMjU2YTEyNDcxOGJmMzkxNjZiNTY0ZDhl
         Njg5OTU0ZmYwYThmMGY0NzliYTI0Y2ZhMjYzNTAxMDliYzUiLCAiZmFtaWx5
         IjogIlRlc3QgRmFtaWx5IiwgImRvd25sb2FkZWQiOiB0cnVlLCAidGltZXN0
-        YW1wIjogMTMyMzExMjE1My4wOSwgIl9sYXN0X3VwZGF0ZWQiOiAxNTUyOTQ5
-        MDIzLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJkaXN0cmlidXRpb24iLCAidmFy
+        YW1wIjogMTMyMzExMjE1My4wOSwgIl9sYXN0X3VwZGF0ZWQiOiAxNTU5MjEx
+        NjM2LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJkaXN0cmlidXRpb24iLCAidmFy
         aWFudCI6ICJUZXN0VmFyaWFudCIsICJpZCI6ICJrcy1UZXN0IEZhbWlseS1U
         ZXN0VmFyaWFudC0xNi14ODZfNjQiLCAidmVyc2lvbiI6ICIxNiIsICJ2ZXJz
         aW9uX3NvcnRfaW5kZXgiOiAiMDItMTYiLCAicHVscF91c2VyX21ldGFkYXRh
-        Ijoge30sICJwYWNrYWdlZGlyIjogIiIsICJfaWQiOiAiMTFkYTdkNDEtNjJm
-        MC00MmUwLWExNGEtNDc4NmI2OGRmNzEwIiwgImFyY2giOiAieDg2XzY0Iiwg
+        Ijoge30sICJwYWNrYWdlZGlyIjogIiIsICJfaWQiOiAiZmQxMjU0MTAtMWMx
+        Ni00Yzk4LWFlMGUtNzg3ODI0YTM3NzgxIiwgImFyY2giOiAieDg2XzY0Iiwg
         Il9ucyI6ICJ1bml0c19kaXN0cmlidXRpb24ifSwgInVwZGF0ZWQiOiAiMjAx
-        OS0wMy0xOFQyMjo0Mzo0M1oiLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0
-        IiwgImNyZWF0ZWQiOiAiMjAxOS0wMy0xOFQyMjo0Mzo0M1oiLCAidW5pdF90
-        eXBlX2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogIjExZGE3ZDQx
-        LTYyZjAtNDJlMC1hMTRhLTQ3ODZiNjhkZjcxMCIsICJfaWQiOiB7IiRvaWQi
-        OiAiNWM5MDFmMWZiZjFiYTllYzA0Y2I5NjZkIn19XQ==
+        OS0wNS0zMFQxMDoyMDozNloiLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0
+        IiwgImNyZWF0ZWQiOiAiMjAxOS0wNS0zMFQxMDoyMDozNloiLCAidW5pdF90
+        eXBlX2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogImZkMTI1NDEw
+        LTFjMTYtNGM5OC1hZTBlLTc4NzgyNGEzNzc4MSIsICJfaWQiOiB7IiRvaWQi
+        OiAiNWNlZmFlNzRjMzhlYjVjOGY5ZmY1YjgwIn19XQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:44 GMT
+  recorded_at: Thu, 30 May 2019 10:20:37 GMT
 - request:
     method: post
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/actions/content/regenerate_applicability//
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/actions/content/regenerate_applicability//
     body:
       encoding: UTF-8
       base64_string: |
@@ -5699,9 +2866,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:44 GMT
+      - Thu, 30 May 2019 10:20:37 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '127'
       Content-Type:
@@ -5709,14 +2876,14 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJncm91cF9pZCI6ICIxY2U4ODlmZC05YjYwLTRkYmUtOWRjOC1kNzRiY2Ex
-        ODIwN2EiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tfZ3JvdXBzLzFj
-        ZTg4OWZkLTliNjAtNGRiZS05ZGM4LWQ3NGJjYTE4MjA3YS8ifQ==
+        eyJncm91cF9pZCI6ICJlNjRlMzBlNS02MjQ0LTRmMTctOWMyOS03MTQ0M2U1
+        MDAwZmUiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tfZ3JvdXBzL2U2
+        NGUzMGU1LTYyNDQtNGYxNy05YzI5LTcxNDQzZTUwMDBmZS8ifQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:44 GMT
+  recorded_at: Thu, 30 May 2019 10:20:37 GMT
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/task_groups/1ce889fd-9b60-4dbe-9dc8-d74bca18207a/state_summary/
+    uri: https://devel.balmora.example.com/pulp/api/v2/task_groups/e64e30e5-6244-4f17-9c29-71443e5000fe/state_summary/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -5735,9 +2902,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:44 GMT
+      - Thu, 30 May 2019 10:20:37 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
       - '"f488fb4a2bc756aee3f1e9f5b238fe1f-gzip"'
       Vary:
@@ -5753,5 +2920,5 @@ http_interactions:
         ImNhbmNlbGVkIjogMCwgIndhaXRpbmciOiAwLCAic2tpcHBlZCI6IDAsICJz
         dXNwZW5kZWQiOiAwLCAiZXJyb3IiOiAwLCAidG90YWwiOiAwfQ==
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:44 GMT
+  recorded_at: Thu, 30 May 2019 10:20:37 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/repo_update.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/repo_update.yml
@@ -1,0 +1,2222 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/content/1559211615167
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IjE1NTkyMTE2MTUxNjciLCJuYW1lIjoiU2NlbmFyaW8geXVtIHBy
+        b2R1Y3QiLCJjb250ZW50VXJsIjoiL2N1c3RvbS9TY2VuYXJpb19Qcm9kdWN0
+        L1NjZW5hcmlvX3l1bV9wcm9kdWN0IiwiZ3BnVXJsIjpudWxsLCJ0eXBlIjoi
+        eXVtIiwiYXJjaGVzIjpudWxsLCJsYWJlbCI6InNjZW5hcmlvX3Rlc3RfU2Nl
+        bmFyaW9fUHJvZHVjdF9TY2VuYXJpb195dW1fcHJvZHVjdCIsIm1ldGFkYXRh
+        RXhwaXJlIjoxLCJ2ZW5kb3IiOiJDdXN0b20ifQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD",
+        oauth_nonce="4udy2WLAT7TGnVDtKBkpR1JBndMe3WaCoI2DLfexN8", oauth_signature="TobtVlplUTHPEQrW5wbrWnOGBj4%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559211657", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '253'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 9ff5ed87-0f1c-426b-b083-91d7a35f3b88
+      X-Version:
+      - 2.6.5-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Thu, 30 May 2019 10:20:57 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxMDoyMDoxNSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDUtMzBUMTA6MjA6MTUrMDAwMCIsInV1aWQiOiI0MDI4Zjlm
+        NzZiMDQzMGE5MDE2YjA4NDEyM2FkMDBhMyIsImlkIjoiMTU1OTIxMTYxNTE2
+        NyIsInR5cGUiOiJ5dW0iLCJsYWJlbCI6InNjZW5hcmlvX3Rlc3RfU2NlbmFy
+        aW9fUHJvZHVjdF9TY2VuYXJpb195dW1fcHJvZHVjdCIsIm5hbWUiOiJTY2Vu
+        YXJpbyB5dW0gcHJvZHVjdCIsInZlbmRvciI6IkN1c3RvbSIsImNvbnRlbnRV
+        cmwiOiIvY3VzdG9tL1NjZW5hcmlvX1Byb2R1Y3QvU2NlbmFyaW9feXVtX3By
+        b2R1Y3QiLCJyZXF1aXJlZFRhZ3MiOm51bGwsImdwZ1VybCI6bnVsbCwibW9k
+        aWZpZWRQcm9kdWN0SWRzIjpbXSwiYXJjaGVzIjpudWxsLCJyZXF1aXJlZFBy
+        b2R1Y3RJZHMiOltdLCJtZXRhZGF0YUV4cGlyZSI6MSwicmVsZWFzZVZlciI6
+        bnVsbH0=
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:57 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:57 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"afd19ef4006b9743fd6ae56e8f78cf65-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2484'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiJ9LCAi
+        ZGlzcGxheV9uYW1lIjogIlNjZW5hcmlvIHl1bSBwcm9kdWN0IiwgImRlc2Ny
+        aXB0aW9uIjogbnVsbCwgImRpc3RyaWJ1dG9ycyI6IFt7InJlcG9faWQiOiAi
+        c2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNS0zMFQx
+        MDoyMDoxNVoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
+        cy9zY2VuYXJpb190ZXN0L2Rpc3RyaWJ1dG9ycy9zY2VuYXJpb190ZXN0X2Ns
+        b25lLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJs
+        aXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Nsb25l
+        X2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRj
+        aHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6
+        IHsiJG9pZCI6ICI1Y2VmYWU1ZmIwMmU1MzExYTI4YTA5NGMifSwgImNvbmZp
+        ZyI6IHsiZGVzdGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiAic2NlbmFyaW9f
+        dGVzdCJ9LCAiaWQiOiAic2NlbmFyaW9fdGVzdF9jbG9uZSJ9LCB7InJlcG9f
+        aWQiOiAic2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0w
+        NS0zMFQxMDoyMDoxNVoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9z
+        aXRvcmllcy9zY2VuYXJpb190ZXN0L2Rpc3RyaWJ1dG9ycy9zY2VuYXJpb190
+        ZXN0LyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJs
+        aXNoIjogIjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgImRpc3RyaWJ1dG9yX3R5
+        cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IHRy
+        dWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRv
+        cnMiLCAiX2lkIjogeyIkb2lkIjogIjVjZWZhZTVmYjAyZTUzMTFhMjhhMDk0
+        YiJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6IGZh
+        bHNlLCAiaHR0cHMiOiB0cnVlLCAicmVsYXRpdmVfdXJsIjogInNjZW5hcmlv
+        X3Rlc3QifSwgImlkIjogInNjZW5hcmlvX3Rlc3QifSwgeyJyZXBvX2lkIjog
+        InNjZW5hcmlvX3Rlc3QiLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDUtMzBU
+        MTA6MjA6MTVaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3Jp
+        ZXMvc2NlbmFyaW9fdGVzdC9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3RyaWJ1
+        dG9yLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJs
+        aXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0X2Rp
+        c3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBh
+        ZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsi
+        JG9pZCI6ICI1Y2VmYWU1ZmIwMmU1MzExYTI4YTA5NGQifSwgImNvbmZpZyI6
+        IHsiaHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogInNjZW5hcmlvX3Rl
+        c3QiLCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6ICJleHBvcnRfZGlzdHJpYnV0
+        b3IifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAxOS0wNS0zMFQxMDoyMDoz
+        NloiLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwgImxh
+        c3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3VudHMi
+        OiB7InBhY2thZ2VfZ3JvdXAiOiAyLCAiZGlzdHJpYnV0aW9uIjogMSwgInBh
+        Y2thZ2VfY2F0ZWdvcnkiOiAxLCAicnBtIjogOCwgImVycmF0dW0iOiAzfSwg
+        Il9ucyI6ICJyZXBvcyIsICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lkIjogInNj
+        ZW5hcmlvX3Rlc3QiLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDUtMzBUMTA6
+        MjA6MTRaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
+        c2NlbmFyaW9fdGVzdC9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMi
+        OiAicmVwb19pbXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
+        aW1wb3J0ZXIiLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rf
+        c3luYyI6ICIyMDE5LTA1LTMwVDEwOjIwOjM2WiIsICJzY3JhdGNocGFkIjog
+        eyJyZXBvbWRfcmV2aXNpb24iOiAxMzIxODkzODAwfSwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1Y2VmYWU1ZWIwMmU1MzExYTI4YTA5NGEifSwgImNvbmZpZyI6IHsi
+        ZmVlZCI6ICJmaWxlOi8vL3Zhci93d3cvdGVzdF9yZXBvcy96b28iLCAic3Ns
+        X3ZhbGlkYXRpb24iOiB0cnVlLCAicmVtb3ZlX21pc3NpbmciOiB0cnVlLCAi
+        ZG93bmxvYWRfcG9saWN5IjogImltbWVkaWF0ZSJ9LCAiaWQiOiAieXVtX2lt
+        cG9ydGVyIn1dLCAibG9jYWxseV9zdG9yZWRfdW5pdHMiOiAxNSwgIl9pZCI6
+        IHsiJG9pZCI6ICI1Y2VmYWU1ZWIwMmU1MzExYTI4YTA5NDkifSwgInRvdGFs
+        X3JlcG9zaXRvcnlfdW5pdHMiOiAxNSwgImlkIjogInNjZW5hcmlvX3Rlc3Qi
+        LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJp
+        b190ZXN0LyJ9
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:57 GMT
+- request:
+    method: put
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/importers/yum_importer//
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpbXBvcnRlcl9jb25maWciOnsic3NsX2NsaWVudF9jZXJ0IjpudWxsLCJz
+        c2xfY2xpZW50X2tleSI6bnVsbCwic3NsX2NhX2NlcnQiOm51bGx9fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '85'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzVkZTQyMDExLTY2NmMtNGExMC1hMWNhLWIwOWY2MDdiMTBkYS8iLCAi
+        dGFza19pZCI6ICI1ZGU0MjAxMS02NjZjLTRhMTAtYTFjYS1iMDlmNjA3YjEw
+        ZGEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:58 GMT
+- request:
+    method: put
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/importers/yum_importer//
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpbXBvcnRlcl9jb25maWciOnsiZG93bmxvYWRfcG9saWN5IjoiaW1tZWRp
+        YXRlIiwicmVtb3ZlX21pc3NpbmciOmZhbHNlLCJmZWVkIjoiZmlsZTovLy92
+        YXIvd3d3L3Rlc3RfcmVwb3Mvem9vIiwidHlwZV9za2lwX2xpc3QiOm51bGws
+        InByb3h5X2hvc3QiOm51bGwsImJhc2ljX2F1dGhfdXNlcm5hbWUiOm51bGws
+        ImJhc2ljX2F1dGhfcGFzc3dvcmQiOm51bGwsInNzbF92YWxpZGF0aW9uIjp0
+        cnVlLCJzc2xfY2xpZW50X2NlcnQiOm51bGwsInNzbF9jbGllbnRfa2V5Ijpu
+        dWxsLCJzc2xfY2FfY2VydCI6bnVsbH19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '294'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzRmOWNkNGE1LTU1MTAtNGE0Zi1iNmRlLTNlMjFmOWMzNjA0Mi8iLCAi
+        dGFza19pZCI6ICI0ZjljZDRhNS01NTEwLTRhNGYtYjZkZS0zZTIxZjljMzYw
+        NDIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:58 GMT
+- request:
+    method: put
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/distributors/scenario_test//
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJkaXN0cmlidXRvcl9jb25maWciOnsicmVsYXRpdmVfdXJsIjoic2NlbmFy
+        aW9fdGVzdCIsImh0dHAiOmZhbHNlLCJodHRwcyI6dHJ1ZSwicHJvdGVjdGVk
+        Ijp0cnVlLCJjaGVja3N1bV90eXBlIjpudWxsfX0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '119'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzQyOTQ4MGVjLWQ3OTUtNDQ1Ny1iOGI5LTI5YzQ5OThkMzg1Mi8iLCAi
+        dGFza19pZCI6ICI0Mjk0ODBlYy1kNzk1LTQ0NTctYjhiOS0yOWM0OTk4ZDM4
+        NTIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:58 GMT
+- request:
+    method: put
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/distributors/scenario_test_clone//
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJkaXN0cmlidXRvcl9jb25maWciOnsiZGVzdGluYXRpb25fZGlzdHJpYnV0
+        b3JfaWQiOiJzY2VuYXJpb190ZXN0In19
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '69'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2ZkYzVhYjY1LWIxMWMtNGVmZS1iNzA3LTIxMDZlMTg0NDcyOC8iLCAi
+        dGFza19pZCI6ICJmZGM1YWI2NS1iMTFjLTRlZmUtYjcwNy0yMTA2ZTE4NDQ3
+        MjgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:58 GMT
+- request:
+    method: put
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/distributors/export_distributor//
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBzIjpm
+        YWxzZSwicmVsYXRpdmVfdXJsIjoic2NlbmFyaW9fdGVzdCJ9fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '82'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2ExOTlhMmRkLWU0ZDItNDVhZS04MzI3LTY4MzZiMzUxYzcxOS8iLCAi
+        dGFza19pZCI6ICJhMTk5YTJkZC1lNGQyLTQ1YWUtODMyNy02ODM2YjM1MWM3
+        MTkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:58 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/5de42011-666c-4a10-a1ca-b09f607b10da/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"c7c28921dae6f177bb3ed9d8ed4b7a87-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1266'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uaW1wb3J0ZXIudXBkYXRlX2ltcG9ydGVyX2NvbmZp
+        ZyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNWRlNDIwMTEtNjY2
+        Yy00YTEwLWExY2EtYjA5ZjYwN2IxMGRhLyIsICJ0YXNrX2lkIjogIjVkZTQy
+        MDExLTY2NmMtNGExMC1hMWNhLWIwOWY2MDdiMTBkYSIsICJ0YWdzIjogWyJw
+        dWxwOnJlcG9zaXRvcnk6c2NlbmFyaW9fdGVzdCIsICJwdWxwOnJlcG9zaXRv
+        cnlfaW1wb3J0ZXI6eXVtX2ltcG9ydGVyIiwgInB1bHA6YWN0aW9uOnVwZGF0
+        ZV9pbXBvcnRlciJdLCAiZmluaXNoX3RpbWUiOiAiMjAxOS0wNS0zMFQxMDoy
+        MDo1OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAi
+        MjAxOS0wNS0zMFQxMDoyMDo1OFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
+        YXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVl
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29y
+        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwu
+        YmFsbW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlcG9faWQiOiAi
+        c2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNS0zMFQx
+        MDoyMDo1OFoiLCAiX2hyZWYiOiAiL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJp
+        b190ZXN0L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBv
+        X2ltcG9ydGVycyIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRl
+        ciIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjog
+        IjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgInNjcmF0Y2hwYWQiOiB7InJlcG9t
+        ZF9yZXZpc2lvbiI6IDEzMjE4OTM4MDB9LCAiX2lkIjogeyIkb2lkIjogIjVj
+        ZWZhZTVlYjAyZTUzMTFhMjhhMDk0YSJ9LCAiY29uZmlnIjogeyJmZWVkIjog
+        ImZpbGU6Ly8vdmFyL3d3dy90ZXN0X3JlcG9zL3pvbyIsICJzc2xfdmFsaWRh
+        dGlvbiI6IHRydWUsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9h
+        ZF9wb2xpY3kiOiAiaW1tZWRpYXRlIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIi
+        fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmYWU4YWMz
+        OGViNWM4ZjlmZjVlMDYifSwgImlkIjogIjVjZWZhZThhYzM4ZWI1YzhmOWZm
+        NWUwNiJ9
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:58 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/4f9cd4a5-5510-4a4f-b6de-3e21f9c36042/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"5b8f09e4c4e9a20745469c21e8ab34f8-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1267'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uaW1wb3J0ZXIudXBkYXRlX2ltcG9ydGVyX2NvbmZp
+        ZyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNGY5Y2Q0YTUtNTUx
+        MC00YTRmLWI2ZGUtM2UyMWY5YzM2MDQyLyIsICJ0YXNrX2lkIjogIjRmOWNk
+        NGE1LTU1MTAtNGE0Zi1iNmRlLTNlMjFmOWMzNjA0MiIsICJ0YWdzIjogWyJw
+        dWxwOnJlcG9zaXRvcnk6c2NlbmFyaW9fdGVzdCIsICJwdWxwOnJlcG9zaXRv
+        cnlfaW1wb3J0ZXI6eXVtX2ltcG9ydGVyIiwgInB1bHA6YWN0aW9uOnVwZGF0
+        ZV9pbXBvcnRlciJdLCAiZmluaXNoX3RpbWUiOiAiMjAxOS0wNS0zMFQxMDoy
+        MDo1OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAi
+        MjAxOS0wNS0zMFQxMDoyMDo1OFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
+        YXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVl
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29y
+        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwu
+        YmFsbW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlcG9faWQiOiAi
+        c2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNS0zMFQx
+        MDoyMDo1OFoiLCAiX2hyZWYiOiAiL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJp
+        b190ZXN0L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBv
+        X2ltcG9ydGVycyIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRl
+        ciIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjog
+        IjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgInNjcmF0Y2hwYWQiOiB7InJlcG9t
+        ZF9yZXZpc2lvbiI6IDEzMjE4OTM4MDB9LCAiX2lkIjogeyIkb2lkIjogIjVj
+        ZWZhZTVlYjAyZTUzMTFhMjhhMDk0YSJ9LCAiY29uZmlnIjogeyJmZWVkIjog
+        ImZpbGU6Ly8vdmFyL3d3dy90ZXN0X3JlcG9zL3pvbyIsICJzc2xfdmFsaWRh
+        dGlvbiI6IHRydWUsICJyZW1vdmVfbWlzc2luZyI6IGZhbHNlLCAiZG93bmxv
+        YWRfcG9saWN5IjogImltbWVkaWF0ZSJ9LCAiaWQiOiAieXVtX2ltcG9ydGVy
+        In0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlOGFj
+        MzhlYjVjOGY5ZmY1ZTFiIn0sICJpZCI6ICI1Y2VmYWU4YWMzOGViNWM4Zjlm
+        ZjVlMWIifQ==
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:58 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/429480ec-d795-4457-b8b9-29c4998d3852/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"a104db0b2ce60eaeb4fe09371b245ff8-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1233'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGlzdHJpYnV0b3JfdXBkYXRlIiwgIl9ocmVm
+        IjogIi9wdWxwL2FwaS92Mi90YXNrcy80Mjk0ODBlYy1kNzk1LTQ0NTctYjhi
+        OS0yOWM0OTk4ZDM4NTIvIiwgInRhc2tfaWQiOiAiNDI5NDgwZWMtZDc5NS00
+        NDU3LWI4YjktMjljNDk5OGQzODUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
+        dG9yeTpzY2VuYXJpb190ZXN0IiwgInB1bHA6cmVwb3NpdG9yeV9kaXN0cmli
+        dXRvcjpzY2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnVwZGF0ZV9kaXN0
+        cmlidXRvciJdLCAiZmluaXNoX3RpbWUiOiAiMjAxOS0wNS0zMFQxMDoyMDo1
+        OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAx
+        OS0wNS0zMFQxMDoyMDo1OFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXdu
+        ZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5l
+        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2Vy
+        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFs
+        bW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlcG9faWQiOiAic2Nl
+        bmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNS0zMFQxMDoy
+        MDo1OFoiLCAiX2hyZWYiOiAiL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJpb190
+        ZXN0L2Rpc3RyaWJ1dG9ycy9zY2VuYXJpb190ZXN0LyIsICJsYXN0X292ZXJy
+        aWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogIjIwMTktMDUtMzBU
+        MTA6MjA6MzZaIiwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Rpc3Ry
+        aWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IHRydWUsICJzY3JhdGNocGFkIjog
+        e30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lk
+        IjogIjVjZWZhZTVmYjAyZTUzMTFhMjhhMDk0YiJ9LCAiY29uZmlnIjogeyJw
+        cm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6IGZhbHNlLCAiaHR0cHMiOiB0cnVl
+        LCAicmVsYXRpdmVfdXJsIjogInNjZW5hcmlvX3Rlc3QifSwgImlkIjogInNj
+        ZW5hcmlvX3Rlc3QifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1Y2VmYWU4YWMzOGViNWM4ZjlmZjVlMzUifSwgImlkIjogIjVjZWZhZThh
+        YzM4ZWI1YzhmOWZmNWUzNSJ9
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:58 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/fdc5ab65-b11c-4efe-b707-2106e1844728/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"0c957da1579300cc27cc051f0c7dff3f-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1205'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGlzdHJpYnV0b3JfdXBkYXRlIiwgIl9ocmVm
+        IjogIi9wdWxwL2FwaS92Mi90YXNrcy9mZGM1YWI2NS1iMTFjLTRlZmUtYjcw
+        Ny0yMTA2ZTE4NDQ3MjgvIiwgInRhc2tfaWQiOiAiZmRjNWFiNjUtYjExYy00
+        ZWZlLWI3MDctMjEwNmUxODQ0NzI4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
+        dG9yeTpzY2VuYXJpb190ZXN0IiwgInB1bHA6cmVwb3NpdG9yeV9kaXN0cmli
+        dXRvcjpzY2VuYXJpb190ZXN0X2Nsb25lIiwgInB1bHA6YWN0aW9uOnVwZGF0
+        ZV9kaXN0cmlidXRvciJdLCAiZmluaXNoX3RpbWUiOiAiMjAxOS0wNS0zMFQx
+        MDoyMDo1OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxOS0wNS0zMFQxMDoyMDo1OFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFs
+        bW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAi
+        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2
+        ZWwuYmFsbW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlcG9faWQi
+        OiAic2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNS0z
+        MFQxMDoyMDo1OFoiLCAiX2hyZWYiOiAiL3YyL3JlcG9zaXRvcmllcy9zY2Vu
+        YXJpb190ZXN0L2Rpc3RyaWJ1dG9ycy9zY2VuYXJpb190ZXN0X2Nsb25lLyIs
+        ICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjog
+        bnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Nsb25lX2Rpc3Ry
+        aWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6
+        IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1Y2VmYWU1ZmIwMmU1MzExYTI4YTA5NGMifSwgImNvbmZpZyI6IHsi
+        ZGVzdGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiAic2NlbmFyaW9fdGVzdCJ9
+        LCAiaWQiOiAic2NlbmFyaW9fdGVzdF9jbG9uZSJ9LCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjVjZWZhZThhYzM4ZWI1YzhmOWZmNWU1MSJ9
+        LCAiaWQiOiAiNWNlZmFlOGFjMzhlYjVjOGY5ZmY1ZTUxIn0=
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:58 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/a199a2dd-e4d2-45ae-8327-6836b351c719/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"b4dc27f504ea691c6d4961e019bff91a-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1216'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGlzdHJpYnV0b3JfdXBkYXRlIiwgIl9ocmVm
+        IjogIi9wdWxwL2FwaS92Mi90YXNrcy9hMTk5YTJkZC1lNGQyLTQ1YWUtODMy
+        Ny02ODM2YjM1MWM3MTkvIiwgInRhc2tfaWQiOiAiYTE5OWEyZGQtZTRkMi00
+        NWFlLTgzMjctNjgzNmIzNTFjNzE5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
+        dG9yeTpzY2VuYXJpb190ZXN0IiwgInB1bHA6cmVwb3NpdG9yeV9kaXN0cmli
+        dXRvcjpleHBvcnRfZGlzdHJpYnV0b3IiLCAicHVscDphY3Rpb246dXBkYXRl
+        X2Rpc3RyaWJ1dG9yIl0sICJmaW5pc2hfdGltZSI6ICIyMDE5LTA1LTMwVDEw
+        OjIwOjU4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6
+        ICIyMDE5LTA1LTMwVDEwOjIwOjU4WiIsICJ0cmFjZWJhY2siOiBudWxsLCAi
+        c3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJx
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxt
+        b3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZl
+        bC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVwb19pZCI6
+        ICJzY2VuYXJpb190ZXN0IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA1LTMw
+        VDEwOjIwOjU4WiIsICJfaHJlZiI6ICIvdjIvcmVwb3NpdG9yaWVzL3NjZW5h
+        cmlvX3Rlc3QvZGlzdHJpYnV0b3JzL2V4cG9ydF9kaXN0cmlidXRvci8iLCAi
+        bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlzaCI6IG51
+        bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4cG9ydF9kaXN0cmlidXRv
+        ciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hwYWQiOiB7fSwg
+        Il9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWNlZmFlNWZiMDJlNTMxMWEyOGEwOTRkIn0sICJjb25maWciOiB7Imh0dHAi
+        OiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJzY2VuYXJpb190ZXN0IiwgImh0
+        dHBzIjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlOGFjMzhlYjVj
+        OGY5ZmY1ZTY1In0sICJpZCI6ICI1Y2VmYWU4YWMzOGViNWM4ZjlmZjVlNjUi
+        fQ==
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:58 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"7e904b68a0f0e4d206dfe03e569d329c-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2485'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJzY3JhdGNocGFkIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiJ9LCAi
+        ZGlzcGxheV9uYW1lIjogIlNjZW5hcmlvIHl1bSBwcm9kdWN0IiwgImRlc2Ny
+        aXB0aW9uIjogbnVsbCwgImRpc3RyaWJ1dG9ycyI6IFt7InJlcG9faWQiOiAi
+        c2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNS0zMFQx
+        MDoyMDo1OFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
+        cy9zY2VuYXJpb190ZXN0L2Rpc3RyaWJ1dG9ycy9zY2VuYXJpb190ZXN0X2Ns
+        b25lLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJs
+        aXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Nsb25l
+        X2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRj
+        aHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6
+        IHsiJG9pZCI6ICI1Y2VmYWU1ZmIwMmU1MzExYTI4YTA5NGMifSwgImNvbmZp
+        ZyI6IHsiZGVzdGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiAic2NlbmFyaW9f
+        dGVzdCJ9LCAiaWQiOiAic2NlbmFyaW9fdGVzdF9jbG9uZSJ9LCB7InJlcG9f
+        aWQiOiAic2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0w
+        NS0zMFQxMDoyMDo1OFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9z
+        aXRvcmllcy9zY2VuYXJpb190ZXN0L2Rpc3RyaWJ1dG9ycy9zY2VuYXJpb190
+        ZXN0LyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJs
+        aXNoIjogIjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgImRpc3RyaWJ1dG9yX3R5
+        cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IHRy
+        dWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRv
+        cnMiLCAiX2lkIjogeyIkb2lkIjogIjVjZWZhZTVmYjAyZTUzMTFhMjhhMDk0
+        YiJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6IGZh
+        bHNlLCAicmVsYXRpdmVfdXJsIjogInNjZW5hcmlvX3Rlc3QiLCAiaHR0cHMi
+        OiB0cnVlfSwgImlkIjogInNjZW5hcmlvX3Rlc3QifSwgeyJyZXBvX2lkIjog
+        InNjZW5hcmlvX3Rlc3QiLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDUtMzBU
+        MTA6MjA6NThaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3Jp
+        ZXMvc2NlbmFyaW9fdGVzdC9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3RyaWJ1
+        dG9yLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJs
+        aXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0X2Rp
+        c3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBh
+        ZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsi
+        JG9pZCI6ICI1Y2VmYWU1ZmIwMmU1MzExYTI4YTA5NGQifSwgImNvbmZpZyI6
+        IHsiaHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogInNjZW5hcmlvX3Rl
+        c3QiLCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6ICJleHBvcnRfZGlzdHJpYnV0
+        b3IifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAxOS0wNS0zMFQxMDoyMDoz
+        NloiLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwgImxh
+        c3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3VudHMi
+        OiB7InBhY2thZ2VfZ3JvdXAiOiAyLCAiZGlzdHJpYnV0aW9uIjogMSwgInBh
+        Y2thZ2VfY2F0ZWdvcnkiOiAxLCAicnBtIjogOCwgImVycmF0dW0iOiAzfSwg
+        Il9ucyI6ICJyZXBvcyIsICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lkIjogInNj
+        ZW5hcmlvX3Rlc3QiLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDUtMzBUMTA6
+        MjA6NThaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
+        c2NlbmFyaW9fdGVzdC9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMi
+        OiAicmVwb19pbXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
+        aW1wb3J0ZXIiLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rf
+        c3luYyI6ICIyMDE5LTA1LTMwVDEwOjIwOjM2WiIsICJzY3JhdGNocGFkIjog
+        eyJyZXBvbWRfcmV2aXNpb24iOiAxMzIxODkzODAwfSwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1Y2VmYWU1ZWIwMmU1MzExYTI4YTA5NGEifSwgImNvbmZpZyI6IHsi
+        ZmVlZCI6ICJmaWxlOi8vL3Zhci93d3cvdGVzdF9yZXBvcy96b28iLCAic3Ns
+        X3ZhbGlkYXRpb24iOiB0cnVlLCAicmVtb3ZlX21pc3NpbmciOiBmYWxzZSwg
+        ImRvd25sb2FkX3BvbGljeSI6ICJpbW1lZGlhdGUifSwgImlkIjogInl1bV9p
+        bXBvcnRlciJ9XSwgImxvY2FsbHlfc3RvcmVkX3VuaXRzIjogMTUsICJfaWQi
+        OiB7IiRvaWQiOiAiNWNlZmFlNWViMDJlNTMxMWEyOGEwOTQ5In0sICJ0b3Rh
+        bF9yZXBvc2l0b3J5X3VuaXRzIjogMTUsICJpZCI6ICJzY2VuYXJpb190ZXN0
+        IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvc2NlbmFy
+        aW9fdGVzdC8ifQ==
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:58 GMT
+- request:
+    method: post
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/actions/publish/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6InNjZW5hcmlvX3Rlc3QiLCJvdmVycmlkZV9jb25maWciOnsiZm9y
+        Y2VfZnVsbCI6ZmFsc2V9fQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '61'
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzY4MmQwM2UzLTc4NmYtNGZmMS04ZTM4LTU4YmFlZTgzMzI0OS8iLCAi
+        dGFza19pZCI6ICI2ODJkMDNlMy03ODZmLTRmZjEtOGUzOC01OGJhZWU4MzMy
+        NDkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:58 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/682d03e3-786f-4ff1-8e38-58baee833249/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"8a2ac9945259baf108604399ea5910a0-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '553'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy82ODJkMDNlMy03ODZmLTRmZjEtOGUzOC01OGJh
+        ZWU4MzMyNDkvIiwgInRhc2tfaWQiOiAiNjgyZDAzZTMtNzg2Zi00ZmYxLThl
+        MzgtNThiYWVlODMzMjQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIiIsICJz
+        dGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3Vs
+        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNl
+        ZmFlOGFjMzhlYjVjOGY5ZmY1ZWMzIn0sICJpZCI6ICI1Y2VmYWU4YWMzOGVi
+        NWM4ZjlmZjVlYzMifQ==
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:58 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/682d03e3-786f-4ff1-8e38-58baee833249/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"1343cabdd07185f57826f524eaaf2192-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4545'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy82ODJkMDNlMy03ODZmLTRmZjEtOGUzOC01OGJh
+        ZWU4MzMyNDkvIiwgInRhc2tfaWQiOiAiNjgyZDAzZTMtNzg2Zi00ZmYxLThl
+        MzgtNThiYWVlODMzMjQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6NThaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4NDRjMTljYi01YzRjLTQ4YWQtYTY5
+        OS03YmY5YjNmNGJkMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBv
+        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
+        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmY0MzdkY2UtYTU1Yi00NmE5
+        LWFmYTMtMjk5NWY4YTE3NWM5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERp
+        c3RyaWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9u
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImEyNWJlZDg0LTIxM2ItNDBmNS04ZDE2
+        LTg1ZjU5ZDIwNjIzMiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwg
+        InN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNmZGNi
+        MmMyLWI4MjItNGU2Yy1hMTU2LWNlY2E5NGNmNzc4OCIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        UHVibGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIzZDAwYzk1My0yZDI3LTRmNzgtOGEwOC1i
+        NzU4OWYyNDM5NDYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwg
+        InN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmU2
+        MzZlNTItY2VlZC00Y2FlLWE2MmEtMTMyNjc2MGUzZWQyIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiOWZjNDM4ZTctMTE5NS00MTNmLTgwZDEt
+        Y2JhZjM0M2RiYzAwIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZp
+        bGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        ImVkZDZlNzkwLTIyMmQtNGViZS1iNmRlLTAwYTcwMTBhYjNjYyIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
+        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFS
+        VEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjViOGFlYWViLWQwNzItNGVk
+        NC1iMzU2LWY3OGI2ODRiMjkzZSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
+        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjAxYTNiNGMwLTNiNTktNDBlMi04MWM2
+        LWM1MWNmZDg3ZWZmYiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUg
+        ZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVt
+        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJmMjliZTk3OC0zOWIyLTQ3NGUtYWNlMC1lZjdiYjlj
+        ODYxYWIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJz
+        dGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICI4NjI2ZjkxNC0zNTQ3LTRlZGEtOTlhYy03NjU1ZDBkNWFkY2Ii
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5
+        cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzM4YTJiN2Yt
+        MmM2NS00Nzk2LWI1ZDctYjI0ZTA1ZGEzNTEyIiwgIm51bV9wcm9jZXNzZWQi
+        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
+        aXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9k
+        aXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
+        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDQ4MDEzZGMtY2IzYS00
+        MTQzLTkwMWMtZjEwZDU4YTk2NjA1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
+        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
+        c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
+        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RB
+        UlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYWZkNjgzYy04MTY5LTQw
+        NzEtOTE4OS0zNTM5Nzg2MjdkZmEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0s
+        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5i
+        YWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRl
+        dmVsLmJhbG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmYWU4YWMzOGViNWM4
+        ZjlmZjVlYzMifSwgImlkIjogIjVjZWZhZThhYzM4ZWI1YzhmOWZmNWVjMyJ9
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:58 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/682d03e3-786f-4ff1-8e38-58baee833249/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"61a78fb888c99051a917e0c2bc543aba-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4539'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy82ODJkMDNlMy03ODZmLTRmZjEtOGUzOC01OGJh
+        ZWU4MzMyNDkvIiwgInRhc2tfaWQiOiAiNjgyZDAzZTMtNzg2Zi00ZmYxLThl
+        MzgtNThiYWVlODMzMjQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6NThaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI4NDRjMTljYi01YzRjLTQ4YWQtYTY5OS03
+        YmY5YjNmNGJkMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMmY0MzdkY2UtYTU1Yi00NmE5LWFmYTMt
+        Mjk5NWY4YTE3NWM5IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogImEyNWJlZDg0LTIxM2ItNDBmNS04ZDE2LTg1ZjU5
+        ZDIwNjIzMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBf
+        dHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
+        VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNmZGNiMmMyLWI4
+        MjItNGU2Yy1hMTU2LWNlY2E5NGNmNzc4OCIsICJudW1fcHJvY2Vzc2VkIjog
+        MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        aGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVt
+        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIzZDAwYzk1My0yZDI3LTRmNzgtOGEwOC1iNzU4OWYy
+        NDM5NDYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBf
+        dHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmU2MzZlNTIt
+        Y2VlZC00Y2FlLWE2MmEtMTMyNjc2MGUzZWQyIiwgIm51bV9wcm9jZXNzZWQi
+        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
+        aXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRl
+        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiOWZjNDM4ZTctMTE5NS00MTNmLTgwZDEtY2JhZjM0
+        M2RiYzAwIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAi
+        c3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVkZDZl
+        NzkwLTIyMmQtNGViZS1iNmRlLTAwYTcwMTBhYjNjYyIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        UHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjViOGFlYWViLWQwNzItNGVkNC1iMzU2
+        LWY3OGI2ODRiMjkzZSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFk
+        YXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjAxYTNiNGMwLTNiNTktNDBlMi04MWM2LWM1MWNm
+        ZDg3ZWZmYiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
+        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJmMjliZTk3OC0zOWIyLTQ3NGUtYWNlMC1lZjdiYjljODYxYWIi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5
+        cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICI4NjI2ZjkxNC0zNTQ3LTRlZGEtOTlhYy03NjU1ZDBkNWFkY2IiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
+        cmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
+        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzM4YTJiN2YtMmM2NS00
+        Nzk2LWI1ZDctYjI0ZTA1ZGEzNTEyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
+        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
+        IGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rv
+        cnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDQ4MDEzZGMtY2IzYS00MTQzLTkw
+        MWMtZjEwZDU4YTk2NjA1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3Rpbmdz
+        IEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0
+        YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYWZkNjgzYy04MTY5LTQwNzEtOTE4
+        OS0zNTM5Nzg2MjdkZmEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3Jh
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtl
+        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJh
+        bG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmYWU4YWMzOGViNWM4ZjlmZjVl
+        YzMifSwgImlkIjogIjVjZWZhZThhYzM4ZWI1YzhmOWZmNWVjMyJ9
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:58 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/682d03e3-786f-4ff1-8e38-58baee833249/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"b0e2bc8278c54a8605516269f02473bc-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4536'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy82ODJkMDNlMy03ODZmLTRmZjEtOGUzOC01OGJh
+        ZWU4MzMyNDkvIiwgInRhc2tfaWQiOiAiNjgyZDAzZTMtNzg2Zi00ZmYxLThl
+        MzgtNThiYWVlODMzMjQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6NThaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI4NDRjMTljYi01YzRjLTQ4YWQtYTY5OS03
+        YmY5YjNmNGJkMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMmY0MzdkY2UtYTU1Yi00NmE5LWFmYTMt
+        Mjk5NWY4YTE3NWM5IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImEyNWJlZDg0LTIxM2ItNDBmNS04ZDE2LTg1ZjU5ZDIw
+        NjIzMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAz
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIklOX1BS
+        T0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNmZGNiMmMyLWI4MjIt
+        NGU2Yy1hMTU2LWNlY2E5NGNmNzc4OCIsICJudW1fcHJvY2Vzc2VkIjogM30s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIzZDAwYzk1My0yZDI3LTRmNzgtOGEwOC1iNzU4OWYyNDM5
+        NDYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmU2MzZlNTItY2Vl
+        ZC00Y2FlLWE2MmEtMTMyNjc2MGUzZWQyIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiOWZjNDM4ZTctMTE5NS00MTNmLTgwZDEtY2JhZjM0M2Ri
+        YzAwIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVkZDZlNzkw
+        LTIyMmQtNGViZS1iNmRlLTAwYTcwMTBhYjNjYyIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjViOGFlYWViLWQwNzItNGVkNC1iMzU2LWY3
+        OGI2ODRiMjkzZSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
+        IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjAxYTNiNGMwLTNiNTktNDBlMi04MWM2LWM1MWNmZDg3
+        ZWZmYiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAi
+        c3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJmMjliZTk3OC0zOWIyLTQ3NGUtYWNlMC1lZjdiYjljODYxYWIiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUi
+        OiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4
+        NjI2ZjkxNC0zNTQ3LTRlZGEtOTlhYy03NjU1ZDBkNWFkY2IiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVw
+        b3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzM4YTJiN2YtMmM2NS00Nzk2
+        LWI1ZDctYjI0ZTA1ZGEzNTEyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZp
+        bGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rvcnki
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZDQ4MDEzZGMtY2IzYS00MTQzLTkwMWMt
+        ZjEwZDU4YTk2NjA1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZp
+        bGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIwYWZkNjgzYy04MTY5LTQwNzEtOTE4OS0z
+        NTM5Nzg2MjdkZmEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9u
+        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1v
+        cmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmYWU4YWMzOGViNWM4ZjlmZjVlYzMi
+        fSwgImlkIjogIjVjZWZhZThhYzM4ZWI1YzhmOWZmNWVjMyJ9
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:58 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/682d03e3-786f-4ff1-8e38-58baee833249/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"c4c2e0725d4b3040056e8fcd3fd0d07d-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4536'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy82ODJkMDNlMy03ODZmLTRmZjEtOGUzOC01OGJh
+        ZWU4MzMyNDkvIiwgInRhc2tfaWQiOiAiNjgyZDAzZTMtNzg2Zi00ZmYxLThl
+        MzgtNThiYWVlODMzMjQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6NThaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI4NDRjMTljYi01YzRjLTQ4YWQtYTY5OS03
+        YmY5YjNmNGJkMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMmY0MzdkY2UtYTU1Yi00NmE5LWFmYTMt
+        Mjk5NWY4YTE3NWM5IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImEyNWJlZDg0LTIxM2ItNDBmNS04ZDE2LTg1ZjU5ZDIw
+        NjIzMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA3
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIklOX1BS
+        T0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNmZGNiMmMyLWI4MjIt
+        NGU2Yy1hMTU2LWNlY2E5NGNmNzc4OCIsICJudW1fcHJvY2Vzc2VkIjogN30s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIzZDAwYzk1My0yZDI3LTRmNzgtOGEwOC1iNzU4OWYyNDM5
+        NDYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmU2MzZlNTItY2Vl
+        ZC00Y2FlLWE2MmEtMTMyNjc2MGUzZWQyIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiOWZjNDM4ZTctMTE5NS00MTNmLTgwZDEtY2JhZjM0M2Ri
+        YzAwIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVkZDZlNzkw
+        LTIyMmQtNGViZS1iNmRlLTAwYTcwMTBhYjNjYyIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjViOGFlYWViLWQwNzItNGVkNC1iMzU2LWY3
+        OGI2ODRiMjkzZSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
+        IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjAxYTNiNGMwLTNiNTktNDBlMi04MWM2LWM1MWNmZDg3
+        ZWZmYiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAi
+        c3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJmMjliZTk3OC0zOWIyLTQ3NGUtYWNlMC1lZjdiYjljODYxYWIiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUi
+        OiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4
+        NjI2ZjkxNC0zNTQ3LTRlZGEtOTlhYy03NjU1ZDBkNWFkY2IiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVw
+        b3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzM4YTJiN2YtMmM2NS00Nzk2
+        LWI1ZDctYjI0ZTA1ZGEzNTEyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZp
+        bGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rvcnki
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZDQ4MDEzZGMtY2IzYS00MTQzLTkwMWMt
+        ZjEwZDU4YTk2NjA1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZp
+        bGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIwYWZkNjgzYy04MTY5LTQwNzEtOTE4OS0z
+        NTM5Nzg2MjdkZmEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9u
+        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1v
+        cmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmYWU4YWMzOGViNWM4ZjlmZjVlYzMi
+        fSwgImlkIjogIjVjZWZhZThhYzM4ZWI1YzhmOWZmNWVjMyJ9
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:58 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/682d03e3-786f-4ff1-8e38-58baee833249/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"8c5afeab5214db66289871484816d17f-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4529'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy82ODJkMDNlMy03ODZmLTRmZjEtOGUzOC01OGJh
+        ZWU4MzMyNDkvIiwgInRhc2tfaWQiOiAiNjgyZDAzZTMtNzg2Zi00ZmYxLThl
+        MzgtNThiYWVlODMzMjQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6NThaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI4NDRjMTljYi01YzRjLTQ4YWQtYTY5OS03
+        YmY5YjNmNGJkMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMmY0MzdkY2UtYTU1Yi00NmE5LWFmYTMt
+        Mjk5NWY4YTE3NWM5IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImEyNWJlZDg0LTIxM2ItNDBmNS04ZDE2LTg1ZjU5ZDIw
+        NjIzMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNmZGNiMmMyLWI4MjItNGU2
+        Yy1hMTU2LWNlY2E5NGNmNzc4OCIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjNkMDBjOTUzLTJkMjctNGY3OC04YTA4LWI3NTg5ZjI0Mzk0NiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
+        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVT
+        UyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZTYzNmU1Mi1jZWVkLTRjYWUt
+        YTYyYS0xMzI2NzYwZTNlZDIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9k
+        dWxlcyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICI5ZmM0MzhlNy0xMTk1LTQxM2YtODBkMS1jYmFmMzQzZGJjMDAiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUi
+        OiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
+        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWRkNmU3OTAtMjIyZC00
+        ZWJlLWI2ZGUtMDBhNzAxMGFiM2NjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
+        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
+        IE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiNWI4YWVhZWItZDA3Mi00ZWQ0LWIzNTYtZjc4YjY4NGIy
+        OTNlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3Rl
+        cF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiMDFhM2I0YzAtM2I1OS00MGUyLTgxYzYtYzUxY2ZkODdlZmZiIiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5
+        cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImYy
+        OWJlOTc4LTM5YjItNDc0ZS1hY2UwLWVmN2JiOWM4NjFhYiIsICJudW1fcHJv
+        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1v
+        dmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjg2MjZmOTE0
+        LTM1NDctNGVkYS05OWFjLTc2NTVkMGQ1YWRjYiIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
+        ZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJjMzhhMmI3Zi0yYzY1LTQ3OTYtYjVkNy1i
+        MjRlMDVkYTM1MTIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8g
+        d2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVt
+        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJkNDgwMTNkYy1jYjNhLTQxNDMtOTAxYy1mMTBkNThh
+        OTY2MDUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJz
+        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjBhZmQ2ODNjLTgxNjktNDA3MS05MTg5LTM1Mzk3ODYy
+        N2RmYSIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2Vy
+        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFt
+        cGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjVjZWZhZThhYzM4ZWI1YzhmOWZmNWVjMyJ9LCAiaWQi
+        OiAiNWNlZmFlOGFjMzhlYjVjOGY5ZmY1ZWMzIn0=
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:58 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/682d03e3-786f-4ff1-8e38-58baee833249/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"7a3be444a4ab95f116f275d35e239ad0-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4523'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy82ODJkMDNlMy03ODZmLTRmZjEtOGUzOC01OGJh
+        ZWU4MzMyNDkvIiwgInRhc2tfaWQiOiAiNjgyZDAzZTMtNzg2Zi00ZmYxLThl
+        MzgtNThiYWVlODMzMjQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6NThaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI4NDRjMTljYi01YzRjLTQ4YWQtYTY5OS03
+        YmY5YjNmNGJkMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMmY0MzdkY2UtYTU1Yi00NmE5LWFmYTMt
+        Mjk5NWY4YTE3NWM5IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImEyNWJlZDg0LTIxM2ItNDBmNS04ZDE2LTg1ZjU5ZDIw
+        NjIzMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNmZGNiMmMyLWI4MjItNGU2
+        Yy1hMTU2LWNlY2E5NGNmNzc4OCIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjNkMDBjOTUzLTJkMjctNGY3OC04YTA4LWI3NTg5ZjI0Mzk0NiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
+        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZTYzNmU1Mi1jZWVkLTRjYWUtYTYy
+        YS0xMzI2NzYwZTNlZDIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
+        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5
+        ZmM0MzhlNy0xMTk1LTQxM2YtODBkMS1jYmFmMzQzZGJjMDAiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
+        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiSU5fUFJPR1JFU1Mi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWRkNmU3OTAtMjIyZC00ZWJlLWI2
+        ZGUtMDBhNzAxMGFiM2NjIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFk
+        YXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiNWI4YWVhZWItZDA3Mi00ZWQ0LWIzNTYtZjc4YjY4NGIyOTNlIiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBl
+        IjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        MDFhM2I0YzAtM2I1OS00MGUyLTgxYzYtYzUxY2ZkODdlZmZiIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
+        Z2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImYyOWJlOTc4
+        LTM5YjItNDc0ZS1hY2UwLWVmN2JiOWM4NjFhYiIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUmVt
+        b3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xk
+        X3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjg2MjZmOTE0LTM1NDct
+        NGVkYS05OWFjLTc2NTVkMGQ1YWRjYiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
+        ZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVt
+        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICJjMzhhMmI3Zi0yYzY1LTQ3OTYtYjVkNy1iMjRlMDVk
+        YTM1MTIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwg
+        InN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJkNDgwMTNkYy1jYjNhLTQxNDMtOTAxYy1mMTBkNThhOTY2MDUi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjBhZmQ2ODNjLTgxNjktNDA3MS05MTg5LTM1Mzk3ODYyN2RmYSIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5jb20uZHEy
+        IiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNv
+        bSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjVjZWZhZThhYzM4ZWI1YzhmOWZmNWVjMyJ9LCAiaWQiOiAiNWNl
+        ZmFlOGFjMzhlYjVjOGY5ZmY1ZWMzIn0=
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:58 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/682d03e3-786f-4ff1-8e38-58baee833249/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"0d4c69bdef46dd2376990fee52450692-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4503'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy82ODJkMDNlMy03ODZmLTRmZjEtOGUzOC01OGJh
+        ZWU4MzMyNDkvIiwgInRhc2tfaWQiOiAiNjgyZDAzZTMtNzg2Zi00ZmYxLThl
+        MzgtNThiYWVlODMzMjQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6NThaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI4NDRjMTljYi01YzRjLTQ4YWQtYTY5OS03
+        YmY5YjNmNGJkMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMmY0MzdkY2UtYTU1Yi00NmE5LWFmYTMt
+        Mjk5NWY4YTE3NWM5IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImEyNWJlZDg0LTIxM2ItNDBmNS04ZDE2LTg1ZjU5ZDIw
+        NjIzMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNmZGNiMmMyLWI4MjItNGU2
+        Yy1hMTU2LWNlY2E5NGNmNzc4OCIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjNkMDBjOTUzLTJkMjctNGY3OC04YTA4LWI3NTg5ZjI0Mzk0NiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
+        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZTYzNmU1Mi1jZWVkLTRjYWUtYTYy
+        YS0xMzI2NzYwZTNlZDIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
+        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5
+        ZmM0MzhlNy0xMTk1LTQxM2YtODBkMS1jYmFmMzQzZGJjMDAiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
+        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZWRkNmU3OTAtMjIyZC00ZWJlLWI2ZGUt
+        MDBhNzAxMGFiM2NjIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRh
+        LiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        NWI4YWVhZWItZDA3Mi00ZWQ0LWIzNTYtZjc4YjY4NGIyOTNlIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
+        biI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNs
+        b3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDFhM2I0YzAt
+        M2I1OS00MGUyLTgxYzYtYzUxY2ZkODdlZmZiIiwgIm51bV9wcm9jZXNzZWQi
+        OiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5l
+        cmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUg
+        c3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjI5YmU5NzgtMzliMi00NzRlLWFj
+        ZTAtZWY3YmI5Yzg2MWFiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVw
+        b2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAi
+        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiODYyNmY5MTQtMzU0Ny00ZWRhLTk5YWMtNzY1NWQw
+        ZDVhZGNiIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAi
+        c3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzM4YTJi
+        N2YtMmM2NS00Nzk2LWI1ZDctYjI0ZTA1ZGEzNTEyIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
+        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiSU5f
+        UFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDQ4MDEzZGMtY2Iz
+        YS00MTQzLTkwMWMtZjEwZDU4YTk2NjA1IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5n
+        IExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVw
+        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
+        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYWZkNjgzYy04MTY5
+        LTQwNzEtOTE4OS0zNTM5Nzg2MjdkZmEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZl
+        bC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5n
+        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0w
+        QGRldmVsLmJhbG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwg
+        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmYWU4YWMzOGVi
+        NWM4ZjlmZjVlYzMifSwgImlkIjogIjVjZWZhZThhYzM4ZWI1YzhmOWZmNWVj
+        MyJ9
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:58 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/682d03e3-786f-4ff1-8e38-58baee833249/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"45aae24f2d5a373a81f92a26a4c0b444-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4497'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy82ODJkMDNlMy03ODZmLTRmZjEtOGUzOC01OGJh
+        ZWU4MzMyNDkvIiwgInRhc2tfaWQiOiAiNjgyZDAzZTMtNzg2Zi00ZmYxLThl
+        MzgtNThiYWVlODMzMjQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6NThaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI4NDRjMTljYi01YzRjLTQ4YWQtYTY5OS03
+        YmY5YjNmNGJkMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiMmY0MzdkY2UtYTU1Yi00NmE5LWFmYTMt
+        Mjk5NWY4YTE3NWM5IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImEyNWJlZDg0LTIxM2ItNDBmNS04ZDE2LTg1ZjU5ZDIw
+        NjIzMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNmZGNiMmMyLWI4MjItNGU2
+        Yy1hMTU2LWNlY2E5NGNmNzc4OCIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjNkMDBjOTUzLTJkMjctNGY3OC04YTA4LWI3NTg5ZjI0Mzk0NiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
+        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZTYzNmU1Mi1jZWVkLTRjYWUtYTYy
+        YS0xMzI2NzYwZTNlZDIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
+        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5
+        ZmM0MzhlNy0xMTk1LTQxM2YtODBkMS1jYmFmMzQzZGJjMDAiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
+        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZWRkNmU3OTAtMjIyZC00ZWJlLWI2ZGUt
+        MDBhNzAxMGFiM2NjIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRh
+        LiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        NWI4YWVhZWItZDA3Mi00ZWQ0LWIzNTYtZjc4YjY4NGIyOTNlIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
+        biI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNs
+        b3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDFhM2I0YzAt
+        M2I1OS00MGUyLTgxYzYtYzUxY2ZkODdlZmZiIiwgIm51bV9wcm9jZXNzZWQi
+        OiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5l
+        cmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUg
+        c3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjI5YmU5NzgtMzliMi00NzRlLWFj
+        ZTAtZWY3YmI5Yzg2MWFiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVw
+        b2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAi
+        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiODYyNmY5MTQtMzU0Ny00ZWRhLTk5YWMtNzY1NWQw
+        ZDVhZGNiIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAi
+        c3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzM4YTJi
+        N2YtMmM2NS00Nzk2LWI1ZDctYjI0ZTA1ZGEzNTEyIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
+        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklO
+        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDQ4MDEzZGMtY2IzYS00
+        MTQzLTkwMWMtZjEwZDU4YTk2NjA1IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwg
+        eyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
+        c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
+        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYWZkNjgzYy04MTY5LTQwNzEt
+        OTE4OS0zNTM5Nzg2MjdkZmEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9XX0sICJx
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxt
+        b3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVs
+        LmJhbG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9y
+        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmYWU4YWMzOGViNWM4Zjlm
+        ZjVlYzMifSwgImlkIjogIjVjZWZhZThhYzM4ZWI1YzhmOWZmNWVjMyJ9
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:58 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/682d03e3-786f-4ff1-8e38-58baee833249/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 30 May 2019 10:20:58 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"512cf8eb8c15c7157964b99621e8a142-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '9043'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy82ODJkMDNlMy03ODZmLTRmZjEtOGUzOC01OGJh
+        ZWU4MzMyNDkvIiwgInRhc2tfaWQiOiAiNjgyZDAzZTMtNzg2Zi00ZmYxLThl
+        MzgtNThiYWVlODMzMjQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6NThaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6NTha
+        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0
+        ZXBfdHlwZSI6ICJzYXZlX3RhciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
+        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4NDRjMTlj
+        Yi01YzRjLTQ4YWQtYTY5OS03YmY5YjNmNGJkMmUiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIklu
+        aXRpYWxpemluZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0
+        aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmY0Mzdk
+        Y2UtYTU1Yi00NmE5LWFmYTMtMjk5NWY4YTE3NWM5IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIERpc3RyaWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
+        ZGlzdHJpYnV0aW9uIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImEyNWJlZDg0LTIxM2It
+        NDBmNS04ZDE2LTg1ZjU5ZDIwNjIzMiIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        IHsibnVtX3N1Y2Nlc3MiOiA4LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjog
+        OCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        ImNmZGNiMmMyLWI4MjItNGU2Yy1hMTU2LWNlY2E5NGNmNzc4OCIsICJudW1f
+        cHJvY2Vzc2VkIjogOH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJk
+        cnBtcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjNkMDBjOTUzLTJkMjctNGY3OC04YTA4
+        LWI3NTg5ZjI0Mzk0NiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEi
+        LCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZTYz
+        NmU1Mi1jZWVkLTRjYWUtYTYyYS0xMzI2NzYwZTNlZDIiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgTW9kdWxlcyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIs
+        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI5ZmM0MzhlNy0xMTk1LTQxM2YtODBkMS1jYmFm
+        MzQzZGJjMDAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIs
+        ICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWRkNmU3
+        OTAtMjIyZC00ZWJlLWI2ZGUtMDBhNzAxMGFiM2NjIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiNWI4YWVhZWItZDA3Mi00ZWQ0LWIzNTYtZjc4
+        YjY4NGIyOTNlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiMDFhM2I0YzAtM2I1OS00MGUyLTgxYzYtYzUxY2ZkODdlZmZi
+        IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
+        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjI5
+        YmU5NzgtMzliMi00NzRlLWFjZTAtZWY3YmI5Yzg2MWFiIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
+        ICJSZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92
+        ZV9vbGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODYyNmY5MTQtMzU0
+        Ny00ZWRhLTk5YWMtNzY1NWQwZDVhZGNiIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
+        aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiYzM4YTJiN2YtMmM2NS00Nzk2LWI1ZDctYjI0ZTA1ZGEz
+        NTEyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJz
+        dGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiZDQ4MDEzZGMtY2IzYS00MTQzLTkwMWMtZjEwZDU4YTk2NjA1IiwgIm51
+        bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjog
+        ImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIw
+        YWZkNjgzYy04MTY5LTQwNzEtOTE4OS0zNTM5Nzg2MjdkZmEiLCAibnVtX3By
+        b2Nlc3NlZCI6IDF9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0
+        ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVs
+        bCwgInJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJzdGFydGVkIjogIjIw
+        MTktMDUtMzBUMTA6MjA6NThaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVz
+        dWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wNS0zMFQxMDoyMDo1OFoiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVt
+        X2Rpc3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7ImdlbmVyYXRlIHNxbGl0ZSI6
+        ICJTS0lQUEVEIiwgInJwbXMiOiAiRklOSVNIRUQiLCAiaW5pdGlhbGl6ZV9y
+        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgInJlbW92ZV9vbGRfcmVwb2Rh
+        dGEiOiAiRklOSVNIRUQiLCAibW9kdWxlcyI6ICJGSU5JU0hFRCIsICJzYXZl
+        X3RhciI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJ
+        TklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNI
+        RUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInJlcG92aWV3Ijog
+        IlNLSVBQRUQiLCAicHVibGlzaF9kaXJlY3RvcnkiOiAiRklOSVNIRUQiLCAi
+        ZXJyYXRhIjogIkZJTklTSEVEIiwgIm1ldGFkYXRhIjogIkZJTklTSEVEIn0s
+        ICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogInNj
+        ZW5hcmlvX3Rlc3QiLCAiaWQiOiAiNWNlZmFlOGFiMDJlNTMzNDM0Y2Y4YjY1
+        IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
+        biI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3RhciIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI4NDRjMTljYi01YzRjLTQ4YWQtYTY5OS03YmY5
+        YjNmNGJkMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1ldGFk
+        YXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiMmY0MzdkY2UtYTU1Yi00NmE5LWFmYTMtMjk5
+        NWY4YTE3NWM5IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2Vz
+        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1dGlv
+        biBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImEyNWJlZDg0LTIxM2ItNDBmNS04ZDE2LTg1ZjU5ZDIwNjIz
+        MiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4LCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6
+        ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNmZGNiMmMyLWI4MjItNGU2Yy1h
+        MTU2LWNlY2E5NGNmNzc4OCIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEZWx0
+        YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjNkMDBjOTUzLTJkMjctNGY3OC04YTA4LWI3NTg5ZjI0Mzk0NiIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0
+        YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJmZTYzNmU1Mi1jZWVkLTRjYWUtYTYyYS0x
+        MzI2NzYwZTNlZDIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxlcyIs
+        ICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5ZmM0
+        MzhlNy0xMTk1LTQxM2YtODBkMS1jYmFmMzQzZGJjMDAiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29tcHMi
+        LCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiZWRkNmU3OTAtMjIyZC00ZWJlLWI2ZGUtMDBh
+        NzAxMGFiM2NjIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2Vz
+        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIs
+        ICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNWI4
+        YWVhZWItZDA3Mi00ZWQ0LWIzNTYtZjc4YjY4NGIyOTNlIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
+        ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNsb3Nl
+        X3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDFhM2I0YzAtM2I1
+        OS00MGUyLTgxYzYtYzUxY2ZkODdlZmZiIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
+        aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3Fs
+        aXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZjI5YmU5NzgtMzliMi00NzRlLWFjZTAt
+        ZWY3YmI5Yzg2MWFiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVwb2Rh
+        dGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiODYyNmY5MTQtMzU0Ny00ZWRhLTk5YWMtNzY1NWQwZDVh
+        ZGNiIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAic3Rl
+        cF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzM4YTJiN2Yt
+        MmM2NS00Nzk2LWI1ZDctYjI0ZTA1ZGEzNTEyIiwgIm51bV9wcm9jZXNzZWQi
+        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJs
+        aXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9k
+        aXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDQ4MDEzZGMtY2IzYS00MTQz
+        LTkwMWMtZjEwZDU4YTk2NjA1IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJu
+        dW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3Rp
+        bmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRh
+        ZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYWZkNjgzYy04MTY5LTQwNzEtOTE4
+        OS0zNTM5Nzg2MjdkZmEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9XX0sICJlcnJv
+        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlOGFjMzhlYjVjOGY5
+        ZmY1ZWMzIn0sICJpZCI6ICI1Y2VmYWU4YWMzOGViNWM4ZjlmZjVlYzMifQ==
+    http_version: 
+  recorded_at: Thu, 30 May 2019 10:20:58 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/support/destroy_org_if_exists.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/support/destroy_org_if_exists.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://theta.partello.example.com:8443/candlepin/owners/scenario_test
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -14,9 +14,9 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="jAxTjRjZQ7yDaaSwD6cYjZLXGgzg3ZSt", oauth_nonce="ZMiMvbhQw2rm32gn7Nr8uUGomwN3tYmEc20k2OY27A",
-        oauth_signature="1Xn4vfdZLc%2BzyfvWTbGRCMFAP9U%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1552949000", oauth_version="1.0"
+      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="gvgmn5e2pGYhGFsLKjSRsgCI0HSq3rpvdjX5xTRel0",
+        oauth_signature="Lymfnkm6GiKU3VALSNt58jLK6lg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1559211612", oauth_version="1.0"
       Cp-User:
       - foreman_admin
   response:
@@ -27,22 +27,22 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - ebee4f14-2058-45a4-acfd-bf757a8f3ed0
+      - f1604f44-e933-462b-942b-0116004bafea
       X-Version:
-      - 2.5.9-1
-      - 2.5.9-1
+      - 2.6.5-1
+      - 2.6.5-1
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 18 Mar 2019 22:43:20 GMT
+      - Thu, 30 May 2019 10:20:12 GMT
     body:
       encoding: UTF-8
       base64_string: |
         eyJkaXNwbGF5TWVzc2FnZSI6Ik9yZ2FuaXphdGlvbiB3aXRoIGlkIHNjZW5h
         cmlvX3Rlc3QgY291bGQgbm90IGJlIGZvdW5kLiIsInJlcXVlc3RVdWlkIjoi
-        ZWJlZTRmMTQtMjA1OC00NWE0LWFjZmQtYmY3NTdhOGYzZWQwIn0=
+        ZjE2MDRmNDQtZTkzMy00NjJiLTk0MmItMDExNjAwNGJhZmVhIn0=
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:20 GMT
+  recorded_at: Thu, 30 May 2019 10:20:12 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/support/destroy_repo_if_exists.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/support/destroy_repo_if_exists.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://theta.partello.example.com/pulp/api/v2/repositories/scenario_test/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -21,9 +21,9 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 18 Mar 2019 22:43:21 GMT
+      - Thu, 30 May 2019 10:20:14 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '422'
       Etag:
@@ -44,5 +44,5 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         InNjZW5hcmlvX3Rlc3QifX0=
     http_version: 
-  recorded_at: Mon, 18 Mar 2019 22:43:21 GMT
+  recorded_at: Thu, 30 May 2019 10:20:14 GMT
 recorded_with: VCR 3.0.3

--- a/test/scenarios/scenario_test.rb
+++ b/test/scenarios/scenario_test.rb
@@ -33,6 +33,9 @@ module Scenarios
       @support.sleep_if_needed
       @support.sync_repo(repo)
       @support.sleep_if_needed
+
+      @support.update_repo(repo.root, :mirror_on_sync => false)
+      @support.sleep_if_needed
       @support.destroy_org(org, repo)
     end
   end

--- a/test/support/scenario_support.rb
+++ b/test/support/scenario_support.rb
@@ -26,10 +26,15 @@ class ScenarioSupport
   def create_repo(repo)
     record("support/destroy_repo_if_exists") { destroy_repo_if_exists(repo) }
     record("repo_create") { ForemanTasks.sync_task(::Actions::Katello::Repository::Create, repo, false, true) }
+    repo.root.reload
   end
 
   def sync_repo(repo)
     record("repo_sync") { ForemanTasks.sync_task(::Actions::Katello::Repository::Sync, repo) }
+  end
+
+  def update_repo(repo, params)
+    record("repo_update") { ForemanTasks.sync_task(::Actions::Katello::Repository::Update, repo, params) }
   end
 
   def sleep_if_needed


### PR DESCRIPTION
as part of a recent refactoring, the pulp2 repo update
task was being called improperly.  This adds an adapter action
in the orchestration layer.