### PR TITLE
Fixes #26240 - Pulp2 Upload Content Refactor

### DIFF
--- a/app/lib/actions/katello/repository/upload_files.rb
+++ b/app/lib/actions/katello/repository/upload_files.rb
@@ -6,6 +6,7 @@ module Actions
   module Katello
     module Repository
       class UploadFiles < Actions::EntryAction
+        include Actions::Katello::PulpSelector
         def plan(repository, files)
           action_subject(repository)
           tmp_files = prepare_tmp_files(files)
@@ -13,17 +14,9 @@ module Actions
             concurrence do
               tmp_files.each do |file|
                 sequence do
-                  upload_request = plan_action(Pulp::Repository::CreateUploadRequest)
-                  plan_action(Pulp::Repository::UploadFile,
-                              upload_id: upload_request.output[:upload_id],
-                              file: file[:path])
-                  plan_action(Pulp::Repository::ImportUpload,
-                              pulp_id: repository.pulp_id,
-                              unit_type_id: repository.unit_type_id,
-                              unit_key: unit_key(file, repository),
-                              upload_id: upload_request.output[:upload_id])
-                  plan_action(Pulp::Repository::DeleteUploadRequest,
-                              upload_id: upload_request.output[:upload_id])
+                  create_action = plan_pulp_action([Pulp::Orchestration::Repository::UploadContent,
+                                                    Pulp3::Orchestration::Repository::UploadContent],
+                                                   repository, SmartProxy.pulp_master!, file)
                 end
               end
             end

--- a/app/lib/actions/pulp/orchestration/repository/upload_content.rb
+++ b/app/lib/actions/pulp/orchestration/repository/upload_content.rb
@@ -1,0 +1,35 @@
+module Actions
+  module Pulp
+    module Orchestration
+      module Repository
+        class UploadContent < Pulp::Abstract
+          def plan(repository, smart_proxy, file)
+            sequence do
+              upload_request = plan_action(Pulp::Repository::CreateUploadRequest)
+              plan_action(Pulp::Repository::UploadFile,
+                          upload_id: upload_request.output[:upload_id],
+                          file: file[:path])
+              plan_action(Pulp::Repository::ImportUpload,
+                          pulp_id: repository.pulp_id,
+                          unit_type_id: repository.unit_type_id,
+                          unit_key: unit_key(file, repository),
+                          upload_id: upload_request.output[:upload_id])
+              plan_action(Pulp::Repository::DeleteUploadRequest,
+                          upload_id: upload_request.output[:upload_id])
+            end
+          end
+
+          def unit_key(file, repository)
+            return {} unless repository.file?
+            {
+                :checksum => Digest::SHA256.hexdigest(File.read(file[:path])),
+                :name => file[:filename],
+                :size => File.size(file[:path])
+            }
+        end
+      end
+    end
+  end
+  end
+end
+

--- a/app/lib/actions/pulp3/orchestration/repository/upload_content.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/upload_content.rb
@@ -1,0 +1,15 @@
+module Actions
+  module Pulp3
+    module Orchestration
+      module Repository
+        class UploadContent < Pulp3::Abstract
+          def plan(repository, smart_proxy, file)
+            sequence do
+              fail("To Do!!")
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The first commit handles refactoring of the Pulp2 upload_content.
WIP:

- [ ] Implement Pulp3 File content Upload