### PR TITLE
Fixes #26908 - subscription group toggle error

### DIFF
--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTable.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTable.js
@@ -130,6 +130,7 @@ class SubscriptionsTable extends Component {
       rows,
       subscriptions,
       tableColumns,
+      toggleSubscriptionGroup: this.toggleSubscriptionGroup,
       inlineEditController: this.getInlineEditController(),
       selectionController: this.getSelectionController(),
     };

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/components/Table.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/components/Table.js
@@ -15,6 +15,7 @@ const Table = ({
   rows,
   editing,
   groupedSubscriptions,
+  toggleSubscriptionGroup,
 }) => {
   const allSubscriptionResults = subscriptions.results;
 
@@ -30,7 +31,7 @@ const Table = ({
       // the group contains more then one subscription
       groupedSubscriptions[rowData.product_id].subscriptions.length > 1,
     isCollapsed: ({ rowData }) => !groupedSubscriptions[rowData.product_id].open,
-    toggle: ({ rowData }) => this.toggleSubscriptionGroup(rowData.product_id),
+    toggle: ({ rowData }) => toggleSubscriptionGroup(rowData.product_id),
   };
 
   const alwaysDisplayColumns = ['select'];
@@ -92,6 +93,7 @@ Table.propTypes = {
     results: PropTypes.array,
   }).isRequired,
   loadSubscriptions: PropTypes.func.isRequired,
+  toggleSubscriptionGroup: PropTypes.func.isRequired,
   selectionController: PropTypes.shape({}).isRequired,
   inlineEditController: PropTypes.shape({}).isRequired,
   groupedSubscriptions: PropTypes.shape({}).isRequired,


### PR DESCRIPTION
JS error when opening subscription group
```
Table.js:33 Uncaught TypeError: Cannot read property 'toggleSubscriptionGroup' of undefined
    at Object.toggle (Table.js:33)
    at onClick (collapseableAndSelectionCellFormatter.js:14)
    at HTMLUnknownElement.callCallback (react-dom.development.js:149)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:199)
    at invokeGuardedCallback (react-dom.development.js:256)
    at invokeGuardedCallbackAndCatchFirstError (react-dom.development.js:270)
    at executeDispatch (react-dom.development.js:561)
    at executeDispatchesInOrder (react-dom.development.js:583)
    at executeDispatchesAndRelease (react-dom.development.js:680)
    at executeDispatchesAndReleaseTopLevel (react-dom.development.js:688)
```

cc @waldenraines @johnpmitsch