### PR TITLE
Fixes #26912 - Better error for subs page on 410

### DIFF
--- a/app/lib/katello/errors.rb
+++ b/app/lib/katello/errors.rb
@@ -116,5 +116,12 @@ module Katello
         end
       end
     end
+
+    class UpstreamConsumerGone < StandardError
+      def message
+        _("The Subscription Allocation providing the imported manifest has been removed. " \
+          "Please create a new Subscription Allocation and import the new manifest.")
+      end
+    end
   end
 end

--- a/app/lib/katello/resources/candlepin/upstream_pool.rb
+++ b/app/lib/katello/resources/candlepin/upstream_pool.rb
@@ -5,11 +5,15 @@ module Katello
         extend PoolResource
 
         class << self
+          def get(*args)
+            resource.get(*args)
+          rescue RestClient::Gone
+            raise Katello::Errors::UpstreamConsumerGone
+          end
+
           def path(id = nil, owner_label = nil)
             super(id, owner_label || upstream_owner_id)
           end
-
-          delegate :get, to: :resource
         end
       end
     end

--- a/app/models/katello/upstream_pool.rb
+++ b/app/models/katello/upstream_pool.rb
@@ -13,11 +13,18 @@ module Katello
           included_fields: included_field_params(quantities_only)
         )
 
-        upstream_response = CP_POOL.get(params: cp_params)
+        upstream_response = fetch_upstream_with_error_handling(cp_params)
         pools = response_to_pools(upstream_response, pool_id_map: pool_id_map)
         total = upstream_response.headers[total_count_header] || pools.count
 
         respond(pools, total)
+      end
+
+      def fetch_upstream_with_error_handling(cp_params)
+        CP_POOL.get(params: cp_params)
+      rescue RestClient::Gone
+        raise "The Subscription Allocation providing the imported manifest has been removed. " \
+              "Please create a new Subscription Allocation and import the new manifest."
       end
 
       def respond(pools, total)

--- a/app/models/katello/upstream_pool.rb
+++ b/app/models/katello/upstream_pool.rb
@@ -13,18 +13,11 @@ module Katello
           included_fields: included_field_params(quantities_only)
         )
 
-        upstream_response = fetch_upstream_with_error_handling(cp_params)
+        upstream_response = CP_POOL.get(params: cp_params)
         pools = response_to_pools(upstream_response, pool_id_map: pool_id_map)
         total = upstream_response.headers[total_count_header] || pools.count
 
         respond(pools, total)
-      end
-
-      def fetch_upstream_with_error_handling(cp_params)
-        CP_POOL.get(params: cp_params)
-      rescue RestClient::Gone
-        raise "The Subscription Allocation providing the imported manifest has been removed. " \
-              "Please create a new Subscription Allocation and import the new manifest."
       end
 
       def respond(pools, total)

--- a/test/models/upstream_pool_test.rb
+++ b/test/models/upstream_pool_test.rb
@@ -105,6 +105,16 @@ module Katello
       assert_equal 1, pools[:total]
     end
 
+    def test_fetch_pools_401_gone
+      Resources::Candlepin::UpstreamPool.expects(:get).raises(RestClient::Gone)
+      error_message = "The Subscription Allocation providing the imported manifest has been removed. " \
+                      "Please create a new Subscription Allocation and import the new manifest."
+
+      assert_raises_with_message(RuntimeError, error_message) do
+        UpstreamPool.fetch_pools({})
+      end
+    end
+
     def test_available
       upstream_pool = Katello::UpstreamPool.new(quantity: -1, consumed: 23)
       assert_equal(-1, upstream_pool.available)

--- a/test/models/upstream_pool_test.rb
+++ b/test/models/upstream_pool_test.rb
@@ -106,11 +106,13 @@ module Katello
     end
 
     def test_fetch_pools_401_gone
-      Resources::Candlepin::UpstreamPool.expects(:get).raises(RestClient::Gone)
+      set_organization(Organization.first)
+
+      RestClient::Resource.any_instance.expects(:get).raises(RestClient::Gone)
       error_message = "The Subscription Allocation providing the imported manifest has been removed. " \
                       "Please create a new Subscription Allocation and import the new manifest."
 
-      assert_raises_with_message(RuntimeError, error_message) do
+      assert_raises_with_message(Katello::Errors::UpstreamConsumerGone, error_message) do
         UpstreamPool.fetch_pools({})
       end
     end


### PR DESCRIPTION
When a Susbscription Allocation is removed from Red Hat Subscription Manager and you
still import that manifest, you will see `410 GONE` errors, meaning the subscription allocation
no longer exists. This commit catches that error and responds with a more friendly message:

```
The Subscription Allocation providing the imported manifest has been removed.
Please create a new Subscription Allocation and import the new manifest.
```
![sub](http://www.clipular.com/c/5742548640071680.png?k=Dhu4vGLDWq1PFKvqqSR_xu3fq8Y)