### PR TITLE
Fixes #26902 - Add uuid param back to CV puppet environment

### DIFF
--- a/app/controllers/katello/api/v2/content_view_puppet_modules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_puppet_modules_controller.rb
@@ -9,6 +9,7 @@ module Katello
     param :content_view_id, :number, :desc => N_("content view identifier"), :required => true
     param :name, String, :desc => N_("name of the puppet module")
     param :author, String, :desc => N_("author of the puppet module")
+    param :uuid, String, :desc => N_("uuid of the puppet module"), :deprecated => true
     param_group :search, ::Katello::Api::V2::ApiController
     def index
       respond(:collection => scoped_search(index_relation.distinct, :name, :asc))


### PR DESCRIPTION
This param was removed [here](https://github.com/Katello/katello/commit/0d5a1ebe7d722113d16146d6f98b6d2a39c351c0#diff-b3f64de16869054a88473910f7fef5cfL12), rightfully so since it only grabs a single puppet module, which is what the show call is for. However, we should deprecate the param like we have the other one in the POST call