### PR TITLE
Fixes #26443 - properly remove gpg from content

### DIFF
--- a/app/lib/actions/candlepin/product/content_update.rb
+++ b/app/lib/actions/candlepin/product/content_update.rb
@@ -19,7 +19,7 @@ module Actions
                      id: input[:content_id],
                      name: input[:name],
                      contentUrl: input[:content_url],
-                     gpgUrl: input[:gpg_key_url],
+                     gpgUrl: input[:gpg_key_url] || '', #candlepin ignores nil
                      type: input[:type],
                      arches: input[:arches],
                      label: input[:label],

--- a/test/fixtures/vcr_cassettes/scenarios/org_create.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/org_create.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/
     body:
       encoding: UTF-8
       base64_string: |
@@ -15,11 +15,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="7AHaN3UJsZubdCVAxCja8wTLotxnwNG3",
-        oauth_nonce="wgg4Fx9NFYD08mNk2wEsWfzPcmzZ8UiSHBNkeDxXig", oauth_signature="7W3CzZtgztAql5A5w%2FkGP7FKGJ0%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559230351", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD",
+        oauth_nonce="06ZsBReMc38CtXdaglb719mc17BPGy1tObB2CtlhVwM", oauth_signature="vWVeYaH7xd5QFJcDOS%2BVAoiW%2ByI%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559683870", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -36,7 +36,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 4c819b79-5fd4-42ee-b392-86695e36948e
+      - 57cb2271-eb02-4d8d-8f77-d60848693de9
       X-Version:
       - 2.6.5-1
       Content-Type:
@@ -44,13 +44,13 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 30 May 2019 15:32:31 GMT
+      - Tue, 04 Jun 2019 21:31:09 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxNTozMjozMSswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDUtMzBUMTU6MzI6MzErMDAwMCIsImlkIjoiNDAyOGY5OTY2
-        YjA2OTdmYzAxNmIwOTVmMDkxODAwNDgiLCJrZXkiOiJzY2VuYXJpb190ZXN0
+        eyJjcmVhdGVkIjoiMjAxOS0wNi0wNFQyMTozMToxMCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDYtMDRUMjE6MzE6MTArMDAwMCIsImlkIjoiNDAyOGY5Zjc2
+        YjFkN2Q4ZDAxNmIyNDY3MmRmNDA3MGYiLCJrZXkiOiJzY2VuYXJpb190ZXN0
         IiwiZGlzcGxheU5hbWUiOiJzY2VuYXJpb190ZXN0IiwicGFyZW50T3duZXIi
         Om51bGwsImNvbnRlbnRQcmVmaXgiOiIvc2NlbmFyaW9fdGVzdC8kZW52Iiwi
         ZGVmYXVsdFNlcnZpY2VMZXZlbCI6bnVsbCwidXBzdHJlYW1Db25zdW1lciI6
@@ -59,10 +59,10 @@ http_interactions:
         Y2Vzc01vZGVMaXN0IjoiZW50aXRsZW1lbnQiLCJsYXN0UmVmcmVzaGVkIjpu
         dWxsLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0=
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:31 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:10 GMT
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/environments
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/environments
     body:
       encoding: UTF-8
       base64_string: |
@@ -74,11 +74,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="7AHaN3UJsZubdCVAxCja8wTLotxnwNG3",
-        oauth_nonce="QrOjhYbbEaSvJPzjTyxQmlnuQt6QdVN4duczvCxMLOM", oauth_signature="aqHJhA7Aw8q35FyvUJGiihcdSwg%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559230351", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD",
+        oauth_nonce="swDeoRkN32nbF39iNA4qhBQA5Gcq9wLgk49vtWTFc", oauth_signature="DtnUokHqHkL1Vr%2BBS8FyDaHNTK8%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559683870", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -95,7 +95,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - ab4723f7-f3af-4876-ae5b-26d7357ada9d
+      - fba99646-5396-41aa-9e9e-3566177cf976
       X-Version:
       - 2.6.5-1
       Content-Type:
@@ -103,22 +103,22 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 30 May 2019 15:32:31 GMT
+      - Tue, 04 Jun 2019 21:31:09 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxNTozMjozMSswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDUtMzBUMTU6MzI6MzErMDAwMCIsImlkIjoiZDgwYTU3ODNj
+        eyJjcmVhdGVkIjoiMjAxOS0wNi0wNFQyMTozMToxMCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDYtMDRUMjE6MzE6MTArMDAwMCIsImlkIjoiZDgwYTU3ODNj
         NTAyZjBmOTY5ZTIzMDg5NDM3YmI3Y2UiLCJuYW1lIjoiTGlicmFyeSIsImRl
-        c2NyaXB0aW9uIjpudWxsLCJvd25lciI6eyJpZCI6IjQwMjhmOTk2NmIwNjk3
-        ZmMwMTZiMDk1ZjA5MTgwMDQ4Iiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRp
+        c2NyaXB0aW9uIjpudWxsLCJvd25lciI6eyJpZCI6IjQwMjhmOWY3NmIxZDdk
+        OGQwMTZiMjQ2NzJkZjQwNzBmIiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRp
         c3BsYXlOYW1lIjoic2NlbmFyaW9fdGVzdCIsImhyZWYiOiIvb3duZXJzL3Nj
         ZW5hcmlvX3Rlc3QifSwiZW52aXJvbm1lbnRDb250ZW50IjpbXX0=
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:31 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:10 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/uebercert
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/uebercert
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -128,11 +128,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="7AHaN3UJsZubdCVAxCja8wTLotxnwNG3", oauth_nonce="En3zASs0suoVrwhIerdiBdD0ahKtuSbxELn70kGO5c4",
-        oauth_signature="YWk3Q%2FLxfHWxllIkPRGOHO%2BkGYM%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1559230351", oauth_version="1.0"
+      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="8ryiZix6a4skJA8xKgcCnAXKptKQDPm9OYulrvgqtQU",
+        oauth_signature="K1Qn99hQOp2BZ2S80qZGEOfP7kg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1559683870", oauth_version="1.0"
       Cp-User:
       - foreman_admin
   response:
@@ -143,7 +143,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - bc9ad54c-3721-4131-9eaa-fd62923772f2
+      - cc63b7df-5a9e-40b0-90fc-a15322013301
       X-Version:
       - 2.6.5-1
       - 2.6.5-1
@@ -152,19 +152,19 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 30 May 2019 15:32:31 GMT
+      - Tue, 04 Jun 2019 21:31:09 GMT
     body:
       encoding: UTF-8
       base64_string: |
         eyJkaXNwbGF5TWVzc2FnZSI6InViZXIgY2VydGlmaWNhdGUgZm9yIG93bmVy
         IHNjZW5hcmlvX3Rlc3Qgd2FzIG5vdCBmb3VuZC4gUGxlYXNlIGdlbmVyYXRl
-        IG9uZS4iLCJyZXF1ZXN0VXVpZCI6ImJjOWFkNTRjLTM3MjEtNDEzMS05ZWFh
-        LWZkNjI5MjM3NzJmMiJ9
+        IG9uZS4iLCJyZXF1ZXN0VXVpZCI6ImNjNjNiN2RmLTVhOWUtNDBiMC05MGZj
+        LWExNTMyMjAxMzMwMSJ9
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:31 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:10 GMT
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/uebercert
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/uebercert
     body:
       encoding: UTF-8
       base64_string: 'e30=
@@ -176,11 +176,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="7AHaN3UJsZubdCVAxCja8wTLotxnwNG3",
-        oauth_nonce="efoknxmPVox9wJKTsqr02nmnJruJQHpmvIXn1fceg", oauth_signature="Iy9HMwwGjn8dzMEDHiUMwft8F9Q%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559230351", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD",
+        oauth_nonce="GpTJXroQ9vIbYDd3KgqbKTa3piryvHPcCMsicojdA", oauth_signature="W7EpsUqe3IBmWerO4XKMPVYKKQs%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559683870", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -197,7 +197,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 617b8dd3-3757-4c82-bdd6-8e200cf13d8c
+      - 9cc3fca3-7916-40b9-87e9-31ae34cf0b00
       X-Version:
       - 2.6.5-1
       Content-Type:
@@ -205,154 +205,153 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 30 May 2019 15:32:33 GMT
+      - Tue, 04 Jun 2019 21:31:12 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxNTozMjozMSswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDUtMzBUMTU6MzI6MzMrMDAwMCIsImlkIjoiNDAyOGY5OTY2
-        YjA2OTdmYzAxNmIwOTVmMGY5ZTAwNGIiLCJrZXkiOiItLS0tLUJFR0lOIFJT
-        QSBQUklWQVRFIEtFWS0tLS0tXG5NSUlKS1FJQkFBS0NBZ0VBaDFLNndTQlpY
-        QzFSU1F6RkJCZkxja2N5WW03YWhyc2ZxRkdBOENnYUlmWmpJYTM5XG5La2Jm
-        azlnVE90Qm9iOGNNVVByOU8yaDZudUlKdXZ0YTNzakJkZmZ5U0gwLzZaZHJk
-        U1ZBUlBPRnNQY0RLaVJDXG5KWHUzREFZOG1XdTNCaUVsc1k5V3gvUGRSY1F6
-        QkFHWGZmcUVxK3pWMTg1Z2t1UzlKSjZtb0prbzk4K2RaSktUXG5IZE4xeUhu
-        UnFmUk9yNGROenluM09jeEczRUxSaVJVNHQ5blVNalFsUmwrWlpXY1pYRmRO
-        cjM0eHo2MUp0OXl0XG5SUzd2U1JNczBPakVYc1kxZ0dKeHdrek02a2h5SmhS
-        Wkx0b0FTQk41aXFmZXovc1pmLzhUcWFmcDk3QTJRbnJoXG5DODJ2ZEgrcFVZ
-        RU5qaDk2dU5ja0ZJUDlDU0p3RnFPL1MwRDJkYVhKTkV3amU5R2lUZ1d5NVJS
-        VjQ2RW5kbFlkXG4rb25IcnRwUTM2a2FjUEZGaEJUMHhGem1OVFR0ZDd5enVH
-        Y2Z4NDhWR3VNQi9BVldVNFluWnBiQ0psMXZybWg0XG5lNzlBMnVwaG5hWURJ
-        c0FDdFNocFpNQkZmalNoTFB6TGFOQlBhQm5qenJlTmlpNkZOa1R3WUprNHp3
-        OENXWTVqXG5qdWMzQ3I5bDJUdWdVY3J3Qm5WUHV6YmxIejN2M1VJOEloa1Vx
-        bWh4Q2VyOVRYZ1BvK3gzbVZFNjltOGo2TGJMXG5ldVd5Z0RwVTI0VGg0NjJw
-        c0xsVmRleHV6UDVBQWoxSzdoY2IrUkdlQVRyMUNLUENsY2RFSzlnOGlmL2Vo
-        WnhmXG5tb0Q5bHNSbXhDOXhULzdsRm5Sdm9KSTdyUitnb3JHd2IrRWpibmVI
-        dFlqcFlBaHI4MnMrSmdka0o5c0NBd0VBXG5BUUtDQWdBWktvMkl0UmRwU1JS
-        QTNac1dNOGFtTGc5MHR1RDFCWC9Sc2Jhazh4QkpHS1UrOGppTzBEZHNLMWNJ
-        XG5MUkgvRjZsMnRmYTZRYWZzUEdWSzNNdjllcUJmN0FpbTZvUWtVUUN1L0lx
-        RFNEYW92b2RjSXZvYU5uUElUTENnXG5aNlBXQS93YWxXbXlMZXdNdVh3elZv
-        aHg2VkViR0NSOHllaXo2TTQwTFQwWHlPUVJrZzdYVVZzQ3hQeTJsOUVpXG5K
-        a2tyNDZIWTBSa2xLcFJUQ2lvbHNFaW9DRjZxSjRCM0lmaEpIMjliK1BCOW5w
-        NXMzUEZFdkVtTkFEbUlBWVRvXG5KU0cvN21Tc3g2SVlYR2dQZWdHZ2kxQTZv
-        bGhERHp3ZlNURHF4T3Z0SGVidU9rZ014RHlUQ0g4cHpzcStnNjlkXG5kUDZz
-        VzdaYkFjZTMrUVBwMnZtMWZDWnJQRjJaSmY0Q2pRaTBUejN4SHkyLzExNmNO
-        aytJYm02T3NiM0JQNkZDXG5aTDM3SlpOakZ4MmJ6N2RDZ1JmbE1KMXBZM1U0
-        NE5DNUIrVEx4M1g3NG9leksrb1Q2ZTMzU2NoQUhNbzlqRS82XG5mZ0tWRlVE
-        ZWNMNk40U01jY1ZqbDFBb0phbTRiNWk2YXMzT3UyZE1Edm5QK1NlbVFVcmk1
-        NHBEUmhJY2RwajhBXG5EOWlma1NzZFBkZWtsVWI0blYwZ1NqKzR2RWprSmo4
-        ZTFZUjZmMTZaMnVaTGl6SWRBMnZRZzBDWmlyOGtVYXowXG5od1RNbWV1VThS
-        OStaZVZRdzNxb1E0TzZaTUNyREx2NFAxTEdBQlBwU3Jmc05IeWJBSi8wVStZ
-        T3cxYkVQdXNGXG5rMUJoeGpzMlpTdnhyeWlEa1hnaElDemVaVXowdnRQNHJ4
-        akV3TTNqem1jTUEwVGtvUUtDQVFFQXpKR1VIUDgrXG5qZ04rekQyWnhDZDdp
-        cFZ0L0tsd3dWVzFSREZzWkd1RDNsd256RXFuMlJuRDBROUNnSUdYbDdxMWs5
-        bW12K1RoXG5tbFFVNFBuVG9rNDkwd0pvZm11bFRDcEM2cDN4YXpMM0lZRy92
-        eUVLMzJmTEhOVmFQNi8vVkhJd0JNajZRMnptXG5SR1ppTklkN0tHOElTZlF1
-        UjVKY0VvY1ZCNkVVV3lnREpXUWxiTjNYVk9vQ1IzVFcyUGtDb1FnV1RkWllU
-        V1FMXG5acXVLYVlnNU5jNmNwd29adFhzRzV4cDkvWWNpSGJ2MElOOFh5ZExt
-        UW4raUd4ZFZraGEySkRKdXFFdk9EY0gwXG5lV3FWazZCSHRYY1hMY3NWVjdI
-        eHhXalM4bjcvYVJoalpmZ0huTnl5eWlqcWZSQ2hReHhDcjgyTWZrNWRxdHBa
-        XG5ZUXhlc2QyOEpua21sUUtDQVFFQXFWaGhod24vYmIvbmtOd1JVV1BacU83
-        N1hwbjhkY05USHBrUWdaWjZ2R2VmXG54KytJTW1mVDcwa3luckYwdVpSZFlz
-        cXArcW5CTDcxZFRQZ0UrV0l2TXV6MEZrQzRid0dLVmE2R2pGOEV1UU1iXG5o
-        V2hPZFdNclpWRFc2M3pCM0NoZGpFVytlMk1NcHZPY1ZIZ1dkMjI3RmR1VCtn
-        MkZaQ3pZOUpWVnZ4bk00djJXXG5aOTZrTGJDTTNkTzJXeVduZmhCdko0N29v
-        aVpvQy8yb09aWERERVB2SWJySlpVVnVJSVcyYjl2MSt0S0R5SENPXG5GU1Az
-        ME5jVk1ib2RDYmt0YjhnRm9vNnI3SWJtWm5XMnpMR2J5ZDA4YjR1N0lXelRk
-        OVRMYmh2RHpUSVY0UDN1XG5wODJZeG01SUdMSmw2UE1sVldSMWJaS1VZUmhG
-        WWFydWNyNEt1UDJvcndLQ0FRRUF0R0Y1dE1mc3BOUzRMZWZ6XG5lbDlHTkVE
-        bkp1OVJtV2kxMlZlck9ERUZxa0NnWnljOU1kWGlNS20vL2doSFgyY25UU09T
-        UVlyVTAzeG9uS2d0XG4wT1FrNTdjcjVLMk9wOFpzRXUwS1AzaEZLYXA3SlZG
-        QmdSVElxTGdJU0Rnc2NJM3ZnWWltQkdZMTlRSkNmZ2NvXG50ZEtTQUlQcmV2
-        aTNieTdsZ0VDczdtUXR3ZjY0Y1hKN3VVaE9raXVZZHVHN1M3c1J6N2k5VENC
-        M1hTVE5lNWkrXG51WTloMm5peGlyRGN1Vk5HM1JNWEpoamhmMHE0Y3lJZ0gy
-        cmp5ZmVkWUovZUk3VEVsbW1oVzhnMmhnbFJzMGFWXG5kSkY2UXNyY0d1T3hT
-        RnpTQlRtdWhVRVlCSVhjVUpqYW5oL09CRkZ4b1BkK1pmNWRiOUl5RGNGVEpw
-        djlzK0ROXG5VeTlvc1FLQ0FRQnZrVnZIcE8yVXQ4N3ZJQjJFdXIwRzBGUHBz
-        cGVpV2tvanFZSTNiaFYwbE95dXczKytmYXNpXG5SZDVFc1BNTzVORlZxZUdz
-        MURRRHFNV1VWUDZwOG1iWUxVWnVkcnRMM3Y3dGppcjB4aEVOZHgrbGw5L0E5
-        Tkg5XG5VUElYZVQwYk43alNGb3oxSzMrRmFvLy9FcEx5b2VlVThmSWUxdE9m
-        K1BBQ3kzUVBrQWJ0TVZickhjS2FtMnRqXG5KZjFKTlppUXRIRVc1YzhjTFNO
-        MWF1dHU3Tnp3OHJ6VVF3UTJaVFMxMW9Jb1ZnbEw4MitCR2E1eC9SMWlpS0Zj
-        XG4vcG5zOHdRZFZmRm9kSWlPTHg0U09ORnpNRHhNRlNhZzhyVVp3MkhhMitZ
-        ZXA4b3JJU2xLN3VGUnltRXhzaXhyXG5vUFVGTVZQU1czb0Y4NEV3S3RaakQw
-        TkRjek1MUjRyZkFvSUJBUUNlYnErSzdNL0o1N2RESzFqdG9mVnpTSVM4XG5J
-        V0xkSVJVaGpaNjhqWUdselNwS1IxVkJyRzFKMXhITFdPV0h1RGtzd0xJdTd0
-        RlRQaFJJWWhWZGVjYVRMc3JaXG5veldOZWxLTGxnZ3lWcEdOYWJLZmVOdVNi
-        Q09XTE5FWDVKQ2JXZi9BSFZTSFRwRWxnejRSQUNnTHIwdm5kcDlhXG53eUxo
-        eVZhWUVCbUN2WkRETm5sSjFWb3V4QmN0ZUxENUhxY2R3MjJ0eXhrMHJoS1c5
-        RXhEVlJlWUZNdDh4aUJFXG54T2NuWkdvaWd1MDl6TzJyNWpVMVpZcnBMd3BP
-        bWNtTUx5WkpFYS9MdTdzRFo3RHc3dFc3Skp5dXFacCtiL2R0XG5uUkxsQ2Ix
-        RUNYaUdMZ1lDSFpZUk12ekM3RER5d0dmczIzNnd5M05qRzhYVHV4SXViY0p0
-        RGFoY3JPcStcbi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tXG4iLCJj
-        ZXJ0IjoiLS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tXG5NSUlIYURDQ0Js
-        Q2dBd0lCQWdJSWE1ZDJHUWFCNmg0d0RRWUpLb1pJaHZjTkFRRUxCUUF3Z1lz
+        eyJjcmVhdGVkIjoiMjAxOS0wNi0wNFQyMTozMToxMCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDYtMDRUMjE6MzE6MTIrMDAwMCIsImlkIjoiNDAyOGY5Zjc2
+        YjFkN2Q4ZDAxNmIyNDY3MzYwZjA3MTIiLCJrZXkiOiItLS0tLUJFR0lOIFJT
+        QSBQUklWQVRFIEtFWS0tLS0tXG5NSUlKS0FJQkFBS0NBZ0VBam4vOTlKeDVv
+        TWdTRndXNlpmbUVyZFpRWmlTUUZ1L2dGckhmR1RyUkJlUmlUNHNzXG52ZXp5
+        ZUFhVWhaWTZ4L3g5cGVTaDlDUlJzUGU1QUVJTWNFOXNnL2RUeGFjVlY2eXFH
+        ZWlvcFNYU3dCMGhFOGYvXG4yc2JueEhQSGlXbzFXT2E2RUdsUFJkSVNVejdG
+        Q0NuUnAvNGd4ZjB0WjhaWnYvTTVOaC9wRzFWemo1SDByVGZyXG4xTThZTC9B
+        c0xOallCNThlY3BGeG1ScjRaeCtBZkVGVkczUVpjRHo1VmZRVmY1VkNRZEIv
+        NHRHSkk0TmFwMWFDXG5mMEw3RWRLaERpT25oU3BKS1lXN1RYK3JScFgvcitS
+        YnoxRjBGdjU1eHgwS1dndVd0cThLUHF1bXhhMWJrbWVyXG5oWXJYbjNaeTlm
+        c2I5d1hhN2ZaM1JDZnpBZU04MFRmeTdxU3haYjFkNnAxZlovUlI1KytxUkcw
+        U1NsR0hRUkdtXG56NWtIWTA2RlRQVHpUd3NpWThJTmxHWnp1WTFiTWJoMEVi
+        UFVWTS9RSjJBWGxKT2JmN2M1NE0zNW0waVlZcG9sXG5vSDNTazdHR1M4dnBF
+        R1ArUVo5M3FSSklQZlVoYzN1OGJQUERaa09BMElkaitMcVpOT0tPSGlEdjhC
+        RmRvNW12XG5HVHIvejRkaTFoNVEwbTdIV3hOdzJoMk9wbHZ5NWRrYXNCa0NC
+        YzVPdTdiTWtQUHdkam1tQnEyeGpFU2VuYStMXG42UFpWSHZ3a1B5Zjd6OVcr
+        SXVmU21vcG82RzdVeU4rQTBwWGNTbWxGK3ZCVnZwMUVJVjFkYVpUZ2wzd2NY
+        U0haXG5oNnNUSXBTQ3RHNWE4cnU0WGpSVzBKcjFFNyswMEpYWENVSG9mM0s4
+        ZmkzSXBrL1hGRXVzYXYrczhxOENBd0VBXG5BUUtDQWdCQzZUeWhBRnhvTDZt
+        MjM3eXZwMk15a1VCOVJjdld5Vm5xcmlpNDJ4Sk05dmxtcWs0ZS9FUzZNVFRL
+        XG5LVWwrb0VPTGd2aTgvOVRRQ1BINGVnc0hMWFFoM3grWjNxTzU0RnlhLzlF
+        NGdyTWIvRkdNelV1Sk9mNllFMWx0XG5YODZlNlBBVFJxK3ZkRDJna3dmSGxv
+        TllvNDVXQ1ZTcHRzeHJ3bFJwNHIvOVVybUpmNXBwUDZuZjZrSk1PRFUxXG45
+        Ymd5ay9lakNrSlNCd1Qrdng4QXVWaXlKR2pSZUFBSDZTMnpFNjNoNDNvNVVm
+        UllGWlNhb0pkMEZFcDZDdklQXG5CcFRoaFlLSEdjRmlXWUZlQ283ZDA1ZDht
+        SjJ2TWx5U0wwT3VGbVQxY09tWmxkWWdXZzkyaG5GV3FtUW0vMkpwXG51RGhn
+        WElKNVhGS1NVVVBjN2d1Zm5lclhQY1FCODNPM0dTUU1CM2kwcngzTjZQRnlw
+        ODJxbm1tWGZqc2NwMHFVXG5HT3NIQUw1YWR5QU1wZmdTT08ydlhwUW9MdnNy
+        M2RjWTBsWFFPaGVPMnh4WTd0dkZ4UkI0R0JQL0hhTkxGYzZzXG5nMzZYanVz
+        aUd4dDdVWkk5dTY4WVFWc0VWcDVWS3UyaENIS0FpaFZhelA1cXVmUWdBSFA2
+        VW92cXFnNTczUHRYXG5KZU03aXY5dFNBcnBQT2NteUJzOVlKbitWRzFoT0hR
+        eHNlcDdObDBwSk1Fdi93ZlZpQUtuS21xanhEVUU3S1NzXG51UU9xQ0pEbENn
+        WUxGTVVaQ0NFQU5yVkF6TzFIbVBaNVUxbXhjaWt0N2E2TDZQWFhTK2pPNmhV
+        UWhWMTROcXdGXG44OFZQSk9vVUFlNm5QdDVzbzJXSU1WVHRCZG1vMTMrcXRi
+        cVptcTNJVStGVXlZNFA0UUtDQVFFQXYycXVEcklOXG5XanI1OFJQNzhINWN6
+        NzNZS25JWDBMaU1hSFhpSVE0bW9LSmZiNldnWUZpZzFud05IMTc1bWtKRk1E
+        QTE2TVNsXG53L0pibzJUQ2tKL2xiYnY5cEtqeDBiT2Z0TGw5dnNWN1poemh6
+        cCttQWhlTHR5cm0vbXJuZUd2cFRPMGpPN1BIXG5JdXFQaWk2Sm5GMnIveHpE
+        VkdHS05XdHkvNnBrM1lFdkFzTTdWNjN3Z0hTa09ISkRxRWJXSUdrS2hGY0dJ
+        b1FTXG5aNitsZ3RXQmFjeVBWTElzVWxDVGZzVUorb25la0QrWDFXaVJBZW1I
+        SWxYbzFxNmJCcnBTdkZ2b2VJdk5ya3lPXG5zZllsWGNPbkJMb0tkQVprRnJx
+        aVRXSk1XL21yclZJSnM4UFdBTmUwZDhCVktiMUxwL0RPSnROV0J5QTRvSCs3
+        XG5QWXdDUmR2TFZ4dHQwUUtDQVFFQXZwUTBTaHBEdks2ZDNoYkxaNCtsbGxr
+        OXoyZFFrZ0ZFRXRrQ0I0V09pcTdvXG53L1MwTlhPVmZhRW4zNXM1R2FKWHNO
+        WkpIcDhucmpZOVZpN1lwbEEvR0RIY3ZVaURLc2hGaDRFZjI5a2diaU9tXG53
+        aEI4YVdvNlVQVHRWZG5XdWw1OGRqM2IwSlJieUJENENIRmFFTXdkME5tS0g1
+        RHFiRE9GVnRZaHV1bjI0RVFMXG5jSVhkaytHRVM1bUxmVk5vTGpsaC94Zms2
+        YzhrNytVVDRkek5MRFFVaWhrRjFSd2kyd3NBa2IvVnF4Y2NqaGsrXG5jM2xQ
+        TnBkbnE5VGlGcGNBaXZIWFBvaTU4elIvVzdyKzNIKzNlRHhQckVCeFZCaFBo
+        VnNTVlNhT3BsWkhDc0hBXG43WjZ5RXhIb240UUJXNEE4dXRmUDF4cWt3bVFB
+        aURoTFhrWUQvSC80ZndLQ0FRRUFtZEZvUFhibk0vTGdsdEd3XG5Tdm5BSzFB
+        clBUQ2g0cC9xZEtjR0ovbnZJSFphcXFVMTB6WmxTUFkydFZia3pRa2tBQzA5
+        cE9jaExleTdwdmw1XG5RQzY5ZHdqeU1qZHcyMHEwczgyN05tb0xWMnN1S1pR
+        eEdzMUJBTmdBOThHQWNFeUhGY0laNWdmNXBoMUhhNHNxXG5HZlZNR1oxTGVh
+        dElITlZUZkErNUxpWjVXSWI2VU9MOXVMd0NtemwzRk9xWGQwUHhwNWNtM3VX
+        eXhJOXBPVkhJXG54UFFVMmNLenl4SGs5S0h4K3RwL2R2c2pUK0xQWS9IOUhh
+        SmJrT2lPdTBGTzZ2NFFPWTVlb2duelFSN0R1QzFaXG5NWHN1bXozbmdEeEo0
+        RlYxZHhPUzJaeHJINEhubnBXMzkrTWVqSVFKSDlOcVZkak44THY3eFQzZmdQ
+        M1pkYm5DXG5GU1Y5Z1FLQ0FRQmhXTXFzMzJXaVIzK1VKZ2lZU2FQSGZLWTUv
+        d2dFekdpOVIrUGxlNjhuMzlnOTRBejlFS0ZYXG5ucTREWmdKd3VhQVpVQnZo
+        YkdLVWRsZzJZWStBeEpTMkF5SkIvWHdpcWxINXVWZFFzVVFEZm1wN3puZitV
+        S2loXG5HYnJ4azJnL29tdm82Z2dTTHZZQzU4Z0taL3dkZ0dYcWZIUTFVNHlx
+        NEZaSDJQRTV6TEN5TlkreVZtNnNUeEdJXG5uRkhJSG9ha3RlTDhyblBiaWxm
+        UHdpKzV1MU9DTk1nWkVsY01XR2JsaEdVeURjOVNxV2VJbmhSc1g1YTZ4L1BJ
+        XG5yZUVlc05zeUhmNVlqdmFNNkUvMXh6clAzdDBVcVpuNDNxSUUxclluNURF
+        bEZhRGdEa29Ua0l5LzA4UWFRWmVWXG5nNVE5N084WWNZeFV6K05BK0Z2ZE9R
+        UW1qNVVSc1R4NUFvSUJBSHFhTXBycVJoSGVvNWYrWFlkTjZ0bFBOaVJVXG5K
+        TEdXNitCTEdiRjVLbjdBS0hMQ3JSYjh4ZkdOWTErWm5nSWNOTTBqanZpdHQ4
+        SldydGpOdjI2YjNyVUFSWi9yXG5ac2t0cUdKTkNFT2U2UWw0c3ZtVkZjWCtx
+        REtrUWtJU3JMaHp0U0JDeWxOU3Z5RnU0Q0VIQ0cvazB0N2YrZGhUXG5lM0Nr
+        dnBpSFdvWWJybFgzQkRUbkJuNzl1ZnNIRE50Z3k0QWNjRTB6THNvMjRoUFRw
+        SS9JZm5UQzBUMVFEbk5FXG5pTVZSUmE1L2NmS1lEOHNFUnZiTHBuWVVKN0ZU
+        Q3BvTjNKcktlbnNxbjN2Sy9pcEUzMWh0STBNai9ob3NIZzNiXG51aWt0dVpZ
+        Z1l3UE9ldnVPd0ZOR1BFUnFYMFdjR1NVMGRWcUlza0lQemJwT25JeGZhUDFX
+        aEF5Q0lwMD1cbi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tXG4iLCJj
+        ZXJ0IjoiLS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tXG5NSUlIWVRDQ0Jr
+        bWdBd0lCQWdJSWNzUzI4SWFkOUNRd0RRWUpLb1pJaHZjTkFRRUxCUUF3Z1lR
         eEN6QUpCZ05WXG5CQVlUQWxWVE1SY3dGUVlEVlFRSURBNU9iM0owYUNCRFlY
         SnZiR2x1WVRFUU1BNEdBMVVFQnd3SFVtRnNaV2xuXG5hREVRTUE0R0ExVUVD
-        Z3dIUzJGMFpXeHNiekVVTUJJR0ExVUVDd3dMVTI5dFpVOXlaMVZ1YVhReEtU
-        QW5CZ05WXG5CQU1NSUdObGJuUnZjemN0WkdWMlpXd3lMbk5oYldseUxtVjRZ
-        VzF3YkdVdVkyOXRNQjRYRFRFNU1EVXpNREUxXG5Nekl6TVZvWERUUTVNVEl3
-        TVRFek1EQXdNRm93R0RFV01CUUdBMVVFQ2d3TmMyTmxibUZ5YVc5ZmRHVnpk
-        RENDXG5BaUl3RFFZSktvWklodmNOQVFFQkJRQURnZ0lQQURDQ0Fnb0NnZ0lC
-        QUlkU3VzRWdXVnd0VVVrTXhRUVh5M0pIXG5NbUp1Mm9hN0g2aFJnUEFvR2lI
-        Mll5R3QvU3BHMzVQWUV6clFhRy9IREZENi9UdG9lcDdpQ2JyN1d0N0l3WFgz
-        XG44a2g5UCttWGEzVWxRRVR6aGJEM0F5b2tRaVY3dHd3R1BKbHJ0d1loSmJH
-        UFZzZnozVVhFTXdRQmwzMzZoS3ZzXG4xZGZPWUpMa3ZTU2VwcUNaS1BmUG5X
-        U1NreDNUZGNoNTBhbjBUcStIVGM4cDl6bk1SdHhDMFlrVk9MZloxREkwXG5K
-        VVpmbVdWbkdWeFhUYTkrTWMrdFNiZmNyVVV1NzBrVExORG94RjdHTllCaWNj
-        Sk16T3BJY2lZVVdTN2FBRWdUXG5lWXFuM3MvN0dYLy9FNm1uNmZld05rSjY0
-        UXZOcjNSL3FWR0JEWTRmZXJqWEpCU0QvUWtpY0JhanYwdEE5bldsXG55VFJN
-        STN2Um9rNEZzdVVVVmVPaEozWldIZnFKeDY3YVVOK3BHbkR4UllRVTlNUmM1
-        alUwN1hlOHM3aG5IOGVQXG5GUnJqQWZ3RlZsT0dKMmFXd2laZGI2NW9lSHUv
-        UU5ycVlaMm1BeUxBQXJVb2FXVEFSWDQwb1N6OHkyalFUMmdaXG40ODYzallv
-        dWhUWkU4R0NaT004UEFsbU9ZNDduTndxL1pkazdvRkhLOEFaMVQ3czI1Ujg5
-        NzkxQ1BDSVpGS3BvXG5jUW5xL1UxNEQ2UHNkNWxST3ZadkkraTJ5M3Jsc29B
-        NlZOdUU0ZU90cWJDNVZYWHNic3orUUFJOVN1NFhHL2tSXG5uZ0U2OVFpandw
-        WEhSQ3ZZUEluLzNvV2NYNXFBL1piRVpzUXZjVS8rNVJaMGI2Q1NPNjBmb0tL
-        eHNHL2hJMjUzXG5oN1dJNldBSWEvTnJQaVlIWkNmYkFnTUJBQUdqZ2dOQU1J
-        SURQREFPQmdOVkhROEJBZjhFQkFNQ0JMQXdFd1lEXG5WUjBsQkF3d0NnWUlL
-        d1lCQlFVSEF3SXdDUVlEVlIwVEJBSXdBREFSQmdsZ2hrZ0JodmhDQVFFRUJB
-        TUNCYUF3XG5IUVlEVlIwT0JCWUVGQUNSZ3VoWXovdzF1Wk9rZDA2MlFFbkFY
-        d1NBTUI4R0ExVWRJd1FZTUJhQUZNV25VNnl0XG5TcFlrODIyL096RzhFV1Vm
-        QXlWbU1ERUdFQ3NHQVFRQmtnZ0pBYTJ3eXZ5VFh3RUVIUXdiYzJObGJtRnlh
-        VzlmXG5kR1Z6ZEY5MVpXSmxjbDl3Y205a2RXTjBNQllHRUNzR0FRUUJrZ2dK
-        QWEyd3l2eVRYd01FQWd3QU1CWUdFQ3NHXG5BUVFCa2dnSkFhMnd5dnlUWHdJ
-        RUFnd0FNQllHRUNzR0FRUUJrZ2dKQWEyd3l2eVRYd1VFQWd3QU1Ca0dFQ3NH
-        XG5BUVFCa2dnSkFxMnd5dnlUWUFFRUJRd0RlWFZ0TUNRR0VTc0dBUVFCa2dn
-        SkFxMnd5dnlUWUFFQkJBOE1EWFZsXG5ZbVZ5WDJOdmJuUmxiblF3TWdZUkt3
-        WUJCQUdTQ0FrQ3JiREsvSk5nQVFJRUhRd2JNVFUxT1RJek1ETTFNVGd6XG5P
-        VjkxWldKbGNsOWpiMjUwWlc1ME1CMEdFU3NHQVFRQmtnZ0pBcTJ3eXZ5VFlB
-        RUZCQWdNQmtOMWMzUnZiVEFsXG5CaEVyQmdFRUFaSUlDUUt0c01yOGsyQUJC
-        Z1FRREE0dmMyTmxibUZ5YVc5ZmRHVnpkREFYQmhFckJnRUVBWklJXG5DUUt0
-        c01yOGsyQUJCd1FDREFBd0dBWVJLd1lCQkFHU0NBa0NyYkRLL0pOZ0FRZ0VB
-        d3dCTVRBckJnb3JCZ0VFXG5BWklJQ1FRQkJCME1HM05qWlc1aGNtbHZYM1Js
-        YzNSZmRXVmlaWEpmY0hKdlpIVmpkREFRQmdvckJnRUVBWklJXG5DUVFDQkFJ
-        TUFEQWRCZ29yQmdFRUFaSUlDUVFEQkE4TURURTFOVGt5TXpBek5URTRNemt3
-        RVFZS0t3WUJCQUdTXG5DQWtFQlFRRERBRXhNQ1FHQ2lzR0FRUUJrZ2dKQkFZ
-        RUZnd1VNakF4T1Mwd05TMHpNRlF4TlRvek1qb3pNVm93XG5KQVlLS3dZQkJB
-        R1NDQWtFQndRV0RCUXlNRFE1TFRFeUxUQXhWREV6T2pBd09qQXdXakFSQmdv
-        ckJnRUVBWklJXG5DUVFNQkFNTUFUQXdFQVlLS3dZQkJBR1NDQWtFQ2dRQ0RB
-        QXdFQVlLS3dZQkJBR1NDQWtFRFFRQ0RBQXdFUVlLXG5Ld1lCQkFHU0NBa0VE
-        Z1FEREFFd01CRUdDaXNHQVFRQmtnZ0pCQXNFQXd3Qk1UQTBCZ29yQmdFRUFa
-        SUlDUVVCXG5CQ1lNSkRFNU9XSTNOekZoTFRVell6UXRORE0xWmkwNFpqUXdM
-        V1ZrWXpJME5UazJNelprTnpBTkJna3Foa2lHXG45dzBCQVFzRkFBT0NBUUVB
-        cEdYR095Y2hOOXRhVWxXL1RpWFpDVW5Tb0c1ZnNwcFIvNnRUbmdVa1RqOWdR
-        bmpqXG56VVBVUFBONmZ4cDFLS25LVDgxVTNaMncwUnB6UmZCQlorMmw2N2hE
-        d2psaXowREp4b0FPaGhORUtCelJOcklwXG5KNUxmWjJaOEZjcndMSEdFK1kz
-        bGZZVWRWZEh1WnVsUWNDT045K0YweXlpWkhvdHU5Y2RWWEhDcGlJcllMdEl0
-        XG5kMTNzNDkxWHdyc0g3TGxCa3YwSy9qYXI5YnJ2dlB2ZDhpN01KbFBzeVk0
-        L1I5elZhdGNkQm81Mit3MXlnMUtnXG5sVHJ0clBNa3k1VEgyVGZ1Vkgvem8r
-        SWRZMVI1OTdBMUpiWUlyZHpqMUtxblc5aXoxS3Y1RlNQWHNBeEpLZitYXG54
-        RW5mQVlTTzhaK3EwSStBa2J4SWdhNjVxR3BwbzdmMmtERUEzdz09XG4tLS0t
-        LUVORCBDRVJUSUZJQ0FURS0tLS0tXG4iLCJzZXJpYWwiOnsiY3JlYXRlZCI6
-        IjIwMTktMDUtMzBUMTU6MzI6MzErMDAwMCIsInVwZGF0ZWQiOiIyMDE5LTA1
-        LTMwVDE1OjMyOjMxKzAwMDAiLCJpZCI6Nzc1Mjc5NTEzMzM5NzAzNTU1MCwi
-        c2VyaWFsIjo3NzUyNzk1MTMzMzk3MDM1NTUwLCJleHBpcmF0aW9uIjoiMjA0
-        OS0xMi0wMVQxMzowMDowMCswMDAwIiwiY29sbGVjdGVkIjpmYWxzZSwicmV2
-        b2tlZCI6ZmFsc2V9LCJvd25lciI6eyJpZCI6IjQwMjhmOTk2NmIwNjk3ZmMw
-        MTZiMDk1ZjA5MTgwMDQ4Iiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRpc3Bs
-        YXlOYW1lIjoic2NlbmFyaW9fdGVzdCIsImhyZWYiOiIvb3duZXJzL3NjZW5h
-        cmlvX3Rlc3QifX0=
+        Z3dIUzJGMFpXeHNiekVVTUJJR0ExVUVDd3dMVTI5dFpVOXlaMVZ1YVhReElq
+        QWdCZ05WXG5CQU1NR1dSbGRtVnNMbUpoYkcxdmNtRXVaWGhoYlhCc1pTNWpi
+        MjB3SGhjTk1Ua3dOakEwTWpFek1URXdXaGNOXG5ORGt4TWpBeE1UTXdNREF3
+        V2pBWU1SWXdGQVlEVlFRS0RBMXpZMlZ1WVhKcGIxOTBaWE4wTUlJQ0lqQU5C
+        Z2txXG5oa2lHOXcwQkFRRUZBQU9DQWc4QU1JSUNDZ0tDQWdFQWpuLzk5Sng1
+        b01nU0Z3VzZaZm1FcmRaUVppU1FGdS9nXG5GckhmR1RyUkJlUmlUNHNzdmV6
+        eWVBYVVoWlk2eC94OXBlU2g5Q1JSc1BlNUFFSU1jRTlzZy9kVHhhY1ZWNnlx
+        XG5HZWlvcFNYU3dCMGhFOGYvMnNibnhIUEhpV28xV09hNkVHbFBSZElTVXo3
+        RkNDblJwLzRneGYwdFo4Wlp2L001XG5OaC9wRzFWemo1SDByVGZyMU04WUwv
+        QXNMTmpZQjU4ZWNwRnhtUnI0WngrQWZFRlZHM1FaY0R6NVZmUVZmNVZDXG5R
+        ZEIvNHRHSkk0TmFwMWFDZjBMN0VkS2hEaU9uaFNwSktZVzdUWCtyUnBYL3Ir
+        UmJ6MUYwRnY1NXh4MEtXZ3VXXG50cThLUHF1bXhhMWJrbWVyaFlyWG4zWnk5
+        ZnNiOXdYYTdmWjNSQ2Z6QWVNODBUZnk3cVN4WmIxZDZwMWZaL1JSXG41Kytx
+        UkcwU1NsR0hRUkdtejVrSFkwNkZUUFR6VHdzaVk4SU5sR1p6dVkxYk1iaDBF
+        YlBVVk0vUUoyQVhsSk9iXG5mN2M1NE0zNW0waVlZcG9sb0gzU2s3R0dTOHZw
+        RUdQK1FaOTNxUkpJUGZVaGMzdThiUFBEWmtPQTBJZGorTHFaXG5OT0tPSGlE
+        djhCRmRvNW12R1RyL3o0ZGkxaDVRMG03SFd4TncyaDJPcGx2eTVka2FzQmtD
+        QmM1T3U3Yk1rUFB3XG5kam1tQnEyeGpFU2VuYStMNlBaVkh2d2tQeWY3ejlX
+        K0l1ZlNtb3BvNkc3VXlOK0EwcFhjU21sRit2QlZ2cDFFXG5JVjFkYVpUZ2wz
+        d2NYU0haaDZzVElwU0N0RzVhOHJ1NFhqUlcwSnIxRTcrMDBKWFhDVUhvZjNL
+        OGZpM0lway9YXG5GRXVzYXYrczhxOENBd0VBQWFPQ0EwQXdnZ004TUE0R0Ex
+        VWREd0VCL3dRRUF3SUVzREFUQmdOVkhTVUVEREFLXG5CZ2dyQmdFRkJRY0RB
+        akFKQmdOVkhSTUVBakFBTUJFR0NXQ0dTQUdHK0VJQkFRUUVBd0lGb0RBZEJn
+        TlZIUTRFXG5GZ1FVSFkxNVRKTjVHbEkzNWhsNnFkZ1c4cENjOWRZd0h3WURW
+        UjBqQkJnd0ZvQVU4QUxEdlVVb0lIR2lQQVd6XG4xZnVKZ0YxRU9FTXdNUVlR
+        S3dZQkJBR1NDQWtCcmJLam5OME5BUVFkREJ0elkyVnVZWEpwYjE5MFpYTjBY
+        M1ZsXG5ZbVZ5WDNCeWIyUjFZM1F3RmdZUUt3WUJCQUdTQ0FrQnJiS2puTjBO
+        QXdRQ0RBQXdGZ1lRS3dZQkJBR1NDQWtCXG5yYktqbk4wTkFnUUNEQUF3RmdZ
+        UUt3WUJCQUdTQ0FrQnJiS2puTjBOQlFRQ0RBQXdHUVlRS3dZQkJBR1NDQWtD
+        XG5yYktqbk4wT0FRUUZEQU41ZFcwd0pBWVJLd1lCQkFHU0NBa0NyYktqbk4w
+        T0FRRUVEd3dOZFdWaVpYSmZZMjl1XG5kR1Z1ZERBeUJoRXJCZ0VFQVpJSUNR
+        S3RzcU9jM1E0QkFnUWREQnN4TlRVNU5qZ3pPRGN3TXpRNVgzVmxZbVZ5XG5Y
+        Mk52Ym5SbGJuUXdIUVlSS3dZQkJBR1NDQWtDcmJLam5OME9BUVVFQ0F3R1Ez
+        VnpkRzl0TUNVR0VTc0dBUVFCXG5rZ2dKQXEyeW81emREZ0VHQkJBTURpOXpZ
+        MlZ1WVhKcGIxOTBaWE4wTUJjR0VTc0dBUVFCa2dnSkFxMnlvNXpkXG5EZ0VI
+        QkFJTUFEQVlCaEVyQmdFRUFaSUlDUUt0c3FPYzNRNEJDQVFEREFFeE1Dc0dD
+        aXNHQVFRQmtnZ0pCQUVFXG5IUXdiYzJObGJtRnlhVzlmZEdWemRGOTFaV0ps
+        Y2w5d2NtOWtkV04wTUJBR0Npc0dBUVFCa2dnSkJBSUVBZ3dBXG5NQjBHQ2lz
+        R0FRUUJrZ2dKQkFNRUR3d05NVFUxT1RZNE16ZzNNRE0wT1RBUkJnb3JCZ0VF
+        QVpJSUNRUUZCQU1NXG5BVEV3SkFZS0t3WUJCQUdTQ0FrRUJnUVdEQlF5TURF
+        NUxUQTJMVEEwVkRJeE9qTXhPakV3V2pBa0Jnb3JCZ0VFXG5BWklJQ1FRSEJC
+        WU1GREl3TkRrdE1USXRNREZVTVRNNk1EQTZNREJhTUJFR0Npc0dBUVFCa2dn
+        SkJBd0VBd3dCXG5NREFRQmdvckJnRUVBWklJQ1FRS0JBSU1BREFRQmdvckJn
+        RUVBWklJQ1FRTkJBSU1BREFSQmdvckJnRUVBWklJXG5DUVFPQkFNTUFUQXdF
+        UVlLS3dZQkJBR1NDQWtFQ3dRRERBRXhNRFFHQ2lzR0FRUUJrZ2dKQlFFRUpn
+        d2tNekl3XG5ZVE5pTVRZdFpERXpNaTAwTlRZekxXRTFaV1V0TVdRd04yVXpN
+        ekk0TjJFME1BMEdDU3FHU0liM0RRRUJDd1VBXG5BNElCQVFBTXMrdnB0VUZW
+        c3NWUXZjWERYM1VhMlcveEE2NmY5U1hwZC9pWVovM1hEcU5sTWRTU21GcWM0
+        enFtXG52Wmo0aXd1aFBKc3JUZUZPRUJ3aUhITFNKWHhCcjJUaG9qbXRNb2g5
+        SittWHlDenFYRHdCM3JMa3BwNDQrSFVLXG5xYzF1aGJXZ2tadHo1VzdnZktZ
+        ZjFDRWJlWSsvc1FTZnhxU0xrcmFRL0RLZEhvREgvc3RvbmpoY0FJK0QxWnZ4
+        XG40WGVvUkZSaGNIZytWMXZaeVdaYmU3SkFrTHZVd2c4aWExNU8yWHcrMWg2
+        YlZiRGZZRGtlK3h1WWRsVFAzSGwyXG5yRTNXVE5nZTV4eXhvbGR2eTZHQUxW
+        bWxKNEpuMzFQT3JOQmFYR3dNTXNOZkNvallnQVlRVmRIMTg2cGNMVlprXG5j
+        TlU5MGMrT0I0OExDU1JSU2d3dlNQU1Btc0pQXG4tLS0tLUVORCBDRVJUSUZJ
+        Q0FURS0tLS0tXG4iLCJzZXJpYWwiOnsiY3JlYXRlZCI6IjIwMTktMDYtMDRU
+        MjE6MzE6MTArMDAwMCIsInVwZGF0ZWQiOiIyMDE5LTA2LTA0VDIxOjMxOjEw
+        KzAwMDAiLCJpZCI6ODI2OTkzNTk1OTkyNTk3ODE0OCwic2VyaWFsIjo4MjY5
+        OTM1OTU5OTI1OTc4MTQ4LCJleHBpcmF0aW9uIjoiMjA0OS0xMi0wMVQxMzow
+        MDowMCswMDAwIiwiY29sbGVjdGVkIjpmYWxzZSwicmV2b2tlZCI6ZmFsc2V9
+        LCJvd25lciI6eyJpZCI6IjQwMjhmOWY3NmIxZDdkOGQwMTZiMjQ2NzJkZjQw
+        NzBmIiwia2V5Ijoic2NlbmFyaW9fdGVzdCIsImRpc3BsYXlOYW1lIjoic2Nl
+        bmFyaW9fdGVzdCIsImhyZWYiOiIvb3duZXJzL3NjZW5hcmlvX3Rlc3QifX0=
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:33 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:12 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/organization_destroy.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/organization_destroy.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -21,9 +21,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 30 May 2019 15:33:38 GMT
+      - Tue, 04 Jun 2019 21:32:17 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '172'
       Content-Type:
@@ -32,14 +32,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzU1MTVlMDBhLTQ5ZTUtNGFiOC1iZjlkLWQzNTBmYzA2MGUyZi8iLCAi
-        dGFza19pZCI6ICI1NTE1ZTAwYS00OWU1LTRhYjgtYmY5ZC1kMzUwZmMwNjBl
-        MmYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzliYmY1NGE3LTk4MTQtNDY0Yy05MTVmLWE4YjI1NzU2OTZlNC8iLCAi
+        dGFza19pZCI6ICI5YmJmNTRhNy05ODE0LTQ2NGMtOTE1Zi1hOGIyNTc1Njk2
+        ZTQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:38 GMT
+  recorded_at: Tue, 04 Jun 2019 21:32:17 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/5515e00a-49e5-4ab8-bf9d-d350fc060e2f/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/9bbf54a7-9814-464c-915f-a8b2575696e4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -49,7 +49,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -58,15 +58,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:33:38 GMT
+      - Tue, 04 Jun 2019 21:32:17 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"900d81e3bdf87397ac0309bc15d833e7-gzip"'
+      - '"c14850265dd6a4d065b7e9e58bd54c1e-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '546'
+      - '670'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -74,75 +74,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81NTE1ZTAwYS00OWU1LTRhYjgtYmY5ZC1kMzUwZmMwNjBl
-        MmYvIiwgInRhc2tfaWQiOiAiNTUxNWUwMGEtNDllNS00YWI4LWJmOWQtZDM1
-        MGZjMDYwZTJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
-        b190ZXN0IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUi
-        OiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBu
-        dWxsLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwg
-        InByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiIiwgInN0YXRlIjog
-        IndhaXRpbmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0IjogbnVs
-        bCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmZjdkMmRm
-        OTY5NGJiMTViOWZhMTgifSwgImlkIjogIjVjZWZmN2QyZGY5Njk0YmIxNWI5
-        ZmExOCJ9
-    http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:38 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/5515e00a-49e5-4ab8-bf9d-d350fc060e2f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 30 May 2019 15:33:38 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"bb76a5fa5b9d5cc1e4024982694de39e-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '684'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81NTE1ZTAwYS00OWU1LTRhYjgtYmY5ZC1kMzUwZmMwNjBl
-        MmYvIiwgInRhc2tfaWQiOiAiNTUxNWUwMGEtNDllNS00YWI4LWJmOWQtZDM1
-        MGZjMDYwZTJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy85YmJmNTRhNy05ODE0LTQ2NGMtOTE1Zi1hOGIyNTc1Njk2
+        ZTQvIiwgInRhc2tfaWQiOiAiOWJiZjU0YTctOTgxNC00NjRjLTkxNWYtYThi
+        MjU3NTY5NmU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUi
         OiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAi
-        MjAxOS0wNS0zMFQxNTozMzozOFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
+        MjAxOS0wNi0wNFQyMTozMjoxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
         YXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVl
-        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZl
-        bDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmci
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
-        Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmZjdk
-        MmRmOTY5NGJiMTViOWZhMTgifSwgImlkIjogIjVjZWZmN2QyZGY5Njk0YmIx
-        NWI5ZmExOCJ9
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5i
+        YWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNmNmUzNjE5ZmE5MzRmMTBhNmQ4
+        NzRhIn0sICJpZCI6ICI1Y2Y2ZTM2MTlmYTkzNGYxMGE2ZDg3NGEifQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:38 GMT
+  recorded_at: Tue, 04 Jun 2019 21:32:17 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/5515e00a-49e5-4ab8-bf9d-d350fc060e2f/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/9bbf54a7-9814-464c-915f-a8b2575696e4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -152,7 +101,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -161,15 +110,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:33:38 GMT
+      - Tue, 04 Jun 2019 21:32:17 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"3aa40868e75868998bf43b9787a779d5-gzip"'
+      - '"c14850265dd6a4d065b7e9e58bd54c1e-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '703'
+      - '670'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -177,25 +126,77 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy81NTE1ZTAwYS00OWU1LTRhYjgtYmY5ZC1kMzUwZmMwNjBl
-        MmYvIiwgInRhc2tfaWQiOiAiNTUxNWUwMGEtNDllNS00YWI4LWJmOWQtZDM1
-        MGZjMDYwZTJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy85YmJmNTRhNy05ODE0LTQ2NGMtOTE1Zi1hOGIyNTc1Njk2
+        ZTQvIiwgInRhc2tfaWQiOiAiOWJiZjU0YTctOTgxNC00NjRjLTkxNWYtYThi
+        MjU3NTY5NmU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUi
-        OiAiMjAxOS0wNS0zMFQxNTozMzozOFoiLCAiX25zIjogInRhc2tfc3RhdHVz
-        IiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0wNS0zMFQxNTozMzozOFoiLCAidHJh
+        OiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAi
+        MjAxOS0wNi0wNFQyMTozMjoxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
+        YXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVl
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5i
+        YWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNmNmUzNjE5ZmE5MzRmMTBhNmQ4
+        NzRhIn0sICJpZCI6ICI1Y2Y2ZTM2MTlmYTkzNGYxMGE2ZDg3NGEifQ==
+    http_version: 
+  recorded_at: Tue, 04 Jun 2019 21:32:17 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/9bbf54a7-9814-464c-915f-a8b2575696e4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 04 Jun 2019 21:32:17 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"da4ded9bc4b54c2ec03514c1fdcfbdfb-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '689'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy85YmJmNTRhNy05ODE0LTQ2NGMtOTE1Zi1hOGIyNTc1Njk2
+        ZTQvIiwgInRhc2tfaWQiOiAiOWJiZjU0YTctOTgxNC00NjRjLTkxNWYtYThi
+        MjU3NTY5NmU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUi
+        OiAiMjAxOS0wNi0wNFQyMTozMjoxN1oiLCAiX25zIjogInRhc2tfc3RhdHVz
+        IiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0wNi0wNFQyMTozMjoxN1oiLCAidHJh
         Y2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNz
         X3JlcG9ydCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwg
-        InN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVk
-        X3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQi
-        OiB7IiRvaWQiOiAiNWNlZmY3ZDJkZjk2OTRiYjE1YjlmYTE4In0sICJpZCI6
-        ICI1Y2VmZjdkMmRmOTY5NGJiMTViOWZhMTgifQ==
+        a2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUi
+        OiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
+        Y2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNvbSIsICJyZXN1
+        bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVj
+        ZjZlMzYxOWZhOTM0ZjEwYTZkODc0YSJ9LCAiaWQiOiAiNWNmNmUzNjE5ZmE5
+        MzRmMTBhNmQ4NzRhIn0=
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:38 GMT
+  recorded_at: Tue, 04 Jun 2019 21:32:17 GMT
 - request:
     method: delete
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/environments/d80a5783c502f0f969e23089437bb7ce
+    uri: https://devel.balmora.example.com:8443/candlepin/environments/d80a5783c502f0f969e23089437bb7ce
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -205,11 +206,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="7AHaN3UJsZubdCVAxCja8wTLotxnwNG3", oauth_nonce="QBPEGQ1rEe5A2gnbg1q9J43KDN9gh5TqyJrCh39dMQ",
-        oauth_signature="8A9bq5JDLSS85%2Fu45yJ1KiEHkac%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1559230418", oauth_version="1.0"
+      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="Jcq6FK2Zgy8TUfhFu2V6A5aO53ZwipIsIZsuPPi3s",
+        oauth_signature="OqXxTYSzcHoc292SywucId63BTk%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1559683937", oauth_version="1.0"
       Cp-User:
       - foreman_admin
   response:
@@ -220,19 +221,19 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 2227d06d-ec47-4cf7-957d-14411e770ada
+      - 69478e19-ca60-4c0c-bf6d-ae90adc5d063
       X-Version:
       - 2.6.5-1
       Date:
-      - Thu, 30 May 2019 15:33:38 GMT
+      - Tue, 04 Jun 2019 21:32:17 GMT
     body:
       encoding: UTF-8
       base64_string: ''
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:38 GMT
+  recorded_at: Tue, 04 Jun 2019 21:32:17 GMT
 - request:
     method: delete
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/content/1559230354273
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/content/1559683873292
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -242,11 +243,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="7AHaN3UJsZubdCVAxCja8wTLotxnwNG3", oauth_nonce="ti4vUeceaq5DtD3Pz7CkwXFhcRSXxiBN7irbjnVW0g",
-        oauth_signature="A1uSM075PGzPzq7ZUscjYPVwzs0%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1559230418", oauth_version="1.0"
+      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="bfrtpDLQpSGeGr7isKRaE2vckQlC0BZchoa7pXALtw",
+        oauth_signature="Lz4lIQuLba7LyuulV5VdkGBTjk8%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1559683937", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -261,19 +262,19 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 9b3fc227-15ae-41c3-8c4a-dc05f7ce5ffc
+      - 4104de55-9f8e-4111-b429-96f40bec0bd9
       X-Version:
       - 2.6.5-1
       Date:
-      - Thu, 30 May 2019 15:33:38 GMT
+      - Tue, 04 Jun 2019 21:32:17 GMT
     body:
       encoding: UTF-8
       base64_string: ''
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:38 GMT
+  recorded_at: Tue, 04 Jun 2019 21:32:17 GMT
 - request:
     method: delete
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -283,11 +284,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="7AHaN3UJsZubdCVAxCja8wTLotxnwNG3", oauth_nonce="BCU6SDhFoxMdk2skKpkgTvWXzBdSEGLTUiB2QerjtzA",
-        oauth_signature="01AogJTeZ%2BEOTzoI%2B1ENHVpG4iU%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1559230418", oauth_version="1.0"
+      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="c9dGtJXyTiBQUI9mq0Ci9qCHSXcTZutT4MgmiWEcg",
+        oauth_signature="uK3BdCcSDvTiIQT3QH1pg3584nU%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1559683937", oauth_version="1.0"
       Cp-User:
       - foreman_admin
   response:
@@ -298,14 +299,14 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 7865dc48-af21-4906-9108-3fb1f7c7ac07
+      - 902aaa8d-ee4e-481e-ba02-816c6ef74872
       X-Version:
       - 2.6.5-1
       Date:
-      - Thu, 30 May 2019 15:33:38 GMT
+      - Tue, 04 Jun 2019 21:32:17 GMT
     body:
       encoding: UTF-8
       base64_string: ''
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:39 GMT
+  recorded_at: Tue, 04 Jun 2019 21:32:18 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/product_create.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/product_create.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/products/
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/products/
     body:
       encoding: UTF-8
       base64_string: |
@@ -15,11 +15,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="7AHaN3UJsZubdCVAxCja8wTLotxnwNG3",
-        oauth_nonce="pYaRau8tM3P20zOPHyahz2m6GVIs1B4cUihXYLMdem0", oauth_signature="KYPopQNPfjho3ARQzGkSdfWkvDY%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559230353", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD",
+        oauth_nonce="8T4ro1B7hlVLtVM6hPRa5I8PsNfHVucf7vsgN5FOw", oauth_signature="ZbUf2amIeqbsnXGuhuxe%2FtRABS4%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559683872", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -36,7 +36,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 57c69aa7-979d-4bc8-9e80-880de7fd62e1
+      - 3fda042f-4416-433b-87de-5b70056b1f5c
       X-Version:
       - 2.6.5-1
       Content-Type:
@@ -44,23 +44,23 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 30 May 2019 15:32:33 GMT
+      - Tue, 04 Jun 2019 21:31:12 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxNTozMjozMyswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDUtMzBUMTU6MzI6MzMrMDAwMCIsInV1aWQiOiI0MDI4Zjk5
-        NjZiMDY5N2ZjMDE2YjA5NWYxMDkwMDA0YyIsImlkIjoiN2M4MjUwMTNjYWIw
+        eyJjcmVhdGVkIjoiMjAxOS0wNi0wNFQyMTozMToxMiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDYtMDRUMjE6MzE6MTIrMDAwMCIsInV1aWQiOiI0MDI4Zjlm
+        NzZiMWQ3ZDhkMDE2YjI0NjczNzU1MDcxMyIsImlkIjoiN2M4MjUwMTNjYWIw
         MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
         dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
         IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
-        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOTk2NmIwNjk3ZmMwMTZiMDk1ZjEwOTAw
-        MDRjIiwicHJvZHVjdENvbnRlbnQiOltdfQ==
+        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOWY3NmIxZDdkOGQwMTZiMjQ2NzM3NTUw
+        NzEzIiwicHJvZHVjdENvbnRlbnQiOltdfQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:33 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:12 GMT
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/pools
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/pools
     body:
       encoding: UTF-8
       base64_string: |
@@ -75,11 +75,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="7AHaN3UJsZubdCVAxCja8wTLotxnwNG3",
-        oauth_nonce="InxowvtJufhmydCJ89Tz7rwVvq44HDRSZmRnWono", oauth_signature="jsqTr7%2FETylX6i3cawwaiSMYD5w%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559230353", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD",
+        oauth_nonce="PE3vEGsh6VzWWxb4tlWjr6VmSvEI8FFo0VNROphcJ20", oauth_signature="LHgNkdSM%2FLLlhNX2pM0TGlPSYyU%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559683872", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -96,7 +96,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - d81719ea-5886-4f56-8c56-7de9750df08d
+      - 6bcc3503-29f6-4118-902c-fa0a652b0e9a
       X-Version:
       - 2.6.5-1
       Content-Type:
@@ -104,14 +104,14 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 30 May 2019 15:32:33 GMT
+      - Tue, 04 Jun 2019 21:31:12 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxNTozMjozMyswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDUtMzBUMTU6MzI6MzMrMDAwMCIsImlkIjoiNDAyOGY5OTY2
-        YjA2OTdmYzAxNmIwOTVmMTBiYjAwNGQiLCJ0eXBlIjoiTk9STUFMIiwib3du
-        ZXIiOnsiaWQiOiI0MDI4Zjk5NjZiMDY5N2ZjMDE2YjA5NWYwOTE4MDA0OCIs
+        eyJjcmVhdGVkIjoiMjAxOS0wNi0wNFQyMTozMToxMiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDYtMDRUMjE6MzE6MTIrMDAwMCIsImlkIjoiNDAyOGY5Zjc2
+        YjFkN2Q4ZDAxNmIyNDY3Mzc4MzA3MTQiLCJ0eXBlIjoiTk9STUFMIiwib3du
+        ZXIiOnsiaWQiOiI0MDI4ZjlmNzZiMWQ3ZDhkMDE2YjI0NjcyZGY0MDcwZiIs
         ImtleSI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5TmFtZSI6InNjZW5hcmlv
         X3Rlc3QiLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0sImFjdGl2
         ZVN1YnNjcmlwdGlvbiI6dHJ1ZSwic291cmNlRW50aXRsZW1lbnQiOm51bGws
@@ -131,13 +131,13 @@ http_interactions:
         ZWRQcm9kdWN0SWQiOm51bGwsImRlcml2ZWRQcm9kdWN0TmFtZSI6bnVsbCwi
         cHJvdmlkZWRQcm9kdWN0cyI6W10sImRlcml2ZWRQcm92aWRlZFByb2R1Y3Rz
         IjpbXSwic3Vic2NyaXB0aW9uU3ViS2V5IjpudWxsLCJzdWJzY3JpcHRpb25J
-        ZCI6bnVsbCwiaHJlZiI6Ii9wb29scy80MDI4Zjk5NjZiMDY5N2ZjMDE2YjA5
-        NWYxMGJiMDA0ZCJ9
+        ZCI6bnVsbCwiaHJlZiI6Ii9wb29scy80MDI4ZjlmNzZiMWQ3ZDhkMDE2YjI0
+        NjczNzgzMDcxNCJ9
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:33 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:12 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -147,11 +147,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="7AHaN3UJsZubdCVAxCja8wTLotxnwNG3", oauth_nonce="mJbM4p7Qub278awPY7VSZ4jJIJLaEPEfCcyyoh6udm0",
-        oauth_signature="A6CNODZqfwTjgnGXfV9gwbmzJ2s%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1559230353", oauth_version="1.0"
+      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="YXRcBKUXps8WMnVcGgzQhpTDGFrV79I7n510R0MQ",
+        oauth_signature="il0D5bgO4zMdxIEMDIQ3jGUeR8s%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1559683872", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -166,7 +166,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 99130e37-1469-4caf-8e50-5af79fc4e650
+      - 93e759f3-e123-4893-bd2d-8970bf7fe3b2
       X-Version:
       - 2.6.5-1
       Content-Type:
@@ -174,23 +174,23 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 30 May 2019 15:32:33 GMT
+      - Tue, 04 Jun 2019 21:31:12 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxNTozMjozMyswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDUtMzBUMTU6MzI6MzMrMDAwMCIsInV1aWQiOiI0MDI4Zjk5
-        NjZiMDY5N2ZjMDE2YjA5NWYxMDkwMDA0YyIsImlkIjoiN2M4MjUwMTNjYWIw
+        eyJjcmVhdGVkIjoiMjAxOS0wNi0wNFQyMTozMToxMiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDYtMDRUMjE6MzE6MTIrMDAwMCIsInV1aWQiOiI0MDI4Zjlm
+        NzZiMWQ3ZDhkMDE2YjI0NjczNzU1MDcxMyIsImlkIjoiN2M4MjUwMTNjYWIw
         MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
         dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
         IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
-        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOTk2NmIwNjk3ZmMwMTZiMDk1ZjEwOTAw
-        MDRjIiwicHJvZHVjdENvbnRlbnQiOltdfQ==
+        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOWY3NmIxZDdkOGQwMTZiMjQ2NzM3NTUw
+        NzEzIiwicHJvZHVjdENvbnRlbnQiOltdfQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:33 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:12 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/pools?add_future=true
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/pools?add_future=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -200,11 +200,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="7AHaN3UJsZubdCVAxCja8wTLotxnwNG3", oauth_nonce="16U7yV0D7RfKe8sQOJAOOecEdTFmPmEa1LcqGtEI",
-        oauth_signature="HQog9fMLXjfF%2Fp3XYEW3IH5Wl3k%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1559230353", oauth_version="1.0"
+      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="Iu7HqBfNAML4tjmHYyvOrpOjZQZtE2D5wwafxGoDk4",
+        oauth_signature="NO6GA3SgbBVrDWZSIsUSXyhbilQ%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1559683872", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -219,7 +219,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - b08fd484-e59c-4da1-9b54-8e9970e480d0
+      - 27f83838-33bf-4363-922a-ff2d8c913e28
       X-Version:
       - 2.6.5-1
       Content-Type:
@@ -227,14 +227,14 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 30 May 2019 15:32:33 GMT
+      - Tue, 04 Jun 2019 21:31:12 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        W3siY3JlYXRlZCI6IjIwMTktMDUtMzBUMTU6MzI6MzMrMDAwMCIsInVwZGF0
-        ZWQiOiIyMDE5LTA1LTMwVDE1OjMyOjMzKzAwMDAiLCJpZCI6IjQwMjhmOTk2
-        NmIwNjk3ZmMwMTZiMDk1ZjEwYmIwMDRkIiwidHlwZSI6Ik5PUk1BTCIsIm93
-        bmVyIjp7ImlkIjoiNDAyOGY5OTY2YjA2OTdmYzAxNmIwOTVmMDkxODAwNDgi
+        W3siY3JlYXRlZCI6IjIwMTktMDYtMDRUMjE6MzE6MTIrMDAwMCIsInVwZGF0
+        ZWQiOiIyMDE5LTA2LTA0VDIxOjMxOjEyKzAwMDAiLCJpZCI6IjQwMjhmOWY3
+        NmIxZDdkOGQwMTZiMjQ2NzM3ODMwNzE0IiwidHlwZSI6Ik5PUk1BTCIsIm93
+        bmVyIjp7ImlkIjoiNDAyOGY5Zjc2YjFkN2Q4ZDAxNmIyNDY3MmRmNDA3MGYi
         LCJrZXkiOiJzY2VuYXJpb190ZXN0IiwiZGlzcGxheU5hbWUiOiJzY2VuYXJp
         b190ZXN0IiwiaHJlZiI6Ii9vd25lcnMvc2NlbmFyaW9fdGVzdCJ9LCJhY3Rp
         dmVTdWJzY3JpcHRpb24iOnRydWUsInNvdXJjZUVudGl0bGVtZW50IjpudWxs
@@ -255,12 +255,12 @@ http_interactions:
         ImRlcml2ZWRQcm9kdWN0TmFtZSI6bnVsbCwicHJvdmlkZWRQcm9kdWN0cyI6
         W10sImRlcml2ZWRQcm92aWRlZFByb2R1Y3RzIjpbXSwic3Vic2NyaXB0aW9u
         U3ViS2V5IjpudWxsLCJzdWJzY3JpcHRpb25JZCI6bnVsbCwiaHJlZiI6Ii9w
-        b29scy80MDI4Zjk5NjZiMDY5N2ZjMDE2YjA5NWYxMGJiMDA0ZCJ9XQ==
+        b29scy80MDI4ZjlmNzZiMWQ3ZDhkMDE2YjI0NjczNzgzMDcxNCJ9XQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:33 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:12 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/pools/4028f9966b0697fc016b095f10bb004d
+    uri: https://devel.balmora.example.com:8443/candlepin/pools/4028f9f76b1d7d8d016b246737830714
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -270,11 +270,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="7AHaN3UJsZubdCVAxCja8wTLotxnwNG3", oauth_nonce="FFSnxxR1XDqaySE4pG5XVO7YbxQi3BIhxD5RKAPk",
-        oauth_signature="XpsEJIAT%2BJQ4NMFFwiJbgDk441M%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1559230353", oauth_version="1.0"
+      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="XcxzGhFlCokDISpNZaO870HGulvndaGJpvlCPkHwufg",
+        oauth_signature="qZsQ9qgXZX8VWvl7hXIaPneh1iY%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1559683872", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -289,7 +289,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - d3445a53-b164-4c12-a9c5-13be6aa8a884
+      - 778d3854-2199-497b-a502-997fce9fcf5d
       X-Version:
       - 2.6.5-1
       Content-Type:
@@ -297,14 +297,14 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 30 May 2019 15:32:33 GMT
+      - Tue, 04 Jun 2019 21:31:12 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxNTozMjozMyswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDUtMzBUMTU6MzI6MzMrMDAwMCIsImlkIjoiNDAyOGY5OTY2
-        YjA2OTdmYzAxNmIwOTVmMTBiYjAwNGQiLCJ0eXBlIjoiTk9STUFMIiwib3du
-        ZXIiOnsiaWQiOiI0MDI4Zjk5NjZiMDY5N2ZjMDE2YjA5NWYwOTE4MDA0OCIs
+        eyJjcmVhdGVkIjoiMjAxOS0wNi0wNFQyMTozMToxMiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDYtMDRUMjE6MzE6MTIrMDAwMCIsImlkIjoiNDAyOGY5Zjc2
+        YjFkN2Q4ZDAxNmIyNDY3Mzc4MzA3MTQiLCJ0eXBlIjoiTk9STUFMIiwib3du
+        ZXIiOnsiaWQiOiI0MDI4ZjlmNzZiMWQ3ZDhkMDE2YjI0NjcyZGY0MDcwZiIs
         ImtleSI6InNjZW5hcmlvX3Rlc3QiLCJkaXNwbGF5TmFtZSI6InNjZW5hcmlv
         X3Rlc3QiLCJocmVmIjoiL293bmVycy9zY2VuYXJpb190ZXN0In0sImFjdGl2
         ZVN1YnNjcmlwdGlvbiI6dHJ1ZSwic291cmNlRW50aXRsZW1lbnQiOm51bGws
@@ -325,12 +325,12 @@ http_interactions:
         ZGVyaXZlZFByb2R1Y3ROYW1lIjpudWxsLCJwcm92aWRlZFByb2R1Y3RzIjpb
         XSwiZGVyaXZlZFByb3ZpZGVkUHJvZHVjdHMiOltdLCJzdWJzY3JpcHRpb25T
         dWJLZXkiOm51bGwsInN1YnNjcmlwdGlvbklkIjpudWxsLCJocmVmIjoiL3Bv
-        b2xzLzQwMjhmOTk2NmIwNjk3ZmMwMTZiMDk1ZjEwYmIwMDRkIn0=
+        b2xzLzQwMjhmOWY3NmIxZDdkOGQwMTZiMjQ2NzM3ODMwNzE0In0=
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:33 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:12 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/activation_keys/?include=pools.pool.id
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/activation_keys/?include=pools.pool.id
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -340,11 +340,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="7AHaN3UJsZubdCVAxCja8wTLotxnwNG3", oauth_nonce="8J1soaxjTyW3oLAqA5Pa1K0ieWckC5yszRNdYFWvvXw",
-        oauth_signature="sa1weshm8yMAjAFRcijNvWc3glY%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1559230353", oauth_version="1.0"
+      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="sx4D02IrvtwAxGj0VMJtWsnPBGAdQyxhC1noHA9k",
+        oauth_signature="mMck1xWRTyPO%2BMlFwXTIraWJA4Y%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1559683872", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -359,7 +359,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - e6b19d35-90d9-4dd8-b443-b3021658fdc6
+      - cc62e7a3-7b29-411e-9117-a6fe47acc08d
       X-Version:
       - 2.6.5-1
       Content-Type:
@@ -367,17 +367,17 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 30 May 2019 15:32:33 GMT
+      - Tue, 04 Jun 2019 21:31:12 GMT
     body:
       encoding: UTF-8
       base64_string: 'W10=
 
 '
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:33 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:12 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/pools/4028f9966b0697fc016b095f10bb004d/entitlements/consumer_uuids
+    uri: https://devel.balmora.example.com:8443/candlepin/pools/4028f9f76b1d7d8d016b246737830714/entitlements/consumer_uuids
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -387,11 +387,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="7AHaN3UJsZubdCVAxCja8wTLotxnwNG3", oauth_nonce="nKKiR9lCvH9hOd3VIMaUnKrb8Quve3ukFuqI99Ygc",
-        oauth_signature="ifDLsdDEk6FtJjLLVSr8l4Wyols%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1559230353", oauth_version="1.0"
+      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="LcruGAeYumn2Ba01wgJNpsIGUoSMtNbGq1eagK4nhQ",
+        oauth_signature="VXw%2B2a1KApsVErf5o%2BoHMImOxS0%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1559683872", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -406,7 +406,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - e93e58bc-09b8-4cc3-8316-b3afd78aded6
+      - 991cec96-b063-4a2d-8677-326c16953daa
       X-Version:
       - 2.6.5-1
       Content-Type:
@@ -414,12 +414,12 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 30 May 2019 15:32:33 GMT
+      - Tue, 04 Jun 2019 21:31:12 GMT
     body:
       encoding: UTF-8
       base64_string: 'W10=
 
 '
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:33 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:12 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/repo_create.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/repo_create.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -35,7 +35,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -46,9 +46,9 @@ http_interactions:
       message: CREATED
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:34 GMT
+      - Tue, 04 Jun 2019 21:31:13 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '332'
       Location:
@@ -63,14 +63,14 @@ http_interactions:
         X2FkZGVkIjogbnVsbCwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
         ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
         aXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lkIjogeyIkb2lk
-        IjogIjVjZWZmNzkyMDVmNWVlMjk2NTllMGZhZCJ9LCAiaWQiOiAic2NlbmFy
+        IjogIjVjZjZlMzIxYjAyZTUzNGJiNTUwNGM1NSJ9LCAiaWQiOiAic2NlbmFy
         aW9fdGVzdCIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVz
         L3NjZW5hcmlvX3Rlc3QvIn0=
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:34 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:13 GMT
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/content/
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/content/
     body:
       encoding: UTF-8
       base64_string: |
@@ -85,11 +85,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="7AHaN3UJsZubdCVAxCja8wTLotxnwNG3",
-        oauth_nonce="akgrJAhQolLliHt0EwxpVXtFzH6D00K9MKI722TNdmI", oauth_signature="dQYrWsOm79GZmOthrmrsP7s8gm4%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559230354", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD",
+        oauth_nonce="gULevP0wv6utbkvGcHxMF7zTKN2Y4pnXnd7NAb5ysHE", oauth_signature="8Q0B5zSzHC7AjM4PZbXmxhcmcDg%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559683873", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -106,7 +106,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 4c17414b-9632-416e-9431-57f6bdeeeb0f
+      - 896f943b-4130-4a10-9c79-c98842d19a58
       X-Version:
       - 2.6.5-1
       Content-Type:
@@ -114,14 +114,14 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 30 May 2019 15:32:33 GMT
+      - Tue, 04 Jun 2019 21:31:13 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxNTozMjozNCswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDUtMzBUMTU6MzI6MzQrMDAwMCIsInV1aWQiOiI0MDI4Zjk5
-        NjZiMDY5N2ZjMDE2YjA5NWYxMzU0MDA0ZiIsImlkIjoiMTU1OTIzMDM1NDI3
-        MyIsInR5cGUiOiJ5dW0iLCJsYWJlbCI6InNjZW5hcmlvX3Rlc3RfU2NlbmFy
+        eyJjcmVhdGVkIjoiMjAxOS0wNi0wNFQyMTozMToxMyswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDYtMDRUMjE6MzE6MTMrMDAwMCIsInV1aWQiOiI0MDI4Zjlm
+        NzZiMWQ3ZDhkMDE2YjI0NjczYTBjMDcxNiIsImlkIjoiMTU1OTY4Mzg3MzI5
+        MiIsInR5cGUiOiJ5dW0iLCJsYWJlbCI6InNjZW5hcmlvX3Rlc3RfU2NlbmFy
         aW9fUHJvZHVjdF9TY2VuYXJpb195dW1fcHJvZHVjdCIsIm5hbWUiOiJTY2Vu
         YXJpbyB5dW0gcHJvZHVjdCIsInZlbmRvciI6IkN1c3RvbSIsImNvbnRlbnRV
         cmwiOiIvY3VzdG9tL1NjZW5hcmlvX1Byb2R1Y3QvU2NlbmFyaW9feXVtX3By
@@ -130,10 +130,10 @@ http_interactions:
         b2R1Y3RJZHMiOltdLCJtZXRhZGF0YUV4cGlyZSI6MSwicmVsZWFzZVZlciI6
         bnVsbH0=
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:34 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:13 GMT
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/content/1559230354273?enabled=true
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/products/7c825013cab01349ae8cb8db187de391/content/1559683873292?enabled=true
     body:
       encoding: UTF-8
       base64_string: ''
@@ -143,11 +143,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="7AHaN3UJsZubdCVAxCja8wTLotxnwNG3",
-        oauth_nonce="hWNTO8HauEd4rTOkuqpz6VwCR3xym7jg6FgYLjP5k", oauth_signature="XHMCZEpN43okb09cNW6cOwEVhPo%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559230354", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD",
+        oauth_nonce="SDB41j7bVl1lxFBnXCNjPwxM17IGuncV2Uw5lsMw", oauth_signature="%2F0wc7pOu7nPmpf%2Fosl4BDXnOC5I%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559683873", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -162,7 +162,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 511795a5-ab83-4555-9039-bacee84d4089
+      - 158543c2-b840-4814-8663-3b3e4c914793
       X-Version:
       - 2.6.5-1
       Content-Type:
@@ -170,21 +170,21 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 30 May 2019 15:32:34 GMT
+      - Tue, 04 Jun 2019 21:31:13 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxNTozMjozMyswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDUtMzBUMTU6MzI6MzQrMDAwMCIsInV1aWQiOiI0MDI4Zjk5
-        NjZiMDY5N2ZjMDE2YjA5NWYxM2ExMDA1MCIsImlkIjoiN2M4MjUwMTNjYWIw
+        eyJjcmVhdGVkIjoiMjAxOS0wNi0wNFQyMTozMToxMiswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDYtMDRUMjE6MzE6MTMrMDAwMCIsInV1aWQiOiI0MDI4Zjlm
+        NzZiMWQ3ZDhkMDE2YjI0NjczYTRjMDcxNyIsImlkIjoiN2M4MjUwMTNjYWIw
         MTM0OWFlOGNiOGRiMTg3ZGUzOTEiLCJuYW1lIjoiU2NlbmFyaW8gUHJvZHVj
         dCIsIm11bHRpcGxpZXIiOjEsImF0dHJpYnV0ZXMiOlt7Im5hbWUiOiJhcmNo
         IiwidmFsdWUiOiJBTEwifV0sImRlcGVuZGVudFByb2R1Y3RJZHMiOltdLCJo
-        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOTk2NmIwNjk3ZmMwMTZiMDk1ZjEzYTEw
-        MDUwIiwicHJvZHVjdENvbnRlbnQiOlt7ImNvbnRlbnQiOnsiY3JlYXRlZCI6
-        IjIwMTktMDUtMzBUMTU6MzI6MzQrMDAwMCIsInVwZGF0ZWQiOiIyMDE5LTA1
-        LTMwVDE1OjMyOjM0KzAwMDAiLCJ1dWlkIjoiNDAyOGY5OTY2YjA2OTdmYzAx
-        NmIwOTVmMTM1NDAwNGYiLCJpZCI6IjE1NTkyMzAzNTQyNzMiLCJ0eXBlIjoi
+        cmVmIjoiL3Byb2R1Y3RzLzQwMjhmOWY3NmIxZDdkOGQwMTZiMjQ2NzNhNGMw
+        NzE3IiwicHJvZHVjdENvbnRlbnQiOlt7ImNvbnRlbnQiOnsiY3JlYXRlZCI6
+        IjIwMTktMDYtMDRUMjE6MzE6MTMrMDAwMCIsInVwZGF0ZWQiOiIyMDE5LTA2
+        LTA0VDIxOjMxOjEzKzAwMDAiLCJ1dWlkIjoiNDAyOGY5Zjc2YjFkN2Q4ZDAx
+        NmIyNDY3M2EwYzA3MTYiLCJpZCI6IjE1NTk2ODM4NzMyOTIiLCJ0eXBlIjoi
         eXVtIiwibGFiZWwiOiJzY2VuYXJpb190ZXN0X1NjZW5hcmlvX1Byb2R1Y3Rf
         U2NlbmFyaW9feXVtX3Byb2R1Y3QiLCJuYW1lIjoiU2NlbmFyaW8geXVtIHBy
         b2R1Y3QiLCJ2ZW5kb3IiOiJDdXN0b20iLCJjb250ZW50VXJsIjoiL2N1c3Rv
@@ -194,13 +194,13 @@ http_interactions:
         XSwibWV0YWRhdGFFeHBpcmUiOjEsInJlbGVhc2VWZXIiOm51bGx9LCJlbmFi
         bGVkIjp0cnVlfV19
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:34 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:13 GMT
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/environments/d80a5783c502f0f969e23089437bb7ce/content
+    uri: https://devel.balmora.example.com:8443/candlepin/environments/d80a5783c502f0f969e23089437bb7ce/content
     body:
       encoding: UTF-8
-      base64_string: 'W3siY29udGVudElkIjoiMTU1OTIzMDM1NDI3MyJ9XQ==
+      base64_string: 'W3siY29udGVudElkIjoiMTU1OTY4Mzg3MzI5MiJ9XQ==
 
 '
     headers:
@@ -209,11 +209,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="7AHaN3UJsZubdCVAxCja8wTLotxnwNG3",
-        oauth_nonce="FQju16PWfJtkPXQz5AeH365mL3ctbmguAG98vA8Ca8", oauth_signature="e5q6spzEREcUg1dOXxMGKw0gzGc%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559230354", oauth_version="1.0"
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD",
+        oauth_nonce="hQb9jXajvo77xaCoy3PbZZtd4bxz3DILPuMXRG1hvKc", oauth_signature="Mt1Mq2gTypUrq1%2BPRgB0fcNgoPo%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559683873", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -230,7 +230,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 49aa6748-9ec9-4a83-a0c3-0dea297cdb33
+      - 3e905378-376b-4cf5-a259-7421062303eb
       X-Version:
       - 2.6.5-1
       Content-Type:
@@ -238,26 +238,26 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 30 May 2019 15:32:34 GMT
+      - Tue, 04 Jun 2019 21:31:13 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxNTozMjozNCswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDUtMzBUMTU6MzI6MzQrMDAwMCIsImlkIjoicmVnZW5fZW50
-        aXRsZW1lbnRfY2VydF9vZl9lbnYzZDdjMjgxNS1jZWNiLTQyMzctOGRkMy05
-        YWUwYzQ5NTcxNmUiLCJzdGF0ZSI6IkNSRUFURUQiLCJzdGFydFRpbWUiOm51
+        eyJjcmVhdGVkIjoiMjAxOS0wNi0wNFQyMTozMToxMyswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDYtMDRUMjE6MzE6MTMrMDAwMCIsImlkIjoicmVnZW5fZW50
+        aXRsZW1lbnRfY2VydF9vZl9lbnZkZDY3ODYxOC0zNzkzLTQwMTktYjYxZC1k
+        YjdkMWE1OWRhZjYiLCJzdGF0ZSI6IkNSRUFURUQiLCJzdGFydFRpbWUiOm51
         bGwsImZpbmlzaFRpbWUiOm51bGwsInJlc3VsdCI6bnVsbCwicHJpbmNpcGFs
         TmFtZSI6ImZvcmVtYW5fYWRtaW4iLCJ0YXJnZXRUeXBlIjpudWxsLCJ0YXJn
         ZXRJZCI6bnVsbCwib3duZXJJZCI6bnVsbCwiY29ycmVsYXRpb25JZCI6bnVs
         bCwicmVzdWx0RGF0YSI6bnVsbCwiZG9uZSI6ZmFsc2UsInN0YXR1c1BhdGgi
-        OiIvam9icy9yZWdlbl9lbnRpdGxlbWVudF9jZXJ0X29mX2VudjNkN2MyODE1
-        LWNlY2ItNDIzNy04ZGQzLTlhZTBjNDk1NzE2ZSIsImdyb3VwIjoiYXN5bmMg
+        OiIvam9icy9yZWdlbl9lbnRpdGxlbWVudF9jZXJ0X29mX2VudmRkNjc4NjE4
+        LTM3OTMtNDAxOS1iNjFkLWRiN2QxYTU5ZGFmNiIsImdyb3VwIjoiYXN5bmMg
         Z3JvdXAifQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:34 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:13 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/?details=true
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -267,7 +267,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -276,11 +276,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:34 GMT
+      - Tue, 04 Jun 2019 21:31:13 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"a40a34f503f98b4bff1e8da2868ca0f1-gzip"'
+      - '"9577fea0940da6f84f3262409ff8ade9-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -293,59 +293,59 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiU2NlbmFyaW8g
         eXVtIHByb2R1Y3QiLCAiZGVzY3JpcHRpb24iOiBudWxsLCAiZGlzdHJpYnV0
         b3JzIjogW3sicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgImxhc3RfdXBk
-        YXRlZCI6ICIyMDE5LTA1LTMwVDE1OjMyOjM0WiIsICJfaHJlZiI6ICIvcHVs
+        YXRlZCI6ICIyMDE5LTA2LTA0VDIxOjMxOjEzWiIsICJfaHJlZiI6ICIvcHVs
         cC9hcGkvdjIvcmVwb3NpdG9yaWVzL3NjZW5hcmlvX3Rlc3QvZGlzdHJpYnV0
         b3JzL3NjZW5hcmlvX3Rlc3RfY2xvbmUvIiwgImxhc3Rfb3ZlcnJpZGVfY29u
         ZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3Jf
         dHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJs
         aXNoIjogZmFsc2UsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19k
-        aXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVjZWZmNzkyMDVmNWVl
-        Mjk2NTllMGZiMCJ9LCAiY29uZmlnIjogeyJkZXN0aW5hdGlvbl9kaXN0cmli
+        aXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVjZjZlMzIxYjAyZTUz
+        NGJiNTUwNGM1OCJ9LCAiY29uZmlnIjogeyJkZXN0aW5hdGlvbl9kaXN0cmli
         dXRvcl9pZCI6ICJzY2VuYXJpb190ZXN0In0sICJpZCI6ICJzY2VuYXJpb190
         ZXN0X2Nsb25lIn0sIHsicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgImxh
-        c3RfdXBkYXRlZCI6ICIyMDE5LTA1LTMwVDE1OjMyOjM0WiIsICJfaHJlZiI6
+        c3RfdXBkYXRlZCI6ICIyMDE5LTA2LTA0VDIxOjMxOjEzWiIsICJfaHJlZiI6
         ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL3NjZW5hcmlvX3Rlc3QvZGlz
         dHJpYnV0b3JzL3NjZW5hcmlvX3Rlc3QvIiwgImxhc3Rfb3ZlcnJpZGVfY29u
         ZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3Jf
         dHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjog
         dHJ1ZSwgInNjcmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1
-        dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmY3OTIwNWY1ZWUyOTY1OWUw
-        ZmFmIn0sICJjb25maWciOiB7InByb3RlY3RlZCI6IHRydWUsICJodHRwIjog
+        dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAiNWNmNmUzMjFiMDJlNTM0YmI1NTA0
+        YzU3In0sICJjb25maWciOiB7InByb3RlY3RlZCI6IHRydWUsICJodHRwIjog
         ZmFsc2UsICJodHRwcyI6IHRydWUsICJyZWxhdGl2ZV91cmwiOiAic2NlbmFy
         aW9fdGVzdCJ9LCAiaWQiOiAic2NlbmFyaW9fdGVzdCJ9LCB7InJlcG9faWQi
-        OiAic2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNS0z
-        MFQxNTozMjozNFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRv
+        OiAic2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNi0w
+        NFQyMTozMToxM1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRv
         cmllcy9zY2VuYXJpb190ZXN0L2Rpc3RyaWJ1dG9ycy9leHBvcnRfZGlzdHJp
         YnV0b3IvIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1
         Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJleHBvcnRf
         ZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNo
         cGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjog
-        eyIkb2lkIjogIjVjZWZmNzkyMDVmNWVlMjk2NTllMGZiMSJ9LCAiY29uZmln
+        eyIkb2lkIjogIjVjZjZlMzIxYjAyZTUzNGJiNTUwNGM1OSJ9LCAiY29uZmln
         IjogeyJodHRwIjogZmFsc2UsICJyZWxhdGl2ZV91cmwiOiAic2NlbmFyaW9f
         dGVzdCIsICJodHRwcyI6IGZhbHNlfSwgImlkIjogImV4cG9ydF9kaXN0cmli
         dXRvciJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3RlcyI6IHsi
         X3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3JlbW92ZWQi
         OiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25zIjogInJl
         cG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAic2NlbmFyaW9fdGVz
-        dCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNS0zMFQxNTozMjozNFoiLCAi
+        dCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNi0wNFQyMTozMToxM1oiLCAi
         X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJpb190
         ZXN0L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2lt
         cG9ydGVycyIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIs
         ICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjogbnVs
-        bCwgInNjcmF0Y2hwYWQiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjZWZm
-        NzkyMDVmNWVlMjk2NTllMGZhZSJ9LCAiY29uZmlnIjogeyJmZWVkIjogImZp
+        bCwgInNjcmF0Y2hwYWQiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjZjZl
+        MzIxYjAyZTUzNGJiNTUwNGM1NiJ9LCAiY29uZmlnIjogeyJmZWVkIjogImZp
         bGU6Ly8vdmFyL3d3dy90ZXN0X3JlcG9zL3pvbyIsICJzc2xfdmFsaWRhdGlv
         biI6IHRydWUsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9w
         b2xpY3kiOiAiaW1tZWRpYXRlIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0s
         ICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQiOiAi
-        NWNlZmY3OTIwNWY1ZWUyOTY1OWUwZmFkIn0sICJ0b3RhbF9yZXBvc2l0b3J5
+        NWNmNmUzMjFiMDJlNTM0YmI1NTA0YzU1In0sICJ0b3RhbF9yZXBvc2l0b3J5
         X3VuaXRzIjogMCwgImlkIjogInNjZW5hcmlvX3Rlc3QiLCAiX2hyZWYiOiAi
         L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJpb190ZXN0LyJ9
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:34 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:13 GMT
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/actions/publish/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/actions/publish/
     body:
       encoding: UTF-8
       base64_string: |
@@ -357,7 +357,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -368,9 +368,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:34 GMT
+      - Tue, 04 Jun 2019 21:31:13 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '172'
       Content-Type:
@@ -379,14 +379,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzQ4ZjM2NzRkLTUzZDAtNGVjYi04NDA5LTY5NjMwNmJiN2U0NC8iLCAi
-        dGFza19pZCI6ICI0OGYzNjc0ZC01M2QwLTRlY2ItODQwOS02OTYzMDZiYjdl
-        NDQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2MzOGRmN2I1LTk4MjQtNDFmYy05ZGY4LTM1YmIyZjEwNDRmOS8iLCAi
+        dGFza19pZCI6ICJjMzhkZjdiNS05ODI0LTQxZmMtOWRmOC0zNWJiMmYxMDQ0
+        ZjkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:34 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:13 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/48f3674d-53d0-4ecb-8409-696306bb7e44/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/c38df7b5-9824-41fc-9df8-35bb2f1044f9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -396,7 +396,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -405,15 +405,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:34 GMT
+      - Tue, 04 Jun 2019 21:31:13 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"82024cc84d06aeda27eefc66d5216cd4-gzip"'
+      - '"5a113359580cc53adc3c7ded2d7e37d0-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '673'
+      - '659'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -421,24 +421,24 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80OGYzNjc0ZC01M2QwLTRlY2ItODQwOS02OTYz
-        MDZiYjdlNDQvIiwgInRhc2tfaWQiOiAiNDhmMzY3NGQtNTNkMC00ZWNiLTg0
-        MDktNjk2MzA2YmI3ZTQ0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy9jMzhkZjdiNS05ODI0LTQxZmMtOWRmOC0zNWJi
+        MmYxMDQ0ZjkvIiwgInRhc2tfaWQiOiAiYzM4ZGY3YjUtOTgyNC00MWZjLTlk
+        ZjgtMzViYjJmMTA0NGY5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
         aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
         IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4
-        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9u
-        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2
-        ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJv
-        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmY3OTJkZjk2OTRiYjE1
-        YjlmNDFhIn0sICJpZCI6ICI1Y2VmZjc5MmRmOTY5NGJiMTViOWY0MWEifQ==
+        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25hbWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFt
+        cGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjVjZjZlMzIxOWZhOTM0ZjEwYTZkODBmNCJ9LCAiaWQi
+        OiAiNWNmNmUzMjE5ZmE5MzRmMTBhNmQ4MGY0In0=
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:34 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:13 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/48f3674d-53d0-4ecb-8409-696306bb7e44/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/c38df7b5-9824-41fc-9df8-35bb2f1044f9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -448,7 +448,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -457,15 +457,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:34 GMT
+      - Tue, 04 Jun 2019 21:31:13 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"e89e5013c677042d669b796815c19f49-gzip"'
+      - '"c423b095cbf44138f1274a700c3719e1-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '4301'
+      - '4300'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -473,105 +473,105 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80OGYzNjc0ZC01M2QwLTRlY2ItODQwOS02OTYz
-        MDZiYjdlNDQvIiwgInRhc2tfaWQiOiAiNDhmMzY3NGQtNTNkMC00ZWNiLTg0
-        MDktNjk2MzA2YmI3ZTQ0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy9jMzhkZjdiNS05ODI0LTQxZmMtOWRmOC0zNWJi
+        MmYxMDQ0ZjkvIiwgInRhc2tfaWQiOiAiYzM4ZGY3YjUtOTgyNC00MWZjLTlk
+        ZjgtMzViYjJmMTA0NGY5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDUtMzBUMTU6MzI6MzRaIiwgInRyYWNlYmFjayI6IG51
+        aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6MTNaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
         InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
         cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImVmNGI2YTBmLWEzNDAtNDExYy1hZWJhLTU4M2Y2YjkxMDMzMyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
-        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxMDFm
-        ZjVhMi1iOWVkLTQ4YzktYjI5MS05ZTczYTYwOTA0NDIiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
-        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJjN2Q3MzQzMi0yMTM0LTRiN2MtYTY3ZS1mMjA4MTQwMDUy
-        ODgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
-        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNzg0Yjg2MC0yMzIz
-        LTQ2MGItYjI4ZS05OGUzYjZmNjc3ZDIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
-        YWwiOiAwLCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
-        ZXBfaWQiOiAiNWI4NTEyNzQtZWFjOC00MjRmLWJkOTctMjA0ZDVjMWJkZThj
-        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
-        ZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBl
-        IjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
-        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODU3ODJjNDgtMTBk
-        My00YmI5LTlmMjYtYWIwNDhhZjkzOWYwIiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjY4YWQzNzgwLTg1NDMtNDRhZS1iNjA2LTgzMTA4OWFj
-        MDdhOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3Rl
-        cF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI2N2Zi
-        ZWYzLWJiNDgtNDNiNi05ZDNlLWI2MGQ3NTc5OTRkMyIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
-        Q2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9y
-        ZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
-        VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY3NjFjNDczLTk2
-        MzctNDNmMy04NzI2LWU3OWUzOTdhNzQ1YSIsICJudW1fcHJvY2Vzc2VkIjog
-        MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
-        dGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNx
-        bGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMWJjMGE4NS01MjlmLTQxOTEt
-        ODViYS02OGIwZjU5MzgwOWMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCBy
-        ZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIs
+        IjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjMzNmI4ODI4LTM3YWMtNGY5My04M2Y3LTdlNTZkOTEzNzVkNiIs
+        ICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
+        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAi
+        c3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICIxOGRiYjgyYi1iZWM4LTQzMGEtYmY5YS1iZDliYmU2Y2MwMTMiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIs
         ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI2NTNhNGU5Zi01NDkzLTQ0NDYtYTdiYy0x
-        OGM1ZjkwYTY0MWEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxl
-        cyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAx
-        LCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiODlmYjYwMDMtMjNmYy00ZWZiLTg0ZGMtZjRiMTkxZDc0ODhjIiwgIm51
-        bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUi
-        OiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTJi
-        NGUyZTktZTczOC00YTZmLWJlMmEtMGU4MzAzNGQ0N2EwIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
-        ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRp
-        YWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxMTVh
-        ODI5MC1hZDI1LTQ4NzktYjdiYi04NzU2NmI2Y2RkZGIiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIiLCAi
-        c3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjog
-        eyIkb2lkIjogIjVjZWZmNzkyZGY5Njk0YmIxNWI5ZjQxYSJ9LCAiaWQiOiAi
-        NWNlZmY3OTJkZjk2OTRiYjE1YjlmNDFhIn0=
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI0ZmJmYWNlNC0wODM1LTQ1ZGMtOGZmOS1m
+        NWRjZjVkYWJhYjMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBN
+        cyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        NTFhZDU2NzAtMTdmYS00MTc0LWJiYjctOGU4N2YyNzQ4YjYxIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjJmZGY2MmMxLWYxZjEtNGU2Ni1hMzI2
+        LTBhYWU4YTkwNmExZSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVz
+        IiwgInN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjA2NTBjZDdlLTExNmYtNDUzZi05ZDAzLWM2MTI0MzEwMmEwNCIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJj
+        b21wcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhOTY2YTkxZi1hYzU2LTQ4MTQt
+        YjI5YS01MzgyMzQxNDkzYTMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0
+        YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICIwYTY0NzU3ZS02NzIzLTQ3MGItYjliYy1iODVkMjk3YmVlZGQi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
+        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
+        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
+        ICIyNzg0ZmVjMy0yNGRiLTRmYzUtOWQzMy1jNzNhYTBiNDcxYmMiLCAibnVt
+        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
+        aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6
+        ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzNmMjlm
+        ODYtZmVjNy00Yzg5LWJhZjQtYTUwM2JiMWUwMjY0IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJS
+        ZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9v
+        bGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzAwYjY1NzgtN2Nl
+        ZS00ZmNiLTkyNWItOWRlZDVlYjc0MmRlIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
+        aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9y
+        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
+        IDAsICJzdGVwX2lkIjogIjdkNTJkMjhmLWE2YTctNGJiMS1iY2M3LTRkMWI2
+        ZTU5MGVlOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIi
+        LCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3Rv
+        dGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjRhZDU2Mzc1LWNhNzktNGY4My04NGZjLWVhZjJkZTFlYmZj
+        OSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
+        ZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBf
+        dHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiMDU1M2RlMGMtMzJmNi00N2Q2LTkwMDItMjFhMzU2ZjljZmNi
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNvbS5k
+        cTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNWNmNmUzMjE5ZmE5MzRmMTBhNmQ4MGY0In0sICJpZCI6ICI1
+        Y2Y2ZTMyMTlmYTkzNGYxMGE2ZDgwZjQifQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:34 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:13 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/48f3674d-53d0-4ecb-8409-696306bb7e44/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/c38df7b5-9824-41fc-9df8-35bb2f1044f9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -581,7 +581,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -590,15 +590,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:34 GMT
+      - Tue, 04 Jun 2019 21:31:13 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"26041ae1c4a02fea825720ecb813b68e-gzip"'
+      - '"12db8fb9586e232440d1708b124c27d8-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '4281'
+      - '4284'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -606,105 +606,105 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80OGYzNjc0ZC01M2QwLTRlY2ItODQwOS02OTYz
-        MDZiYjdlNDQvIiwgInRhc2tfaWQiOiAiNDhmMzY3NGQtNTNkMC00ZWNiLTg0
-        MDktNjk2MzA2YmI3ZTQ0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy9jMzhkZjdiNS05ODI0LTQxZmMtOWRmOC0zNWJi
+        MmYxMDQ0ZjkvIiwgInRhc2tfaWQiOiAiYzM4ZGY3YjUtOTgyNC00MWZjLTlk
+        ZjgtMzViYjJmMTA0NGY5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDUtMzBUMTU6MzI6MzRaIiwgInRyYWNlYmFjayI6IG51
+        aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6MTNaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
         InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
         cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
         IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImVmNGI2YTBmLWEzNDAtNDExYy1hZWJhLTU4M2Y2YjkxMDMzMyIsICJu
+        IjogIjMzNmI4ODI4LTM3YWMtNGY5My04M2Y3LTdlNTZkOTEzNzVkNiIsICJu
         dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
         cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
         cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxMDFm
-        ZjVhMi1iOWVkLTQ4YzktYjI5MS05ZTczYTYwOTA0NDIiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxOGRi
+        YjgyYi1iZWM4LTQzMGEtYmY5YS1iZDliYmU2Y2MwMTMiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
         c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJjN2Q3MzQzMi0yMTM0LTRiN2MtYTY3ZS1mMjA4MTQwMDUy
-        ODgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICI0ZmJmYWNlNC0wODM1LTQ1ZGMtOGZmOS1mNWRjZjVkYWJh
+        YjMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
         X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
         U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNzg0Yjg2MC0yMzIz
-        LTQ2MGItYjI4ZS05OGUzYjZmNjc3ZDIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1MWFkNTY3MC0xN2Zh
+        LTQxNzQtYmJiNy04ZTg3ZjI3NDhiNjEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
         LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
         bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
         YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNWI4NTEyNzQtZWFjOC00MjRmLWJkOTctMjA0ZDVjMWJkZThjIiwg
+        aWQiOiAiMmZkZjYyYzEtZjFmMS00ZTY2LWEzMjYtMGFhZThhOTA2YTFlIiwg
         Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
-        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4NTc4MmM0OC0xMGQzLTRiYjkt
-        OWYyNi1hYjA0OGFmOTM5ZjAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29t
-        cHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwi
-        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiNjhhZDM3ODAtODU0My00NGFlLWI2MDYtODMxMDg5YWMwN2E5IiwgIm51
-        bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAi
-        bWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjY3ZmJlZjMtYmI0OC00M2I2
-        LTlkM2UtYjYwZDc1Nzk5NGQzIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
-        dW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8g
-        bWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiZjc2MWM0NzMtOTYzNy00M2YzLTg3MjYtZTc5
-        ZTM5N2E3NDVhIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2Vz
-        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxl
-        cyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3Rv
-        dGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYjFiYzBhODUtNTI5Zi00MTkxLTg1YmEtNjhiMGY1OTM4MDljIiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBl
-        IjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiSU5fUFJP
+        R1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDY1MGNkN2UtMTE2Zi00
+        NTNmLTlkMDMtYzYxMjQzMTAyYTA0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
+        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
+        IENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3Rv
+        dGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImE5NjZhOTFmLWFjNTYtNDgxNC1iMjlhLTUzODIzNDE0OTNh
+        MyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90
+        eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBhNjQ3NTdl
+        LTY3MjMtNDcwYi1iOWJjLWI4NWQyOTdiZWVkZCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xv
+        c2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI3ODRmZWMzLTI0ZGIt
+        NGZjNS05ZDMzLWM3M2FhMGI0NzFiYyIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
+        ZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0
+        ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzM2YyOWY4Ni1mZWM3LTRjODktYmFm
+        NC1hNTAzYmIxZTAyNjQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBv
+        ZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICIzMDBiNjU3OC03Y2VlLTRmY2ItOTI1Yi05ZGVk
+        NWViNzQyZGUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIs
+        ICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        NjUzYTRlOWYtNTQ5My00NDQ2LWE3YmMtMThjNWY5MGE2NDFhIiwgIm51bV9w
+        N2Q1MmQyOGYtYTZhNy00YmIxLWJjYzctNGQxYjZlNTkwZWU5IiwgIm51bV9w
         cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
-        biI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJl
-        cG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFS
-        VEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjg5ZmI2MDAzLTIzZmMtNGVm
-        Yi04NGRjLWY0YjE5MWQ3NDg4YyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBm
-        aWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5
-        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImUyYjRlMmU5LWU3MzgtNGE2Zi1iZTJh
-        LTBlODMwMzRkNDdhMCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
-        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBG
-        aWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMTE1YTgyOTAtYWQyNS00ODc5LWI3YmIt
-        ODc1NjZiNmNkZGRiIiwgIm51bV9wcm9jZXNzZWQiOiAwfV19LCAicXVldWUi
-        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIu
-        c2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAi
-        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
-        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVs
-        bCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmZjc5MmRm
-        OTY5NGJiMTViOWY0MWEifSwgImlkIjogIjVjZWZmNzkyZGY5Njk0YmIxNWI5
-        ZjQxYSJ9
+        biI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAi
+        cHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGFkNTYz
+        NzUtY2E3OS00ZjgzLTg0ZmMtZWFmMmRlMWViZmM5IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJX
+        cml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxp
+        emVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNTUzZGUw
+        Yy0zMmY2LTQ3ZDYtOTAwMi0yMWEzNTZmOWNmY2IiLCAibnVtX3Byb2Nlc3Nl
+        ZCI6IDB9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJy
+        dW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dv
+        cmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
+        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2Y2ZTMy
+        MTlmYTkzNGYxMGE2ZDgwZjQifSwgImlkIjogIjVjZjZlMzIxOWZhOTM0ZjEw
+        YTZkODBmNCJ9
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:34 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:13 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/48f3674d-53d0-4ecb-8409-696306bb7e44/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/c38df7b5-9824-41fc-9df8-35bb2f1044f9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -714,7 +714,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -723,11 +723,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:34 GMT
+      - Tue, 04 Jun 2019 21:31:13 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"4e7b75e704d49cbd8c22f66f5ed05779-gzip"'
+      - '"57c2816b62f79510ac20308a434caab5-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -739,104 +739,104 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80OGYzNjc0ZC01M2QwLTRlY2ItODQwOS02OTYz
-        MDZiYjdlNDQvIiwgInRhc2tfaWQiOiAiNDhmMzY3NGQtNTNkMC00ZWNiLTg0
-        MDktNjk2MzA2YmI3ZTQ0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy9jMzhkZjdiNS05ODI0LTQxZmMtOWRmOC0zNWJi
+        MmYxMDQ0ZjkvIiwgInRhc2tfaWQiOiAiYzM4ZGY3YjUtOTgyNC00MWZjLTlk
+        ZjgtMzViYjJmMTA0NGY5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDUtMzBUMTU6MzI6MzRaIiwgInRyYWNlYmFjayI6IG51
+        aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6MTNaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
         InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
         cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
         IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImVmNGI2YTBmLWEzNDAtNDExYy1hZWJhLTU4M2Y2YjkxMDMzMyIsICJu
+        IjogIjMzNmI4ODI4LTM3YWMtNGY5My04M2Y3LTdlNTZkOTEzNzVkNiIsICJu
         dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
         cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
         cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxMDFm
-        ZjVhMi1iOWVkLTQ4YzktYjI5MS05ZTczYTYwOTA0NDIiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxOGRi
+        YjgyYi1iZWM4LTQzMGEtYmY5YS1iZDliYmU2Y2MwMTMiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
         c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJjN2Q3MzQzMi0yMTM0LTRiN2MtYTY3ZS1mMjA4MTQwMDUy
-        ODgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICI0ZmJmYWNlNC0wODM1LTQ1ZGMtOGZmOS1mNWRjZjVkYWJh
+        YjMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
         X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
         U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNzg0Yjg2MC0yMzIz
-        LTQ2MGItYjI4ZS05OGUzYjZmNjc3ZDIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1MWFkNTY3MC0xN2Zh
+        LTQxNzQtYmJiNy04ZTg3ZjI3NDhiNjEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
         LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
         bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
         YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNWI4NTEyNzQtZWFjOC00MjRmLWJkOTctMjA0ZDVjMWJkZThjIiwg
+        aWQiOiAiMmZkZjYyYzEtZjFmMS00ZTY2LWEzMjYtMGFhZThhOTA2YTFlIiwg
         Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
-        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4NTc4MmM0OC0xMGQzLTRiYjkt
-        OWYyNi1hYjA0OGFmOTM5ZjAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29t
-        cHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwi
-        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiNjhhZDM3ODAtODU0My00NGFlLWI2MDYtODMxMDg5YWMwN2E5IiwgIm51
-        bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAi
-        bWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
         RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjY3ZmJlZjMtYmI0OC00M2I2
-        LTlkM2UtYjYwZDc1Nzk5NGQzIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
-        dW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8g
-        bWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiZjc2MWM0NzMtOTYzNy00M2YzLTg3MjYtZTc5
-        ZTM5N2E3NDVhIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2Vz
-        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxl
-        cyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3Rv
-        dGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYjFiYzBhODUtNTI5Zi00MTkxLTg1YmEtNjhiMGY1OTM4MDljIiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNj
-        cmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBl
-        IjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAi
-        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjUz
-        YTRlOWYtNTQ5My00NDQ2LWE3YmMtMThjNWY5MGE2NDFhIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
-        ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92
-        aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiODlmYjYwMDMtMjNmYy00ZWZiLTg0ZGMt
-        ZjRiMTkxZDc0ODhjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRv
-        IHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiZTJiNGUyZTktZTczOC00YTZmLWJlMmEtMGU4MzAzNGQ0
-        N2EwIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEs
-        ICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3Rl
-        cF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIxMTVhODI5MC1hZDI1LTQ4NzktYjdiYi04NzU2NmI2Y2RkZGIi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9y
-        ZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxl
-        LmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRldmVsMi5z
-        YW1pci5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjZWZmNzkyZGY5Njk0YmIxNWI5ZjQx
-        YSJ9LCAiaWQiOiAiNWNlZmY3OTJkZjk2OTRiYjE1YjlmNDFhIn0=
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDY1MGNkN2UtMTE2Zi00NTNm
+        LTlkMDMtYzYxMjQzMTAyYTA0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
+        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImE5NjZhOTFmLWFjNTYtNDgxNC1iMjlhLTUzODIzNDE0OTNhMyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
+        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBhNjQ3NTdlLTY3MjMtNDcw
+        Yi1iOWJjLWI4NWQyOTdiZWVkZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
+        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjI3ODRmZWMzLTI0ZGItNGZjNS05ZDMzLWM3
+        M2FhMGI0NzFiYyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjMzZjI5Zjg2LWZlYzctNGM4OS1iYWY0LWE1MDNiYjFlMDI2NCIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
+        Y3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjMwMGI2NTc4LTdjZWUtNGZjYi05MjViLTlkZWQ1ZWI3NDJkZSIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJy
+        ZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RB
+        UlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3ZDUyZDI4Zi1hNmE3LTRi
+        YjEtYmNjNy00ZDFiNmU1OTBlZTkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
+        ZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9y
+        eSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0YWQ1NjM3NS1jYTc5LTRmODMtODRm
+        Yy1lYWYyZGUxZWJmYzkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3Mg
+        RmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjA1NTNkZTBjLTMyZjYtNDdkNi05MDAy
+        LTIxYTM1NmY5Y2ZjYiIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVl
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEu
+        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2Vy
+        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFs
+        bW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjZjZlMzIxOWZhOTM0ZjEwYTZkODBm
+        NCJ9LCAiaWQiOiAiNWNmNmUzMjE5ZmE5MzRmMTBhNmQ4MGY0In0=
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:34 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:13 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/48f3674d-53d0-4ecb-8409-696306bb7e44/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/c38df7b5-9824-41fc-9df8-35bb2f1044f9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -846,7 +846,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -855,15 +855,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:34 GMT
+      - Tue, 04 Jun 2019 21:31:13 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"ee4dd025024bc4f73ea08cdbc1e8a32a-gzip"'
+      - '"f8e73cc7e4077fa019504c976145754d-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '8546'
+      - '4255'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -871,194 +871,326 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy80OGYzNjc0ZC01M2QwLTRlY2ItODQwOS02OTYz
-        MDZiYjdlNDQvIiwgInRhc2tfaWQiOiAiNDhmMzY3NGQtNTNkMC00ZWNiLTg0
-        MDktNjk2MzA2YmI3ZTQ0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy9jMzhkZjdiNS05ODI0LTQxZmMtOWRmOC0zNWJi
+        MmYxMDQ0ZjkvIiwgInRhc2tfaWQiOiAiYzM4ZGY3YjUtOTgyNC00MWZjLTlk
+        ZjgtMzViYjJmMTA0NGY5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogIjIwMTktMDUtMzBUMTU6MzI6MzRaIiwgIl9ucyI6ICJ0YXNr
-        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTktMDUtMzBUMTU6MzI6MzRa
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6MTNaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjMzNmI4ODI4LTM3YWMtNGY5My04M2Y3LTdlNTZkOTEzNzVkNiIsICJu
+        dW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmlidXRpb24gZmlsZXMiLCAic3Rl
+        cF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxOGRi
+        YjgyYi1iZWM4LTQzMGEtYmY5YS1iZDliYmU2Y2MwMTMiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5cGUiOiAicnBtcyIsICJpdGVt
+        c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICI0ZmJmYWNlNC0wODM1LTQ1ZGMtOGZmOS1mNWRjZjVkYWJh
+        YjMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVw
+        X3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1MWFkNTY3MC0xN2Zh
+        LTQxNzQtYmJiNy04ZTg3ZjI3NDhiNjEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
+        bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
+        YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiMmZkZjYyYzEtZjFmMS00ZTY2LWEzMjYtMGFhZThhOTA2YTFlIiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjog
+        Im1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDY1MGNkN2UtMTE2Zi00NTNm
+        LTlkMDMtYzYxMjQzMTAyYTA0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENv
+        bXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFs
+        IjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogImE5NjZhOTFmLWFjNTYtNDgxNC1iMjlhLTUzODIzNDE0OTNhMyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjog
+        Im1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBhNjQ3NTdlLTY3MjMtNDcw
+        Yi1iOWJjLWI4NWQyOTdiZWVkZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
+        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
+        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjI3ODRmZWMzLTI0ZGItNGZjNS05ZDMzLWM3
+        M2FhMGI0NzFiYyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmls
+        ZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjMzZjI5Zjg2LWZlYzctNGM4OS1iYWY0LWE1MDNiYjFlMDI2NCIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVz
+        Y3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjMw
+        MGI2NTc4LTdjZWUtNGZjYi05MjViLTlkZWQ1ZWI3NDJkZSIsICJudW1fcHJv
+        Y2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBv
+        dmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjdkNTJkMjhmLWE2YTctNGJiMS1iY2M3
+        LTRkMWI2ZTU5MGVlOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0
+        byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjRhZDU2Mzc1LWNhNzktNGY4My04NGZjLWVhZjJkZTFl
+        YmZjOSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAx
+        LCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0
+        ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiMDU1M2RlMGMtMzJmNi00N2Q2LTkwMDItMjFhMzU2ZjljZmNi
+        IiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAicXVldWUiOiAicmVzZXJ2ZWRf
+        cmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNvbS5k
+        cTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNl
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUu
+        Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNWNmNmUzMjE5ZmE5MzRmMTBhNmQ4MGY0In0sICJpZCI6ICI1
+        Y2Y2ZTMyMTlmYTkzNGYxMGE2ZDgwZjQifQ==
+    http_version: 
+  recorded_at: Tue, 04 Jun 2019 21:31:13 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/c38df7b5-9824-41fc-9df8-35bb2f1044f9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 04 Jun 2019 21:31:13 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"6ed7c4d1fc8b47649905b2c72d85f11c-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '8535'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy9jMzhkZjdiNS05ODI0LTQxZmMtOWRmOC0zNWJi
+        MmYxMDQ0ZjkvIiwgInRhc2tfaWQiOiAiYzM4ZGY3YjUtOTgyNC00MWZjLTlk
+        ZjgtMzViYjJmMTA0NGY5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6MTNaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6MTNa
         IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
         cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
         Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcgcmVwbyBt
         ZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
         YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImVmNGI2YTBmLWEzNDAtNDExYy1hZWJh
-        LTU4M2Y2YjkxMDMzMyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjMzNmI4ODI4LTM3YWMtNGY5My04M2Y3
+        LTdlNTZkOTEzNzVkNiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
         Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEaXN0cmli
         dXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlvbiIsICJp
         dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIxMDFmZjVhMi1iOWVkLTQ4YzktYjI5MS05ZTczYTYw
-        OTA0NDIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICIxOGRiYjgyYi1iZWM4LTQzMGEtYmY5YS1iZDliYmU2
+        Y2MwMTMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
         MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgUlBNcyIsICJzdGVwX3R5
         cGUiOiAicnBtcyIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
         U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjN2Q3MzQzMi0yMTM0LTRi
-        N2MtYTY3ZS1mMjA4MTQwMDUyODgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0ZmJmYWNlNC0wODM1LTQ1
+        ZGMtOGZmOS1mNWRjZjVkYWJhYjMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
         Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
         RGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICJkNzg0Yjg2MC0yMzIzLTQ2MGItYjI4ZS05OGUzYjZmNjc3ZDIiLCAi
+        ZCI6ICI1MWFkNTY3MC0xN2ZhLTQxNzQtYmJiNy04ZTg3ZjI3NDhiNjEiLCAi
         bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
         aXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJl
         cnJhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
         LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNWI4NTEyNzQtZWFjOC00MjRmLWJk
-        OTctMjA0ZDVjMWJkZThjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmZkZjYyYzEtZjFmMS00ZTY2LWEz
+        MjYtMGFhZThhOTA2YTFlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
         c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVs
-        ZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAx
-        LCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4
-        NTc4MmM0OC0xMGQzLTRiYjktOWYyNi1hYjA0OGFmOTM5ZjAiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
-        cHMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNjhhZDM3ODAtODU0My00NGFlLWI2MDYt
-        ODMxMDg5YWMwN2E5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRh
-        LiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAw
+        ZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAw
         LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        MjY3ZmJlZjMtYmI0OC00M2I2LTlkM2UtYjYwZDc1Nzk5NGQzIiwgIm51bV9w
-        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
-        biI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNs
-        b3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjc2MWM0NzMt
-        OTYzNy00M2YzLTg3MjYtZTc5ZTM5N2E3NDVhIiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5l
-        cmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUg
-        c3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjFiYzBhODUtNTI5Zi00MTkxLTg1
-        YmEtNjhiMGY1OTM4MDljIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVw
-        b2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAi
-        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiNjUzYTRlOWYtNTQ5My00NDQ2LWE3YmMtMThjNWY5
-        MGE2NDFhIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAi
-        c3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODlmYjYw
-        MDMtMjNmYy00ZWZiLTg0ZGMtZjRiMTkxZDc0ODhjIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
-        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklO
-        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTJiNGUyZTktZTczOC00
-        YTZmLWJlMmEtMGU4MzAzNGQ0N2EwIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwg
-        eyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
-        c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxMTVhODI5MC1hZDI1LTQ4Nzkt
-        YjdiYi04NzU2NmI2Y2RkZGIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9XX0sICJx
-        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRl
-        dmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNo
-        ZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0
-        IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJleGNlcHRpb24iOiBudWxsLCAi
-        cmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgInN0YXJ0ZWQiOiAiMjAxOS0w
-        NS0zMFQxNTozMjozNFoiLCAiX25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRz
-        IiwgImNvbXBsZXRlZCI6ICIyMDE5LTA1LTMwVDE1OjMyOjM0WiIsICJ0cmFj
-        ZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fZGlz
-        dHJpYnV0b3IiLCAic3VtbWFyeSI6IHsiZ2VuZXJhdGUgc3FsaXRlIjogIlNL
-        SVBQRUQiLCAicnBtcyI6ICJGSU5JU0hFRCIsICJpbml0aWFsaXplX3JlcG9f
-        bWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicmVtb3ZlX29sZF9yZXBvZGF0YSI6
-        ICJGSU5JU0hFRCIsICJtb2R1bGVzIjogIlNLSVBQRUQiLCAiY2xvc2VfcmVw
-        b19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJkcnBtcyI6ICJTS0lQUEVEIiwg
-        ImNvbXBzIjogIkZJTklTSEVEIiwgImRpc3RyaWJ1dGlvbiI6ICJGSU5JU0hF
-        RCIsICJyZXBvdmlldyI6ICJTS0lQUEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5
-        IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0
-        YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0
-        cmlidXRvcl9pZCI6ICJzY2VuYXJpb190ZXN0IiwgImlkIjogIjVjZWZmNzky
-        MDVmNWVlMmFlMDk3MDRjMiIsICJkZXRhaWxzIjogW3sibnVtX3N1Y2Nlc3Mi
-        OiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRh
-        dGEiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJlZjRiNmEwZi1hMzQwLTQxMWMtYWViYS01ODNm
-        NmI5MTAzMzMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
-        IjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9u
-        IGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNf
-        dG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
-        ZXBfaWQiOiAiMTAxZmY1YTItYjllZC00OGM5LWIyOTEtOWU3M2E2MDkwNDQy
-        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
-        ZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjog
-        InJwbXMiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzdkNzM0MzItMjEzNC00YjdjLWE2
-        N2UtZjIwODE0MDA1Mjg4IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRh
-        IFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjog
-        MSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        ZDc4NGI4NjAtMjMyMy00NjBiLWIyOGUtOThlM2I2ZjY3N2QyIiwgIm51bV9w
+        MDY1MGNkN2UtMTE2Zi00NTNmLTlkMDMtYzYxMjQzMTAyYTA0IiwgIm51bV9w
         cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
-        biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
-        IiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjViODUxMjc0LWVhYzgtNDI0Zi1iZDk3LTIw
-        NGQ1YzFiZGU4YyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
-        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwg
-        InN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODU3ODJj
-        NDgtMTBkMy00YmI5LTlmMjYtYWIwNDhhZjkzOWYwIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwg
+        biI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNv
+        bXBzIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwg
+        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImE5NjZhOTFmLWFjNTYtNDgxNC1iMjlh
+        LTUzODIzNDE0OTNhMyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0
+        YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjog
+        MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjBhNjQ3NTdlLTY3MjMtNDcwYi1iOWJjLWI4NWQyOTdiZWVkZCIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRp
+        b24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJj
+        bG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI3ODRmZWMz
+        LTI0ZGItNGZjNS05ZDMzLWM3M2FhMGI0NzFiYyIsICJudW1fcHJvY2Vzc2Vk
+        IjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
+        ZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRl
+        IHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjMzZjI5Zjg2LWZlYzctNGM4OS1i
+        YWY0LWE1MDNiYjFlMDI2NCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJl
+        cG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9y
         X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjY4YWQzNzgwLTg1NDMtNDRhZS1iNjA2LTgzMTA4
-        OWFjMDdhOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAi
-        c3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0
-        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI2N2Zi
-        ZWYzLWJiNDgtNDNiNi05ZDNlLWI2MGQ3NTc5OTRkMyIsICJudW1fcHJvY2Vz
+        IDAsICJzdGVwX2lkIjogIjMwMGI2NTc4LTdjZWUtNGZjYi05MjViLTlkZWQ1
+        ZWI3NDJkZSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
+        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwg
+        InN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdkNTJk
+        MjhmLWE2YTctNGJiMS1iY2M3LTRkMWI2ZTU5MGVlOSIsICJudW1fcHJvY2Vz
         c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        Q2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9y
-        ZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
+        UHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxp
+        c2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
         TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY3NjFjNDczLTk2Mzct
-        NDNmMy04NzI2LWU3OWUzOTdhNzQ1YSIsICJudW1fcHJvY2Vzc2VkIjogMX0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
-        ZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0
-        ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogImIxYmMwYTg1LTUyOWYtNDE5MS04NWJhLTY4
-        YjBmNTkzODA5YyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
-        c3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRh
-        IiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRhZDU2Mzc1LWNhNzkt
+        NGY4My04NGZjLWVhZjJkZTFlYmZjOSIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        IHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBM
+        aXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9f
+        bWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDU1M2RlMGMtMzJmNi00N2Q2
+        LTkwMDItMjFhMzU2ZjljZmNiIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAi
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFs
+        bW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAi
+        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2
+        ZWwuYmFsbW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6
+        ICJzdWNjZXNzIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNj
+        ZW5hcmlvX3Rlc3QiLCAic3RhcnRlZCI6ICIyMDE5LTA2LTA0VDIxOjMxOjEz
+        WiIsICJfbnMiOiAicmVwb19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVk
+        IjogIjIwMTktMDYtMDRUMjE6MzE6MTNaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJz
+        dW1tYXJ5IjogeyJnZW5lcmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJycG1z
+        IjogIkZJTklTSEVEIiwgImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSI6ICJG
+        SU5JU0hFRCIsICJyZW1vdmVfb2xkX3JlcG9kYXRhIjogIkZJTklTSEVEIiwg
+        Im1vZHVsZXMiOiAiRklOSVNIRUQiLCAiY2xvc2VfcmVwb19tZXRhZGF0YSI6
+        ICJGSU5JU0hFRCIsICJkcnBtcyI6ICJTS0lQUEVEIiwgImNvbXBzIjogIkZJ
+        TklTSEVEIiwgImRpc3RyaWJ1dGlvbiI6ICJGSU5JU0hFRCIsICJyZXBvdmll
+        dyI6ICJTS0lQUEVEIiwgInB1Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVE
+        IiwgImVycmF0YSI6ICJGSU5JU0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hF
+        RCJ9LCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6
+        ICJzY2VuYXJpb190ZXN0IiwgImlkIjogIjVjZjZlMzIxYjAyZTUzMGFhYWE0
+        ZjQ0ZSIsICJkZXRhaWxzIjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90
+        eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICIzMzZiODgyOC0zN2FjLTRmOTMtODNmNy03ZTU2ZDkxMzc1ZDYiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0
+        ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMThk
+        YmI4MmItYmVjOC00MzBhLWJmOWEtYmQ5YmJlNmNjMDEzIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
+        ICJQdWJsaXNoaW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRl
+        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiNGZiZmFjZTQtMDgzNS00NWRjLThmZjktZjVkY2Y1ZGFi
+        YWIzIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3Rl
+        cF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        IlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTFhZDU2NzAtMTdm
+        YS00MTc0LWJiYjctOGU4N2YyNzQ4YjYxIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjJmZGY2MmMxLWYxZjEtNGU2Ni1hMzI2LTBhYWU4YTkwNmExZSIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
+        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6
+        ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA2NTBjZDdlLTExNmYtNDUz
+        Zi05ZDAzLWM2MTI0MzEwMmEwNCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBD
+        b21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3Rh
+        bCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICJhOTY2YTkxZi1hYzU2LTQ4MTQtYjI5YS01MzgyMzQxNDkzYTMiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6
+        ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
+        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYTY0NzU3ZS02NzIzLTQ3
+        MGItYjliYy1iODVkMjk3YmVlZGQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVw
+        byBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0
+        YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIyNzg0ZmVjMy0yNGRiLTRmYzUtOWQzMy1j
+        NzNhYTBiNDcxYmMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZp
+        bGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICIzM2YyOWY4Ni1mZWM3LTRjODktYmFmNC1hNTAzYmIxZTAyNjQi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
+        c2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5
+        cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIz
+        MDBiNjU3OC03Y2VlLTRmY2ItOTI1Yi05ZGVkNWViNzQyZGUiLCAibnVtX3By
+        b2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVw
+        b3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3ZDUyZDI4Zi1hNmE3LTRiYjEtYmNj
+        Ny00ZDFiNmU1OTBlZTkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
+        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMg
+        dG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJp
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICI0YWQ1NjM3NS1jYTc5LTRmODMtODRmYy1lYWYyZGUx
+        ZWJmYzkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        MSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJz
+        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
         bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogIjY1M2E0ZTlmLTU0OTMtNDQ0Ni1hN2JjLTE4YzVmOTBhNjQx
-        YSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
-        ZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjg5ZmI2MDAzLTIz
-        ZmMtNGVmYi04NGRjLWY0YjE5MWQ3NDg4YyIsICJudW1fcHJvY2Vzc2VkIjog
-        MH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGly
-        ZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUyYjRlMmU5LWU3MzgtNGE2Zi1i
-        ZTJhLTBlODMwMzRkNDdhMCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVt
-        X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5n
-        cyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMTE1YTgyOTAtYWQyNS00ODc5LWI3YmIt
-        ODc1NjZiNmNkZGRiIiwgIm51bV9wcm9jZXNzZWQiOiAxfV19LCAiZXJyb3Ii
-        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjZWZmNzkyZGY5Njk0YmIxNWI5
-        ZjQxYSJ9LCAiaWQiOiAiNWNlZmY3OTJkZjk2OTRiYjE1YjlmNDFhIn0=
+        dGVwX2lkIjogIjA1NTNkZTBjLTMyZjYtNDdkNi05MDAyLTIxYTM1NmY5Y2Zj
+        YiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1Y2Y2ZTMyMTlmYTkzNGYxMGE2ZDgwZjQifSwgImlk
+        IjogIjVjZjZlMzIxOWZhOTM0ZjEwYTZkODBmNCJ9
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:34 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:13 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/repo_sync.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/repo_sync.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/actions/sync/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -14,7 +14,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -25,9 +25,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:55 GMT
+      - Tue, 04 Jun 2019 21:31:34 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '172'
       Content-Type:
@@ -36,14 +36,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2Y3ODc3YTA5LWZkMTctNDU4Yi1hNTI5LTdlODE3NmVmYzdkNS8iLCAi
-        dGFza19pZCI6ICJmNzg3N2EwOS1mZDE3LTQ1OGItYTUyOS03ZTgxNzZlZmM3
-        ZDUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2IwY2RhMTA2LWI3MGMtNDk2Yi1hOGY5LTc0N2NiMzIyYjg1YS8iLCAi
+        dGFza19pZCI6ICJiMGNkYTEwNi1iNzBjLTQ5NmItYThmOS03NDdjYjMyMmI4
+        NWEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:55 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:34 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/f7877a09-fd17-458b-a529-7e8176efc7d5/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b0cda106-b70c-496b-a8f9-747cb322b85a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -53,7 +53,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -62,15 +62,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:55 GMT
+      - Tue, 04 Jun 2019 21:31:34 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"09cc8bcef32689a1b1b540aa277712d7-gzip"'
+      - '"a7dd7291d219e7e53b214e13459ff332-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '682'
+      - '544'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -78,25 +78,22 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNzg3N2EwOS1mZDE3LTQ1OGItYTUyOS03ZTgxNzZlZmM3
-        ZDUvIiwgInRhc2tfaWQiOiAiZjc4NzdhMDktZmQxNy00NThiLWE1MjktN2U4
-        MTc2ZWZjN2Q1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9iMGNkYTEwNi1iNzBjLTQ5NmItYThmOS03NDdjYjMyMmI4
+        NWEvIiwgInRhc2tfaWQiOiAiYjBjZGExMDYtYjcwYy00OTZiLWE4ZjktNzQ3
+        Y2IzMjJiODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDUtMzBUMTU6MzI6NTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
-        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVl
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwy
-        LnNhbWlyLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNl
-        bnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmY3YTdk
-        Zjk2OTRiYjE1YjlmNTBiIn0sICJpZCI6ICI1Y2VmZjdhN2RmOTY5NGJiMTVi
-        OWY1MGIifQ==
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogbnVs
+        bCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIiIsICJzdGF0ZSI6ICJ3
+        YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3VsdCI6IG51bGws
+        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNmNmUzMzY5ZmE5
+        MzRmMTBhNmQ4MWU5In0sICJpZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgx
+        ZTkifQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:55 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:34 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/f7877a09-fd17-458b-a529-7e8176efc7d5/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b0cda106-b70c-496b-a8f9-747cb322b85a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -106,7 +103,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -115,15 +112,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:55 GMT
+      - Tue, 04 Jun 2019 21:31:34 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"9d9cc43042a929616ffe266ec7db9ffb-gzip"'
+      - '"fe1f2346d9e21483e71f9828818c728d-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1191'
+      - '1177'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -131,12 +128,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNzg3N2EwOS1mZDE3LTQ1OGItYTUyOS03ZTgxNzZlZmM3
-        ZDUvIiwgInRhc2tfaWQiOiAiZjc4NzdhMDktZmQxNy00NThiLWE1MjktN2U4
-        MTc2ZWZjN2Q1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9iMGNkYTEwNi1iNzBjLTQ5NmItYThmOS03NDdjYjMyMmI4
+        NWEvIiwgInRhc2tfaWQiOiAiYjBjZGExMDYtYjcwYy00OTZiLWE4ZjktNzQ3
+        Y2IzMjJiODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDUtMzBUMTU6MzI6NTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
@@ -150,17 +147,17 @@ http_interactions:
         YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
         VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiSU5fUFJPR1JF
         U1MifX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
-        Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRl
-        IjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
-        Y2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20i
-        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1Y2VmZjdhN2RmOTY5NGJiMTViOWY1MGIifSwgImlkIjogIjVjZWZm
-        N2E3ZGY5Njk0YmIxNWI5ZjUwYiJ9
+        ZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVu
+        bmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNmNmUzMzY5
+        ZmE5MzRmMTBhNmQ4MWU5In0sICJpZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2
+        ZDgxZTkifQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:55 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:34 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/f7877a09-fd17-458b-a529-7e8176efc7d5/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b0cda106-b70c-496b-a8f9-747cb322b85a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -170,7 +167,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -179,15 +176,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:55 GMT
+      - Tue, 04 Jun 2019 21:31:34 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"fe1b81e5a60df4b96b9b9da757077ef1-gzip"'
+      - '"2b5804643cfc7cc5425e3d3181fab196-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1188'
+      - '1174'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -195,12 +192,76 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNzg3N2EwOS1mZDE3LTQ1OGItYTUyOS03ZTgxNzZlZmM3
-        ZDUvIiwgInRhc2tfaWQiOiAiZjc4NzdhMDktZmQxNy00NThiLWE1MjktN2U4
-        MTc2ZWZjN2Q1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9iMGNkYTEwNi1iNzBjLTQ5NmItYThmOS03NDdjYjMyMmI4
+        NWEvIiwgInRhc2tfaWQiOiAiYjBjZGExMDYtYjcwYy00OTZiLWE4ZjktNzQ3
+        Y2IzMjJiODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDUtMzBUMTU6MzI6NTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
+        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2
+        ZWwuYmFsbW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGws
+        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNmNmUzMzY5ZmE5
+        MzRmMTBhNmQ4MWU5In0sICJpZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgx
+        ZTkifQ==
+    http_version: 
+  recorded_at: Tue, 04 Jun 2019 21:31:34 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b0cda106-b70c-496b-a8f9-747cb322b85a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 04 Jun 2019 21:31:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"5145916a90ed43863cae786e5256c9ba-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1174'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iMGNkYTEwNi1iNzBjLTQ5NmItYThmOS03NDdjYjMyMmI4
+        NWEvIiwgInRhc2tfaWQiOiAiYjBjZGExMDYtYjcwYy00OTZiLWE4ZjktNzQ3
+        Y2IzMjJiODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
@@ -213,18 +274,18 @@ http_interactions:
         dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
         YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
         VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
-        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
-        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAi
-        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
-        ICI1Y2VmZjdhN2RmOTY5NGJiMTViOWY1MGIifSwgImlkIjogIjVjZWZmN2E3
-        ZGY5Njk0YmIxNWI5ZjUwYiJ9
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2
+        ZWwuYmFsbW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGws
+        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNmNmUzMzY5ZmE5
+        MzRmMTBhNmQ4MWU5In0sICJpZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgx
+        ZTkifQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:55 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:34 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/f7877a09-fd17-458b-a529-7e8176efc7d5/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b0cda106-b70c-496b-a8f9-747cb322b85a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -234,7 +295,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -243,15 +304,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:55 GMT
+      - Tue, 04 Jun 2019 21:31:34 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"fe1b81e5a60df4b96b9b9da757077ef1-gzip"'
+      - '"5145916a90ed43863cae786e5256c9ba-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1188'
+      - '1174'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -259,12 +320,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNzg3N2EwOS1mZDE3LTQ1OGItYTUyOS03ZTgxNzZlZmM3
-        ZDUvIiwgInRhc2tfaWQiOiAiZjc4NzdhMDktZmQxNy00NThiLWE1MjktN2U4
-        MTc2ZWZjN2Q1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9iMGNkYTEwNi1iNzBjLTQ5NmItYThmOS03NDdjYjMyMmI4
+        NWEvIiwgInRhc2tfaWQiOiAiYjBjZGExMDYtYjcwYy00OTZiLWE4ZjktNzQ3
+        Y2IzMjJiODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDUtMzBUMTU6MzI6NTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
@@ -277,18 +338,18 @@ http_interactions:
         dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
         YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
         VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
-        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
-        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAi
-        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
-        ICI1Y2VmZjdhN2RmOTY5NGJiMTViOWY1MGIifSwgImlkIjogIjVjZWZmN2E3
-        ZGY5Njk0YmIxNWI5ZjUwYiJ9
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2
+        ZWwuYmFsbW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGws
+        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNmNmUzMzY5ZmE5
+        MzRmMTBhNmQ4MWU5In0sICJpZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgx
+        ZTkifQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:55 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:34 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/f7877a09-fd17-458b-a529-7e8176efc7d5/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b0cda106-b70c-496b-a8f9-747cb322b85a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -298,7 +359,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -307,15 +368,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:55 GMT
+      - Tue, 04 Jun 2019 21:31:34 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"fe1b81e5a60df4b96b9b9da757077ef1-gzip"'
+      - '"5145916a90ed43863cae786e5256c9ba-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1188'
+      - '1174'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -323,12 +384,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNzg3N2EwOS1mZDE3LTQ1OGItYTUyOS03ZTgxNzZlZmM3
-        ZDUvIiwgInRhc2tfaWQiOiAiZjc4NzdhMDktZmQxNy00NThiLWE1MjktN2U4
-        MTc2ZWZjN2Q1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9iMGNkYTEwNi1iNzBjLTQ5NmItYThmOS03NDdjYjMyMmI4
+        NWEvIiwgInRhc2tfaWQiOiAiYjBjZGExMDYtYjcwYy00OTZiLWE4ZjktNzQ3
+        Y2IzMjJiODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDUtMzBUMTU6MzI6NTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
@@ -341,18 +402,18 @@ http_interactions:
         dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
         YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
         VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
-        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
-        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
-        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAi
-        cmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
-        ICI1Y2VmZjdhN2RmOTY5NGJiMTViOWY1MGIifSwgImlkIjogIjVjZWZmN2E3
-        ZGY5Njk0YmIxNWI5ZjUwYiJ9
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2
+        ZWwuYmFsbW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGws
+        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNmNmUzMzY5ZmE5
+        MzRmMTBhNmQ4MWU5In0sICJpZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgx
+        ZTkifQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:55 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:34 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/f7877a09-fd17-458b-a529-7e8176efc7d5/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b0cda106-b70c-496b-a8f9-747cb322b85a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -362,7 +423,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -371,15 +432,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:55 GMT
+      - Tue, 04 Jun 2019 21:31:34 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"c6be695b0de844f285c7249222b49733-gzip"'
+      - '"5145916a90ed43863cae786e5256c9ba-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1185'
+      - '1174'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -387,12 +448,76 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNzg3N2EwOS1mZDE3LTQ1OGItYTUyOS03ZTgxNzZlZmM3
-        ZDUvIiwgInRhc2tfaWQiOiAiZjc4NzdhMDktZmQxNy00NThiLWE1MjktN2U4
-        MTc2ZWZjN2Q1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9iMGNkYTEwNi1iNzBjLTQ5NmItYThmOS03NDdjYjMyMmI4
+        NWEvIiwgInRhc2tfaWQiOiAiYjBjZGExMDYtYjcwYy00OTZiLWE4ZjktNzQ3
+        Y2IzMjJiODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDUtMzBUMTU6MzI6NTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiSU5fUFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1z
+        X3RvdGFsIjogMCwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0
+        YXRlIjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5P
+        VF9TVEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fX19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2
+        ZWwuYmFsbW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmlu
+        ZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGws
+        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNmNmUzMzY5ZmE5
+        MzRmMTBhNmQ4MWU5In0sICJpZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgx
+        ZTkifQ==
+    http_version: 
+  recorded_at: Tue, 04 Jun 2019 21:31:34 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b0cda106-b70c-496b-a8f9-747cb322b85a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 04 Jun 2019 21:31:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"b144343dea97860c506d18b9eeb14531-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1171'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iMGNkYTEwNi1iNzBjLTQ5NmItYThmOS03NDdjYjMyMmI4
+        NWEvIiwgInRhc2tfaWQiOiAiYjBjZGExMDYtYjcwYy00OTZiLWE4ZjktNzQ3
+        Y2IzMjJiODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
@@ -401,22 +526,22 @@ http_interactions:
         bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
         OiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
         IjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
-        dGFsIjogMywgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFp
+        dGFsIjogMCwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFp
         bHMiOiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRl
         IjogIk5PVF9TVEFSVEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5PVF9T
         VEFSVEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
-        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9z
-        Ny1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1
-        bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
-        a2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVz
-        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        Y2VmZjdhN2RmOTY5NGJiMTViOWY1MGIifSwgImlkIjogIjVjZWZmN2E3ZGY5
-        Njk0YmIxNWI5ZjUwYiJ9
+        LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwu
+        YmFsbW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIs
+        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBk
+        ZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNmNmUzMzY5ZmE5MzRm
+        MTBhNmQ4MWU5In0sICJpZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgxZTki
+        fQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:55 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:34 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/f7877a09-fd17-458b-a529-7e8176efc7d5/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b0cda106-b70c-496b-a8f9-747cb322b85a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -426,7 +551,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -435,15 +560,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:55 GMT
+      - Tue, 04 Jun 2019 21:31:34 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"e92e3b2252718e0ff536df7d3c792255-gzip"'
+      - '"54867f2a7c4833401252a06dad8d8772-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1179'
+      - '1165'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -451,12 +576,75 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNzg3N2EwOS1mZDE3LTQ1OGItYTUyOS03ZTgxNzZlZmM3
-        ZDUvIiwgInRhc2tfaWQiOiAiZjc4NzdhMDktZmQxNy00NThiLWE1MjktN2U4
-        MTc2ZWZjN2Q1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9iMGNkYTEwNi1iNzBjLTQ5NmItYThmOS03NDdjYjMyMmI4
+        NWEvIiwgInRhc2tfaWQiOiAiYjBjZGExMDYtYjcwYy00OTZiLWE4ZjktNzQ3
+        Y2IzMjJiODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDUtMzBUMTU6MzI6NTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIk5PVF9TVEFSVEVE
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVl
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5i
+        YWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNmNmUzMzY5ZmE5MzRmMTBhNmQ4
+        MWU5In0sICJpZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgxZTkifQ==
+    http_version: 
+  recorded_at: Tue, 04 Jun 2019 21:31:34 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b0cda106-b70c-496b-a8f9-747cb322b85a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 04 Jun 2019 21:31:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"a57bf8a0c345899a70536b118c006b71-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1165'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iMGNkYTEwNi1iNzBjLTQ5NmItYThmOS03NDdjYjMyMmI4
+        NWEvIiwgInRhc2tfaWQiOiAiYjBjZGExMDYtYjcwYy00OTZiLWE4ZjktNzQ3
+        Y2IzMjJiODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
@@ -469,18 +657,17 @@ http_interactions:
         OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
         IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIklOX1BST0dSRVNT
         In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVl
-        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZl
-        bDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmci
-        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
-        Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmZjdh
-        N2RmOTY5NGJiMTViOWY1MGIifSwgImlkIjogIjVjZWZmN2E3ZGY5Njk0YmIx
-        NWI5ZjUwYiJ9
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5i
+        YWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNmNmUzMzY5ZmE5MzRmMTBhNmQ4
+        MWU5In0sICJpZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgxZTkifQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:55 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:34 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/f7877a09-fd17-458b-a529-7e8176efc7d5/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b0cda106-b70c-496b-a8f9-747cb322b85a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -490,7 +677,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -499,15 +686,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:55 GMT
+      - Tue, 04 Jun 2019 21:31:34 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"70b6a04d2489a276e9df656c9dcd5050-gzip"'
+      - '"a57bf8a0c345899a70536b118c006b71-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1176'
+      - '1165'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -515,12 +702,75 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNzg3N2EwOS1mZDE3LTQ1OGItYTUyOS03ZTgxNzZlZmM3
-        ZDUvIiwgInRhc2tfaWQiOiAiZjc4NzdhMDktZmQxNy00NThiLWE1MjktN2U4
-        MTc2ZWZjN2Q1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9iMGNkYTEwNi1iNzBjLTQ5NmItYThmOS03NDdjYjMyMmI4
+        NWEvIiwgInRhc2tfaWQiOiAiYjBjZGExMDYtYjcwYy00OTZiLWE4ZjktNzQ3
+        Y2IzMjJiODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDUtMzBUMTU6MzI6NTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiTk9UX1NUQVJURUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIk5PVF9TVEFSVEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIklOX1BST0dSRVNT
+        In0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVl
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5i
+        YWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6
+        IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNmNmUzMzY5ZmE5MzRmMTBhNmQ4
+        MWU5In0sICJpZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgxZTkifQ==
+    http_version: 
+  recorded_at: Tue, 04 Jun 2019 21:31:34 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b0cda106-b70c-496b-a8f9-747cb322b85a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 04 Jun 2019 21:31:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"06a29b6cf3e4900c015f70de5e6a4566-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1162'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iMGNkYTEwNi1iNzBjLTQ5NmItYThmOS03NDdjYjMyMmI4
+        NWEvIiwgInRhc2tfaWQiOiAiYjBjZGExMDYtYjcwYy00OTZiLWE4ZjktNzQ3
+        Y2IzMjJiODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
@@ -533,18 +783,17 @@ http_interactions:
         OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
         IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
         ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUi
-        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIu
-        c2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAi
-        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2Vu
-        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVs
-        bCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmZjdhN2Rm
-        OTY5NGJiMTViOWY1MGIifSwgImlkIjogIjVjZWZmN2E3ZGY5Njk0YmIxNWI5
-        ZjUwYiJ9
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5l
+        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJf
+        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxt
+        b3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51
+        bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNmNmUzMzY5ZmE5MzRmMTBhNmQ4MWU5
+        In0sICJpZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgxZTkifQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:55 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:34 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/f7877a09-fd17-458b-a529-7e8176efc7d5/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b0cda106-b70c-496b-a8f9-747cb322b85a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -554,7 +803,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -563,15 +812,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:55 GMT
+      - Tue, 04 Jun 2019 21:31:34 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"8ba8bf09073a6a029fd2671eacadd734-gzip"'
+      - '"f58f7a9a891e362712a090f7a4747f65-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1170'
+      - '1159'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -579,12 +828,75 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNzg3N2EwOS1mZDE3LTQ1OGItYTUyOS03ZTgxNzZlZmM3
-        ZDUvIiwgInRhc2tfaWQiOiAiZjc4NzdhMDktZmQxNy00NThiLWE1MjktN2U4
-        MTc2ZWZjN2Q1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9iMGNkYTEwNi1iNzBjLTQ5NmItYThmOS03NDdjYjMyMmI4
+        NWEvIiwgInRhc2tfaWQiOiAiYjBjZGExMDYtYjcwYy00OTZiLWE4ZjktNzQ3
+        Y2IzMjJiODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
         bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
-        MTktMDUtMzBUMTU6MzI6NTVaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        MTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IklOX1BST0dSRVNTIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFt
+        cGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFt
+        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3Jh
+        LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNWNmNmUzMzY5ZmE5MzRmMTBhNmQ4MWU5In0s
+        ICJpZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgxZTkifQ==
+    http_version: 
+  recorded_at: Tue, 04 Jun 2019 21:31:34 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b0cda106-b70c-496b-a8f9-747cb322b85a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 04 Jun 2019 21:31:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"87f5ed069b0427af58e950ee75e4bddb-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1156'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iMGNkYTEwNi1iNzBjLTQ5NmItYThmOS03NDdjYjMyMmI4
+        NWEvIiwgInRhc2tfaWQiOiAiYjBjZGExMDYtYjcwYy00OTZiLWE4ZjktNzQ3
+        Y2IzMjJiODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
         bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
         cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
         OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
@@ -597,17 +909,17 @@ http_interactions:
         Iml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklT
         SEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
         ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAicmVz
-        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIu
-        ZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2Vy
-        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
-        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
-        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmZjdhN2RmOTY5NGJi
-        MTViOWY1MGIifSwgImlkIjogIjVjZWZmN2E3ZGY5Njk0YmIxNWI5ZjUwYiJ9
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNWNmNmUzMzY5ZmE5MzRmMTBhNmQ4MWU5In0sICJp
+        ZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgxZTkifQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:55 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:34 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/f7877a09-fd17-458b-a529-7e8176efc7d5/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b0cda106-b70c-496b-a8f9-747cb322b85a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -617,7 +929,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -626,15 +938,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:55 GMT
+      - Tue, 04 Jun 2019 21:31:34 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"7263ad6a3f686d7d32c8c6594c5f6d71-gzip"'
+      - '"87f5ed069b0427af58e950ee75e4bddb-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2423'
+      - '1156'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -642,16 +954,79 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNzg3N2EwOS1mZDE3LTQ1OGItYTUyOS03ZTgxNzZlZmM3
-        ZDUvIiwgInRhc2tfaWQiOiAiZjc4NzdhMDktZmQxNy00NThiLWE1MjktN2U4
-        MTc2ZWZjN2Q1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9iMGNkYTEwNi1iNzBjLTQ5NmItYThmOS03NDdjYjMyMmI4
+        NWEvIiwgInRhc2tfaWQiOiAiYjBjZGExMDYtYjcwYy00OTZiLWE4ZjktNzQ3
+        Y2IzMjJiODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTktMDUtMzBUMTU6MzI6NTVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTktMDUtMzBUMTU6MzI6NTVaIiwgInRyYWNl
+        bnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIw
+        MTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3
+        bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9pbXBv
+        cnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwi
+        OiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNpemVf
+        bGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3RhdGUi
+        OiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFsIjog
+        MywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        Iml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRh
+        ZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFtcGxl
+        LmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
+        YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
+        aWQiOiB7IiRvaWQiOiAiNWNmNmUzMzY5ZmE5MzRmMTBhNmQ4MWU5In0sICJp
+        ZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgxZTkifQ==
+    http_version: 
+  recorded_at: Tue, 04 Jun 2019 21:31:34 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b0cda106-b70c-496b-a8f9-747cb322b85a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 04 Jun 2019 21:31:34 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"38e5083e9c374005a65c90f13fffae87-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2409'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iMGNkYTEwNi1iNzBjLTQ5NmItYThmOS03NDdjYjMyMmI4
+        NWEvIiwgInRhc2tfaWQiOiAiYjBjZGExMDYtYjcwYy00OTZiLWE4ZjktNzQ3
+        Y2IzMjJiODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNl
         YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzL2E4YjhmMTdkLTk2MGUtNDNiMi1hZDAwLTdhN2Rl
-        MWE2MWQ2ZC8iLCAidGFza19pZCI6ICJhOGI4ZjE3ZC05NjBlLTQzYjItYWQw
-        MC03YTdkZTFhNjFkNmQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bHAvYXBpL3YyL3Rhc2tzLzcwMzY2ZWY5LTQ0NjUtNGE2MC1iZTQ1LWQ0NWIy
+        ZTk5Y2I1NC8iLCAidGFza19pZCI6ICI3MDM2NmVmOS00NDY1LTRhNjAtYmU0
+        NS1kNDViMmU5OWNiNTQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
         bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
         dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
         cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
@@ -663,42 +1038,42 @@ http_interactions:
         XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
         ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
-        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
-        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
-        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
-        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
-        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wNS0z
-        MFQxNTozMjo1NVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDE5LTA1LTMwVDE1OjMyOjU1WiIsICJpbXBvcnRlcl90
-        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
-        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
-        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
-        b3VudCI6IDAsICJpZCI6ICI1Y2VmZjdhNzA1ZjVlZTJhZTA5NzA0ZDciLCAi
-        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
-        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
-        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
-        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
-        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjZWZmN2E3ZGY5Njk0YmIxNWI5ZjUw
-        YiJ9LCAiaWQiOiAiNWNlZmY3YTdkZjk2OTRiYjE1YjlmNTBiIn0=
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFt
+        cGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
+        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
+        OiBudWxsLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzdGFydGVkIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwg
+        Il9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAx
+        OS0wNi0wNFQyMTozMTozNFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
+        aW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5Ijog
+        eyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUs
+        ICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQi
+        OiAiNWNmNmUzMzZiMDJlNTMwYWFhYTRmNDYzIiwgImRldGFpbHMiOiB7Im1v
+        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
+        aXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRl
+        dGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBt
+        X3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6
+        IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJy
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgxZTkifSwgImlkIjogIjVj
+        ZjZlMzM2OWZhOTM0ZjEwYTZkODFlOSJ9
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:55 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:34 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/a8b8f17d-960e-43b2-ad00-7a7de1a61d6d/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/70366ef9-4465-4a60-be45-d45b2e99cb54/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -708,7 +1083,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -717,15 +1092,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:55 GMT
+      - Tue, 04 Jun 2019 21:31:34 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"d0a09cc1ef9aeb2bcce67d94b2958804-gzip"'
+      - '"7fd0b6d145da3979b6beb8f70194dfde-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '4559'
+      - '4545'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -733,111 +1108,110 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9hOGI4ZjE3ZC05NjBlLTQzYjItYWQwMC03YTdk
-        ZTFhNjFkNmQvIiwgInRhc2tfaWQiOiAiYThiOGYxN2QtOTYwZS00M2IyLWFk
-        MDAtN2E3ZGUxYTYxZDZkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy83MDM2NmVmOS00NDY1LTRhNjAtYmU0NS1kNDVi
+        MmU5OWNiNTQvIiwgInRhc2tfaWQiOiAiNzAzNjZlZjktNDQ2NS00YTYwLWJl
+        NDUtZDQ1YjJlOTljYjU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDUtMzBUMTU6MzI6NTVaIiwgInRyYWNlYmFjayI6IG51
+        aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
         dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
         ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzODI0MzFhYi02YThmLTQwMTMtYjVm
-        Mi1jNTgyNzY4MmY0NTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9z
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5YWExN2E4MC0wYTk3LTRkZTEtYmQy
+        OS05NGYxYmJiMTY5MzYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
         dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBv
         IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
         YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
         RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjNiZGY2ODgtNDliNC00YWVh
-        LWE5NDUtYjgzZTI5MDBiMzg1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDI3ZTk3OWUtMTMzMC00YzIy
+        LWJkYjQtZWQzYjhmMDM4NjJhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
         dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERp
         c3RyaWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9u
         IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjgyMGY0ZjUxLTljYTEtNDgxMi1hNzU1
-        LTc5NDVkOTY1NjgzZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjY1YTliNmEzLWNjMzQtNGQxMi05MGFi
+        LWRjMjQ2ODkwNmE1ZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
         Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwg
         InN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
         IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBjYzRl
-        ZTQ5LTc5NGQtNGJkZC1hNjRlLWM2NjM1ZmRiOTJiYyIsICJudW1fcHJvY2Vz
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM3ZGE5
+        ZDQ5LTIyM2UtNDI3YS05NDRkLWFiZWIxOWY3NDVhOCIsICJudW1fcHJvY2Vz
         c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
         UHVibGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIs
         ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJiZjU5ZWMzOS1lYjhhLTRmMWEtYWFlZS00
-        Y2EyODM0MjE0NWYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIzNGE3MDI4Yy0yOTVlLTRjNGUtYmExYy1m
+        NzhmNmFiZTczYTkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
         ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwg
         InN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
         dGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzhl
-        NzA3OWItZmM4My00M2JhLWFhY2MtZGViMzJlNTMyM2YyIiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjVi
+        Y2FjYWQtYTRjNy00ZDQ2LTgzZWMtZmI4ZjUwMTIzZGViIiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMi
         LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiNjFlYWRmYmQtZTM0MS00MmYxLTlkYTYt
-        YTRmZTc0NmVhZDQxIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiOTg1MWExOTQtYWYzYi00ZDc2LWFiMzYt
+        YzBlMzg4ZDhhMjdiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZp
         bGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
         ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjQ0NTFmYmM5LTAxM2YtNGIwZS1iMDdlLTc2MzgyMzU1YjUxYSIsICJudW1f
+        ImUzZWFiMDUxLTQwZDQtNGY4Ny04MjNmLTI3ZTFhMzMwZDdjMCIsICJudW1f
         cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
         b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
         dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFS
         VEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjhjZDE2YTQyLTM2MGMtNDg2
-        NC04NGVkLTgxNzU2NTk0Y2Q3MyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjczYWNiNzIwLTBlM2ItNGIx
+        OC1iM2E2LTkwOTQzYTU5ZmZmYyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
         bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
         IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
         IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjBjMTBjMDI0LWFlNWItNDEwMS1hZjY1
-        LWFkOTI0YTVjYjczYyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjhmYTA3Yjg0LTQzZWMtNGUzMS1iODIy
+        LTJmYzk5MDdiYTNiYSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
         Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUg
         ZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVt
         c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJlYTFkMWJlNS0yYmZkLTQ0ZDItOTE3Mi0yNWU1MWIw
-        NWUzMWUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICJlMjg2ZDMyMC1hN2M5LTQwNWMtOGUxMi01ZjhhMDMy
+        OGVjNjUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
         MCwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJz
         dGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3Rh
         bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIyZGU4YjA2Yy0yYjAwLTQ2MTAtODRjNS0zYWM3NjM3NDljYjki
+        cF9pZCI6ICIyZmMyNmIyMS1mZGNlLTQyODEtYmNmMi00OGYxZTk4YTEyMDEi
         LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5
         cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
         Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTFlOGY2NzEt
-        NGVlYS00ZTdjLWI4NGItZWJhYzQ1MTkwZTcyIiwgIm51bV9wcm9jZXNzZWQi
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTU2OGQ3NzAt
+        OGZmMi00MWIyLTk1Y2QtOWRmYzU0M2FhNThjIiwgIm51bV9wcm9jZXNzZWQi
         OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
         aXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9k
         aXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
         QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDFjYjU3YzgtM2U0Ny00
-        ODAyLWJjMzYtMjQ1YTdjYzBhNDA4IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjM2MDNhOWYtZmRmMi00
+        ZTBjLTk2ZWUtY2IwODMzODAyZTAxIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
         eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
         c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
         ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RB
         UlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0MjBkMTY0OC1kMDcwLTQ2
-        ODMtYjAwZC02N2JkNGY3OTI0MGYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0s
-        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3
-        LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVu
-        bmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVj
-        ZWZmN2E3ZGY5Njk0YmIxNWI5ZjY4OCJ9LCAiaWQiOiAiNWNlZmY3YTdkZjk2
-        OTRiYjE1YjlmNjg4In0=
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjODk3OTMyYi03YTZkLTQ0
+        MjItOWM0NS0xMTczOWU0ZGM4ZmIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0s
+        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5i
+        YWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRl
+        dmVsLmJhbG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYx
+        MGE2ZDgzODgifSwgImlkIjogIjVjZjZlMzM2OWZhOTM0ZjEwYTZkODM4OCJ9
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:55 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:34 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/f7877a09-fd17-458b-a529-7e8176efc7d5/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b0cda106-b70c-496b-a8f9-747cb322b85a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -847,7 +1221,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -856,15 +1230,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:55 GMT
+      - Tue, 04 Jun 2019 21:31:34 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"7263ad6a3f686d7d32c8c6594c5f6d71-gzip"'
+      - '"38e5083e9c374005a65c90f13fffae87-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2423'
+      - '2409'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -872,16 +1246,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNzg3N2EwOS1mZDE3LTQ1OGItYTUyOS03ZTgxNzZlZmM3
-        ZDUvIiwgInRhc2tfaWQiOiAiZjc4NzdhMDktZmQxNy00NThiLWE1MjktN2U4
-        MTc2ZWZjN2Q1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9iMGNkYTEwNi1iNzBjLTQ5NmItYThmOS03NDdjYjMyMmI4
+        NWEvIiwgInRhc2tfaWQiOiAiYjBjZGExMDYtYjcwYy00OTZiLWE4ZjktNzQ3
+        Y2IzMjJiODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTktMDUtMzBUMTU6MzI6NTVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTktMDUtMzBUMTU6MzI6NTVaIiwgInRyYWNl
+        IjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNl
         YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzL2E4YjhmMTdkLTk2MGUtNDNiMi1hZDAwLTdhN2Rl
-        MWE2MWQ2ZC8iLCAidGFza19pZCI6ICJhOGI4ZjE3ZC05NjBlLTQzYjItYWQw
-        MC03YTdkZTFhNjFkNmQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bHAvYXBpL3YyL3Rhc2tzLzcwMzY2ZWY5LTQ0NjUtNGE2MC1iZTQ1LWQ0NWIy
+        ZTk5Y2I1NC8iLCAidGFza19pZCI6ICI3MDM2NmVmOS00NDY1LTRhNjAtYmU0
+        NS1kNDViMmU5OWNiNTQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
         bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
         dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
         cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
@@ -893,42 +1267,42 @@ http_interactions:
         XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
         ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
-        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
-        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
-        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
-        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
-        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wNS0z
-        MFQxNTozMjo1NVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDE5LTA1LTMwVDE1OjMyOjU1WiIsICJpbXBvcnRlcl90
-        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
-        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
-        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
-        b3VudCI6IDAsICJpZCI6ICI1Y2VmZjdhNzA1ZjVlZTJhZTA5NzA0ZDciLCAi
-        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
-        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
-        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
-        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
-        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjZWZmN2E3ZGY5Njk0YmIxNWI5ZjUw
-        YiJ9LCAiaWQiOiAiNWNlZmY3YTdkZjk2OTRiYjE1YjlmNTBiIn0=
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFt
+        cGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
+        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
+        OiBudWxsLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzdGFydGVkIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwg
+        Il9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAx
+        OS0wNi0wNFQyMTozMTozNFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
+        aW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5Ijog
+        eyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUs
+        ICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQi
+        OiAiNWNmNmUzMzZiMDJlNTMwYWFhYTRmNDYzIiwgImRldGFpbHMiOiB7Im1v
+        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
+        aXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRl
+        dGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBt
+        X3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6
+        IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJy
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgxZTkifSwgImlkIjogIjVj
+        ZjZlMzM2OWZhOTM0ZjEwYTZkODFlOSJ9
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:55 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:34 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/a8b8f17d-960e-43b2-ad00-7a7de1a61d6d/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/70366ef9-4465-4a60-be45-d45b2e99cb54/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -938,7 +1312,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -947,15 +1321,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:55 GMT
+      - Tue, 04 Jun 2019 21:31:34 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"5d278da6eb00cf376b03f9e06f03226f-gzip"'
+      - '"b66c40a586c3a5516815d24661f7439a-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '4550'
+      - '4536'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -963,111 +1337,110 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9hOGI4ZjE3ZC05NjBlLTQzYjItYWQwMC03YTdk
-        ZTFhNjFkNmQvIiwgInRhc2tfaWQiOiAiYThiOGYxN2QtOTYwZS00M2IyLWFk
-        MDAtN2E3ZGUxYTYxZDZkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy83MDM2NmVmOS00NDY1LTRhNjAtYmU0NS1kNDVi
+        MmU5OWNiNTQvIiwgInRhc2tfaWQiOiAiNzAzNjZlZjktNDQ2NS00YTYwLWJl
+        NDUtZDQ1YjJlOTljYjU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDUtMzBUMTU6MzI6NTVaIiwgInRyYWNlYmFjayI6IG51
+        aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
         InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
         ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIzODI0MzFhYi02YThmLTQwMTMtYjVmMi1j
-        NTgyNzY4MmY0NTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI5YWExN2E4MC0wYTk3LTRkZTEtYmQyOS05
+        NGYxYmJiMTY5MzYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
         dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
         dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYjNiZGY2ODgtNDliNC00YWVhLWE5NDUt
-        YjgzZTI5MDBiMzg1IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNDI3ZTk3OWUtMTMzMC00YzIyLWJkYjQt
+        ZWQzYjhmMDM4NjJhIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
         Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
         dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
         ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjgyMGY0ZjUxLTljYTEtNDgxMi1hNzU1LTc5NDVkOTY1
-        NjgzZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAz
+        ICJzdGVwX2lkIjogIjY1YTliNmEzLWNjMzQtNGQxMi05MGFiLWRjMjQ2ODkw
+        NmE1ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAy
         LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
         ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIklOX1BS
         T0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBjYzRlZTQ5LTc5NGQt
-        NGJkZC1hNjRlLWM2NjM1ZmRiOTJiYyIsICJudW1fcHJvY2Vzc2VkIjogM30s
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM3ZGE5ZDQ5LTIyM2Ut
+        NDI3YS05NDRkLWFiZWIxOWY3NDVhOCIsICJudW1fcHJvY2Vzc2VkIjogMn0s
         IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
         ZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICJiZjU5ZWMzOS1lYjhhLTRmMWEtYWFlZS00Y2EyODM0MjE0
-        NWYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICIzNGE3MDI4Yy0yOTVlLTRjNGUtYmExYy1mNzhmNmFiZTcz
+        YTkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlw
         ZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
         X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzhlNzA3OWItZmM4
-        My00M2JhLWFhY2MtZGViMzJlNTMyM2YyIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjViY2FjYWQtYTRj
+        Ny00ZDQ2LTgzZWMtZmI4ZjUwMTIzZGViIiwgIm51bV9wcm9jZXNzZWQiOiAw
         fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
         aW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNf
         dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
         YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiNjFlYWRmYmQtZTM0MS00MmYxLTlkYTYtYTRmZTc0NmVh
-        ZDQxIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        InN0ZXBfaWQiOiAiOTg1MWExOTQtYWYzYi00ZDc2LWFiMzYtYzBlMzg4ZDhh
+        MjdiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
         ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
         cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
         Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ0NTFmYmM5
-        LTAxM2YtNGIwZS1iMDdlLTc2MzgyMzU1YjUxYSIsICJudW1fcHJvY2Vzc2Vk
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUzZWFiMDUx
+        LTQwZDQtNGY4Ny04MjNmLTI3ZTFhMzMwZDdjMCIsICJudW1fcHJvY2Vzc2Vk
         IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
         bGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwg
         Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
         cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjhjZDE2YTQyLTM2MGMtNDg2NC04NGVkLTgx
-        NzU2NTk0Y2Q3MyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        cyI6IDAsICJzdGVwX2lkIjogIjczYWNiNzIwLTBlM2ItNGIxOC1iM2E2LTkw
+        OTQzYTU5ZmZmYyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
         c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
         IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
         X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjBjMTBjMDI0LWFlNWItNDEwMS1hZjY1LWFkOTI0YTVj
-        YjczYyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        ICJzdGVwX2lkIjogIjhmYTA3Yjg0LTQzZWMtNGUzMS1iODIyLTJmYzk5MDdi
+        YTNiYSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
         LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAi
         c3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6
         IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICJlYTFkMWJlNS0yYmZkLTQ0ZDItOTE3Mi0yNWU1MWIwNWUzMWUiLCAi
+        ZCI6ICJlMjg2ZDMyMC1hN2M5LTQwNWMtOGUxMi01ZjhhMDMyOGVjNjUiLCAi
         bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
         aXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUi
         OiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
         ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIy
-        ZGU4YjA2Yy0yYjAwLTQ2MTAtODRjNS0zYWM3NjM3NDljYjkiLCAibnVtX3By
+        ZmMyNmIyMS1mZGNlLTQyODEtYmNmMi00OGYxZTk4YTEyMDEiLCAibnVtX3By
         b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
         IjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVw
         b3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
         RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTFlOGY2NzEtNGVlYS00ZTdj
-        LWI4NGItZWJhYzQ1MTkwZTcyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTU2OGQ3NzAtOGZmMi00MWIy
+        LTk1Y2QtOWRmYzU0M2FhNThjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
         dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZp
         bGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rvcnki
         LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZDFjYjU3YzgtM2U0Ny00ODAyLWJjMzYt
-        MjQ1YTdjYzBhNDA4IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiYjM2MDNhOWYtZmRmMi00ZTBjLTk2ZWUt
+        Y2IwODMzODAyZTAxIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZp
         bGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI0MjBkMTY0OC1kMDcwLTQ2ODMtYjAwZC02
-        N2JkNGY3OTI0MGYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRldmVsMi5z
-        YW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50
-        b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxs
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjZWZmN2E3ZGY5
-        Njk0YmIxNWI5ZjY4OCJ9LCAiaWQiOiAiNWNlZmY3YTdkZjk2OTRiYjE1Yjlm
-        Njg4In0=
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJjODk3OTMyYi03YTZkLTQ0MjItOWM0NS0x
+        MTczOWU0ZGM4ZmIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9u
+        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1v
+        cmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgzODgi
+        fSwgImlkIjogIjVjZjZlMzM2OWZhOTM0ZjEwYTZkODM4OCJ9
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:55 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:34 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/f7877a09-fd17-458b-a529-7e8176efc7d5/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b0cda106-b70c-496b-a8f9-747cb322b85a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1077,7 +1450,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -1086,15 +1459,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:55 GMT
+      - Tue, 04 Jun 2019 21:31:35 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"7263ad6a3f686d7d32c8c6594c5f6d71-gzip"'
+      - '"38e5083e9c374005a65c90f13fffae87-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2423'
+      - '2409'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1102,16 +1475,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNzg3N2EwOS1mZDE3LTQ1OGItYTUyOS03ZTgxNzZlZmM3
-        ZDUvIiwgInRhc2tfaWQiOiAiZjc4NzdhMDktZmQxNy00NThiLWE1MjktN2U4
-        MTc2ZWZjN2Q1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9iMGNkYTEwNi1iNzBjLTQ5NmItYThmOS03NDdjYjMyMmI4
+        NWEvIiwgInRhc2tfaWQiOiAiYjBjZGExMDYtYjcwYy00OTZiLWE4ZjktNzQ3
+        Y2IzMjJiODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTktMDUtMzBUMTU6MzI6NTVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTktMDUtMzBUMTU6MzI6NTVaIiwgInRyYWNl
+        IjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNl
         YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzL2E4YjhmMTdkLTk2MGUtNDNiMi1hZDAwLTdhN2Rl
-        MWE2MWQ2ZC8iLCAidGFza19pZCI6ICJhOGI4ZjE3ZC05NjBlLTQzYjItYWQw
-        MC03YTdkZTFhNjFkNmQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bHAvYXBpL3YyL3Rhc2tzLzcwMzY2ZWY5LTQ0NjUtNGE2MC1iZTQ1LWQ0NWIy
+        ZTk5Y2I1NC8iLCAidGFza19pZCI6ICI3MDM2NmVmOS00NDY1LTRhNjAtYmU0
+        NS1kNDViMmU5OWNiNTQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
         bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
         dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
         cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
@@ -1123,42 +1496,42 @@ http_interactions:
         XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
         ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
-        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
-        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
-        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
-        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
-        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wNS0z
-        MFQxNTozMjo1NVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDE5LTA1LTMwVDE1OjMyOjU1WiIsICJpbXBvcnRlcl90
-        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
-        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
-        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
-        b3VudCI6IDAsICJpZCI6ICI1Y2VmZjdhNzA1ZjVlZTJhZTA5NzA0ZDciLCAi
-        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
-        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
-        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
-        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
-        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjZWZmN2E3ZGY5Njk0YmIxNWI5ZjUw
-        YiJ9LCAiaWQiOiAiNWNlZmY3YTdkZjk2OTRiYjE1YjlmNTBiIn0=
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFt
+        cGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
+        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
+        OiBudWxsLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzdGFydGVkIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwg
+        Il9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAx
+        OS0wNi0wNFQyMTozMTozNFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
+        aW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5Ijog
+        eyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUs
+        ICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQi
+        OiAiNWNmNmUzMzZiMDJlNTMwYWFhYTRmNDYzIiwgImRldGFpbHMiOiB7Im1v
+        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
+        aXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRl
+        dGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBt
+        X3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6
+        IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJy
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgxZTkifSwgImlkIjogIjVj
+        ZjZlMzM2OWZhOTM0ZjEwYTZkODFlOSJ9
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:56 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:35 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/a8b8f17d-960e-43b2-ad00-7a7de1a61d6d/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/70366ef9-4465-4a60-be45-d45b2e99cb54/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1168,7 +1541,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -1177,15 +1550,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:56 GMT
+      - Tue, 04 Jun 2019 21:31:35 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"03e5b4d9588674714b20b7768ea473d1-gzip"'
+      - '"8c62d0bda3ad9a7ca094d9871b70bb1b-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '4543'
+      - '4529'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1193,110 +1566,110 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9hOGI4ZjE3ZC05NjBlLTQzYjItYWQwMC03YTdk
-        ZTFhNjFkNmQvIiwgInRhc2tfaWQiOiAiYThiOGYxN2QtOTYwZS00M2IyLWFk
-        MDAtN2E3ZGUxYTYxZDZkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy83MDM2NmVmOS00NDY1LTRhNjAtYmU0NS1kNDVi
+        MmU5OWNiNTQvIiwgInRhc2tfaWQiOiAiNzAzNjZlZjktNDQ2NS00YTYwLWJl
+        NDUtZDQ1YjJlOTljYjU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDUtMzBUMTU6MzI6NTVaIiwgInRyYWNlYmFjayI6IG51
+        aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
         InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
         ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIzODI0MzFhYi02YThmLTQwMTMtYjVmMi1j
-        NTgyNzY4MmY0NTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI5YWExN2E4MC0wYTk3LTRkZTEtYmQyOS05
+        NGYxYmJiMTY5MzYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
         dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
         dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYjNiZGY2ODgtNDliNC00YWVhLWE5NDUt
-        YjgzZTI5MDBiMzg1IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNDI3ZTk3OWUtMTMzMC00YzIyLWJkYjQt
+        ZWQzYjhmMDM4NjJhIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
         Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
         dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
         ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjgyMGY0ZjUxLTljYTEtNDgxMi1hNzU1LTc5NDVkOTY1
-        NjgzZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        ICJzdGVwX2lkIjogIjY1YTliNmEzLWNjMzQtNGQxMi05MGFiLWRjMjQ2ODkw
+        NmE1ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
         LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
         ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBjYzRlZTQ5LTc5NGQtNGJk
-        ZC1hNjRlLWM2NjM1ZmRiOTJiYyIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM3ZGE5ZDQ5LTIyM2UtNDI3
+        YS05NDRkLWFiZWIxOWY3NDVhOCIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
         bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
         ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
         bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImJmNTllYzM5LWViOGEtNGYxYS1hYWVlLTRjYTI4MzQyMTQ1ZiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
+        IjogIjM0YTcwMjhjLTI5NWUtNGM0ZS1iYTFjLWY3OGY2YWJlNzNhOSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAyLCAiZGVzY3Jp
         cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
         cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVT
         UyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjOGU3MDc5Yi1mYzgzLTQzYmEt
-        YWFjYy1kZWIzMmU1MzIzZjIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2NWJjYWNhZC1hNGM3LTRkNDYt
+        ODNlYy1mYjhmNTAxMjNkZWIiLCAibnVtX3Byb2Nlc3NlZCI6IDJ9LCB7Im51
         bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9k
         dWxlcyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6
         IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI2MWVhZGZiZC1lMzQxLTQyZjEtOWRhNi1hNGZlNzQ2ZWFkNDEiLCAi
+        ZCI6ICI5ODUxYTE5NC1hZjNiLTRkNzYtYWIzNi1jMGUzODhkOGEyN2IiLCAi
         bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
         aXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUi
         OiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
         QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDQ1MWZiYzktMDEzZi00
-        YjBlLWIwN2UtNzYzODIzNTViNTFhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTNlYWIwNTEtNDBkNC00
+        Zjg3LTgyM2YtMjdlMWEzMzBkN2MwIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
         eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
         IE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNf
         dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
         YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiOGNkMTZhNDItMzYwYy00ODY0LTg0ZWQtODE3NTY1OTRj
-        ZDczIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        InN0ZXBfaWQiOiAiNzNhY2I3MjAtMGUzYi00YjE4LWIzYTYtOTA5NDNhNTlm
+        ZmZjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
         ICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3Rl
         cF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
         OiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMGMxMGMwMjQtYWU1Yi00MTAxLWFmNjUtYWQ5MjRhNWNiNzNjIiwg
+        aWQiOiAiOGZhMDdiODQtNDNlYy00ZTMxLWI4MjItMmZjOTkwN2JhM2JhIiwg
         Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
         cmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5
         cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
         YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVh
-        MWQxYmU1LTJiZmQtNDRkMi05MTcyLTI1ZTUxYjA1ZTMxZSIsICJudW1fcHJv
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUy
+        ODZkMzIwLWE3YzktNDA1Yy04ZTEyLTVmOGEwMzI4ZWM2NSIsICJudW1fcHJv
         Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
         OiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1v
         dmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
         Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJkZThiMDZj
-        LTJiMDAtNDYxMC04NGM1LTNhYzc2Mzc0OWNiOSIsICJudW1fcHJvY2Vzc2Vk
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJmYzI2YjIx
+        LWZkY2UtNDI4MS1iY2YyLTQ4ZjFlOThhMTIwMSIsICJudW1fcHJvY2Vzc2Vk
         IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
         ZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIs
         ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI5MWU4ZjY3MS00ZWVhLTRlN2MtYjg0Yi1l
-        YmFjNDUxOTBlNzIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJlNTY4ZDc3MC04ZmYyLTQxYjItOTVjZC05
+        ZGZjNTQzYWE1OGMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
         ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8g
         d2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVt
         c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJkMWNiNTdjOC0zZTQ3LTQ4MDItYmMzNi0yNDVhN2Nj
-        MGE0MDgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICJiMzYwM2E5Zi1mZGYyLTRlMGMtOTZlZS1jYjA4MzM4
+        MDJlMDEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
         MCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJz
         dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
         X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjQyMGQxNjQ4LWQwNzAtNDY4My1iMDBkLTY3YmQ0Zjc5
-        MjQwZiIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4
-        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9u
-        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2
-        ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJv
-        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmY3YTdkZjk2OTRiYjE1
-        YjlmNjg4In0sICJpZCI6ICI1Y2VmZjdhN2RmOTY5NGJiMTViOWY2ODgifQ==
+        ICJzdGVwX2lkIjogImM4OTc5MzJiLTdhNmQtNDQyMi05YzQ1LTExNzM5ZTRk
+        YzhmYiIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2Vy
+        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFt
+        cGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjVjZjZlMzM2OWZhOTM0ZjEwYTZkODM4OCJ9LCAiaWQi
+        OiAiNWNmNmUzMzY5ZmE5MzRmMTBhNmQ4Mzg4In0=
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:56 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:35 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/f7877a09-fd17-458b-a529-7e8176efc7d5/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b0cda106-b70c-496b-a8f9-747cb322b85a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1306,7 +1679,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -1315,15 +1688,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:56 GMT
+      - Tue, 04 Jun 2019 21:31:35 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"7263ad6a3f686d7d32c8c6594c5f6d71-gzip"'
+      - '"38e5083e9c374005a65c90f13fffae87-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2423'
+      - '2409'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1331,16 +1704,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNzg3N2EwOS1mZDE3LTQ1OGItYTUyOS03ZTgxNzZlZmM3
-        ZDUvIiwgInRhc2tfaWQiOiAiZjc4NzdhMDktZmQxNy00NThiLWE1MjktN2U4
-        MTc2ZWZjN2Q1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9iMGNkYTEwNi1iNzBjLTQ5NmItYThmOS03NDdjYjMyMmI4
+        NWEvIiwgInRhc2tfaWQiOiAiYjBjZGExMDYtYjcwYy00OTZiLWE4ZjktNzQ3
+        Y2IzMjJiODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTktMDUtMzBUMTU6MzI6NTVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTktMDUtMzBUMTU6MzI6NTVaIiwgInRyYWNl
+        IjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNl
         YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzL2E4YjhmMTdkLTk2MGUtNDNiMi1hZDAwLTdhN2Rl
-        MWE2MWQ2ZC8iLCAidGFza19pZCI6ICJhOGI4ZjE3ZC05NjBlLTQzYjItYWQw
-        MC03YTdkZTFhNjFkNmQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bHAvYXBpL3YyL3Rhc2tzLzcwMzY2ZWY5LTQ0NjUtNGE2MC1iZTQ1LWQ0NWIy
+        ZTk5Y2I1NC8iLCAidGFza19pZCI6ICI3MDM2NmVmOS00NDY1LTRhNjAtYmU0
+        NS1kNDViMmU5OWNiNTQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
         bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
         dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
         cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
@@ -1352,42 +1725,42 @@ http_interactions:
         XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
         ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
-        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
-        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
-        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
-        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
-        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wNS0z
-        MFQxNTozMjo1NVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDE5LTA1LTMwVDE1OjMyOjU1WiIsICJpbXBvcnRlcl90
-        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
-        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
-        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
-        b3VudCI6IDAsICJpZCI6ICI1Y2VmZjdhNzA1ZjVlZTJhZTA5NzA0ZDciLCAi
-        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
-        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
-        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
-        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
-        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjZWZmN2E3ZGY5Njk0YmIxNWI5ZjUw
-        YiJ9LCAiaWQiOiAiNWNlZmY3YTdkZjk2OTRiYjE1YjlmNTBiIn0=
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFt
+        cGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
+        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
+        OiBudWxsLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzdGFydGVkIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwg
+        Il9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAx
+        OS0wNi0wNFQyMTozMTozNFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
+        aW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5Ijog
+        eyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUs
+        ICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQi
+        OiAiNWNmNmUzMzZiMDJlNTMwYWFhYTRmNDYzIiwgImRldGFpbHMiOiB7Im1v
+        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
+        aXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRl
+        dGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBt
+        X3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6
+        IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJy
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgxZTkifSwgImlkIjogIjVj
+        ZjZlMzM2OWZhOTM0ZjEwYTZkODFlOSJ9
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:56 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:35 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/a8b8f17d-960e-43b2-ad00-7a7de1a61d6d/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/70366ef9-4465-4a60-be45-d45b2e99cb54/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1397,7 +1770,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -1406,11 +1779,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:56 GMT
+      - Tue, 04 Jun 2019 21:31:35 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"d4a07964ddd49e1d651e5f211856b13e-gzip"'
+      - '"f6838a16efc05763f57f857b8c00bf82-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -1422,110 +1795,110 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9hOGI4ZjE3ZC05NjBlLTQzYjItYWQwMC03YTdk
-        ZTFhNjFkNmQvIiwgInRhc2tfaWQiOiAiYThiOGYxN2QtOTYwZS00M2IyLWFk
-        MDAtN2E3ZGUxYTYxZDZkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy83MDM2NmVmOS00NDY1LTRhNjAtYmU0NS1kNDVi
+        MmU5OWNiNTQvIiwgInRhc2tfaWQiOiAiNzAzNjZlZjktNDQ2NS00YTYwLWJl
+        NDUtZDQ1YjJlOTljYjU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDUtMzBUMTU6MzI6NTVaIiwgInRyYWNlYmFjayI6IG51
+        aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
         InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
         ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIzODI0MzFhYi02YThmLTQwMTMtYjVmMi1j
-        NTgyNzY4MmY0NTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI5YWExN2E4MC0wYTk3LTRkZTEtYmQyOS05
+        NGYxYmJiMTY5MzYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
         dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
         dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiYjNiZGY2ODgtNDliNC00YWVhLWE5NDUt
-        YjgzZTI5MDBiMzg1IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNDI3ZTk3OWUtMTMzMC00YzIyLWJkYjQt
+        ZWQzYjhmMDM4NjJhIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
         Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
         dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
         ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjgyMGY0ZjUxLTljYTEtNDgxMi1hNzU1LTc5NDVkOTY1
-        NjgzZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        ICJzdGVwX2lkIjogIjY1YTliNmEzLWNjMzQtNGQxMi05MGFiLWRjMjQ2ODkw
+        NmE1ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
         LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
         ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBjYzRlZTQ5LTc5NGQtNGJk
-        ZC1hNjRlLWM2NjM1ZmRiOTJiYyIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM3ZGE5ZDQ5LTIyM2UtNDI3
+        YS05NDRkLWFiZWIxOWY3NDVhOCIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
         bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
         ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
         bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImJmNTllYzM5LWViOGEtNGYxYS1hYWVlLTRjYTI4MzQyMTQ1ZiIsICJu
+        IjogIjM0YTcwMjhjLTI5NWUtNGM0ZS1iYTFjLWY3OGY2YWJlNzNhOSIsICJu
         dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
         cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
         cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjOGU3MDc5Yi1mYzgzLTQzYmEtYWFj
-        Yy1kZWIzMmU1MzIzZjIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2NWJjYWNhZC1hNGM3LTRkNDYtODNl
+        Yy1mYjhmNTAxMjNkZWIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
         dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
-        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjYx
-        ZWFkZmJkLWUzNDEtNDJmMS05ZGE2LWE0ZmU3NDZlYWQ0MSIsICJudW1fcHJv
-        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI0NDUxZmJjOS0wMTNmLTRiMGUtYjA3ZS03
-        NjM4MjM1NWI1MWEiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEu
-        IiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAs
+        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
         ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4
-        Y2QxNmE0Mi0zNjBjLTQ4NjQtODRlZC04MTc1NjU5NGNkNzMiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9u
-        IjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xv
-        c2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYzEwYzAyNC1h
-        ZTViLTQxMDEtYWY2NS1hZDkyNGE1Y2I3M2MiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVy
-        YXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBz
-        cWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlYTFkMWJlNS0yYmZkLTQ0ZDItOTE3
-        Mi0yNWU1MWIwNWUzMWUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBv
-        ZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIyZGU4YjA2Yy0yYjAwLTQ2MTAtODRjNS0zYWM3NjM3
-        NDljYjkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJz
-        dGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5MWU4ZjY3
-        MS00ZWVhLTRlN2MtYjg0Yi1lYmFjNDUxOTBlNzIiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNo
-        X2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkMWNiNTdjOC0zZTQ3LTQ4
-        MDItYmMzNi0yNDVhN2NjMGE0MDgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
-        Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlz
-        dGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQyMGQxNjQ4LWQwNzAtNDY4My1i
-        MDBkLTY3YmQ0Zjc5MjQwZiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2
-        ZWwyLnNhbWlyLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5n
-        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0w
-        QGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
-        IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmY3
-        YTdkZjk2OTRiYjE1YjlmNjg4In0sICJpZCI6ICI1Y2VmZjdhN2RmOTY5NGJi
-        MTViOWY2ODgifQ==
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5
+        ODUxYTE5NC1hZjNiLTRkNzYtYWIzNi1jMGUzODhkOGEyN2IiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
+        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZTNlYWIwNTEtNDBkNC00Zjg3LTgyM2Yt
+        MjdlMWEzMzBkN2MwIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRh
+        LiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        NzNhY2I3MjAtMGUzYi00YjE4LWIzYTYtOTA5NDNhNTlmZmZjIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
+        biI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNs
+        b3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOGZhMDdiODQt
+        NDNlYy00ZTMxLWI4MjItMmZjOTkwN2JhM2JhIiwgIm51bV9wcm9jZXNzZWQi
+        OiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5l
+        cmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUg
+        c3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTI4NmQzMjAtYTdjOS00MDVjLThl
+        MTItNWY4YTAzMjhlYzY1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVw
+        b2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAi
+        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiSU5fUFJPR1JFU1MiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiMmZjMjZiMjEtZmRjZS00MjgxLWJjZjItNDhm
+        MWU5OGExMjAxIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMi
+        LCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        ImU1NjhkNzcwLThmZjItNDFiMi05NWNkLTlkZmM1NDNhYTU4YyIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjog
+        InB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImIzNjAz
+        YTlmLWZkZjItNGUwYy05NmVlLWNiMDgzMzgwMmUwMSIsICJudW1fcHJvY2Vz
+        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
+        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
+        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzg5Nzkz
+        MmItN2E2ZC00NDIyLTljNDUtMTE3MzllNGRjOGZiIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
+        LTBAZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAi
+        cnVubmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
+        IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNmNmUz
+        MzY5ZmE5MzRmMTBhNmQ4Mzg4In0sICJpZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYx
+        MGE2ZDgzODgifQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:56 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:35 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/f7877a09-fd17-458b-a529-7e8176efc7d5/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b0cda106-b70c-496b-a8f9-747cb322b85a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1535,7 +1908,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -1544,15 +1917,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:56 GMT
+      - Tue, 04 Jun 2019 21:31:35 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"7263ad6a3f686d7d32c8c6594c5f6d71-gzip"'
+      - '"38e5083e9c374005a65c90f13fffae87-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2423'
+      - '2409'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1560,16 +1933,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNzg3N2EwOS1mZDE3LTQ1OGItYTUyOS03ZTgxNzZlZmM3
-        ZDUvIiwgInRhc2tfaWQiOiAiZjc4NzdhMDktZmQxNy00NThiLWE1MjktN2U4
-        MTc2ZWZjN2Q1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        aS92Mi90YXNrcy9iMGNkYTEwNi1iNzBjLTQ5NmItYThmOS03NDdjYjMyMmI4
+        NWEvIiwgInRhc2tfaWQiOiAiYjBjZGExMDYtYjcwYy00OTZiLWE4ZjktNzQ3
+        Y2IzMjJiODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
         b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
-        IjIwMTktMDUtMzBUMTU6MzI6NTVaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
-        ICJzdGFydF90aW1lIjogIjIwMTktMDUtMzBUMTU6MzI6NTVaIiwgInRyYWNl
+        IjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNl
         YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
-        bHAvYXBpL3YyL3Rhc2tzL2E4YjhmMTdkLTk2MGUtNDNiMi1hZDAwLTdhN2Rl
-        MWE2MWQ2ZC8iLCAidGFza19pZCI6ICJhOGI4ZjE3ZC05NjBlLTQzYjItYWQw
-        MC03YTdkZTFhNjFkNmQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bHAvYXBpL3YyL3Rhc2tzLzcwMzY2ZWY5LTQ0NjUtNGE2MC1iZTQ1LWQ0NWIy
+        ZTk5Y2I1NC8iLCAidGFza19pZCI6ICI3MDM2NmVmOS00NDY1LTRhNjAtYmU0
+        NS1kNDViMmU5OWNiNTQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
         bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
         dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
         cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
@@ -1581,42 +1954,42 @@ http_interactions:
         XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
         ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
-        aXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
-        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRv
-        czctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVz
-        dWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJfaWQiOiAieXVtX2ltcG9ydGVy
-        IiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rl
-        c3QiLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wNS0z
-        MFQxNTozMjo1NVoiLCAiX25zIjogInJlcG9fc3luY19yZXN1bHRzIiwgImNv
-        bXBsZXRlZCI6ICIyMDE5LTA1LTMwVDE1OjMyOjU1WiIsICJpbXBvcnRlcl90
-        eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVs
-        bCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVE
-        In0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjog
-        eyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRk
-        ZWRfY291bnQiOiAxNSwgInJlbW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9j
-        b3VudCI6IDAsICJpZCI6ICI1Y2VmZjdhNzA1ZjVlZTJhZTA5NzA0ZDciLCAi
-        ZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwg
-        ImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXpl
-        X2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9k
-        b25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJl
-        cnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19s
-        ZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
-        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVjZWZmN2E3ZGY5Njk0YmIxNWI5ZjUw
-        YiJ9LCAiaWQiOiAiNWNlZmY3YTdkZjk2OTRiYjE1YjlmNTBiIn0=
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFt
+        cGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
+        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
+        OiBudWxsLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzdGFydGVkIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwg
+        Il9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAx
+        OS0wNi0wNFQyMTozMTozNFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
+        aW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5Ijog
+        eyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUs
+        ICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQi
+        OiAiNWNmNmUzMzZiMDJlNTMwYWFhYTRmNDYzIiwgImRldGFpbHMiOiB7Im1v
+        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
+        aXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRl
+        dGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBt
+        X3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6
+        IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJy
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgxZTkifSwgImlkIjogIjVj
+        ZjZlMzM2OWZhOTM0ZjEwYTZkODFlOSJ9
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:56 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:35 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/a8b8f17d-960e-43b2-ad00-7a7de1a61d6d/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/70366ef9-4465-4a60-be45-d45b2e99cb54/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1626,7 +1999,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -1635,15 +2008,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:56 GMT
+      - Tue, 04 Jun 2019 21:31:35 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"b02db4c6ce8aca4a704d50c88a4b6fed-gzip"'
+      - '"c15b8819eb060ddc95962f3d4d297d63-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '9054'
+      - '4497'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1651,211 +2024,438 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9hOGI4ZjE3ZC05NjBlLTQzYjItYWQwMC03YTdk
-        ZTFhNjFkNmQvIiwgInRhc2tfaWQiOiAiYThiOGYxN2QtOTYwZS00M2IyLWFk
-        MDAtN2E3ZGUxYTYxZDZkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy83MDM2NmVmOS00NDY1LTRhNjAtYmU0NS1kNDVi
+        MmU5OWNiNTQvIiwgInRhc2tfaWQiOiAiNzAzNjZlZjktNDQ2NS00YTYwLWJl
+        NDUtZDQ1YjJlOTljYjU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogIjIwMTktMDUtMzBUMTU6MzI6NTZaIiwgIl9ucyI6ICJ0YXNr
-        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTktMDUtMzBUMTU6MzI6NTVa
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI5YWExN2E4MC0wYTk3LTRkZTEtYmQyOS05
+        NGYxYmJiMTY5MzYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNDI3ZTk3OWUtMTMzMC00YzIyLWJkYjQt
+        ZWQzYjhmMDM4NjJhIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjY1YTliNmEzLWNjMzQtNGQxMi05MGFiLWRjMjQ2ODkw
+        NmE1ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM3ZGE5ZDQ5LTIyM2UtNDI3
+        YS05NDRkLWFiZWIxOWY3NDVhOCIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjM0YTcwMjhjLTI5NWUtNGM0ZS1iYTFjLWY3OGY2YWJlNzNhOSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
+        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2NWJjYWNhZC1hNGM3LTRkNDYtODNl
+        Yy1mYjhmNTAxMjNkZWIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
+        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5
+        ODUxYTE5NC1hZjNiLTRkNzYtYWIzNi1jMGUzODhkOGEyN2IiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
+        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZTNlYWIwNTEtNDBkNC00Zjg3LTgyM2Yt
+        MjdlMWEzMzBkN2MwIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRh
+        LiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        NzNhY2I3MjAtMGUzYi00YjE4LWIzYTYtOTA5NDNhNTlmZmZjIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
+        biI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNs
+        b3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOGZhMDdiODQt
+        NDNlYy00ZTMxLWI4MjItMmZjOTkwN2JhM2JhIiwgIm51bV9wcm9jZXNzZWQi
+        OiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5l
+        cmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUg
+        c3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTI4NmQzMjAtYTdjOS00MDVjLThl
+        MTItNWY4YTAzMjhlYzY1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVw
+        b2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAi
+        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiMmZjMjZiMjEtZmRjZS00MjgxLWJjZjItNDhmMWU5
+        OGExMjAxIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAi
+        c3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTU2OGQ3
+        NzAtOGZmMi00MWIyLTk1Y2QtOWRmYzU0M2FhNThjIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
+        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklO
+        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjM2MDNhOWYtZmRmMi00
+        ZTBjLTk2ZWUtY2IwODMzODAyZTAxIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwg
+        eyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
+        c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
+        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjODk3OTMyYi03YTZkLTQ0MjIt
+        OWM0NS0xMTczOWU0ZGM4ZmIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9XX0sICJx
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxt
+        b3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVs
+        LmJhbG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9y
+        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2
+        ZDgzODgifSwgImlkIjogIjVjZjZlMzM2OWZhOTM0ZjEwYTZkODM4OCJ9
+    http_version: 
+  recorded_at: Tue, 04 Jun 2019 21:31:35 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/b0cda106-b70c-496b-a8f9-747cb322b85a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 04 Jun 2019 21:31:35 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"38e5083e9c374005a65c90f13fffae87-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '2409'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy9iMGNkYTEwNi1iNzBjLTQ5NmItYThmOS03NDdjYjMyMmI4
+        NWEvIiwgInRhc2tfaWQiOiAiYjBjZGExMDYtYjcwYy00OTZiLWE4ZjktNzQ3
+        Y2IzMjJiODVhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpzY2VuYXJp
+        b190ZXN0IiwgInB1bHA6YWN0aW9uOnN5bmMiXSwgImZpbmlzaF90aW1lIjog
+        IjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIs
+        ICJzdGFydF90aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgInRyYWNl
+        YmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3Rhc2tzLzcwMzY2ZWY5LTQ0NjUtNGE2MC1iZTQ1LWQ0NWIy
+        ZTk5Y2I1NC8iLCAidGFza19pZCI6ICI3MDM2NmVmOS00NDY1LTRhNjAtYmU0
+        NS1kNDViMmU5OWNiNTQifV0sICJwcm9ncmVzc19yZXBvcnQiOiB7Inl1bV9p
+        bXBvcnRlciI6IHsiY29udGVudCI6IHsiaXRlbXNfdG90YWwiOiAwLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
+        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJzaXplX3RvdGFsIjogMCwgInNp
+        emVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3RvdGFs
+        IjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjogIkZJ
+        TklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJt
+        ZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFt
+        cGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
+        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
+        OiBudWxsLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgInRyYWNlYmFj
+        ayI6IG51bGwsICJzdGFydGVkIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwg
+        Il9ucyI6ICJyZXBvX3N5bmNfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAx
+        OS0wNi0wNFQyMTozMTozNFoiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
+        aW1wb3J0ZXIiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJzdW1tYXJ5Ijog
+        eyJtb2R1bGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6
+        IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbXBzIjogeyJzdGF0ZSI6ICJG
+        SU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsic3RhdGUiOiAiRklOSVNIRUQi
+        fSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFkYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fSwgImFkZGVkX2NvdW50IjogMTUs
+        ICJyZW1vdmVkX2NvdW50IjogMCwgInVwZGF0ZWRfY291bnQiOiAwLCAiaWQi
+        OiAiNWNmNmUzMzZiMDJlNTMwYWFhYTRmNDYzIiwgImRldGFpbHMiOiB7Im1v
+        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
+        aXplX3RvdGFsIjogMCwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwi
+        OiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAic2l6ZV9sZWZ0IjogMCwgImRl
+        dGFpbHMiOiB7InJwbV90b3RhbCI6IDAsICJycG1fZG9uZSI6IDAsICJkcnBt
+        X3RvdGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6
+        IFtdfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2Vf
+        ZHVwbGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1
+        dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJy
+        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
+        JG9pZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgxZTkifSwgImlkIjogIjVj
+        ZjZlMzM2OWZhOTM0ZjEwYTZkODFlOSJ9
+    http_version: 
+  recorded_at: Tue, 04 Jun 2019 21:31:35 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/70366ef9-4465-4a60-be45-d45b2e99cb54/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 04 Jun 2019 21:31:35 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"f79ef14ec418d101b9e7ae136c042371-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '9043'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy83MDM2NmVmOS00NDY1LTRhNjAtYmU0NS1kNDVi
+        MmU5OWNiNTQvIiwgInRhc2tfaWQiOiAiNzAzNjZlZjktNDQ2NS00YTYwLWJl
+        NDUtZDQ1YjJlOTljYjU0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6MzVaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6MzRa
         IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
         cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
         Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0
         ZXBfdHlwZSI6ICJzYXZlX3RhciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzODI0MzFh
-        Yi02YThmLTQwMTMtYjVmMi1jNTgyNzY4MmY0NTYiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5YWExN2E4
+        MC0wYTk3LTRkZTEtYmQyOS05NGYxYmJiMTY5MzYiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIklu
         aXRpYWxpemluZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0
         aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
         dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjNiZGY2
-        ODgtNDliNC00YWVhLWE5NDUtYjgzZTI5MDBiMzg1IiwgIm51bV9wcm9jZXNz
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDI3ZTk3
+        OWUtMTMzMC00YzIyLWJkYjQtZWQzYjhmMDM4NjJhIiwgIm51bV9wcm9jZXNz
         ZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
         dWJsaXNoaW5nIERpc3RyaWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
         ZGlzdHJpYnV0aW9uIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
         TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjgyMGY0ZjUxLTljYTEt
-        NDgxMi1hNzU1LTc5NDVkOTY1NjgzZCIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjY1YTliNmEzLWNjMzQt
+        NGQxMi05MGFiLWRjMjQ2ODkwNmE1ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0s
         IHsibnVtX3N1Y2Nlc3MiOiA4LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
         ZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjog
         OCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
         ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjBjYzRlZTQ5LTc5NGQtNGJkZC1hNjRlLWM2NjM1ZmRiOTJiYyIsICJudW1f
+        IjM3ZGE5ZDQ5LTIyM2UtNDI3YS05NDRkLWFiZWIxOWY3NDVhOCIsICJudW1f
         cHJvY2Vzc2VkIjogOH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
         b24iOiAiUHVibGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJk
         cnBtcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImJmNTllYzM5LWViOGEtNGYxYS1hYWVl
-        LTRjYTI4MzQyMTQ1ZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjM0YTcwMjhjLTI5NWUtNGM0ZS1iYTFj
+        LWY3OGY2YWJlNzNhOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
         Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEi
         LCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjOGU3
-        MDc5Yi1mYzgzLTQzYmEtYWFjYy1kZWIzMmU1MzIzZjIiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2NWJj
+        YWNhZC1hNGM3LTRkNDYtODNlYy1mYjhmNTAxMjNkZWIiLCAibnVtX3Byb2Nl
         c3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgTW9kdWxlcyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjYxZWFkZmJkLWUzNDEtNDJmMS05ZGE2LWE0ZmU3
-        NDZlYWQ0MSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NDUxZmJj
-        OS0wMTNmLTRiMGUtYjA3ZS03NjM4MjM1NWI1MWEiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI4Y2QxNmE0Mi0zNjBjLTQ4NjQtODRlZC04MTc1
-        NjU5NGNkNzMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIwYzEwYzAyNC1hZTViLTQxMDEtYWY2NS1hZDkyNGE1Y2I3M2Mi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlYTFk
-        MWJlNS0yYmZkLTQ0ZDItOTE3Mi0yNWU1MWIwNWUzMWUiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3Zl
-        X29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyZGU4YjA2Yy0yYjAw
-        LTQ2MTAtODRjNS0zYWM3NjM3NDljYjkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRp
-        bmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICI5MWU4ZjY3MS00ZWVhLTRlN2MtYjg0Yi1lYmFjNDUxOTBl
-        NzIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0
-        ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJkMWNiNTdjOC0zZTQ3LTQ4MDItYmMzNi0yNDVhN2NjMGE0MDgiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0
-        aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAi
-        aW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQy
-        MGQxNjQ4LWQwNzAtNDY4My1iMDBkLTY3YmQ0Zjc5MjQwZiIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX1dfSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dv
-        cmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFt
-        cGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4
-        Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAi
-        c3RhcnRlZCI6ICIyMDE5LTA1LTMwVDE1OjMyOjU1WiIsICJfbnMiOiAicmVw
-        b19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTktMDUtMzBU
-        MTU6MzI6NTZaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90
-        eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5l
-        cmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJycG1zIjogIkZJTklTSEVEIiwg
-        ImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJyZW1v
-        dmVfb2xkX3JlcG9kYXRhIjogIkZJTklTSEVEIiwgIm1vZHVsZXMiOiAiU0tJ
-        UFBFRCIsICJzYXZlX3RhciI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21l
-        dGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29t
-        cHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwg
-        InJlcG92aWV3IjogIlNLSVBQRUQiLCAicHVibGlzaF9kaXJlY3RvcnkiOiAi
-        RklOSVNIRUQiLCAiZXJyYXRhIjogIkZJTklTSEVEIiwgIm1ldGFkYXRhIjog
-        IkZJTklTSEVEIn0sICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1
-        dG9yX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAiaWQiOiAiNWNlZmY3YTgwNWY1
-        ZWUyYWUwOTcwNGQ4IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEs
-        ICJkZXNjcmlwdGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJzYXZlX3RhciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzODI0MzFhYi02YThmLTQw
-        MTMtYjVmMi1jNTgyNzY4MmY0NTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
-        Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemlu
-        ZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3Jl
-        cG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklO
-        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjNiZGY2ODgtNDliNC00
-        YWVhLWE5NDUtYjgzZTI5MDBiMzg1IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwg
-        eyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
-        IERpc3RyaWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0
-        aW9uIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjgyMGY0ZjUxLTljYTEtNDgxMi1hNzU1
-        LTc5NDVkOTY1NjgzZCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiA4LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwg
-        InN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjBjYzRlZTQ5
-        LTc5NGQtNGJkZC1hNjRlLWM2NjM1ZmRiOTJiYyIsICJudW1fcHJvY2Vzc2Vk
-        IjogOH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImJmNTllYzM5LWViOGEtNGYxYS1hYWVlLTRjYTI4MzQy
-        MTQ1ZiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAz
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90
-        eXBlIjogImVycmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjOGU3MDc5Yi1mYzgz
-        LTQzYmEtYWFjYy1kZWIzMmU1MzIzZjIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9
-        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgTW9kdWxlcyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjYxZWFkZmJkLWUzNDEtNDJmMS05ZGE2LWE0ZmU3NDZlYWQ0MSIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVz
-        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlw
-        ZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NDUxZmJjOS0wMTNmLTRi
-        MGUtYjA3ZS03NjM4MjM1NWI1MWEiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7
-        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        TWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI4Y2QxNmE0Mi0zNjBjLTQ4NjQtODRlZC04MTc1NjU5NGNkNzMi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
-        c2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
+        OiAwLCAic3RlcF9pZCI6ICI5ODUxYTE5NC1hZjNiLTRkNzYtYWIzNi1jMGUz
+        ODhkOGEyN2IiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIs
+        ICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTNlYWIw
+        NTEtNDBkNC00Zjg3LTgyM2YtMjdlMWEzMzBkN2MwIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiNzNhY2I3MjAtMGUzYi00YjE4LWIzYTYtOTA5
+        NDNhNTlmZmZjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiOGZhMDdiODQtNDNlYy00ZTMxLWI4MjItMmZjOTkwN2JhM2Jh
+        IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
+        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTI4
+        NmQzMjAtYTdjOS00MDVjLThlMTItNWY4YTAzMjhlYzY1IiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
+        ICJSZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92
+        ZV9vbGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmZjMjZiMjEtZmRj
+        ZS00MjgxLWJjZjItNDhmMWU5OGExMjAxIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
+        aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiZTU2OGQ3NzAtOGZmMi00MWIyLTk1Y2QtOWRmYzU0M2Fh
+        NThjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJz
+        dGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiYjM2MDNhOWYtZmRmMi00ZTBjLTk2ZWUtY2IwODMzODAyZTAxIiwgIm51
+        bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjog
+        ImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
         ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIw
-        YzEwYzAyNC1hZTViLTQxMDEtYWY2NS1hZDkyNGE1Y2I3M2MiLCAibnVtX3By
-        b2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJn
-        ZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlYTFkMWJlNS0yYmZk
-        LTQ0ZDItOTE3Mi0yNWU1MWIwNWUzMWUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5n
-        IG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBv
-        ZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJj
+        ODk3OTMyYi03YTZkLTQ0MjItOWM0NS0xMTczOWU0ZGM4ZmIiLCAibnVtX3By
+        b2Nlc3NlZCI6IDF9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0
+        ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVs
+        bCwgInJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJzdGFydGVkIjogIjIw
+        MTktMDYtMDRUMjE6MzE6MzRaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVz
+        dWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wNi0wNFQyMTozMTozNVoiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVt
+        X2Rpc3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7ImdlbmVyYXRlIHNxbGl0ZSI6
+        ICJTS0lQUEVEIiwgInJwbXMiOiAiRklOSVNIRUQiLCAiaW5pdGlhbGl6ZV9y
+        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgInJlbW92ZV9vbGRfcmVwb2Rh
+        dGEiOiAiRklOSVNIRUQiLCAibW9kdWxlcyI6ICJGSU5JU0hFRCIsICJzYXZl
+        X3RhciI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJ
+        TklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNI
+        RUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInJlcG92aWV3Ijog
+        IlNLSVBQRUQiLCAicHVibGlzaF9kaXJlY3RvcnkiOiAiRklOSVNIRUQiLCAi
+        ZXJyYXRhIjogIkZJTklTSEVEIiwgIm1ldGFkYXRhIjogIkZJTklTSEVEIn0s
+        ICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogInNj
+        ZW5hcmlvX3Rlc3QiLCAiaWQiOiAiNWNmNmUzMzdiMDJlNTMwYWFhYTRmNDY0
+        IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
+        biI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3RhciIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICI5YWExN2E4MC0wYTk3LTRkZTEtYmQyOS05NGYx
+        YmJiMTY5MzYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1ldGFk
+        YXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiNDI3ZTk3OWUtMTMzMC00YzIyLWJkYjQtZWQz
+        YjhmMDM4NjJhIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2Vz
+        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1dGlv
+        biBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjY1YTliNmEzLWNjMzQtNGQxMi05MGFiLWRjMjQ2ODkwNmE1
+        ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4LCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6
+        ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM3ZGE5ZDQ5LTIyM2UtNDI3YS05
+        NDRkLWFiZWIxOWY3NDVhOCIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEZWx0
+        YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjM0YTcwMjhjLTI5NWUtNGM0ZS1iYTFjLWY3OGY2YWJlNzNhOSIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0
+        YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI2NWJjYWNhZC1hNGM3LTRkNDYtODNlYy1m
+        YjhmNTAxMjNkZWIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxlcyIs
+        ICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5ODUx
+        YTE5NC1hZjNiLTRkNzYtYWIzNi1jMGUzODhkOGEyN2IiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29tcHMi
+        LCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiZTNlYWIwNTEtNDBkNC00Zjg3LTgyM2YtMjdl
+        MWEzMzBkN2MwIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2Vz
+        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIs
+        ICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzNh
+        Y2I3MjAtMGUzYi00YjE4LWIzYTYtOTA5NDNhNTlmZmZjIiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
+        ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNsb3Nl
+        X3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOGZhMDdiODQtNDNl
+        Yy00ZTMxLWI4MjItMmZjOTkwN2JhM2JhIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
+        aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3Fs
+        aXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZTI4NmQzMjAtYTdjOS00MDVjLThlMTIt
+        NWY4YTAzMjhlYzY1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVwb2Rh
+        dGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiMmZjMjZiMjEtZmRjZS00MjgxLWJjZjItNDhmMWU5OGEx
+        MjAxIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAic3Rl
+        cF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTU2OGQ3NzAt
+        OGZmMi00MWIyLTk1Y2QtOWRmYzU0M2FhNThjIiwgIm51bV9wcm9jZXNzZWQi
+        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJs
+        aXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9k
+        aXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjM2MDNhOWYtZmRmMi00ZTBj
+        LTk2ZWUtY2IwODMzODAyZTAxIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJu
+        dW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3Rp
+        bmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRh
+        ZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyZGU4YjA2Yy0yYjAwLTQ2MTAtODRj
-        NS0zYWM3NjM3NDljYjkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBm
-        aWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwi
-        OiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI5MWU4ZjY3MS00ZWVhLTRlN2MtYjg0Yi1lYmFjNDUxOTBlNzIiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6
-        ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkMWNiNTdj
-        OC0zZTQ3LTQ4MDItYmMzNi0yNDVhN2NjMGE0MDgiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldy
-        aXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6
-        ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQyMGQxNjQ4LWQw
-        NzAtNDY4My1iMDBkLTY3YmQ0Zjc5MjQwZiIsICJudW1fcHJvY2Vzc2VkIjog
-        MX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmZjdh
-        N2RmOTY5NGJiMTViOWY2ODgifSwgImlkIjogIjVjZWZmN2E3ZGY5Njk0YmIx
-        NWI5ZjY4OCJ9
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjODk3OTMyYi03YTZkLTQ0MjItOWM0
+        NS0xMTczOWU0ZGM4ZmIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9XX0sICJlcnJv
+        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNmNmUzMzY5ZmE5MzRmMTBh
+        NmQ4Mzg4In0sICJpZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgzODgifQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:56 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:35 GMT
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1869,7 +2469,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -1880,9 +2480,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:56 GMT
+      - Tue, 04 Jun 2019 21:31:35 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -1892,121 +2492,121 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJ3YWxydXMtMC4zLTAuOC5z
-        cmMucnBtIiwgIm5hbWUiOiAid2FscnVzIiwgImNoZWNrc3VtIjogIjZlOGQ2
-        ZGMwNTdlM2UyYzk4MTlmMGRjN2U2YzdiN2Y4NmJmMmU4NTcxYmJhNDE0YWRl
-        YzdmYjYyMWE0NjFkZmQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ug
-        b2Ygd2FscnVzIiwgImZpbGVuYW1lIjogIndhbHJ1cy0wLjMtMC44Lm5vYXJj
+        W3sibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJtb25rZXktMC4zLTAuOC5z
+        cmMucnBtIiwgIm5hbWUiOiAibW9ua2V5IiwgImNoZWNrc3VtIjogIjBlOGZh
+        NTBkMDEyOGZiYWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4
+        ZTJjODRkZTg1MDFkYjEiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ug
+        b2YgbW9ua2V5IiwgImZpbGVuYW1lIjogIm1vbmtleS0wLjMtMC44Lm5vYXJj
         aC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19t
         b2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJy
-        ZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiMTAwYjM0Y2YtOTIzMC00MWRiLWFh
-        ZmMtNGFmMmY0MGJjZTVlIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVk
-        IjogIjIwMTktMDUtMzBUMTU6MzI6NTVaIiwgInJlcG9faWQiOiAic2NlbmFy
-        aW9fdGVzdCIsICJjcmVhdGVkIjogIjIwMTktMDUtMzBUMTU6MzI6NTVaIiwg
-        InVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIxMDBiMzRjZi05
-        MjMwLTQxZGItYWFmYy00YWYyZjQwYmNlNWUiLCAiX2lkIjogeyIkb2lkIjog
-        IjVjZWZmN2E3ZGY5Njk0YmIxNWI5ZjU3ZCJ9fSwgeyJtZXRhZGF0YSI6IHsi
-        c291cmNlcnBtIjogInNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsICJuYW1l
-        IjogInNxdWlycmVsIiwgImNoZWNrc3VtIjogIjI1MTc2OGJkZDE1ZjEzZDc4
-        NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3
-        ZDIiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwi
-        LCAiZmlsZW5hbWUiOiAic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwg
-        ImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6
-        IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6
-        ICIwLjgiLCAiX2lkIjogIjU5NWY0MTZhLTkzYjEtNDA5ZC1hOGU0LWUyODBm
-        YWZlOTI1NyIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDE5
-        LTA1LTMwVDE1OjMyOjU1WiIsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rlc3Qi
-        LCAiY3JlYXRlZCI6ICIyMDE5LTA1LTMwVDE1OjMyOjU1WiIsICJ1bml0X3R5
-        cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiNTk1ZjQxNmEtOTNiMS00MDlk
-        LWE4ZTQtZTI4MGZhZmU5MjU3IiwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmZjdh
-        N2RmOTY5NGJiMTViOWY1OGIifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJw
-        bSI6ICJwZW5ndWluLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogInBlbmd1
-        aW4iLCAiY2hlY2tzdW0iOiAiM2ZjYjJjOTI3ZGU5ZTEzYmY2ODQ2OTAzMmEy
-        OGIxMzlkM2U1YWQyZTU4NTY0ZmMyMTBmZDZlNDg2MzViZTY5NCIsICJzdW1t
-        YXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBwZW5ndWluIiwgImZpbGVuYW1l
-        IjogInBlbmd1aW4tMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAi
-        LCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2Nv
-        bnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lk
-        IjogImI0MGIyODBiLTJkNzctNGY2MS04NWEwLTkzNzUyMDRmNDVjMiIsICJh
-        cmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA1LTMwVDE1OjMy
-        OjU1WiIsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAiY3JlYXRlZCI6
-        ICIyMDE5LTA1LTMwVDE1OjMyOjU1WiIsICJ1bml0X3R5cGVfaWQiOiAicnBt
-        IiwgInVuaXRfaWQiOiAiYjQwYjI4MGItMmQ3Ny00ZjYxLTg1YTAtOTM3NTIw
-        NGY0NWMyIiwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmZjdhN2RmOTY5NGJiMTVi
-        OWY1NmIifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJtb25rZXkt
-        MC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAibW9ua2V5IiwgImNoZWNrc3Vt
-        IjogIjBlOGZhNTBkMDEyOGZiYWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2
-        OWY2MTY2Y2I4ZTJjODRkZTg1MDFkYjEiLCAic3VtbWFyeSI6ICJBIGR1bW15
-        IHBhY2thZ2Ugb2YgbW9ua2V5IiwgImZpbGVuYW1lIjogIm1vbmtleS0wLjMt
-        MC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAu
-        MyIsICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjog
-        InJwbSIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiYjk5NzVmZDEtZDBk
-        OS00Mjk5LTg1MTMtNzBkZWFkYzk1ZWFlIiwgImFyY2giOiAibm9hcmNoIn0s
-        ICJ1cGRhdGVkIjogIjIwMTktMDUtMzBUMTU6MzI6NTVaIiwgInJlcG9faWQi
-        OiAic2NlbmFyaW9fdGVzdCIsICJjcmVhdGVkIjogIjIwMTktMDUtMzBUMTU6
-        MzI6NTVaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJi
-        OTk3NWZkMS1kMGQ5LTQyOTktODUxMy03MGRlYWRjOTVlYWUiLCAiX2lkIjog
-        eyIkb2lkIjogIjVjZWZmN2E3ZGY5Njk0YmIxNWI5ZjU2MiJ9fSwgeyJtZXRh
-        ZGF0YSI6IHsic291cmNlcnBtIjogImdpcmFmZmUtMC4zLTAuOC5zcmMucnBt
-        IiwgIm5hbWUiOiAiZ2lyYWZmZSIsICJjaGVja3N1bSI6ICJmMjVkNjdkMWQ5
-        ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTky
-        MjAwOWY5ZjE0IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGdp
-        cmFmZmUiLCAiZmlsZW5hbWUiOiAiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5y
-        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1
-        bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxl
-        YXNlIjogIjAuOCIsICJfaWQiOiAiYzIwODljZjEtODljMC00YTkwLThmNGQt
-        NTcxNTYwYzE1NjBlIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjog
-        IjIwMTktMDUtMzBUMTU6MzI6NTVaIiwgInJlcG9faWQiOiAic2NlbmFyaW9f
-        dGVzdCIsICJjcmVhdGVkIjogIjIwMTktMDUtMzBUMTU6MzI6NTVaIiwgInVu
-        aXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJjMjA4OWNmMS04OWMw
-        LTRhOTAtOGY0ZC01NzE1NjBjMTU2MGUiLCAiX2lkIjogeyIkb2lkIjogIjVj
-        ZWZmN2E3ZGY5Njk0YmIxNWI5ZjU0MiJ9fSwgeyJtZXRhZGF0YSI6IHsic291
-        cmNlcnBtIjogImNoZWV0YWgtMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAi
-        Y2hlZXRhaCIsICJjaGVja3N1bSI6ICI0MjJkMGJhYTBjZDlkNzcxM2FlNzk2
-        ZTg4NmEyM2UxN2Y1NzhmOTI0Zjc0ODgwZGViZGJiN2Q2NWZiMzY4ZGFlIiwg
-        InN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCAiZmls
-        ZW5hbWUiOiAiY2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2gi
+        ZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiMGRmOGY1MzktM2RmZC00MTdkLWFl
+        NjUtMjNiN2M1MzJlOTE2IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVk
+        IjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgInJlcG9faWQiOiAic2NlbmFy
+        aW9fdGVzdCIsICJjcmVhdGVkIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwg
+        InVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIwZGY4ZjUzOS0z
+        ZGZkLTQxN2QtYWU2NS0yM2I3YzUzMmU5MTYiLCAiX2lkIjogeyIkb2lkIjog
+        IjVjZjZlMzM2OWZhOTM0ZjEwYTZkODI0NiJ9fSwgeyJtZXRhZGF0YSI6IHsi
+        c291cmNlcnBtIjogImdpcmFmZmUtMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUi
+        OiAiZ2lyYWZmZSIsICJjaGVja3N1bSI6ICJmMjVkNjdkMWQ5ZGEwNGYxMmU1
+        N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTkyMjAwOWY5ZjE0
+        IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGdpcmFmZmUiLCAi
+        ZmlsZW5hbWUiOiAiZ2lyYWZmZS0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBv
+        Y2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFyIjogZmFs
+        c2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjAu
+        OCIsICJfaWQiOiAiMzQxZmU4ZTItM2FhYy00ZWE0LWFhMWMtYmY3YThmYWU3
+        MDEyIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMTktMDYt
+        MDRUMjE6MzE6MzRaIiwgInJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJj
+        cmVhdGVkIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgInVuaXRfdHlwZV9p
+        ZCI6ICJycG0iLCAidW5pdF9pZCI6ICIzNDFmZThlMi0zYWFjLTRlYTQtYWEx
+        Yy1iZjdhOGZhZTcwMTIiLCAiX2lkIjogeyIkb2lkIjogIjVjZjZlMzM2OWZh
+        OTM0ZjEwYTZkODIyYSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjog
+        InBlbmd1aW4tMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAicGVuZ3VpbiIs
+        ICJjaGVja3N1bSI6ICIzZmNiMmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEz
+        OWQzZTVhZDJlNTg1NjRmYzIxMGZkNmU0ODYzNWJlNjk0IiwgInN1bW1hcnki
+        OiAiQSBkdW1teSBwYWNrYWdlIG9mIHBlbmd1aW4iLCAiZmlsZW5hbWUiOiAi
+        cGVuZ3Vpbi0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2
+        ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29udGVu
+        dF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAi
+        MzZlZmU2MmItMjYxNy00NzA4LTlkZDAtZjlkZDVmMmZmYzcxIiwgImFyY2gi
+        OiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMTktMDYtMDRUMjE6MzE6MzRa
+        IiwgInJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJjcmVhdGVkIjogIjIw
+        MTktMDYtMDRUMjE6MzE6MzRaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAi
+        dW5pdF9pZCI6ICIzNmVmZTYyYi0yNjE3LTQ3MDgtOWRkMC1mOWRkNWYyZmZj
+        NzEiLCAiX2lkIjogeyIkb2lkIjogIjVjZjZlMzM2OWZhOTM0ZjEwYTZkODI1
+        MyJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogInNxdWlycmVsLTAu
+        My0wLjguc3JjLnJwbSIsICJuYW1lIjogInNxdWlycmVsIiwgImNoZWNrc3Vt
+        IjogIjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAxNTUxZTI1
+        Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCAic3VtbWFyeSI6ICJBIGR1bW15
+        IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCAiZmlsZW5hbWUiOiAic3F1aXJyZWwt
+        MC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
+        ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9p
+        ZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjc0NTVhYzUx
+        LWEyYTUtNDc0Yi1iMTM4LTQ2MTk2YjZiNzIwMiIsICJhcmNoIjogIm5vYXJj
+        aCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA2LTA0VDIxOjMxOjM0WiIsICJyZXBv
+        X2lkIjogInNjZW5hcmlvX3Rlc3QiLCAiY3JlYXRlZCI6ICIyMDE5LTA2LTA0
+        VDIxOjMxOjM0WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQi
+        OiAiNzQ1NWFjNTEtYTJhNS00NzRiLWIxMzgtNDYxOTZiNmI3MjAyIiwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgyNmYifX0sIHsi
+        bWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJjaGVldGFoLTAuMy0wLjguc3Jj
+        LnJwbSIsICJuYW1lIjogImNoZWV0YWgiLCAiY2hlY2tzdW0iOiAiNDIyZDBi
+        YWEwY2Q5ZDc3MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRi
+        YjdkNjVmYjM2OGRhZSIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBv
+        ZiBjaGVldGFoIiwgImZpbGVuYW1lIjogImNoZWV0YWgtMC4zLTAuOC5ub2Fy
+        Y2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNf
+        bW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAi
+        cmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjhlYzFkZWM3LTBiYTQtNDdiMC1i
+        Mjc1LTE4YzkyYzQ0ZWM0OSIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRl
+        ZCI6ICIyMDE5LTA2LTA0VDIxOjMxOjM0WiIsICJyZXBvX2lkIjogInNjZW5h
+        cmlvX3Rlc3QiLCAiY3JlYXRlZCI6ICIyMDE5LTA2LTA0VDIxOjMxOjM0WiIs
+        ICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiOGVjMWRlYzct
+        MGJhNC00N2IwLWIyNzUtMThjOTJjNDRlYzQ5IiwgIl9pZCI6IHsiJG9pZCI6
+        ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgyNWMifX0sIHsibWV0YWRhdGEiOiB7
+        InNvdXJjZXJwbSI6ICJ3YWxydXMtMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUi
+        OiAid2FscnVzIiwgImNoZWNrc3VtIjogIjZlOGQ2ZGMwNTdlM2UyYzk4MTlm
+        MGRjN2U2YzdiN2Y4NmJmMmU4NTcxYmJhNDE0YWRlYzdmYjYyMWE0NjFkZmQi
+        LCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwgImZp
+        bGVuYW1lIjogIndhbHJ1cy0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2gi
         OiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFyIjogZmFsc2Us
         ICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjAuOCIs
-        ICJfaWQiOiAiYzJiOTdiMmMtY2Y1OS00MzA4LWE1ODAtNjlkOWY0NzM2NWE5
-        IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMTktMDUtMzBU
-        MTU6MzI6NTVaIiwgInJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJjcmVh
-        dGVkIjogIjIwMTktMDUtMzBUMTU6MzI6NTVaIiwgInVuaXRfdHlwZV9pZCI6
-        ICJycG0iLCAidW5pdF9pZCI6ICJjMmI5N2IyYy1jZjU5LTQzMDgtYTU4MC02
-        OWQ5ZjQ3MzY1YTkiLCAiX2lkIjogeyIkb2lkIjogIjVjZWZmN2E3ZGY5Njk0
-        YmIxNWI5ZjU3NCJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImxp
-        b24tMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAibGlvbiIsICJjaGVja3N1
-        bSI6ICIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4NzE2Y2QzZmNkZDdhODk4
-        MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0IiwgInN1bW1hcnkiOiAiQSBkdW1t
-        eSBwYWNrYWdlIG9mIGxpb24iLCAiZmlsZW5hbWUiOiAibGlvbi0wLjMtMC44
-        Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIs
-        ICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJw
-        bSIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiZDUxYTU1MjctM2I3YS00
-        MmIzLWEwNmEtYTMyMWQ5ZWI0OWYxIiwgImFyY2giOiAibm9hcmNoIn0sICJ1
-        cGRhdGVkIjogIjIwMTktMDUtMzBUMTU6MzI6NTVaIiwgInJlcG9faWQiOiAi
-        c2NlbmFyaW9fdGVzdCIsICJjcmVhdGVkIjogIjIwMTktMDUtMzBUMTU6MzI6
-        NTVaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJkNTFh
-        NTUyNy0zYjdhLTQyYjMtYTA2YS1hMzIxZDllYjQ5ZjEiLCAiX2lkIjogeyIk
-        b2lkIjogIjVjZWZmN2E3ZGY5Njk0YmIxNWI5ZjU1OSJ9fSwgeyJtZXRhZGF0
-        YSI6IHsic291cmNlcnBtIjogImVsZXBoYW50LTAuMy0wLjguc3JjLnJwbSIs
-        ICJuYW1lIjogImVsZXBoYW50IiwgImNoZWNrc3VtIjogIjNlMWM3MGNkMWI0
-        MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcy
-        YTBhNzAxZjMiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgZWxl
-        cGhhbnQiLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gu
+        ICJfaWQiOiAiOTAxMzQ5YzYtOTBhYS00NWE3LTk0MGItMDA3M2U0N2Y5MjAy
+        IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMTktMDYtMDRU
+        MjE6MzE6MzRaIiwgInJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJjcmVh
+        dGVkIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgInVuaXRfdHlwZV9pZCI6
+        ICJycG0iLCAidW5pdF9pZCI6ICI5MDEzNDljNi05MGFhLTQ1YTctOTQwYi0w
+        MDczZTQ3ZjkyMDIiLCAiX2lkIjogeyIkb2lkIjogIjVjZjZlMzM2OWZhOTM0
+        ZjEwYTZkODI2NSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImVs
+        ZXBoYW50LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogImVsZXBoYW50Iiwg
+        ImNoZWNrc3VtIjogIjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0
+        NTMwNmJiOTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCAic3VtbWFyeSI6
+        ICJBIGR1bW15IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCAiZmlsZW5hbWUiOiAi
+        ZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAi
+        dmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRl
+        bnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjog
+        Ijk3YTI2MGU2LTM5ZmMtNDYxZS1iM2IwLWZkNjBkZjg1ZTk0ZSIsICJhcmNo
+        IjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA2LTA0VDIxOjMxOjM0
+        WiIsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAiY3JlYXRlZCI6ICIy
+        MDE5LTA2LTA0VDIxOjMxOjM0WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwg
+        InVuaXRfaWQiOiAiOTdhMjYwZTYtMzlmYy00NjFlLWIzYjAtZmQ2MGRmODVl
+        OTRlIiwgIl9pZCI6IHsiJG9pZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgy
+        MzMifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJsaW9uLTAuMy0w
+        Ljguc3JjLnJwbSIsICJuYW1lIjogImxpb24iLCAiY2hlY2tzdW0iOiAiMTI0
+        MDBkYzk1YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0Mzdh
+        YjY0Y2Q2MmVmYTNlNGFlNCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2Fn
+        ZSBvZiBsaW9uIiwgImZpbGVuYW1lIjogImxpb24tMC4zLTAuOC5ub2FyY2gu
         cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9k
         dWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVs
-        ZWFzZSI6ICIwLjgiLCAiX2lkIjogImQ4ZWIzZjY3LWI5NTYtNDNhNC1iMGU0
-        LWRkNjVmN2I5ZDllNSIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6
-        ICIyMDE5LTA1LTMwVDE1OjMyOjU1WiIsICJyZXBvX2lkIjogInNjZW5hcmlv
-        X3Rlc3QiLCAiY3JlYXRlZCI6ICIyMDE5LTA1LTMwVDE1OjMyOjU1WiIsICJ1
-        bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiZDhlYjNmNjctYjk1
-        Ni00M2E0LWIwZTQtZGQ2NWY3YjlkOWU1IiwgIl9pZCI6IHsiJG9pZCI6ICI1
-        Y2VmZjdhN2RmOTY5NGJiMTViOWY1NTAifX1d
+        ZWFzZSI6ICIwLjgiLCAiX2lkIjogImEzNTc5NDRlLTZmZDctNDMyMy1hNDIy
+        LTc3ZDcwOTk0NWFlNyIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6
+        ICIyMDE5LTA2LTA0VDIxOjMxOjM0WiIsICJyZXBvX2lkIjogInNjZW5hcmlv
+        X3Rlc3QiLCAiY3JlYXRlZCI6ICIyMDE5LTA2LTA0VDIxOjMxOjM0WiIsICJ1
+        bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiYTM1Nzk0NGUtNmZk
+        Ny00MzIzLWE0MjItNzdkNzA5OTQ1YWU3IiwgIl9pZCI6IHsiJG9pZCI6ICI1
+        Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgyM2MifX1d
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:56 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:35 GMT
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2020,7 +2620,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2031,9 +2631,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:56 GMT
+      - Tue, 04 Jun 2019 21:31:35 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '2'
       Content-Type:
@@ -2044,10 +2644,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:56 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:35 GMT
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2059,7 +2659,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2070,9 +2670,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:56 GMT
+      - Tue, 04 Jun 2019 21:31:35 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '2'
       Content-Type:
@@ -2083,10 +2683,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:56 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:35 GMT
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2098,7 +2698,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2109,139 +2709,139 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:56 GMT
+      - Tue, 04 Jun 2019 21:31:35 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '5210'
+      - '5211'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTExLTEwIDAwOjAwOjAw
+        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAx
         IiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjog
-        W3siaHJlZiI6ICJodHRwczovL3Jobi5yZWRoYXQuY29tL2VycmF0YS9SSFNB
-        LTIwMTAtMDg1OC5odG1sIiwgInR5cGUiOiAic2VsZiIsICJpZCI6IG51bGws
-        ICJ0aXRsZSI6ICJSSFNBLTIwMTA6MDg1OCJ9LCB7ImhyZWYiOiAiaHR0cHM6
-        Ly9idWd6aWxsYS5yZWRoYXQuY29tL2J1Z3ppbGxhL3Nob3dfYnVnLmNnaT9p
-        ZD02Mjc4ODIiLCAidHlwZSI6ICJidWd6aWxsYSIsICJpZCI6ICI2Mjc4ODIi
-        LCAidGl0bGUiOiAiQ1ZFLTIwMTAtMDQwNSBiemlwMjogaW50ZWdlciBvdmVy
-        ZmxvdyBmbGF3IGluIEJaMl9kZWNvbXByZXNzIn0sIHsiaHJlZiI6ICJodHRw
-        czovL3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5L2RhdGEvY3ZlL0NWRS0yMDEw
-        LTA0MDUuaHRtbCIsICJ0eXBlIjogImN2ZSIsICJpZCI6ICJDVkUtMjAxMC0w
-        NDA1IiwgInRpdGxlIjogIkNWRS0yMDEwLTA0MDUifSwgeyJocmVmIjogImh0
-        dHA6Ly93d3cucmVkaGF0LmNvbS9zZWN1cml0eS91cGRhdGVzL2NsYXNzaWZp
-        Y2F0aW9uLyNpbXBvcnRhbnQiLCAidHlwZSI6ICJvdGhlciIsICJpZCI6IG51
-        bGwsICJ0aXRsZSI6IG51bGx9XSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9
-        LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIlJIU0Et
-        MjAxMDowODU4IiwgImZyb20iOiAic2VjdXJpdHlAcmVkaGF0LmNvbSIsICJz
-        ZXZlcml0eSI6ICJJbXBvcnRhbnQiLCAidGl0bGUiOiAiSW1wb3J0YW50OiBi
-        emlwMiBzZWN1cml0eSB1cGRhdGUiLCAiX25zIjogInVuaXRzX2VycmF0dW0i
-        LCAidmVyc2lvbiI6ICIzIiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwg
-        InR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFt7InBhY2thZ2VzIjog
-        W3sic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3JjLnJwbSIsICJuYW1l
-        IjogImJ6aXAyLWRldmVsIiwgInN1bSI6IFsic2hhMjU2IiwgImVhNjdjNjY0
-        ZGExZmY5NmE2ZGM5NGQzMzAwOWI3M2Q4ZmFiMzFiNTk4MjQxODNmYjQ1ZTli
-        YTJlYmY4MmQ1ODMiXSwgImZpbGVuYW1lIjogImJ6aXAyLWRldmVsLTEuMC41
-        LTcuZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjog
-        IjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogImk2ODYi
-        fSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5h
-        bWUiOiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1NiIsICJjOWYwNjRh
-        Njg2MjU3M2ZiOWYyYTZhZmY3YzM2MjFmMTk0MGI0OTJkZjJlZGZjMmViYmRj
-        MGI4MzA1ZjUxMTQ3Il0sICJmaWxlbmFtZSI6ICJiemlwMi1saWJzLTEuMC41
-        LTcuZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjog
-        IjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogImk2ODYi
-        fSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5h
-        bWUiOiAiYnppcDIiLCAic3VtIjogWyJzaGEyNTYiLCAiYjhhM2Y3MmJjMmIw
-        ZDg5YmE3MzcwOTlhYzk4YmY4ZDJhZjRiZWEwMmQzMTg4NGMwMmRiOTdmN2Y2
-        NmMzZDVjMiJdLCAiZmlsZW5hbWUiOiAiYnppcDItMS4wLjUtNy5lbDZfMC54
-        ODZfNjQucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIs
-        ICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJz
-        cmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAi
-        YnppcDItZGV2ZWwiLCAic3VtIjogWyJzaGEyNTYiLCAiN2Y2MzEyNGU0NjU1
-        YjdjOTJkMjNlYzRjMzgyMjZmNWQzNzQ2NTY4ODUzZGZmNzUwZmM4NWUwNThl
-        NzRiNWNmNiJdLCAiZmlsZW5hbWUiOiAiYnppcDItZGV2ZWwtMS4wLjUtNy5l
-        bDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIx
-        LjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQi
-        fSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5h
-        bWUiOiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1NiIsICI4MDJmNDM5
-        OWRiZGQwMTQ3NmUyNTRjM2IzMmM0MGFmZjU5Y2Y1ZDIzYTQ1ZmE0ODhjNjkx
-        N2NlODkwNGQ2YjRkIl0sICJmaWxlbmFtZSI6ICJiemlwMi1saWJzLTEuMC41
-        LTcuZWw2XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24i
-        OiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAieDg2
-        XzY0In1dLCAibmFtZSI6ICJjb2xsZWN0aW9uLTAiLCAic2hvcnQiOiAiIn1d
-        LCAic3RhdHVzIjogImZpbmFsIiwgInVwZGF0ZWQiOiAiMjAxMC0xMS0xMCAw
-        MDowMDowMCIsICJkZXNjcmlwdGlvbiI6ICJiemlwMiBpcyBhIGZyZWVseSBh
-        dmFpbGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNvbXByZXNzb3IuIEl0IHBy
-        b3ZpZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11c3QgYmUgcmVzdGFydGVk
-        IGZvciB0aGUgdXBkYXRlIHRvIHRha2UgZWZmZWN0LiIsICJfbGFzdF91cGRh
-        dGVkIjogMTU1OTIzMDM3NSwgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2Us
-        ICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICJDb3B5cmlnaHQgMjAxMCBS
-        ZWQgSGF0IEluYyIsICJzb2x1dGlvbiI6ICJCZWZvcmUgYXBwbHlpbmcgdGhp
-        cyB1cGRhdGUsIG1ha2Ugc3VyZSBhbGwgcHJldmlvdXNseS1yZWxlYXNlZCBl
-        cnJhdGFcbnJlbGV2YW50IHRvIHlvdXIgc3lzdGVtIGhhdmUgYmVlbiBhcHBs
-        aWVkLlxuXG5UaGlzIHVwZGF0ZSBpcyBhdmFpbGFibGUgdmlhIHRoZSBSZWQg
-        SGF0IE5ldHdvcmsuIERldGFpbHMgb24gaG93IHRvXG51c2UgdGhlIFJlZCBI
-        YXQgTmV0d29yayB0byBhcHBseSB0aGlzIHVwZGF0ZSBhcmUgYXZhaWxhYmxl
-        IGF0XG5odHRwOi8va2Jhc2UucmVkaGF0LmNvbS9mYXEvZG9jcy9ET0MtMTEy
-        NTkiLCAic3VtbWFyeSI6ICJVcGRhdGVkIGJ6aXAyIHBhY2thZ2VzIHRoYXQg
-        Zml4IG9uZSBzZWN1cml0eSBpc3N1ZSIsICJyZWxlYXNlIjogIiIsICJfaWQi
-        OiAiOTVhMzE1ZGUtNWZiMC00NTQ1LWE4NTktNGQ2OGU5YmVmOTZhIn0sICJ1
-        cGRhdGVkIjogIjIwMTktMDUtMzBUMTU6MzI6NTVaIiwgInJlcG9faWQiOiAi
-        c2NlbmFyaW9fdGVzdCIsICJjcmVhdGVkIjogIjIwMTktMDUtMzBUMTU6MzI6
-        NTVaIiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVuaXRfaWQiOiAi
-        OTVhMzE1ZGUtNWZiMC00NTQ1LWE4NTktNGQ2OGU5YmVmOTZhIiwgIl9pZCI6
-        IHsiJG9pZCI6ICI1Y2VmZjdhN2RmOTY5NGJiMTViOWY2MTYifX0sIHsibWV0
-        YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAxIiwgInJl
-        bG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjogW10sICJw
-        dWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAi
-        ZXJyYXR1bSIsICJpZCI6ICJSSEVBLTIwMTA6MDAwMiIsICJmcm9tIjogImx6
-        YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjog
-        Ik9uZSBwYWNrYWdlIGVycmF0YSIsICJfbnMiOiAidW5pdHNfZXJyYXR1bSIs
-        ICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAi
-        dHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBb
-        eyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIsICJuYW1l
-        IjogImVsZXBoYW50IiwgInN1bSI6IG51bGwsICJmaWxlbmFtZSI6ICJlbGVw
-        aGFudC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJz
-        aW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJhcmNoIjogIm5vYXJj
-        aCJ9XSwgIm5hbWUiOiAiY29sbGVjdGlvbi0wIiwgInNob3J0IjogIiJ9XSwg
-        InN0YXR1cyI6ICJzdGFibGUiLCAidXBkYXRlZCI6ICIiLCAiZGVzY3JpcHRp
-        b24iOiAiT25lIHBhY2thZ2UgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAx
-        NTU5MjMwMzc1LCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hj
-        b3VudCI6ICIiLCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3Vt
-        bWFyeSI6ICIiLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJlMDUyNmIzOS02
-        YzM5LTRmNzctYWEwOC0xN2UzZWExMzFjMTgifSwgInVwZGF0ZWQiOiAiMjAx
-        OS0wNS0zMFQxNTozMjo1NVoiLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0
-        IiwgImNyZWF0ZWQiOiAiMjAxOS0wNS0zMFQxNTozMjo1NVoiLCAidW5pdF90
-        eXBlX2lkIjogImVycmF0dW0iLCAidW5pdF9pZCI6ICJlMDUyNmIzOS02YzM5
-        LTRmNzctYWEwOC0xN2UzZWExMzFjMTgiLCAiX2lkIjogeyIkb2lkIjogIjVj
-        ZWZmN2E3ZGY5Njk0YmIxNWI5ZjYzMCJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNz
-        dWVkIjogIjIwMTAtMDEtMDEgMDE6MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0
-        ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRh
-        ZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlk
-        IjogIlJIRUEtMjAxMDowMDAxIiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0
-        LmNvbSIsICJzZXZlcml0eSI6ICIiLCAidGl0bGUiOiAiRW1wdHkgZXJyYXRh
-        IiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMSIsICJy
-        ZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5Iiwg
-        InBrZ2xpc3QiOiBbXSwgInN0YXR1cyI6ICJzdGFibGUiLCAidXBkYXRlZCI6
-        ICIiLCAiZGVzY3JpcHRpb24iOiAiRW1wdHkgZXJyYXRhIiwgIl9sYXN0X3Vw
-        ZGF0ZWQiOiAxNTU5MjMwMzc1LCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxz
-        ZSwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6
-        ICIiLCAic3VtbWFyeSI6ICIiLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJm
-        YTE3N2E5Zi0zNTgyLTRjYWUtYjY1Yi04NzUzYjNlMDMwNDQifSwgInVwZGF0
-        ZWQiOiAiMjAxOS0wNS0zMFQxNTozMjo1NVoiLCAicmVwb19pZCI6ICJzY2Vu
-        YXJpb190ZXN0IiwgImNyZWF0ZWQiOiAiMjAxOS0wNS0zMFQxNTozMjo1NVoi
-        LCAidW5pdF90eXBlX2lkIjogImVycmF0dW0iLCAidW5pdF9pZCI6ICJmYTE3
-        N2E5Zi0zNTgyLTRjYWUtYjY1Yi04NzUzYjNlMDMwNDQiLCAiX2lkIjogeyIk
-        b2lkIjogIjVjZWZmN2E3ZGY5Njk0YmIxNWI5ZjVmNyJ9fV0=
+        W10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVf
+        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJSSEVBLTIwMTA6MDAwMiIsICJmcm9t
+        IjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRp
+        dGxlIjogIk9uZSBwYWNrYWdlIGVycmF0YSIsICJfbnMiOiAidW5pdHNfZXJy
+        YXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZh
+        bHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFja2Fn
+        ZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIs
+        ICJuYW1lIjogImVsZXBoYW50IiwgInN1bSI6IG51bGwsICJmaWxlbmFtZSI6
+        ICJlbGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiBudWxs
+        LCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6
+        ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6
+        ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRl
+        c2NyaXB0aW9uIjogIk9uZSBwYWNrYWdlIGVycmF0YSIsICJfbGFzdF91cGRh
+        dGVkIjogMTU1OTY4Mzg5NCwgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2Us
+        ICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAi
+        IiwgInN1bW1hcnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiMTky
+        NDExOGYtNTk1OS00Mjk1LWE3ODctNDcxYjM0MjViZmU3In0sICJ1cGRhdGVk
+        IjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgInJlcG9faWQiOiAic2NlbmFy
+        aW9fdGVzdCIsICJjcmVhdGVkIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwg
+        InVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVuaXRfaWQiOiAiMTkyNDEx
+        OGYtNTk1OS00Mjk1LWE3ODctNDcxYjM0MjViZmU3IiwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgzMWUifX0sIHsibWV0YWRhdGEi
+        OiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAxIiwgInJlbG9naW5f
+        c3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjogW10sICJwdWxwX3Vz
+        ZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1
+        bSIsICJpZCI6ICJSSEVBLTIwMTA6MDAwMSIsICJmcm9tIjogImx6YXArcHVi
+        QHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIkVtcHR5
+        IGVycmF0YSIsICJfbnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjog
+        IjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1
+        cml0eSIsICJwa2dsaXN0IjogW10sICJzdGF0dXMiOiAic3RhYmxlIiwgInVw
+        ZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjogIkVtcHR5IGVycmF0YSIsICJf
+        bGFzdF91cGRhdGVkIjogMTU1OTY4Mzg5NCwgInJlc3RhcnRfc3VnZ2VzdGVk
+        IjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAic29s
+        dXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJf
+        aWQiOiAiNTk0ODY4NWYtY2YyOC00NGNjLWIzYTctMjY5NTg5NjA3ZGI5In0s
+        ICJ1cGRhdGVkIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgInJlcG9faWQi
+        OiAic2NlbmFyaW9fdGVzdCIsICJjcmVhdGVkIjogIjIwMTktMDYtMDRUMjE6
+        MzE6MzRaIiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVuaXRfaWQi
+        OiAiNTk0ODY4NWYtY2YyOC00NGNjLWIzYTctMjY5NTg5NjA3ZGI5IiwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgyZTYifX0sIHsi
+        bWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTExLTEwIDAwOjAwOjAwIiwg
+        InJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjogW3si
+        aHJlZiI6ICJodHRwczovL3Jobi5yZWRoYXQuY29tL2VycmF0YS9SSFNBLTIw
+        MTAtMDg1OC5odG1sIiwgInR5cGUiOiAic2VsZiIsICJpZCI6IG51bGwsICJ0
+        aXRsZSI6ICJSSFNBLTIwMTA6MDg1OCJ9LCB7ImhyZWYiOiAiaHR0cHM6Ly9i
+        dWd6aWxsYS5yZWRoYXQuY29tL2J1Z3ppbGxhL3Nob3dfYnVnLmNnaT9pZD02
+        Mjc4ODIiLCAidHlwZSI6ICJidWd6aWxsYSIsICJpZCI6ICI2Mjc4ODIiLCAi
+        dGl0bGUiOiAiQ1ZFLTIwMTAtMDQwNSBiemlwMjogaW50ZWdlciBvdmVyZmxv
+        dyBmbGF3IGluIEJaMl9kZWNvbXByZXNzIn0sIHsiaHJlZiI6ICJodHRwczov
+        L3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5L2RhdGEvY3ZlL0NWRS0yMDEwLTA0
+        MDUuaHRtbCIsICJ0eXBlIjogImN2ZSIsICJpZCI6ICJDVkUtMjAxMC0wNDA1
+        IiwgInRpdGxlIjogIkNWRS0yMDEwLTA0MDUifSwgeyJocmVmIjogImh0dHA6
+        Ly93d3cucmVkaGF0LmNvbS9zZWN1cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0
+        aW9uLyNpbXBvcnRhbnQiLCAidHlwZSI6ICJvdGhlciIsICJpZCI6IG51bGws
+        ICJ0aXRsZSI6IG51bGx9XSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAi
+        X2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIlJIU0EtMjAx
+        MDowODU4IiwgImZyb20iOiAic2VjdXJpdHlAcmVkaGF0LmNvbSIsICJzZXZl
+        cml0eSI6ICJJbXBvcnRhbnQiLCAidGl0bGUiOiAiSW1wb3J0YW50OiBiemlw
+        MiBzZWN1cml0eSB1cGRhdGUiLCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAi
+        dmVyc2lvbiI6ICIzIiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5
+        cGUiOiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3si
+        c3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3JjLnJwbSIsICJuYW1lIjog
+        ImJ6aXAyLWRldmVsIiwgInN1bSI6IFsic2hhMjU2IiwgImVhNjdjNjY0ZGEx
+        ZmY5NmE2ZGM5NGQzMzAwOWI3M2Q4ZmFiMzFiNTk4MjQxODNmYjQ1ZTliYTJl
+        YmY4MmQ1ODMiXSwgImZpbGVuYW1lIjogImJ6aXAyLWRldmVsLTEuMC41LTcu
+        ZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEu
+        MC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogImk2ODYifSwg
+        eyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUi
+        OiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1NiIsICJjOWYwNjRhNjg2
+        MjU3M2ZiOWYyYTZhZmY3YzM2MjFmMTk0MGI0OTJkZjJlZGZjMmViYmRjMGI4
+        MzA1ZjUxMTQ3Il0sICJmaWxlbmFtZSI6ICJiemlwMi1saWJzLTEuMC41LTcu
+        ZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEu
+        MC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJhcmNoIjogImk2ODYifSwg
+        eyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUi
+        OiAiYnppcDIiLCAic3VtIjogWyJzaGEyNTYiLCAiYjhhM2Y3MmJjMmIwZDg5
+        YmE3MzcwOTlhYzk4YmY4ZDJhZjRiZWEwMmQzMTg4NGMwMmRiOTdmN2Y2NmMz
+        ZDVjMiJdLCAiZmlsZW5hbWUiOiAiYnppcDItMS4wLjUtNy5lbDZfMC54ODZf
+        NjQucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJy
+        ZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJzcmMi
+        OiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnpp
+        cDItZGV2ZWwiLCAic3VtIjogWyJzaGEyNTYiLCAiN2Y2MzEyNGU0NjU1Yjdj
+        OTJkMjNlYzRjMzgyMjZmNWQzNzQ2NTY4ODUzZGZmNzUwZmM4NWUwNThlNzRi
+        NWNmNiJdLCAiZmlsZW5hbWUiOiAiYnppcDItZGV2ZWwtMS4wLjUtNy5lbDZf
+        MC54ODZfNjQucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAu
+        NSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifSwg
+        eyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUi
+        OiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1NiIsICI4MDJmNDM5OWRi
+        ZGQwMTQ3NmUyNTRjM2IzMmM0MGFmZjU5Y2Y1ZDIzYTQ1ZmE0ODhjNjkxN2Nl
+        ODkwNGQ2YjRkIl0sICJmaWxlbmFtZSI6ICJiemlwMi1saWJzLTEuMC41LTcu
+        ZWw2XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAi
+        MS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2giOiAieDg2XzY0
+        In1dLCAibmFtZSI6ICJjb2xsZWN0aW9uLTAiLCAic2hvcnQiOiAiIn1dLCAi
+        c3RhdHVzIjogImZpbmFsIiwgInVwZGF0ZWQiOiAiMjAxMC0xMS0xMCAwMDow
+        MDowMCIsICJkZXNjcmlwdGlvbiI6ICJiemlwMiBpcyBhIGZyZWVseSBhdmFp
+        bGFibGUsIGhpZ2gtcXVhbGl0eSBkYXRhIGNvbXByZXNzb3IuIEl0IHByb3Zp
+        ZGVzIGJvdGhcbmxpYmJ6MiBsaWJyYXJ5IG11c3QgYmUgcmVzdGFydGVkIGZv
+        ciB0aGUgdXBkYXRlIHRvIHRha2UgZWZmZWN0LiIsICJfbGFzdF91cGRhdGVk
+        IjogMTU1OTY4Mzg5NCwgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJw
+        dXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICJDb3B5cmlnaHQgMjAxMCBSZWQg
+        SGF0IEluYyIsICJzb2x1dGlvbiI6ICJCZWZvcmUgYXBwbHlpbmcgdGhpcyB1
+        cGRhdGUsIG1ha2Ugc3VyZSBhbGwgcHJldmlvdXNseS1yZWxlYXNlZCBlcnJh
+        dGFcbnJlbGV2YW50IHRvIHlvdXIgc3lzdGVtIGhhdmUgYmVlbiBhcHBsaWVk
+        LlxuXG5UaGlzIHVwZGF0ZSBpcyBhdmFpbGFibGUgdmlhIHRoZSBSZWQgSGF0
+        IE5ldHdvcmsuIERldGFpbHMgb24gaG93IHRvXG51c2UgdGhlIFJlZCBIYXQg
+        TmV0d29yayB0byBhcHBseSB0aGlzIHVwZGF0ZSBhcmUgYXZhaWxhYmxlIGF0
+        XG5odHRwOi8va2Jhc2UucmVkaGF0LmNvbS9mYXEvZG9jcy9ET0MtMTEyNTki
+        LCAic3VtbWFyeSI6ICJVcGRhdGVkIGJ6aXAyIHBhY2thZ2VzIHRoYXQgZml4
+        IG9uZSBzZWN1cml0eSBpc3N1ZSIsICJyZWxlYXNlIjogIiIsICJfaWQiOiAi
+        OWE1YmE5ZTYtYmU2OS00NGYzLThlMjAtOTViYWNhNDg4NmY3In0sICJ1cGRh
+        dGVkIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgInJlcG9faWQiOiAic2Nl
+        bmFyaW9fdGVzdCIsICJjcmVhdGVkIjogIjIwMTktMDYtMDRUMjE6MzE6MzRa
+        IiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVuaXRfaWQiOiAiOWE1
+        YmE5ZTYtYmU2OS00NGYzLThlMjAtOTViYWNhNDg4NmY3IiwgIl9pZCI6IHsi
+        JG9pZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgzMDAifX1d
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:56 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:35 GMT
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2253,7 +2853,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2264,9 +2864,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:56 GMT
+      - Tue, 04 Jun 2019 21:31:35 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '2'
       Content-Type:
@@ -2277,10 +2877,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:56 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:35 GMT
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2292,7 +2892,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2303,9 +2903,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:56 GMT
+      - Tue, 04 Jun 2019 21:31:35 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -2319,41 +2919,41 @@ http_interactions:
         ZW5ndWluIl0sICJyZXBvX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAibmFtZSI6
         ICJiaXJkIiwgInVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1
         ZSwgIl9ucyI6ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0X3VwZGF0
-        ZWQiOiAxNTU4NzA3NDcyLCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtd
+        ZWQiOiAxNTU5NjgzODk0LCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtd
         LCAidHJhbnNsYXRlZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rlc2NyaXB0
         aW9uIjoge30sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRlZmF1bHRf
         cGFja2FnZV9uYW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNr
-        YWdlX2dyb3VwIiwgImlkIjogImJpcmQiLCAiX2lkIjogImE2OTRjNmM3LTI0
-        OGQtNGY2Mi04MGRmLTRhM2MwMzFkZDQwOSIsICJkaXNwbGF5X29yZGVyIjog
+        YWdlX2dyb3VwIiwgImlkIjogImJpcmQiLCAiX2lkIjogImI3MjllNWFlLWFh
+        ODAtNDZlMi1iMWJjLWZhNTMyMDhjNzhmZSIsICJkaXNwbGF5X29yZGVyIjog
         MTAyNCwgImNvbmRpdGlvbmFsX3BhY2thZ2VfbmFtZXMiOiBbXX0sICJ1cGRh
-        dGVkIjogIjIwMTktMDUtMzBUMTU6MzI6NTVaIiwgInJlcG9faWQiOiAic2Nl
-        bmFyaW9fdGVzdCIsICJjcmVhdGVkIjogIjIwMTktMDUtMzBUMTU6MzI6NTVa
+        dGVkIjogIjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgInJlcG9faWQiOiAic2Nl
+        bmFyaW9fdGVzdCIsICJjcmVhdGVkIjogIjIwMTktMDYtMDRUMjE6MzE6MzRa
         IiwgInVuaXRfdHlwZV9pZCI6ICJwYWNrYWdlX2dyb3VwIiwgInVuaXRfaWQi
-        OiAiYTY5NGM2YzctMjQ4ZC00ZjYyLTgwZGYtNGEzYzAzMWRkNDA5IiwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1Y2VmZjdhN2RmOTY5NGJiMTViOWY2NDUifX0sIHsi
+        OiAiYjcyOWU1YWUtYWE4MC00NmUyLWIxYmMtZmE1MzIwOGM3OGZlIiwgIl9p
+        ZCI6IHsiJG9pZCI6ICI1Y2Y2ZTMzNjlmYTkzNGYxMGE2ZDgzMzQifX0sIHsi
         bWV0YWRhdGEiOiB7Im1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJlbGVw
         aGFudCxnaXJhZmZlLGNoZWV0YWgsbGlvbixtb25rZXkscGVuZ3VpbixzcXVp
         cnJlbCx3YWxydXMiLCAicGVuZ3VpbiJdLCAicmVwb19pZCI6ICJzY2VuYXJp
         b190ZXN0IiwgIm5hbWUiOiAibWFtbWFsIiwgInVzZXJfdmlzaWJsZSI6IHRy
         dWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9ucyI6ICJ1bml0c19wYWNrYWdlX2dy
-        b3VwIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTU4NzA3NDcyLCAib3B0aW9uYWxf
+        b3VwIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTU5NjgzODk0LCAib3B0aW9uYWxf
         cGFja2FnZV9uYW1lcyI6IFtdLCAidHJhbnNsYXRlZF9uYW1lIjoge30sICJ0
         cmFuc2xhdGVkX2Rlc2NyaXB0aW9uIjoge30sICJwdWxwX3VzZXJfbWV0YWRh
         dGEiOiB7fSwgImRlZmF1bHRfcGFja2FnZV9uYW1lcyI6IFtdLCAiX2NvbnRl
         bnRfdHlwZV9pZCI6ICJwYWNrYWdlX2dyb3VwIiwgImlkIjogIm1hbW1hbCIs
-        ICJfaWQiOiAiZWJlOTc1OTktNTc5OC00MDJhLWIzYTQtY2Y0OGM4ZmI4MDc0
+        ICJfaWQiOiAiZThhOTg3ODgtYzJiNC00ZGFiLThjYzEtNWM0MDI3MzllNzZl
         IiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFja2Fn
-        ZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAiMjAxOS0wNS0zMFQxNTozMjo1
-        NVoiLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgImNyZWF0ZWQiOiAi
-        MjAxOS0wNS0zMFQxNTozMjo1NVoiLCAidW5pdF90eXBlX2lkIjogInBhY2th
-        Z2VfZ3JvdXAiLCAidW5pdF9pZCI6ICJlYmU5NzU5OS01Nzk4LTQwMmEtYjNh
-        NC1jZjQ4YzhmYjgwNzQiLCAiX2lkIjogeyIkb2lkIjogIjVjZWZmN2E3ZGY5
-        Njk0YmIxNWI5ZjY1MSJ9fV0=
+        ZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQiOiAiMjAxOS0wNi0wNFQyMTozMToz
+        NFoiLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgImNyZWF0ZWQiOiAi
+        MjAxOS0wNi0wNFQyMTozMTozNFoiLCAidW5pdF90eXBlX2lkIjogInBhY2th
+        Z2VfZ3JvdXAiLCAidW5pdF9pZCI6ICJlOGE5ODc4OC1jMmI0LTRkYWItOGNj
+        MS01YzQwMjczOWU3NmUiLCAiX2lkIjogeyIkb2lkIjogIjVjZjZlMzM2OWZh
+        OTM0ZjEwYTZkODM0MyJ9fV0=
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:56 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:35 GMT
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2365,7 +2965,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2376,9 +2976,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:56 GMT
+      - Tue, 04 Jun 2019 21:31:35 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '2'
       Content-Type:
@@ -2389,10 +2989,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:56 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:35 GMT
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2404,7 +3004,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2415,9 +3015,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:56 GMT
+      - Tue, 04 Jun 2019 21:31:35 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '2'
       Content-Type:
@@ -2428,10 +3028,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:56 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:35 GMT
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2445,7 +3045,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2456,9 +3056,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:56 GMT
+      - Tue, 04 Jun 2019 21:31:35 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '2'
       Content-Type:
@@ -2469,10 +3069,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:56 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:35 GMT
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/search/units/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/search/units/
     body:
       encoding: UTF-8
       base64_string: 'eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkaXN0cmlidXRpb24iXX19
@@ -2484,7 +3084,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2495,9 +3095,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:56 GMT
+      - Tue, 04 Jun 2019 21:31:35 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -2521,24 +3121,24 @@ http_interactions:
         cy9kaXN0cmlidXRpb24vOWIvODMxMjU2YTEyNDcxOGJmMzkxNjZiNTY0ZDhl
         Njg5OTU0ZmYwYThmMGY0NzliYTI0Y2ZhMjYzNTAxMDliYzUiLCAiZmFtaWx5
         IjogIlRlc3QgRmFtaWx5IiwgImRvd25sb2FkZWQiOiB0cnVlLCAidGltZXN0
-        YW1wIjogMTMyMzExMjE1My4wOSwgIl9sYXN0X3VwZGF0ZWQiOiAxNTU5MjMw
-        Mzc1LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJkaXN0cmlidXRpb24iLCAidmFy
+        YW1wIjogMTMyMzExMjE1My4wOSwgIl9sYXN0X3VwZGF0ZWQiOiAxNTU5Njgz
+        ODk0LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJkaXN0cmlidXRpb24iLCAidmFy
         aWFudCI6ICJUZXN0VmFyaWFudCIsICJpZCI6ICJrcy1UZXN0IEZhbWlseS1U
         ZXN0VmFyaWFudC0xNi14ODZfNjQiLCAidmVyc2lvbiI6ICIxNiIsICJ2ZXJz
         aW9uX3NvcnRfaW5kZXgiOiAiMDItMTYiLCAicHVscF91c2VyX21ldGFkYXRh
-        Ijoge30sICJwYWNrYWdlZGlyIjogIiIsICJfaWQiOiAiNDE5YTAxODItMmY3
-        Ni00NTZjLWE5OGMtN2ZlZjNkNDRjODI1IiwgImFyY2giOiAieDg2XzY0Iiwg
+        Ijoge30sICJwYWNrYWdlZGlyIjogIiIsICJfaWQiOiAiZWFjNTBlZjEtYzRk
+        Ni00NmIzLWFjMTktMjE2YjZjYjc1NWFiIiwgImFyY2giOiAieDg2XzY0Iiwg
         Il9ucyI6ICJ1bml0c19kaXN0cmlidXRpb24ifSwgInVwZGF0ZWQiOiAiMjAx
-        OS0wNS0zMFQxNTozMjo1NVoiLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0
-        IiwgImNyZWF0ZWQiOiAiMjAxOS0wNS0zMFQxNTozMjo1NVoiLCAidW5pdF90
-        eXBlX2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogIjQxOWEwMTgy
-        LTJmNzYtNDU2Yy1hOThjLTdmZWYzZDQ0YzgyNSIsICJfaWQiOiB7IiRvaWQi
-        OiAiNWNlZmY3YTdkZjk2OTRiYjE1YjlmNWQzIn19XQ==
+        OS0wNi0wNFQyMTozMTozNFoiLCAicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0
+        IiwgImNyZWF0ZWQiOiAiMjAxOS0wNi0wNFQyMTozMTozNFoiLCAidW5pdF90
+        eXBlX2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogImVhYzUwZWYx
+        LWM0ZDYtNDZiMy1hYzE5LTIxNmI2Y2I3NTVhYiIsICJfaWQiOiB7IiRvaWQi
+        OiAiNWNmNmUzMzY5ZmE5MzRmMTBhNmQ4MmJhIn19XQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:56 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:35 GMT
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/actions/content/regenerate_applicability//
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/actions/content/regenerate_applicability//
     body:
       encoding: UTF-8
       base64_string: |
@@ -2550,7 +3150,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2561,9 +3161,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:56 GMT
+      - Tue, 04 Jun 2019 21:31:35 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '127'
       Content-Type:
@@ -2571,14 +3171,14 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJncm91cF9pZCI6ICI2NjliMmM4Mi04NWJhLTQ4NmItYmUxMy0wNTNkZDFh
-        MjY4MzAiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tfZ3JvdXBzLzY2
-        OWIyYzgyLTg1YmEtNDg2Yi1iZTEzLTA1M2RkMWEyNjgzMC8ifQ==
+        eyJncm91cF9pZCI6ICIwMTQzYTZlOS0yZjFkLTRlMGItODdjZC1mZjA2NDZk
+        OTExNmQiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tfZ3JvdXBzLzAx
+        NDNhNmU5LTJmMWQtNGUwYi04N2NkLWZmMDY0NmQ5MTE2ZC8ifQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:56 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:35 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/task_groups/669b2c82-85ba-486b-be13-053dd1a26830/state_summary/
+    uri: https://devel.balmora.example.com/pulp/api/v2/task_groups/0143a6e9-2f1d-4e0b-87cd-ff0646d9116d/state_summary/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2588,7 +3188,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -2597,9 +3197,9 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:56 GMT
+      - Tue, 04 Jun 2019 21:31:35 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
       - '"f488fb4a2bc756aee3f1e9f5b238fe1f-gzip"'
       Vary:
@@ -2615,5 +3215,5 @@ http_interactions:
         ImNhbmNlbGVkIjogMCwgIndhaXRpbmciOiAwLCAic2tpcHBlZCI6IDAsICJz
         dXNwZW5kZWQiOiAwLCAiZXJyb3IiOiAwLCAidG90YWwiOiAwfQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:56 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:35 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/repo_update.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/repo_update.yml
@@ -2,16 +2,16 @@
 http_interactions:
 - request:
     method: put
-    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/content/1559211615167
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test/content/1559683873292
     body:
       encoding: UTF-8
       base64_string: |
-        eyJpZCI6IjE1NTkyMTE2MTUxNjciLCJuYW1lIjoiU2NlbmFyaW8geXVtIHBy
+        eyJpZCI6IjE1NTk2ODM4NzMyOTIiLCJuYW1lIjoiU2NlbmFyaW8geXVtIHBy
         b2R1Y3QiLCJjb250ZW50VXJsIjoiL2N1c3RvbS9TY2VuYXJpb19Qcm9kdWN0
-        L1NjZW5hcmlvX3l1bV9wcm9kdWN0IiwiZ3BnVXJsIjpudWxsLCJ0eXBlIjoi
-        eXVtIiwiYXJjaGVzIjpudWxsLCJsYWJlbCI6InNjZW5hcmlvX3Rlc3RfU2Nl
-        bmFyaW9fUHJvZHVjdF9TY2VuYXJpb195dW1fcHJvZHVjdCIsIm1ldGFkYXRh
-        RXhwaXJlIjoxLCJ2ZW5kb3IiOiJDdXN0b20ifQ==
+        L1NjZW5hcmlvX3l1bV9wcm9kdWN0IiwiZ3BnVXJsIjoiIiwidHlwZSI6Inl1
+        bSIsImFyY2hlcyI6bnVsbCwibGFiZWwiOiJzY2VuYXJpb190ZXN0X1NjZW5h
+        cmlvX1Byb2R1Y3RfU2NlbmFyaW9feXVtX3Byb2R1Y3QiLCJtZXRhZGF0YUV4
+        cGlyZSI6MSwidmVuZG9yIjoiQ3VzdG9tIn0=
     headers:
       Accept:
       - application/json
@@ -21,8 +21,8 @@ http_interactions:
       - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
       - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD",
-        oauth_nonce="4udy2WLAT7TGnVDtKBkpR1JBndMe3WaCoI2DLfexN8", oauth_signature="TobtVlplUTHPEQrW5wbrWnOGBj4%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559211657", oauth_version="1.0"
+        oauth_nonce="WZM1eRXFZOV15FchrUH1kyRTBYbKwpOKTAKWNgNns", oauth_signature="hpdmvMx3uHsJJ%2B99%2F4KM29euR9Q%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559683916", oauth_version="1.0"
       Accept-Language:
       - en
       Content-Type:
@@ -30,7 +30,7 @@ http_interactions:
       Cp-User:
       - foreman_admin
       Content-Length:
-      - '253'
+      - '251'
   response:
     status:
       code: 200
@@ -39,7 +39,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - 9ff5ed87-0f1c-426b-b083-91d7a35f3b88
+      - bb8214ae-b920-44af-9593-611ea7e4b765
       X-Version:
       - 2.6.5-1
       Content-Type:
@@ -47,14 +47,14 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 30 May 2019 10:20:57 GMT
+      - Tue, 04 Jun 2019 21:31:56 GMT
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxMDoyMDoxNSswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDUtMzBUMTA6MjA6MTUrMDAwMCIsInV1aWQiOiI0MDI4Zjlm
-        NzZiMDQzMGE5MDE2YjA4NDEyM2FkMDBhMyIsImlkIjoiMTU1OTIxMTYxNTE2
-        NyIsInR5cGUiOiJ5dW0iLCJsYWJlbCI6InNjZW5hcmlvX3Rlc3RfU2NlbmFy
+        eyJjcmVhdGVkIjoiMjAxOS0wNi0wNFQyMTozMToxMyswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDYtMDRUMjE6MzE6NTYrMDAwMCIsInV1aWQiOiI0MDI4Zjlm
+        NzZiMWQ3ZDhkMDE2YjI0NjdlMWRjMDcxYSIsImlkIjoiMTU1OTY4Mzg3MzI5
+        MiIsInR5cGUiOiJ5dW0iLCJsYWJlbCI6InNjZW5hcmlvX3Rlc3RfU2NlbmFy
         aW9fUHJvZHVjdF9TY2VuYXJpb195dW1fcHJvZHVjdCIsIm5hbWUiOiJTY2Vu
         YXJpbyB5dW0gcHJvZHVjdCIsInZlbmRvciI6IkN1c3RvbSIsImNvbnRlbnRV
         cmwiOiIvY3VzdG9tL1NjZW5hcmlvX1Byb2R1Y3QvU2NlbmFyaW9feXVtX3By
@@ -63,10 +63,10 @@ http_interactions:
         b2R1Y3RJZHMiOltdLCJtZXRhZGF0YUV4cGlyZSI6MSwicmVsZWFzZVZlciI6
         bnVsbH0=
     http_version: 
-  recorded_at: Thu, 30 May 2019 10:20:57 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:56 GMT
 - request:
     method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/5de42011-666c-4a10-a1ca-b09f607b10da/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -85,1792 +85,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 10:20:58 GMT
+      - Tue, 04 Jun 2019 21:31:56 GMT
       Server:
       - Apache/2.4.6 (CentOS)
       Etag:
-      - '"c7c28921dae6f177bb3ed9d8ed4b7a87-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1266'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uaW1wb3J0ZXIudXBkYXRlX2ltcG9ydGVyX2NvbmZp
-        ZyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNWRlNDIwMTEtNjY2
-        Yy00YTEwLWExY2EtYjA5ZjYwN2IxMGRhLyIsICJ0YXNrX2lkIjogIjVkZTQy
-        MDExLTY2NmMtNGExMC1hMWNhLWIwOWY2MDdiMTBkYSIsICJ0YWdzIjogWyJw
-        dWxwOnJlcG9zaXRvcnk6c2NlbmFyaW9fdGVzdCIsICJwdWxwOnJlcG9zaXRv
-        cnlfaW1wb3J0ZXI6eXVtX2ltcG9ydGVyIiwgInB1bHA6YWN0aW9uOnVwZGF0
-        ZV9pbXBvcnRlciJdLCAiZmluaXNoX3RpbWUiOiAiMjAxOS0wNS0zMFQxMDoy
-        MDo1OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAi
-        MjAxOS0wNS0zMFQxMDoyMDo1OFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
-        YXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVl
-        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
-        YS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29y
-        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwu
-        YmFsbW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlcG9faWQiOiAi
-        c2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNS0zMFQx
-        MDoyMDo1OFoiLCAiX2hyZWYiOiAiL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJp
-        b190ZXN0L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBv
-        X2ltcG9ydGVycyIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRl
-        ciIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjog
-        IjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgInNjcmF0Y2hwYWQiOiB7InJlcG9t
-        ZF9yZXZpc2lvbiI6IDEzMjE4OTM4MDB9LCAiX2lkIjogeyIkb2lkIjogIjVj
-        ZWZhZTVlYjAyZTUzMTFhMjhhMDk0YSJ9LCAiY29uZmlnIjogeyJmZWVkIjog
-        ImZpbGU6Ly8vdmFyL3d3dy90ZXN0X3JlcG9zL3pvbyIsICJzc2xfdmFsaWRh
-        dGlvbiI6IHRydWUsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9h
-        ZF9wb2xpY3kiOiAiaW1tZWRpYXRlIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIi
-        fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmYWU4YWMz
-        OGViNWM4ZjlmZjVlMDYifSwgImlkIjogIjVjZWZhZThhYzM4ZWI1YzhmOWZm
-        NWUwNiJ9
-    http_version: 
-  recorded_at: Thu, 30 May 2019 10:20:58 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/4f9cd4a5-5510-4a4f-b6de-3e21f9c36042/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 30 May 2019 10:20:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"5b8f09e4c4e9a20745469c21e8ab34f8-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1267'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uaW1wb3J0ZXIudXBkYXRlX2ltcG9ydGVyX2NvbmZp
-        ZyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvNGY5Y2Q0YTUtNTUx
-        MC00YTRmLWI2ZGUtM2UyMWY5YzM2MDQyLyIsICJ0YXNrX2lkIjogIjRmOWNk
-        NGE1LTU1MTAtNGE0Zi1iNmRlLTNlMjFmOWMzNjA0MiIsICJ0YWdzIjogWyJw
-        dWxwOnJlcG9zaXRvcnk6c2NlbmFyaW9fdGVzdCIsICJwdWxwOnJlcG9zaXRv
-        cnlfaW1wb3J0ZXI6eXVtX2ltcG9ydGVyIiwgInB1bHA6YWN0aW9uOnVwZGF0
-        ZV9pbXBvcnRlciJdLCAiZmluaXNoX3RpbWUiOiAiMjAxOS0wNS0zMFQxMDoy
-        MDo1OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAi
-        MjAxOS0wNS0zMFQxMDoyMDo1OFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
-        YXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVl
-        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
-        YS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29y
-        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwu
-        YmFsbW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlcG9faWQiOiAi
-        c2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNS0zMFQx
-        MDoyMDo1OFoiLCAiX2hyZWYiOiAiL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJp
-        b190ZXN0L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBv
-        X2ltcG9ydGVycyIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRl
-        ciIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjog
-        IjIwMTktMDUtMzBUMTA6MjA6MzZaIiwgInNjcmF0Y2hwYWQiOiB7InJlcG9t
-        ZF9yZXZpc2lvbiI6IDEzMjE4OTM4MDB9LCAiX2lkIjogeyIkb2lkIjogIjVj
-        ZWZhZTVlYjAyZTUzMTFhMjhhMDk0YSJ9LCAiY29uZmlnIjogeyJmZWVkIjog
-        ImZpbGU6Ly8vdmFyL3d3dy90ZXN0X3JlcG9zL3pvbyIsICJzc2xfdmFsaWRh
-        dGlvbiI6IHRydWUsICJyZW1vdmVfbWlzc2luZyI6IGZhbHNlLCAiZG93bmxv
-        YWRfcG9saWN5IjogImltbWVkaWF0ZSJ9LCAiaWQiOiAieXVtX2ltcG9ydGVy
-        In0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlOGFj
-        MzhlYjVjOGY5ZmY1ZTFiIn0sICJpZCI6ICI1Y2VmYWU4YWMzOGViNWM4Zjlm
-        ZjVlMWIifQ==
-    http_version: 
-  recorded_at: Thu, 30 May 2019 10:20:58 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/429480ec-d795-4457-b8b9-29c4998d3852/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 30 May 2019 10:20:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"a104db0b2ce60eaeb4fe09371b245ff8-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1233'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGlzdHJpYnV0b3JfdXBkYXRlIiwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi90YXNrcy80Mjk0ODBlYy1kNzk1LTQ0NTctYjhi
-        OS0yOWM0OTk4ZDM4NTIvIiwgInRhc2tfaWQiOiAiNDI5NDgwZWMtZDc5NS00
-        NDU3LWI4YjktMjljNDk5OGQzODUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
-        dG9yeTpzY2VuYXJpb190ZXN0IiwgInB1bHA6cmVwb3NpdG9yeV9kaXN0cmli
-        dXRvcjpzY2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnVwZGF0ZV9kaXN0
-        cmlidXRvciJdLCAiZmluaXNoX3RpbWUiOiAiMjAxOS0wNS0zMFQxMDoyMDo1
-        OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAx
-        OS0wNS0zMFQxMDoyMDo1OFoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXdu
-        ZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUi
-        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5l
-        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2Vy
-        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFs
-        bW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlcG9faWQiOiAic2Nl
-        bmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNS0zMFQxMDoy
-        MDo1OFoiLCAiX2hyZWYiOiAiL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJpb190
-        ZXN0L2Rpc3RyaWJ1dG9ycy9zY2VuYXJpb190ZXN0LyIsICJsYXN0X292ZXJy
-        aWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogIjIwMTktMDUtMzBU
-        MTA6MjA6MzZaIiwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Rpc3Ry
-        aWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IHRydWUsICJzY3JhdGNocGFkIjog
-        e30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lk
-        IjogIjVjZWZhZTVmYjAyZTUzMTFhMjhhMDk0YiJ9LCAiY29uZmlnIjogeyJw
-        cm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6IGZhbHNlLCAiaHR0cHMiOiB0cnVl
-        LCAicmVsYXRpdmVfdXJsIjogInNjZW5hcmlvX3Rlc3QifSwgImlkIjogInNj
-        ZW5hcmlvX3Rlc3QifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
-        ICI1Y2VmYWU4YWMzOGViNWM4ZjlmZjVlMzUifSwgImlkIjogIjVjZWZhZThh
-        YzM4ZWI1YzhmOWZmNWUzNSJ9
-    http_version: 
-  recorded_at: Thu, 30 May 2019 10:20:58 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/fdc5ab65-b11c-4efe-b707-2106e1844728/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 30 May 2019 10:20:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"0c957da1579300cc27cc051f0c7dff3f-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1205'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGlzdHJpYnV0b3JfdXBkYXRlIiwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi90YXNrcy9mZGM1YWI2NS1iMTFjLTRlZmUtYjcw
-        Ny0yMTA2ZTE4NDQ3MjgvIiwgInRhc2tfaWQiOiAiZmRjNWFiNjUtYjExYy00
-        ZWZlLWI3MDctMjEwNmUxODQ0NzI4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
-        dG9yeTpzY2VuYXJpb190ZXN0IiwgInB1bHA6cmVwb3NpdG9yeV9kaXN0cmli
-        dXRvcjpzY2VuYXJpb190ZXN0X2Nsb25lIiwgInB1bHA6YWN0aW9uOnVwZGF0
-        ZV9kaXN0cmlidXRvciJdLCAiZmluaXNoX3RpbWUiOiAiMjAxOS0wNS0zMFQx
-        MDoyMDo1OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxOS0wNS0zMFQxMDoyMDo1OFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFs
-        bW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAi
-        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2
-        ZWwuYmFsbW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlcG9faWQi
-        OiAic2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNS0z
-        MFQxMDoyMDo1OFoiLCAiX2hyZWYiOiAiL3YyL3JlcG9zaXRvcmllcy9zY2Vu
-        YXJpb190ZXN0L2Rpc3RyaWJ1dG9ycy9zY2VuYXJpb190ZXN0X2Nsb25lLyIs
-        ICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjog
-        bnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Nsb25lX2Rpc3Ry
-        aWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6
-        IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1Y2VmYWU1ZmIwMmU1MzExYTI4YTA5NGMifSwgImNvbmZpZyI6IHsi
-        ZGVzdGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiAic2NlbmFyaW9fdGVzdCJ9
-        LCAiaWQiOiAic2NlbmFyaW9fdGVzdF9jbG9uZSJ9LCAiZXJyb3IiOiBudWxs
-        LCAiX2lkIjogeyIkb2lkIjogIjVjZWZhZThhYzM4ZWI1YzhmOWZmNWU1MSJ9
-        LCAiaWQiOiAiNWNlZmFlOGFjMzhlYjVjOGY5ZmY1ZTUxIn0=
-    http_version: 
-  recorded_at: Thu, 30 May 2019 10:20:58 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/a199a2dd-e4d2-45ae-8327-6836b351c719/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 30 May 2019 10:20:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"b4dc27f504ea691c6d4961e019bff91a-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1216'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        LnRhc2tzLnJlcG9zaXRvcnkuZGlzdHJpYnV0b3JfdXBkYXRlIiwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi90YXNrcy9hMTk5YTJkZC1lNGQyLTQ1YWUtODMy
-        Ny02ODM2YjM1MWM3MTkvIiwgInRhc2tfaWQiOiAiYTE5OWEyZGQtZTRkMi00
-        NWFlLTgzMjctNjgzNmIzNTFjNzE5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
-        dG9yeTpzY2VuYXJpb190ZXN0IiwgInB1bHA6cmVwb3NpdG9yeV9kaXN0cmli
-        dXRvcjpleHBvcnRfZGlzdHJpYnV0b3IiLCAicHVscDphY3Rpb246dXBkYXRl
-        X2Rpc3RyaWJ1dG9yIl0sICJmaW5pc2hfdGltZSI6ICIyMDE5LTA1LTMwVDEw
-        OjIwOjU4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6
-        ICIyMDE5LTA1LTMwVDEwOjIwOjU4WiIsICJ0cmFjZWJhY2siOiBudWxsLCAi
-        c3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJx
-        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxt
-        b3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
-        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZl
-        bC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVwb19pZCI6
-        ICJzY2VuYXJpb190ZXN0IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA1LTMw
-        VDEwOjIwOjU4WiIsICJfaHJlZiI6ICIvdjIvcmVwb3NpdG9yaWVzL3NjZW5h
-        cmlvX3Rlc3QvZGlzdHJpYnV0b3JzL2V4cG9ydF9kaXN0cmlidXRvci8iLCAi
-        bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlzaCI6IG51
-        bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4cG9ydF9kaXN0cmlidXRv
-        ciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hwYWQiOiB7fSwg
-        Il9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWNlZmFlNWZiMDJlNTMxMWEyOGEwOTRkIn0sICJjb25maWciOiB7Imh0dHAi
-        OiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJzY2VuYXJpb190ZXN0IiwgImh0
-        dHBzIjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sICJl
-        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlOGFjMzhlYjVj
-        OGY5ZmY1ZTY1In0sICJpZCI6ICI1Y2VmYWU4YWMzOGViNWM4ZjlmZjVlNjUi
-        fQ==
-    http_version: 
-  recorded_at: Thu, 30 May 2019 10:20:58 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/682d03e3-786f-4ff1-8e38-58baee833249/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 30 May 2019 10:20:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"8a2ac9945259baf108604399ea5910a0-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '553'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82ODJkMDNlMy03ODZmLTRmZjEtOGUzOC01OGJh
-        ZWU4MzMyNDkvIiwgInRhc2tfaWQiOiAiNjgyZDAzZTMtNzg2Zi00ZmYxLThl
-        MzgtNThiYWVlODMzMjQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
-        IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogIiIsICJz
-        dGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9uYW1lIjogbnVsbCwgInJlc3Vs
-        dCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNl
-        ZmFlOGFjMzhlYjVjOGY5ZmY1ZWMzIn0sICJpZCI6ICI1Y2VmYWU4YWMzOGVi
-        NWM4ZjlmZjVlYzMifQ==
-    http_version: 
-  recorded_at: Thu, 30 May 2019 10:20:58 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/682d03e3-786f-4ff1-8e38-58baee833249/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 30 May 2019 10:20:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"1343cabdd07185f57826f524eaaf2192-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4545'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82ODJkMDNlMy03ODZmLTRmZjEtOGUzOC01OGJh
-        ZWU4MzMyNDkvIiwgInRhc2tfaWQiOiAiNjgyZDAzZTMtNzg2Zi00ZmYxLThl
-        MzgtNThiYWVlODMzMjQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6NThaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
-        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
-        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4NDRjMTljYi01YzRjLTQ4YWQtYTY5
-        OS03YmY5YjNmNGJkMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBv
-        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
-        YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmY0MzdkY2UtYTU1Yi00NmE5
-        LWFmYTMtMjk5NWY4YTE3NWM5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
-        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERp
-        c3RyaWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9u
-        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImEyNWJlZDg0LTIxM2ItNDBmNS04ZDE2
-        LTg1ZjU5ZDIwNjIzMiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
-        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwg
-        InN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNmZGNi
-        MmMyLWI4MjItNGU2Yy1hMTU2LWNlY2E5NGNmNzc4OCIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
-        UHVibGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIzZDAwYzk1My0yZDI3LTRmNzgtOGEwOC1i
-        NzU4OWYyNDM5NDYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwg
-        InN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmU2
-        MzZlNTItY2VlZC00Y2FlLWE2MmEtMTMyNjc2MGUzZWQyIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
-        ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiOWZjNDM4ZTctMTE5NS00MTNmLTgwZDEt
-        Y2JhZjM0M2RiYzAwIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZp
-        bGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImVkZDZlNzkwLTIyMmQtNGViZS1iNmRlLTAwYTcwMTBhYjNjYyIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFS
-        VEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjViOGFlYWViLWQwNzItNGVk
-        NC1iMzU2LWY3OGI2ODRiMjkzZSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
-        IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
-        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjAxYTNiNGMwLTNiNTktNDBlMi04MWM2
-        LWM1MWNmZDg3ZWZmYiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
-        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUg
-        ZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVt
-        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJmMjliZTk3OC0zOWIyLTQ3NGUtYWNlMC1lZjdiYjlj
-        ODYxYWIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJz
-        dGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI4NjI2ZjkxNC0zNTQ3LTRlZGEtOTlhYy03NjU1ZDBkNWFkY2Ii
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5
-        cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzM4YTJiN2Yt
-        MmM2NS00Nzk2LWI1ZDctYjI0ZTA1ZGEzNTEyIiwgIm51bV9wcm9jZXNzZWQi
-        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
-        aXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9k
-        aXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
-        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDQ4MDEzZGMtY2IzYS00
-        MTQzLTkwMWMtZjEwZDU4YTk2NjA1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
-        c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RB
-        UlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYWZkNjgzYy04MTY5LTQw
-        NzEtOTE4OS0zNTM5Nzg2MjdkZmEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0s
-        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5i
-        YWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRl
-        dmVsLmJhbG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
-        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmYWU4YWMzOGViNWM4
-        ZjlmZjVlYzMifSwgImlkIjogIjVjZWZhZThhYzM4ZWI1YzhmOWZmNWVjMyJ9
-    http_version: 
-  recorded_at: Thu, 30 May 2019 10:20:58 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/682d03e3-786f-4ff1-8e38-58baee833249/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 30 May 2019 10:20:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"61a78fb888c99051a917e0c2bc543aba-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4539'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82ODJkMDNlMy03ODZmLTRmZjEtOGUzOC01OGJh
-        ZWU4MzMyNDkvIiwgInRhc2tfaWQiOiAiNjgyZDAzZTMtNzg2Zi00ZmYxLThl
-        MzgtNThiYWVlODMzMjQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6NThaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
-        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI4NDRjMTljYi01YzRjLTQ4YWQtYTY5OS03
-        YmY5YjNmNGJkMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
-        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMmY0MzdkY2UtYTU1Yi00NmE5LWFmYTMt
-        Mjk5NWY4YTE3NWM5IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
-        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImEyNWJlZDg0LTIxM2ItNDBmNS04ZDE2LTg1ZjU5
-        ZDIwNjIzMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBf
-        dHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
-        VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNmZGNiMmMyLWI4
-        MjItNGU2Yy1hMTU2LWNlY2E5NGNmNzc4OCIsICJudW1fcHJvY2Vzc2VkIjog
-        MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVt
-        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIzZDAwYzk1My0yZDI3LTRmNzgtOGEwOC1iNzU4OWYy
-        NDM5NDYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBf
-        dHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmU2MzZlNTIt
-        Y2VlZC00Y2FlLWE2MmEtMTMyNjc2MGUzZWQyIiwgIm51bV9wcm9jZXNzZWQi
-        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
-        aXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiOWZjNDM4ZTctMTE5NS00MTNmLTgwZDEtY2JhZjM0
-        M2RiYzAwIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAi
-        c3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVkZDZl
-        NzkwLTIyMmQtNGViZS1iNmRlLTAwYTcwMTBhYjNjYyIsICJudW1fcHJvY2Vz
-        c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
-        UHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRh
-        IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjViOGFlYWViLWQwNzItNGVkNC1iMzU2
-        LWY3OGI2ODRiMjkzZSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
-        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFk
-        YXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogIjAxYTNiNGMwLTNiNTktNDBlMi04MWM2LWM1MWNm
-        ZDg3ZWZmYiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMi
-        LCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJmMjliZTk3OC0zOWIyLTQ3NGUtYWNlMC1lZjdiYjljODYxYWIi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5
-        cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI4NjI2ZjkxNC0zNTQ3LTRlZGEtOTlhYy03NjU1ZDBkNWFkY2IiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0
-        aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
-        cmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
-        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzM4YTJiN2YtMmM2NS00
-        Nzk2LWI1ZDctYjI0ZTA1ZGEzNTEyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
-        IGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rv
-        cnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDQ4MDEzZGMtY2IzYS00MTQzLTkw
-        MWMtZjEwZDU4YTk2NjA1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3Rpbmdz
-        IEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0
-        YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYWZkNjgzYy04MTY5LTQwNzEtOTE4
-        OS0zNTM5Nzg2MjdkZmEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1
-        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3Jh
-        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtl
-        cl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJh
-        bG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjog
-        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmYWU4YWMzOGViNWM4ZjlmZjVl
-        YzMifSwgImlkIjogIjVjZWZhZThhYzM4ZWI1YzhmOWZmNWVjMyJ9
-    http_version: 
-  recorded_at: Thu, 30 May 2019 10:20:58 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/682d03e3-786f-4ff1-8e38-58baee833249/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 30 May 2019 10:20:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"b0e2bc8278c54a8605516269f02473bc-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4536'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82ODJkMDNlMy03ODZmLTRmZjEtOGUzOC01OGJh
-        ZWU4MzMyNDkvIiwgInRhc2tfaWQiOiAiNjgyZDAzZTMtNzg2Zi00ZmYxLThl
-        MzgtNThiYWVlODMzMjQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6NThaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
-        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI4NDRjMTljYi01YzRjLTQ4YWQtYTY5OS03
-        YmY5YjNmNGJkMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
-        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMmY0MzdkY2UtYTU1Yi00NmE5LWFmYTMt
-        Mjk5NWY4YTE3NWM5IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
-        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImEyNWJlZDg0LTIxM2ItNDBmNS04ZDE2LTg1ZjU5ZDIw
-        NjIzMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAz
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
-        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIklOX1BS
-        T0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNmZGNiMmMyLWI4MjIt
-        NGU2Yy1hMTU2LWNlY2E5NGNmNzc4OCIsICJudW1fcHJvY2Vzc2VkIjogM30s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICIzZDAwYzk1My0yZDI3LTRmNzgtOGEwOC1iNzU4OWYyNDM5
-        NDYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlw
-        ZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
-        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmU2MzZlNTItY2Vl
-        ZC00Y2FlLWE2MmEtMTMyNjc2MGUzZWQyIiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiOWZjNDM4ZTctMTE5NS00MTNmLTgwZDEtY2JhZjM0M2Ri
-        YzAwIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVkZDZlNzkw
-        LTIyMmQtNGViZS1iNmRlLTAwYTcwMTBhYjNjYyIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjViOGFlYWViLWQwNzItNGVkNC1iMzU2LWY3
-        OGI2ODRiMjkzZSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
-        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
-        IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjAxYTNiNGMwLTNiNTktNDBlMi04MWM2LWM1MWNmZDg3
-        ZWZmYiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
-        LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAi
-        c3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICJmMjliZTk3OC0zOWIyLTQ3NGUtYWNlMC1lZjdiYjljODYxYWIiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUi
-        OiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4
-        NjI2ZjkxNC0zNTQ3LTRlZGEtOTlhYy03NjU1ZDBkNWFkY2IiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVw
-        b3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzM4YTJiN2YtMmM2NS00Nzk2
-        LWI1ZDctYjI0ZTA1ZGEzNTEyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
-        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZp
-        bGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rvcnki
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZDQ4MDEzZGMtY2IzYS00MTQzLTkwMWMt
-        ZjEwZDU4YTk2NjA1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZp
-        bGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIwYWZkNjgzYy04MTY5LTQwNzEtOTE4OS0z
-        NTM5Nzg2MjdkZmEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9u
-        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1v
-        cmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVs
-        bCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmYWU4YWMzOGViNWM4ZjlmZjVlYzMi
-        fSwgImlkIjogIjVjZWZhZThhYzM4ZWI1YzhmOWZmNWVjMyJ9
-    http_version: 
-  recorded_at: Thu, 30 May 2019 10:20:58 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/682d03e3-786f-4ff1-8e38-58baee833249/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 30 May 2019 10:20:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"c4c2e0725d4b3040056e8fcd3fd0d07d-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4536'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82ODJkMDNlMy03ODZmLTRmZjEtOGUzOC01OGJh
-        ZWU4MzMyNDkvIiwgInRhc2tfaWQiOiAiNjgyZDAzZTMtNzg2Zi00ZmYxLThl
-        MzgtNThiYWVlODMzMjQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6NThaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
-        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI4NDRjMTljYi01YzRjLTQ4YWQtYTY5OS03
-        YmY5YjNmNGJkMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
-        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMmY0MzdkY2UtYTU1Yi00NmE5LWFmYTMt
-        Mjk5NWY4YTE3NWM5IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
-        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImEyNWJlZDg0LTIxM2ItNDBmNS04ZDE2LTg1ZjU5ZDIw
-        NjIzMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA3
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
-        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIklOX1BS
-        T0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNmZGNiMmMyLWI4MjIt
-        NGU2Yy1hMTU2LWNlY2E5NGNmNzc4OCIsICJudW1fcHJvY2Vzc2VkIjogN30s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICIzZDAwYzk1My0yZDI3LTRmNzgtOGEwOC1iNzU4OWYyNDM5
-        NDYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlw
-        ZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
-        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmU2MzZlNTItY2Vl
-        ZC00Y2FlLWE2MmEtMTMyNjc2MGUzZWQyIiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
-        aW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiOWZjNDM4ZTctMTE5NS00MTNmLTgwZDEtY2JhZjM0M2Ri
-        YzAwIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
-        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImVkZDZlNzkw
-        LTIyMmQtNGViZS1iNmRlLTAwYTcwMTBhYjNjYyIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwg
-        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
-        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjViOGFlYWViLWQwNzItNGVkNC1iMzU2LWY3
-        OGI2ODRiMjkzZSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
-        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
-        IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjAxYTNiNGMwLTNiNTktNDBlMi04MWM2LWM1MWNmZDg3
-        ZWZmYiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
-        LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAi
-        c3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICJmMjliZTk3OC0zOWIyLTQ3NGUtYWNlMC1lZjdiYjljODYxYWIiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUi
-        OiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4
-        NjI2ZjkxNC0zNTQ3LTRlZGEtOTlhYy03NjU1ZDBkNWFkY2IiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVw
-        b3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzM4YTJiN2YtMmM2NS00Nzk2
-        LWI1ZDctYjI0ZTA1ZGEzNTEyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
-        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZp
-        bGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rvcnki
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZDQ4MDEzZGMtY2IzYS00MTQzLTkwMWMt
-        ZjEwZDU4YTk2NjA1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZp
-        bGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIwYWZkNjgzYy04MTY5LTQwNzEtOTE4OS0z
-        NTM5Nzg2MjdkZmEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6
-        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
-        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9u
-        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1v
-        cmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVs
-        bCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmYWU4YWMzOGViNWM4ZjlmZjVlYzMi
-        fSwgImlkIjogIjVjZWZhZThhYzM4ZWI1YzhmOWZmNWVjMyJ9
-    http_version: 
-  recorded_at: Thu, 30 May 2019 10:20:58 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/682d03e3-786f-4ff1-8e38-58baee833249/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 30 May 2019 10:20:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"8c5afeab5214db66289871484816d17f-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4529'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82ODJkMDNlMy03ODZmLTRmZjEtOGUzOC01OGJh
-        ZWU4MzMyNDkvIiwgInRhc2tfaWQiOiAiNjgyZDAzZTMtNzg2Zi00ZmYxLThl
-        MzgtNThiYWVlODMzMjQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6NThaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
-        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI4NDRjMTljYi01YzRjLTQ4YWQtYTY5OS03
-        YmY5YjNmNGJkMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
-        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMmY0MzdkY2UtYTU1Yi00NmE5LWFmYTMt
-        Mjk5NWY4YTE3NWM5IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
-        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImEyNWJlZDg0LTIxM2ItNDBmNS04ZDE2LTg1ZjU5ZDIw
-        NjIzMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
-        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNmZGNiMmMyLWI4MjItNGU2
-        Yy1hMTU2LWNlY2E5NGNmNzc4OCIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
-        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjNkMDBjOTUzLTJkMjctNGY3OC04YTA4LWI3NTg5ZjI0Mzk0NiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
-        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVT
-        UyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZTYzNmU1Mi1jZWVkLTRjYWUt
-        YTYyYS0xMzI2NzYwZTNlZDIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
-        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9k
-        dWxlcyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI5ZmM0MzhlNy0xMTk1LTQxM2YtODBkMS1jYmFmMzQzZGJjMDAiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUi
-        OiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
-        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWRkNmU3OTAtMjIyZC00
-        ZWJlLWI2ZGUtMDBhNzAxMGFiM2NjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
-        IE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiNWI4YWVhZWItZDA3Mi00ZWQ0LWIzNTYtZjc4YjY4NGIy
-        OTNlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
-        ICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3Rl
-        cF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
-        OiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMDFhM2I0YzAtM2I1OS00MGUyLTgxYzYtYzUxY2ZkODdlZmZiIiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5
-        cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImYy
-        OWJlOTc4LTM5YjItNDc0ZS1hY2UwLWVmN2JiOWM4NjFhYiIsICJudW1fcHJv
-        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1v
-        dmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjg2MjZmOTE0
-        LTM1NDctNGVkYS05OWFjLTc2NTVkMGQ1YWRjYiIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
-        ZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJjMzhhMmI3Zi0yYzY1LTQ3OTYtYjVkNy1i
-        MjRlMDVkYTM1MTIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8g
-        d2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVt
-        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJkNDgwMTNkYy1jYjNhLTQxNDMtOTAxYy1mMTBkNThh
-        OTY2MDUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjBhZmQ2ODNjLTgxNjktNDA3MS05MTg5LTM1Mzk3ODYy
-        N2RmYSIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFt
-        cGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
-        IjogeyIkb2lkIjogIjVjZWZhZThhYzM4ZWI1YzhmOWZmNWVjMyJ9LCAiaWQi
-        OiAiNWNlZmFlOGFjMzhlYjVjOGY5ZmY1ZWMzIn0=
-    http_version: 
-  recorded_at: Thu, 30 May 2019 10:20:58 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/682d03e3-786f-4ff1-8e38-58baee833249/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 30 May 2019 10:20:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"7a3be444a4ab95f116f275d35e239ad0-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4523'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82ODJkMDNlMy03ODZmLTRmZjEtOGUzOC01OGJh
-        ZWU4MzMyNDkvIiwgInRhc2tfaWQiOiAiNjgyZDAzZTMtNzg2Zi00ZmYxLThl
-        MzgtNThiYWVlODMzMjQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6NThaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
-        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI4NDRjMTljYi01YzRjLTQ4YWQtYTY5OS03
-        YmY5YjNmNGJkMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
-        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMmY0MzdkY2UtYTU1Yi00NmE5LWFmYTMt
-        Mjk5NWY4YTE3NWM5IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
-        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImEyNWJlZDg0LTIxM2ItNDBmNS04ZDE2LTg1ZjU5ZDIw
-        NjIzMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
-        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNmZGNiMmMyLWI4MjItNGU2
-        Yy1hMTU2LWNlY2E5NGNmNzc4OCIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
-        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjNkMDBjOTUzLTJkMjctNGY3OC04YTA4LWI3NTg5ZjI0Mzk0NiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
-        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZTYzNmU1Mi1jZWVkLTRjYWUtYTYy
-        YS0xMzI2NzYwZTNlZDIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
-        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5
-        ZmM0MzhlNy0xMTk1LTQxM2YtODBkMS1jYmFmMzQzZGJjMDAiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
-        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiSU5fUFJPR1JFU1Mi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWRkNmU3OTAtMjIyZC00ZWJlLWI2
-        ZGUtMDBhNzAxMGFiM2NjIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1f
-        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFk
-        YXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
-        OiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNWI4YWVhZWItZDA3Mi00ZWQ0LWIzNTYtZjc4YjY4NGIyOTNlIiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBl
-        IjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        MDFhM2I0YzAtM2I1OS00MGUyLTgxYzYtYzUxY2ZkODdlZmZiIiwgIm51bV9w
-        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
-        biI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
-        Z2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImYyOWJlOTc4
-        LTM5YjItNDc0ZS1hY2UwLWVmN2JiOWM4NjFhYiIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUmVt
-        b3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xk
-        X3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
-        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjg2MjZmOTE0LTM1NDct
-        NGVkYS05OWFjLTc2NTVkMGQ1YWRjYiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
-        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
-        ZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVt
-        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJjMzhhMmI3Zi0yYzY1LTQ3OTYtYjVkNy1iMjRlMDVk
-        YTM1MTIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwg
-        InN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJkNDgwMTNkYy1jYjNhLTQxNDMtOTAxYy1mMTBkNThhOTY2MDUi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjBhZmQ2ODNjLTgxNjktNDA3MS05MTg5LTM1Mzk3ODYyN2RmYSIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2VydmVkX3Jl
-        c291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
-        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNv
-        bSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
-        b2lkIjogIjVjZWZhZThhYzM4ZWI1YzhmOWZmNWVjMyJ9LCAiaWQiOiAiNWNl
-        ZmFlOGFjMzhlYjVjOGY5ZmY1ZWMzIn0=
-    http_version: 
-  recorded_at: Thu, 30 May 2019 10:20:58 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/682d03e3-786f-4ff1-8e38-58baee833249/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 30 May 2019 10:20:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"0d4c69bdef46dd2376990fee52450692-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4503'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82ODJkMDNlMy03ODZmLTRmZjEtOGUzOC01OGJh
-        ZWU4MzMyNDkvIiwgInRhc2tfaWQiOiAiNjgyZDAzZTMtNzg2Zi00ZmYxLThl
-        MzgtNThiYWVlODMzMjQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6NThaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
-        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI4NDRjMTljYi01YzRjLTQ4YWQtYTY5OS03
-        YmY5YjNmNGJkMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
-        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMmY0MzdkY2UtYTU1Yi00NmE5LWFmYTMt
-        Mjk5NWY4YTE3NWM5IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
-        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImEyNWJlZDg0LTIxM2ItNDBmNS04ZDE2LTg1ZjU5ZDIw
-        NjIzMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
-        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNmZGNiMmMyLWI4MjItNGU2
-        Yy1hMTU2LWNlY2E5NGNmNzc4OCIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
-        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjNkMDBjOTUzLTJkMjctNGY3OC04YTA4LWI3NTg5ZjI0Mzk0NiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
-        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZTYzNmU1Mi1jZWVkLTRjYWUtYTYy
-        YS0xMzI2NzYwZTNlZDIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
-        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5
-        ZmM0MzhlNy0xMTk1LTQxM2YtODBkMS1jYmFmMzQzZGJjMDAiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
-        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZWRkNmU3OTAtMjIyZC00ZWJlLWI2ZGUt
-        MDBhNzAxMGFiM2NjIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRh
-        LiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        NWI4YWVhZWItZDA3Mi00ZWQ0LWIzNTYtZjc4YjY4NGIyOTNlIiwgIm51bV9w
-        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
-        biI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNs
-        b3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDFhM2I0YzAt
-        M2I1OS00MGUyLTgxYzYtYzUxY2ZkODdlZmZiIiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5l
-        cmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUg
-        c3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjI5YmU5NzgtMzliMi00NzRlLWFj
-        ZTAtZWY3YmI5Yzg2MWFiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVw
-        b2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAi
-        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiODYyNmY5MTQtMzU0Ny00ZWRhLTk5YWMtNzY1NWQw
-        ZDVhZGNiIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAi
-        c3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzM4YTJi
-        N2YtMmM2NS00Nzk2LWI1ZDctYjI0ZTA1ZGEzNTEyIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
-        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiSU5f
-        UFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDQ4MDEzZGMtY2Iz
-        YS00MTQzLTkwMWMtZjEwZDU4YTk2NjA1IiwgIm51bV9wcm9jZXNzZWQiOiAw
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5n
-        IExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVw
-        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
-        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYWZkNjgzYy04MTY5
-        LTQwNzEtOTE4OS0zNTM5Nzg2MjdkZmEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZl
-        bC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5n
-        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0w
-        QGRldmVsLmJhbG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwg
-        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmYWU4YWMzOGVi
-        NWM4ZjlmZjVlYzMifSwgImlkIjogIjVjZWZhZThhYzM4ZWI1YzhmOWZmNWVj
-        MyJ9
-    http_version: 
-  recorded_at: Thu, 30 May 2019 10:20:58 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/682d03e3-786f-4ff1-8e38-58baee833249/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 30 May 2019 10:20:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"45aae24f2d5a373a81f92a26a4c0b444-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4497'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82ODJkMDNlMy03ODZmLTRmZjEtOGUzOC01OGJh
-        ZWU4MzMyNDkvIiwgInRhc2tfaWQiOiAiNjgyZDAzZTMtNzg2Zi00ZmYxLThl
-        MzgtNThiYWVlODMzMjQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6NThaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
-        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI4NDRjMTljYi01YzRjLTQ4YWQtYTY5OS03
-        YmY5YjNmNGJkMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
-        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiMmY0MzdkY2UtYTU1Yi00NmE5LWFmYTMt
-        Mjk5NWY4YTE3NWM5IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
-        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImEyNWJlZDg0LTIxM2ItNDBmNS04ZDE2LTg1ZjU5ZDIw
-        NjIzMiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
-        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNmZGNiMmMyLWI4MjItNGU2
-        Yy1hMTU2LWNlY2E5NGNmNzc4OCIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
-        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjNkMDBjOTUzLTJkMjctNGY3OC04YTA4LWI3NTg5ZjI0Mzk0NiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
-        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZTYzNmU1Mi1jZWVkLTRjYWUtYTYy
-        YS0xMzI2NzYwZTNlZDIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
-        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5
-        ZmM0MzhlNy0xMTk1LTQxM2YtODBkMS1jYmFmMzQzZGJjMDAiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
-        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZWRkNmU3OTAtMjIyZC00ZWJlLWI2ZGUt
-        MDBhNzAxMGFiM2NjIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRh
-        LiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        NWI4YWVhZWItZDA3Mi00ZWQ0LWIzNTYtZjc4YjY4NGIyOTNlIiwgIm51bV9w
-        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
-        biI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNs
-        b3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
-        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDFhM2I0YzAt
-        M2I1OS00MGUyLTgxYzYtYzUxY2ZkODdlZmZiIiwgIm51bV9wcm9jZXNzZWQi
-        OiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5l
-        cmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUg
-        c3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
-        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjI5YmU5NzgtMzliMi00NzRlLWFj
-        ZTAtZWY3YmI5Yzg2MWFiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVw
-        b2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAi
-        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
-        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiODYyNmY5MTQtMzU0Ny00ZWRhLTk5YWMtNzY1NWQw
-        ZDVhZGNiIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
-        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAi
-        c3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzM4YTJi
-        N2YtMmM2NS00Nzk2LWI1ZDctYjI0ZTA1ZGEzNTEyIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
-        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklO
-        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDQ4MDEzZGMtY2IzYS00
-        MTQzLTkwMWMtZjEwZDU4YTk2NjA1IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwg
-        eyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
-        c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
-        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
-        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYWZkNjgzYy04MTY5LTQwNzEt
-        OTE4OS0zNTM5Nzg2MjdkZmEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9XX0sICJx
-        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxt
-        b3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndv
-        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVs
-        LmJhbG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9y
-        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmYWU4YWMzOGViNWM4Zjlm
-        ZjVlYzMifSwgImlkIjogIjVjZWZhZThhYzM4ZWI1YzhmOWZmNWVjMyJ9
-    http_version: 
-  recorded_at: Thu, 30 May 2019 10:20:58 GMT
-- request:
-    method: get
-    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/682d03e3-786f-4ff1-8e38-58baee833249/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 30 May 2019 10:20:58 GMT
-      Server:
-      - Apache/2.4.6 (CentOS)
-      Etag:
-      - '"512cf8eb8c15c7157964b99621e8a142-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '9043'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy82ODJkMDNlMy03ODZmLTRmZjEtOGUzOC01OGJh
-        ZWU4MzMyNDkvIiwgInRhc2tfaWQiOiAiNjgyZDAzZTMtNzg2Zi00ZmYxLThl
-        MzgtNThiYWVlODMzMjQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6NThaIiwgIl9ucyI6ICJ0YXNr
-        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTktMDUtMzBUMTA6MjA6NTha
-        IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
-        cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0
-        ZXBfdHlwZSI6ICJzYXZlX3RhciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4NDRjMTlj
-        Yi01YzRjLTQ4YWQtYTY5OS03YmY5YjNmNGJkMmUiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIklu
-        aXRpYWxpemluZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0
-        aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmY0Mzdk
-        Y2UtYTU1Yi00NmE5LWFmYTMtMjk5NWY4YTE3NWM5IiwgIm51bV9wcm9jZXNz
-        ZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIERpc3RyaWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
-        ZGlzdHJpYnV0aW9uIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
-        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImEyNWJlZDg0LTIxM2It
-        NDBmNS04ZDE2LTg1ZjU5ZDIwNjIzMiIsICJudW1fcHJvY2Vzc2VkIjogMX0s
-        IHsibnVtX3N1Y2Nlc3MiOiA4LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
-        ZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjog
-        OCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImNmZGNiMmMyLWI4MjItNGU2Yy1hMTU2LWNlY2E5NGNmNzc4OCIsICJudW1f
-        cHJvY2Vzc2VkIjogOH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJk
-        cnBtcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjNkMDBjOTUzLTJkMjctNGY3OC04YTA4
-        LWI3NTg5ZjI0Mzk0NiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
-        Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEi
-        LCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmZTYz
-        NmU1Mi1jZWVkLTRjYWUtYTYyYS0xMzI2NzYwZTNlZDIiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgTW9kdWxlcyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIs
-        ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI5ZmM0MzhlNy0xMTk1LTQxM2YtODBkMS1jYmFm
-        MzQzZGJjMDAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIs
-        ICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3Rh
-        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZWRkNmU3
-        OTAtMjIyZC00ZWJlLWI2ZGUtMDBhNzAxMGFiM2NjIiwgIm51bV9wcm9jZXNz
-        ZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
-        dWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiNWI4YWVhZWItZDA3Mi00ZWQ0LWIzNTYtZjc4
-        YjY4NGIyOTNlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
-        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEi
-        LCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
-        ZXBfaWQiOiAiMDFhM2I0YzAtM2I1OS00MGUyLTgxYzYtYzUxY2ZkODdlZmZi
-        IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
-        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
-        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjI5
-        YmU5NzgtMzliMi00NzRlLWFjZTAtZWY3YmI5Yzg2MWFiIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
-        ICJSZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92
-        ZV9vbGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODYyNmY5MTQtMzU0
-        Ny00ZWRhLTk5YWMtNzY1NWQwZDVhZGNiIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
-        aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiYzM4YTJiN2YtMmM2NS00Nzk2LWI1ZDctYjI0ZTA1ZGEz
-        NTEyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEs
-        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJz
-        dGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwi
-        OiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiZDQ4MDEzZGMtY2IzYS00MTQzLTkwMWMtZjEwZDU4YTk2NjA1IiwgIm51
-        bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjog
-        ImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIw
-        YWZkNjgzYy04MTY5LTQwNzEtOTE4OS0zNTM5Nzg2MjdkZmEiLCAibnVtX3By
-        b2Nlc3NlZCI6IDF9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
-        b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0
-        ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJl
-        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVs
-        bCwgInJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJzdGFydGVkIjogIjIw
-        MTktMDUtMzBUMTA6MjA6NThaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVz
-        dWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wNS0zMFQxMDoyMDo1OFoiLCAi
-        dHJhY2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVt
-        X2Rpc3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7ImdlbmVyYXRlIHNxbGl0ZSI6
-        ICJTS0lQUEVEIiwgInJwbXMiOiAiRklOSVNIRUQiLCAiaW5pdGlhbGl6ZV9y
-        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgInJlbW92ZV9vbGRfcmVwb2Rh
-        dGEiOiAiRklOSVNIRUQiLCAibW9kdWxlcyI6ICJGSU5JU0hFRCIsICJzYXZl
-        X3RhciI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJ
-        TklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNI
-        RUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInJlcG92aWV3Ijog
-        IlNLSVBQRUQiLCAicHVibGlzaF9kaXJlY3RvcnkiOiAiRklOSVNIRUQiLCAi
-        ZXJyYXRhIjogIkZJTklTSEVEIiwgIm1ldGFkYXRhIjogIkZJTklTSEVEIn0s
-        ICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogInNj
-        ZW5hcmlvX3Rlc3QiLCAiaWQiOiAiNWNlZmFlOGFiMDJlNTMzNDM0Y2Y4YjY1
-        IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
-        biI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3RhciIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI4NDRjMTljYi01YzRjLTQ4YWQtYTY5OS03YmY5
-        YjNmNGJkMmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1ldGFk
-        YXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiMmY0MzdkY2UtYTU1Yi00NmE5LWFmYTMtMjk5
-        NWY4YTE3NWM5IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2Vz
-        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1dGlv
-        biBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
-        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
-        dGVwX2lkIjogImEyNWJlZDg0LTIxM2ItNDBmNS04ZDE2LTg1ZjU5ZDIwNjIz
-        MiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiA4LCAi
-        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6
-        ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogOCwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImNmZGNiMmMyLWI4MjItNGU2Yy1h
-        MTU2LWNlY2E5NGNmNzc4OCIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsibnVt
-        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEZWx0
-        YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjNkMDBjOTUzLTJkMjctNGY3OC04YTA4LWI3NTg5ZjI0Mzk0NiIsICJudW1f
-        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0
-        YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICJmZTYzNmU1Mi1jZWVkLTRjYWUtYTYyYS0x
-        MzI2NzYwZTNlZDIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxlcyIs
-        ICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5ZmM0
-        MzhlNy0xMTk1LTQxM2YtODBkMS1jYmFmMzQzZGJjMDAiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29tcHMi
-        LCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiZWRkNmU3OTAtMjIyZC00ZWJlLWI2ZGUtMDBh
-        NzAxMGFiM2NjIiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2Vz
-        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIs
-        ICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAi
-        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNWI4
-        YWVhZWItZDA3Mi00ZWQ0LWIzNTYtZjc4YjY4NGIyOTNlIiwgIm51bV9wcm9j
-        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
-        ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNsb3Nl
-        X3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDFhM2I0YzAtM2I1
-        OS00MGUyLTgxYzYtYzUxY2ZkODdlZmZiIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
-        aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3Fs
-        aXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZjI5YmU5NzgtMzliMi00NzRlLWFjZTAt
-        ZWY3YmI5Yzg2MWFiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVwb2Rh
-        dGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAiaXRl
-        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiODYyNmY5MTQtMzU0Ny00ZWRhLTk5YWMtNzY1NWQwZDVh
-        ZGNiIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAs
-        ICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAic3Rl
-        cF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
-        IjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzM4YTJiN2Yt
-        MmM2NS00Nzk2LWI1ZDctYjI0ZTA1ZGEzNTEyIiwgIm51bV9wcm9jZXNzZWQi
-        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJs
-        aXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9k
-        aXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDQ4MDEzZGMtY2IzYS00MTQz
-        LTkwMWMtZjEwZDU4YTk2NjA1IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJu
-        dW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3Rp
-        bmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRh
-        ZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwYWZkNjgzYy04MTY5LTQwNzEtOTE4
-        OS0zNTM5Nzg2MjdkZmEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9XX0sICJlcnJv
-        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmFlOGFjMzhlYjVjOGY5
-        ZmY1ZWMzIn0sICJpZCI6ICI1Y2VmYWU4YWMzOGViNWM4ZjlmZjVlYzMifQ==
-    http_version: 
-  recorded_at: Thu, 30 May 2019 10:20:58 GMT
-- request:
-    method: put
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test/content/1559230354273
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJpZCI6IjE1NTkyMzAzNTQyNzMiLCJuYW1lIjoiU2NlbmFyaW8geXVtIHBy
-        b2R1Y3QiLCJjb250ZW50VXJsIjoiL2N1c3RvbS9TY2VuYXJpb19Qcm9kdWN0
-        L1NjZW5hcmlvX3l1bV9wcm9kdWN0IiwiZ3BnVXJsIjpudWxsLCJ0eXBlIjoi
-        eXVtIiwiYXJjaGVzIjpudWxsLCJsYWJlbCI6InNjZW5hcmlvX3Rlc3RfU2Nl
-        bmFyaW9fUHJvZHVjdF9TY2VuYXJpb195dW1fcHJvZHVjdCIsIm1ldGFkYXRh
-        RXhwaXJlIjoxLCJ2ZW5kb3IiOiJDdXN0b20ifQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="7AHaN3UJsZubdCVAxCja8wTLotxnwNG3",
-        oauth_nonce="8RRBqNxhCuy80QTY5wJeIwvCpJ4t91gPOz5J4jWQg", oauth_signature="nFQ2Yd9FzUJTIb%2Bt32SuxTxqVjY%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1559230397", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-      Content-Length:
-      - '253'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 4e4e961c-5acc-4825-8a68-b3bbb7692cc9
-      X-Version:
-      - 2.6.5-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Thu, 30 May 2019 15:33:17 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcmVhdGVkIjoiMjAxOS0wNS0zMFQxNTozMjozNCswMDAwIiwidXBkYXRl
-        ZCI6IjIwMTktMDUtMzBUMTU6MzI6MzQrMDAwMCIsInV1aWQiOiI0MDI4Zjk5
-        NjZiMDY5N2ZjMDE2YjA5NWYxMzU0MDA0ZiIsImlkIjoiMTU1OTIzMDM1NDI3
-        MyIsInR5cGUiOiJ5dW0iLCJsYWJlbCI6InNjZW5hcmlvX3Rlc3RfU2NlbmFy
-        aW9fUHJvZHVjdF9TY2VuYXJpb195dW1fcHJvZHVjdCIsIm5hbWUiOiJTY2Vu
-        YXJpbyB5dW0gcHJvZHVjdCIsInZlbmRvciI6IkN1c3RvbSIsImNvbnRlbnRV
-        cmwiOiIvY3VzdG9tL1NjZW5hcmlvX1Byb2R1Y3QvU2NlbmFyaW9feXVtX3By
-        b2R1Y3QiLCJyZXF1aXJlZFRhZ3MiOm51bGwsImdwZ1VybCI6bnVsbCwibW9k
-        aWZpZWRQcm9kdWN0SWRzIjpbXSwiYXJjaGVzIjpudWxsLCJyZXF1aXJlZFBy
-        b2R1Y3RJZHMiOltdLCJtZXRhZGF0YUV4cGlyZSI6MSwicmVsZWFzZVZlciI6
-        bnVsbH0=
-    http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:17 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 30 May 2019 15:33:17 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"3a0d594e5e41e54c4d15dee114a8ed10-gzip"'
+      - '"d6a7a4913369d82568ba8621b1795010-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -1883,64 +102,64 @@ http_interactions:
         eyJzY3JhdGNocGFkIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiJ9LCAi
         ZGlzcGxheV9uYW1lIjogIlNjZW5hcmlvIHl1bSBwcm9kdWN0IiwgImRlc2Ny
         aXB0aW9uIjogbnVsbCwgImRpc3RyaWJ1dG9ycyI6IFt7InJlcG9faWQiOiAi
-        c2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNS0zMFQx
-        NTozMjozNFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
+        c2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNi0wNFQy
+        MTozMToxM1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
         cy9zY2VuYXJpb190ZXN0L2Rpc3RyaWJ1dG9ycy9zY2VuYXJpb190ZXN0X2Ns
         b25lLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJs
         aXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Nsb25l
         X2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRj
         aHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6
-        IHsiJG9pZCI6ICI1Y2VmZjc5MjA1ZjVlZTI5NjU5ZTBmYjAifSwgImNvbmZp
+        IHsiJG9pZCI6ICI1Y2Y2ZTMyMWIwMmU1MzRiYjU1MDRjNTgifSwgImNvbmZp
         ZyI6IHsiZGVzdGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiAic2NlbmFyaW9f
         dGVzdCJ9LCAiaWQiOiAic2NlbmFyaW9fdGVzdF9jbG9uZSJ9LCB7InJlcG9f
         aWQiOiAic2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0w
-        NS0zMFQxNTozMjozNFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9z
+        Ni0wNFQyMTozMToxM1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9z
         aXRvcmllcy9zY2VuYXJpb190ZXN0L2Rpc3RyaWJ1dG9ycy9zY2VuYXJpb190
         ZXN0LyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJs
-        aXNoIjogIjIwMTktMDUtMzBUMTU6MzI6NTZaIiwgImRpc3RyaWJ1dG9yX3R5
+        aXNoIjogIjIwMTktMDYtMDRUMjE6MzE6MzVaIiwgImRpc3RyaWJ1dG9yX3R5
         cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IHRy
         dWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRv
-        cnMiLCAiX2lkIjogeyIkb2lkIjogIjVjZWZmNzkyMDVmNWVlMjk2NTllMGZh
-        ZiJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6IGZh
+        cnMiLCAiX2lkIjogeyIkb2lkIjogIjVjZjZlMzIxYjAyZTUzNGJiNTUwNGM1
+        NyJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6IGZh
         bHNlLCAiaHR0cHMiOiB0cnVlLCAicmVsYXRpdmVfdXJsIjogInNjZW5hcmlv
         X3Rlc3QifSwgImlkIjogInNjZW5hcmlvX3Rlc3QifSwgeyJyZXBvX2lkIjog
-        InNjZW5hcmlvX3Rlc3QiLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDUtMzBU
-        MTU6MzI6MzRaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3Jp
+        InNjZW5hcmlvX3Rlc3QiLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDYtMDRU
+        MjE6MzE6MTNaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3Jp
         ZXMvc2NlbmFyaW9fdGVzdC9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3RyaWJ1
         dG9yLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJs
         aXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0X2Rp
         c3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBh
         ZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsi
-        JG9pZCI6ICI1Y2VmZjc5MjA1ZjVlZTI5NjU5ZTBmYjEifSwgImNvbmZpZyI6
+        JG9pZCI6ICI1Y2Y2ZTMyMWIwMmU1MzRiYjU1MDRjNTkifSwgImNvbmZpZyI6
         IHsiaHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogInNjZW5hcmlvX3Rl
         c3QiLCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6ICJleHBvcnRfZGlzdHJpYnV0
-        b3IifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAxOS0wNS0zMFQxNTozMjo1
-        NVoiLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwgImxh
+        b3IifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAxOS0wNi0wNFQyMTozMToz
+        NFoiLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwgImxh
         c3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3VudHMi
         OiB7InBhY2thZ2VfZ3JvdXAiOiAyLCAiZGlzdHJpYnV0aW9uIjogMSwgInBh
         Y2thZ2VfY2F0ZWdvcnkiOiAxLCAicnBtIjogOCwgImVycmF0dW0iOiAzfSwg
         Il9ucyI6ICJyZXBvcyIsICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lkIjogInNj
-        ZW5hcmlvX3Rlc3QiLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDUtMzBUMTU6
-        MzI6MzRaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
+        ZW5hcmlvX3Rlc3QiLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDYtMDRUMjE6
+        MzE6MTNaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
         c2NlbmFyaW9fdGVzdC9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMi
         OiAicmVwb19pbXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
         aW1wb3J0ZXIiLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rf
-        c3luYyI6ICIyMDE5LTA1LTMwVDE1OjMyOjU1WiIsICJzY3JhdGNocGFkIjog
+        c3luYyI6ICIyMDE5LTA2LTA0VDIxOjMxOjM0WiIsICJzY3JhdGNocGFkIjog
         eyJyZXBvbWRfcmV2aXNpb24iOiAxMzIxODkzODAwfSwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1Y2VmZjc5MjA1ZjVlZTI5NjU5ZTBmYWUifSwgImNvbmZpZyI6IHsi
+        ZCI6ICI1Y2Y2ZTMyMWIwMmU1MzRiYjU1MDRjNTYifSwgImNvbmZpZyI6IHsi
         ZmVlZCI6ICJmaWxlOi8vL3Zhci93d3cvdGVzdF9yZXBvcy96b28iLCAic3Ns
         X3ZhbGlkYXRpb24iOiB0cnVlLCAicmVtb3ZlX21pc3NpbmciOiB0cnVlLCAi
         ZG93bmxvYWRfcG9saWN5IjogImltbWVkaWF0ZSJ9LCAiaWQiOiAieXVtX2lt
         cG9ydGVyIn1dLCAibG9jYWxseV9zdG9yZWRfdW5pdHMiOiAxNSwgIl9pZCI6
-        IHsiJG9pZCI6ICI1Y2VmZjc5MjA1ZjVlZTI5NjU5ZTBmYWQifSwgInRvdGFs
+        IHsiJG9pZCI6ICI1Y2Y2ZTMyMWIwMmU1MzRiYjU1MDRjNTUifSwgInRvdGFs
         X3JlcG9zaXRvcnlfdW5pdHMiOiAxNSwgImlkIjogInNjZW5hcmlvX3Rlc3Qi
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJp
         b190ZXN0LyJ9
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:17 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:56 GMT
 - request:
     method: put
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/importers/yum_importer//
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/importers/yum_importer//
     body:
       encoding: UTF-8
       base64_string: |
@@ -1952,7 +171,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -1963,9 +182,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 30 May 2019 15:33:17 GMT
+      - Tue, 04 Jun 2019 21:31:56 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '172'
       Content-Type:
@@ -1974,14 +193,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2UzY2I1ZmU3LTEyZjQtNDE1MC1iNWIwLTQ1ZTU1ZjEzZmYyYi8iLCAi
-        dGFza19pZCI6ICJlM2NiNWZlNy0xMmY0LTQxNTAtYjViMC00NWU1NWYxM2Zm
-        MmIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2JkZDc2ZTJlLWY5MmQtNDU2Ny05NDVhLWFlYmYxYzM4YjAwNi8iLCAi
+        dGFza19pZCI6ICJiZGQ3NmUyZS1mOTJkLTQ1NjctOTQ1YS1hZWJmMWMzOGIw
+        MDYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:17 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:56 GMT
 - request:
     method: put
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/importers/yum_importer//
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/importers/yum_importer//
     body:
       encoding: UTF-8
       base64_string: |
@@ -1998,7 +217,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2009,9 +228,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 30 May 2019 15:33:17 GMT
+      - Tue, 04 Jun 2019 21:31:56 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '172'
       Content-Type:
@@ -2020,14 +239,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2IzNDMxZWE1LTlhYzAtNGJkYi1iMGJmLTZmYWEwY2QxNmJjNy8iLCAi
-        dGFza19pZCI6ICJiMzQzMWVhNS05YWMwLTRiZGItYjBiZi02ZmFhMGNkMTZi
-        YzcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2U3OWYxNWNkLTZhNTItNGZiYi05NDMwLTliMmMzMGI3ZjJkMS8iLCAi
+        dGFza19pZCI6ICJlNzlmMTVjZC02YTUyLTRmYmItOTQzMC05YjJjMzBiN2Yy
+        ZDEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:17 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:56 GMT
 - request:
     method: put
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/distributors/scenario_test//
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/distributors/scenario_test//
     body:
       encoding: UTF-8
       base64_string: |
@@ -2040,7 +259,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2051,9 +270,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 30 May 2019 15:33:17 GMT
+      - Tue, 04 Jun 2019 21:31:56 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '172'
       Content-Type:
@@ -2062,14 +281,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzcyNzAxMWVjLWUxYzYtNDYzOC1iNTNiLTQ5MTU4MTkwYjVhNS8iLCAi
-        dGFza19pZCI6ICI3MjcwMTFlYy1lMWM2LTQ2MzgtYjUzYi00OTE1ODE5MGI1
-        YTUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzZlNjIyYWFlLThlMmItNGNhYy05NzRjLWY4YzBkZjg1Y2NlNC8iLCAi
+        dGFza19pZCI6ICI2ZTYyMmFhZS04ZTJiLTRjYWMtOTc0Yy1mOGMwZGY4NWNj
+        ZTQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:17 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:56 GMT
 - request:
     method: put
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/distributors/scenario_test_clone//
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/distributors/scenario_test_clone//
     body:
       encoding: UTF-8
       base64_string: |
@@ -2081,7 +300,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2092,9 +311,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 30 May 2019 15:33:17 GMT
+      - Tue, 04 Jun 2019 21:31:56 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '172'
       Content-Type:
@@ -2103,14 +322,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzFlYTQxODA5LWI4MzYtNGU0Ny1iZGUzLWVkMDhlNWY4Yjc1Ny8iLCAi
-        dGFza19pZCI6ICIxZWE0MTgwOS1iODM2LTRlNDctYmRlMy1lZDA4ZTVmOGI3
-        NTcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2Q3NWYzNDExLTU0MjQtNGNkMy05ZDgyLWViODk1Y2NjZGY0ZS8iLCAi
+        dGFza19pZCI6ICJkNzVmMzQxMS01NDI0LTRjZDMtOWQ4Mi1lYjg5NWNjY2Rm
+        NGUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:17 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:56 GMT
 - request:
     method: put
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/distributors/export_distributor//
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/distributors/export_distributor//
     body:
       encoding: UTF-8
       base64_string: |
@@ -2122,7 +341,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2133,9 +352,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 30 May 2019 15:33:17 GMT
+      - Tue, 04 Jun 2019 21:31:56 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '172'
       Content-Type:
@@ -2144,14 +363,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2EwZGU3YWZkLTFmOGQtNDQ2ZC1iYzlkLWU2NTJiYTQ0MjAyMS8iLCAi
-        dGFza19pZCI6ICJhMGRlN2FmZC0xZjhkLTQ0NmQtYmM5ZC1lNjUyYmE0NDIw
-        MjEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2M4MTUxNjFhLWQ0NzMtNDE2Ni04YzdjLTUyNzlkYzgzOTgyNi8iLCAi
+        dGFza19pZCI6ICJjODE1MTYxYS1kNDczLTQxNjYtOGM3Yy01Mjc5ZGM4Mzk4
+        MjYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:17 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:56 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/e3cb5fe7-12f4-4150-b5b0-45e55f13ff2b/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/bdd76e2e-f92d-4567-945a-aebf1c38b006/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2161,7 +380,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -2170,15 +389,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:33:17 GMT
+      - Tue, 04 Jun 2019 21:31:56 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"cb094266a3180be1b7a374086faa851e-gzip"'
+      - '"36885ce4fe4330a6794681c5aeb41f5a-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1280'
+      - '1266'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2186,38 +405,38 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uaW1wb3J0ZXIudXBkYXRlX2ltcG9ydGVyX2NvbmZp
-        ZyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZTNjYjVmZTctMTJm
-        NC00MTUwLWI1YjAtNDVlNTVmMTNmZjJiLyIsICJ0YXNrX2lkIjogImUzY2I1
-        ZmU3LTEyZjQtNDE1MC1iNWIwLTQ1ZTU1ZjEzZmYyYiIsICJ0YWdzIjogWyJw
+        ZyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYmRkNzZlMmUtZjky
+        ZC00NTY3LTk0NWEtYWViZjFjMzhiMDA2LyIsICJ0YXNrX2lkIjogImJkZDc2
+        ZTJlLWY5MmQtNDU2Ny05NDVhLWFlYmYxYzM4YjAwNiIsICJ0YWdzIjogWyJw
         dWxwOnJlcG9zaXRvcnk6c2NlbmFyaW9fdGVzdCIsICJwdWxwOnJlcG9zaXRv
         cnlfaW1wb3J0ZXI6eXVtX2ltcG9ydGVyIiwgInB1bHA6YWN0aW9uOnVwZGF0
-        ZV9pbXBvcnRlciJdLCAiZmluaXNoX3RpbWUiOiAiMjAxOS0wNS0zMFQxNToz
-        MzoxN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAi
-        MjAxOS0wNS0zMFQxNTozMzoxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
+        ZV9pbXBvcnRlciJdLCAiZmluaXNoX3RpbWUiOiAiMjAxOS0wNi0wNFQyMToz
+        MTo1NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAi
+        MjAxOS0wNi0wNFQyMTozMTo1NloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
         YXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVl
-        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZl
-        bDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVk
-        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0w
-        QGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
-        IHsicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgImxhc3RfdXBkYXRlZCI6
-        ICIyMDE5LTA1LTMwVDE1OjMzOjE3WiIsICJfaHJlZiI6ICIvdjIvcmVwb3Np
-        dG9yaWVzL3NjZW5hcmlvX3Rlc3QvaW1wb3J0ZXJzL3l1bV9pbXBvcnRlci8i
-        LCAiX25zIjogInJlcG9faW1wb3J0ZXJzIiwgImltcG9ydGVyX3R5cGVfaWQi
-        OiAieXVtX2ltcG9ydGVyIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30s
-        ICJsYXN0X3N5bmMiOiAiMjAxOS0wNS0zMFQxNTozMjo1NVoiLCAic2NyYXRj
-        aHBhZCI6IHsicmVwb21kX3JldmlzaW9uIjogMTMyMTg5MzgwMH0sICJfaWQi
-        OiB7IiRvaWQiOiAiNWNlZmY3OTIwNWY1ZWUyOTY1OWUwZmFlIn0sICJjb25m
-        aWciOiB7ImZlZWQiOiAiZmlsZTovLy92YXIvd3d3L3Rlc3RfcmVwb3Mvem9v
-        IiwgInNzbF92YWxpZGF0aW9uIjogdHJ1ZSwgInJlbW92ZV9taXNzaW5nIjog
-        dHJ1ZSwgImRvd25sb2FkX3BvbGljeSI6ICJpbW1lZGlhdGUifSwgImlkIjog
-        Inl1bV9pbXBvcnRlciJ9LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVjZWZmN2JkZGY5Njk0YmIxNWI5Zjg0OCJ9LCAiaWQiOiAiNWNlZmY3
-        YmRkZjk2OTRiYjE1YjlmODQ4In0=
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29y
+        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwu
+        YmFsbW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlcG9faWQiOiAi
+        c2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNi0wNFQy
+        MTozMTo1NloiLCAiX2hyZWYiOiAiL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJp
+        b190ZXN0L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBv
+        X2ltcG9ydGVycyIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRl
+        ciIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjog
+        IjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgInNjcmF0Y2hwYWQiOiB7InJlcG9t
+        ZF9yZXZpc2lvbiI6IDEzMjE4OTM4MDB9LCAiX2lkIjogeyIkb2lkIjogIjVj
+        ZjZlMzIxYjAyZTUzNGJiNTUwNGM1NiJ9LCAiY29uZmlnIjogeyJmZWVkIjog
+        ImZpbGU6Ly8vdmFyL3d3dy90ZXN0X3JlcG9zL3pvbyIsICJzc2xfdmFsaWRh
+        dGlvbiI6IHRydWUsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9h
+        ZF9wb2xpY3kiOiAiaW1tZWRpYXRlIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIi
+        fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2Y2ZTM0Yzlm
+        YTkzNGYxMGE2ZDg1NjQifSwgImlkIjogIjVjZjZlMzRjOWZhOTM0ZjEwYTZk
+        ODU2NCJ9
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:17 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:56 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/b3431ea5-9ac0-4bdb-b0bf-6faa0cd16bc7/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/e79f15cd-6a52-4fbb-9430-9b2c30b7f2d1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2227,7 +446,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -2236,15 +455,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:33:17 GMT
+      - Tue, 04 Jun 2019 21:31:56 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"c0b6b6146b7eece595a8c2f3b3120e35-gzip"'
+      - '"ed77239c5684b5c15898956bdf83025c-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1281'
+      - '1267'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2252,38 +471,38 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uaW1wb3J0ZXIudXBkYXRlX2ltcG9ydGVyX2NvbmZp
-        ZyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvYjM0MzFlYTUtOWFj
-        MC00YmRiLWIwYmYtNmZhYTBjZDE2YmM3LyIsICJ0YXNrX2lkIjogImIzNDMx
-        ZWE1LTlhYzAtNGJkYi1iMGJmLTZmYWEwY2QxNmJjNyIsICJ0YWdzIjogWyJw
+        ZyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZTc5ZjE1Y2QtNmE1
+        Mi00ZmJiLTk0MzAtOWIyYzMwYjdmMmQxLyIsICJ0YXNrX2lkIjogImU3OWYx
+        NWNkLTZhNTItNGZiYi05NDMwLTliMmMzMGI3ZjJkMSIsICJ0YWdzIjogWyJw
         dWxwOnJlcG9zaXRvcnk6c2NlbmFyaW9fdGVzdCIsICJwdWxwOnJlcG9zaXRv
         cnlfaW1wb3J0ZXI6eXVtX2ltcG9ydGVyIiwgInB1bHA6YWN0aW9uOnVwZGF0
-        ZV9pbXBvcnRlciJdLCAiZmluaXNoX3RpbWUiOiAiMjAxOS0wNS0zMFQxNToz
-        MzoxN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAi
-        MjAxOS0wNS0zMFQxNTozMzoxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
+        ZV9pbXBvcnRlciJdLCAiZmluaXNoX3RpbWUiOiAiMjAxOS0wNi0wNFQyMToz
+        MTo1NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAi
+        MjAxOS0wNi0wNFQyMTozMTo1NloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNw
         YXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVl
-        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZl
-        bDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVk
-        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0w
-        QGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
-        IHsicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgImxhc3RfdXBkYXRlZCI6
-        ICIyMDE5LTA1LTMwVDE1OjMzOjE3WiIsICJfaHJlZiI6ICIvdjIvcmVwb3Np
-        dG9yaWVzL3NjZW5hcmlvX3Rlc3QvaW1wb3J0ZXJzL3l1bV9pbXBvcnRlci8i
-        LCAiX25zIjogInJlcG9faW1wb3J0ZXJzIiwgImltcG9ydGVyX3R5cGVfaWQi
-        OiAieXVtX2ltcG9ydGVyIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30s
-        ICJsYXN0X3N5bmMiOiAiMjAxOS0wNS0zMFQxNTozMjo1NVoiLCAic2NyYXRj
-        aHBhZCI6IHsicmVwb21kX3JldmlzaW9uIjogMTMyMTg5MzgwMH0sICJfaWQi
-        OiB7IiRvaWQiOiAiNWNlZmY3OTIwNWY1ZWUyOTY1OWUwZmFlIn0sICJjb25m
-        aWciOiB7ImZlZWQiOiAiZmlsZTovLy92YXIvd3d3L3Rlc3RfcmVwb3Mvem9v
-        IiwgInNzbF92YWxpZGF0aW9uIjogdHJ1ZSwgInJlbW92ZV9taXNzaW5nIjog
-        ZmFsc2UsICJkb3dubG9hZF9wb2xpY3kiOiAiaW1tZWRpYXRlIn0sICJpZCI6
-        ICJ5dW1faW1wb3J0ZXIifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1Y2VmZjdiZGRmOTY5NGJiMTViOWY4NWUifSwgImlkIjogIjVjZWZm
-        N2JkZGY5Njk0YmIxNWI5Zjg1ZSJ9
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9y
+        YS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29y
+        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwu
+        YmFsbW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlcG9faWQiOiAi
+        c2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNi0wNFQy
+        MTozMTo1NloiLCAiX2hyZWYiOiAiL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJp
+        b190ZXN0L2ltcG9ydGVycy95dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBv
+        X2ltcG9ydGVycyIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRl
+        ciIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjog
+        IjIwMTktMDYtMDRUMjE6MzE6MzRaIiwgInNjcmF0Y2hwYWQiOiB7InJlcG9t
+        ZF9yZXZpc2lvbiI6IDEzMjE4OTM4MDB9LCAiX2lkIjogeyIkb2lkIjogIjVj
+        ZjZlMzIxYjAyZTUzNGJiNTUwNGM1NiJ9LCAiY29uZmlnIjogeyJmZWVkIjog
+        ImZpbGU6Ly8vdmFyL3d3dy90ZXN0X3JlcG9zL3pvbyIsICJzc2xfdmFsaWRh
+        dGlvbiI6IHRydWUsICJyZW1vdmVfbWlzc2luZyI6IGZhbHNlLCAiZG93bmxv
+        YWRfcG9saWN5IjogImltbWVkaWF0ZSJ9LCAiaWQiOiAieXVtX2ltcG9ydGVy
+        In0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNmNmUzNGM5
+        ZmE5MzRmMTBhNmQ4NTc4In0sICJpZCI6ICI1Y2Y2ZTM0YzlmYTkzNGYxMGE2
+        ZDg1NzgifQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:17 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:56 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/727011ec-e1c6-4638-b53b-49158190b5a5/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/6e622aae-8e2b-4cac-974c-f8c0df85cce4/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2293,7 +512,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -2302,15 +521,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:33:17 GMT
+      - Tue, 04 Jun 2019 21:31:56 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"696829441679e914da2be730880147cf-gzip"'
+      - '"db6118129abb07fb4ebd5a71651d26fe-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1247'
+      - '1233'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2318,37 +537,37 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGlzdHJpYnV0b3JfdXBkYXRlIiwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi90YXNrcy83MjcwMTFlYy1lMWM2LTQ2MzgtYjUz
-        Yi00OTE1ODE5MGI1YTUvIiwgInRhc2tfaWQiOiAiNzI3MDExZWMtZTFjNi00
-        NjM4LWI1M2ItNDkxNTgxOTBiNWE1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
+        IjogIi9wdWxwL2FwaS92Mi90YXNrcy82ZTYyMmFhZS04ZTJiLTRjYWMtOTc0
+        Yy1mOGMwZGY4NWNjZTQvIiwgInRhc2tfaWQiOiAiNmU2MjJhYWUtOGUyYi00
+        Y2FjLTk3NGMtZjhjMGRmODVjY2U0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
         dG9yeTpzY2VuYXJpb190ZXN0IiwgInB1bHA6cmVwb3NpdG9yeV9kaXN0cmli
         dXRvcjpzY2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnVwZGF0ZV9kaXN0
-        cmlidXRvciJdLCAiZmluaXNoX3RpbWUiOiAiMjAxOS0wNS0zMFQxNTozMzox
-        N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAx
-        OS0wNS0zMFQxNTozMzoxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXdu
+        cmlidXRvciJdLCAiZmluaXNoX3RpbWUiOiAiMjAxOS0wNi0wNFQyMTozMTo1
+        NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAx
+        OS0wNi0wNFQyMTozMTo1NloiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXdu
         ZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUi
-        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIu
-        c2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwg
-        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNl
-        bnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
-        cmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgImxhc3RfdXBkYXRlZCI6ICIy
-        MDE5LTA1LTMwVDE1OjMzOjE3WiIsICJfaHJlZiI6ICIvdjIvcmVwb3NpdG9y
-        aWVzL3NjZW5hcmlvX3Rlc3QvZGlzdHJpYnV0b3JzL3NjZW5hcmlvX3Rlc3Qv
-        IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
-        OiAiMjAxOS0wNS0zMFQxNTozMjo1NloiLCAiZGlzdHJpYnV0b3JfdHlwZV9p
-        ZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogdHJ1ZSwg
-        InNjcmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIs
-        ICJfaWQiOiB7IiRvaWQiOiAiNWNlZmY3OTIwNWY1ZWUyOTY1OWUwZmFmIn0s
-        ICJjb25maWciOiB7InByb3RlY3RlZCI6IHRydWUsICJodHRwIjogZmFsc2Us
-        ICJodHRwcyI6IHRydWUsICJyZWxhdGl2ZV91cmwiOiAic2NlbmFyaW9fdGVz
-        dCJ9LCAiaWQiOiAic2NlbmFyaW9fdGVzdCJ9LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVjZWZmN2JkZGY5Njk0YmIxNWI5Zjg2YyJ9LCAi
-        aWQiOiAiNWNlZmY3YmRkZjk2OTRiYjE1YjlmODZjIn0=
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5l
+        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2Vy
+        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFs
+        bW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlcG9faWQiOiAic2Nl
+        bmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNi0wNFQyMToz
+        MTo1NloiLCAiX2hyZWYiOiAiL3YyL3JlcG9zaXRvcmllcy9zY2VuYXJpb190
+        ZXN0L2Rpc3RyaWJ1dG9ycy9zY2VuYXJpb190ZXN0LyIsICJsYXN0X292ZXJy
+        aWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogIjIwMTktMDYtMDRU
+        MjE6MzE6MzVaIiwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Rpc3Ry
+        aWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IHRydWUsICJzY3JhdGNocGFkIjog
+        e30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lk
+        IjogIjVjZjZlMzIxYjAyZTUzNGJiNTUwNGM1NyJ9LCAiY29uZmlnIjogeyJw
+        cm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6IGZhbHNlLCAiaHR0cHMiOiB0cnVl
+        LCAicmVsYXRpdmVfdXJsIjogInNjZW5hcmlvX3Rlc3QifSwgImlkIjogInNj
+        ZW5hcmlvX3Rlc3QifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1Y2Y2ZTM0YzlmYTkzNGYxMGE2ZDg1OGQifSwgImlkIjogIjVjZjZlMzRj
+        OWZhOTM0ZjEwYTZkODU4ZCJ9
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:17 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:56 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/1ea41809-b836-4e47-bde3-ed08e5f8b757/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/d75f3411-5424-4cd3-9d82-eb895cccdf4e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2358,7 +577,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -2367,15 +586,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:33:17 GMT
+      - Tue, 04 Jun 2019 21:31:56 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"81be3ea580dc1d2d48907181144483fc-gzip"'
+      - '"753562657f5b5a0f1059eedc21e5317c-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1219'
+      - '1205'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2383,37 +602,36 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGlzdHJpYnV0b3JfdXBkYXRlIiwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi90YXNrcy8xZWE0MTgwOS1iODM2LTRlNDctYmRl
-        My1lZDA4ZTVmOGI3NTcvIiwgInRhc2tfaWQiOiAiMWVhNDE4MDktYjgzNi00
-        ZTQ3LWJkZTMtZWQwOGU1ZjhiNzU3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
+        IjogIi9wdWxwL2FwaS92Mi90YXNrcy9kNzVmMzQxMS01NDI0LTRjZDMtOWQ4
+        Mi1lYjg5NWNjY2RmNGUvIiwgInRhc2tfaWQiOiAiZDc1ZjM0MTEtNTQyNC00
+        Y2QzLTlkODItZWI4OTVjY2NkZjRlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
         dG9yeTpzY2VuYXJpb190ZXN0IiwgInB1bHA6cmVwb3NpdG9yeV9kaXN0cmli
         dXRvcjpzY2VuYXJpb190ZXN0X2Nsb25lIiwgInB1bHA6YWN0aW9uOnVwZGF0
-        ZV9kaXN0cmlidXRvciJdLCAiZmluaXNoX3RpbWUiOiAiMjAxOS0wNS0zMFQx
-        NTozMzoxN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxOS0wNS0zMFQxNTozMzoxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        ZV9kaXN0cmlidXRvciJdLCAiZmluaXNoX3RpbWUiOiAiMjAxOS0wNi0wNFQy
+        MTozMTo1NloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxOS0wNi0wNFQyMTozMTo1NloiLCAidHJhY2ViYWNrIjogbnVsbCwg
         InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1k
-        ZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlz
-        aGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3Vs
-        dCI6IHsicmVwb19pZCI6ICJzY2VuYXJpb190ZXN0IiwgImxhc3RfdXBkYXRl
-        ZCI6ICIyMDE5LTA1LTMwVDE1OjMzOjE3WiIsICJfaHJlZiI6ICIvdjIvcmVw
-        b3NpdG9yaWVzL3NjZW5hcmlvX3Rlc3QvZGlzdHJpYnV0b3JzL3NjZW5hcmlv
-        X3Rlc3RfY2xvbmUvIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJs
-        YXN0X3B1Ymxpc2giOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5
-        dW1fY2xvbmVfZGlzdHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2Us
-        ICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMi
-        LCAiX2lkIjogeyIkb2lkIjogIjVjZWZmNzkyMDVmNWVlMjk2NTllMGZiMCJ9
-        LCAiY29uZmlnIjogeyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJz
-        Y2VuYXJpb190ZXN0In0sICJpZCI6ICJzY2VuYXJpb190ZXN0X2Nsb25lIn0s
-        ICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmY3YmRkZjk2
-        OTRiYjE1YjlmODhhIn0sICJpZCI6ICI1Y2VmZjdiZGRmOTY5NGJiMTViOWY4
-        OGEifQ==
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFs
+        bW9yYS5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAi
+        d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2
+        ZWwuYmFsbW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlcG9faWQi
+        OiAic2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNi0w
+        NFQyMTozMTo1NloiLCAiX2hyZWYiOiAiL3YyL3JlcG9zaXRvcmllcy9zY2Vu
+        YXJpb190ZXN0L2Rpc3RyaWJ1dG9ycy9zY2VuYXJpb190ZXN0X2Nsb25lLyIs
+        ICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjog
+        bnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Nsb25lX2Rpc3Ry
+        aWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6
+        IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1Y2Y2ZTMyMWIwMmU1MzRiYjU1MDRjNTgifSwgImNvbmZpZyI6IHsi
+        ZGVzdGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiAic2NlbmFyaW9fdGVzdCJ9
+        LCAiaWQiOiAic2NlbmFyaW9fdGVzdF9jbG9uZSJ9LCAiZXJyb3IiOiBudWxs
+        LCAiX2lkIjogeyIkb2lkIjogIjVjZjZlMzRjOWZhOTM0ZjEwYTZkODVhZiJ9
+        LCAiaWQiOiAiNWNmNmUzNGM5ZmE5MzRmMTBhNmQ4NWFmIn0=
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:17 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:56 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/a0de7afd-1f8d-446d-bc9d-e652ba442021/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/c815161a-d473-4166-8c7c-5279dc839826/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2423,7 +641,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -2432,15 +650,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:33:17 GMT
+      - Tue, 04 Jun 2019 21:31:56 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"686200295c63bac15bb6c5633b801b44-gzip"'
+      - '"4406ff56fda04c3e45d077aa4205a52b-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1230'
+      - '1216'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2448,37 +666,37 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGlzdHJpYnV0b3JfdXBkYXRlIiwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi90YXNrcy9hMGRlN2FmZC0xZjhkLTQ0NmQtYmM5
-        ZC1lNjUyYmE0NDIwMjEvIiwgInRhc2tfaWQiOiAiYTBkZTdhZmQtMWY4ZC00
-        NDZkLWJjOWQtZTY1MmJhNDQyMDIxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
+        IjogIi9wdWxwL2FwaS92Mi90YXNrcy9jODE1MTYxYS1kNDczLTQxNjYtOGM3
+        Yy01Mjc5ZGM4Mzk4MjYvIiwgInRhc2tfaWQiOiAiYzgxNTE2MWEtZDQ3My00
+        MTY2LThjN2MtNTI3OWRjODM5ODI2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
         dG9yeTpzY2VuYXJpb190ZXN0IiwgInB1bHA6cmVwb3NpdG9yeV9kaXN0cmli
         dXRvcjpleHBvcnRfZGlzdHJpYnV0b3IiLCAicHVscDphY3Rpb246dXBkYXRl
-        X2Rpc3RyaWJ1dG9yIl0sICJmaW5pc2hfdGltZSI6ICIyMDE5LTA1LTMwVDE1
-        OjMzOjE3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6
-        ICIyMDE5LTA1LTMwVDE1OjMzOjE3WiIsICJ0cmFjZWJhY2siOiBudWxsLCAi
+        X2Rpc3RyaWJ1dG9yIl0sICJmaW5pc2hfdGltZSI6ICIyMDE5LTA2LTA0VDIx
+        OjMxOjU2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6
+        ICIyMDE5LTA2LTA0VDIxOjMxOjU2WiIsICJ0cmFjZWJhY2siOiBudWxsLCAi
         c3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJx
-        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRl
-        dmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNo
-        ZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb20iLCAicmVzdWx0
-        IjogeyJyZXBvX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAibGFzdF91cGRhdGVk
-        IjogIjIwMTktMDUtMzBUMTU6MzM6MTdaIiwgIl9ocmVmIjogIi92Mi9yZXBv
-        c2l0b3JpZXMvc2NlbmFyaW9fdGVzdC9kaXN0cmlidXRvcnMvZXhwb3J0X2Rp
-        c3RyaWJ1dG9yLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFz
-        dF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhw
-        b3J0X2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2Ny
-        YXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9p
-        ZCI6IHsiJG9pZCI6ICI1Y2VmZjc5MjA1ZjVlZTI5NjU5ZTBmYjEifSwgImNv
-        bmZpZyI6IHsiaHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogInNjZW5h
-        cmlvX3Rlc3QiLCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6ICJleHBvcnRfZGlz
-        dHJpYnV0b3IifSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        Y2VmZjdiZGRmOTY5NGJiMTViOWY4YTEifSwgImlkIjogIjVjZWZmN2JkZGY5
-        Njk0YmIxNWI5ZjhhMSJ9
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxt
+        b3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3
+        b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZl
+        bC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVwb19pZCI6
+        ICJzY2VuYXJpb190ZXN0IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA2LTA0
+        VDIxOjMxOjU2WiIsICJfaHJlZiI6ICIvdjIvcmVwb3NpdG9yaWVzL3NjZW5h
+        cmlvX3Rlc3QvZGlzdHJpYnV0b3JzL2V4cG9ydF9kaXN0cmlidXRvci8iLCAi
+        bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlzaCI6IG51
+        bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4cG9ydF9kaXN0cmlidXRv
+        ciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hwYWQiOiB7fSwg
+        Il9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWNmNmUzMjFiMDJlNTM0YmI1NTA0YzU5In0sICJjb25maWciOiB7Imh0dHAi
+        OiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJzY2VuYXJpb190ZXN0IiwgImh0
+        dHBzIjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNmNmUzNGM5ZmE5MzRm
+        MTBhNmQ4NWM4In0sICJpZCI6ICI1Y2Y2ZTM0YzlmYTkzNGYxMGE2ZDg1Yzgi
+        fQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:17 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:56 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/?details=true
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2488,7 +706,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -2497,11 +715,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:33:17 GMT
+      - Tue, 04 Jun 2019 21:31:56 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"fb9d8fce19f04524d103a52466510fc1-gzip"'
+      - '"d94540d6435ca86f0e247e5d2d18ba8a-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -2514,64 +732,64 @@ http_interactions:
         eyJzY3JhdGNocGFkIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiJ9LCAi
         ZGlzcGxheV9uYW1lIjogIlNjZW5hcmlvIHl1bSBwcm9kdWN0IiwgImRlc2Ny
         aXB0aW9uIjogbnVsbCwgImRpc3RyaWJ1dG9ycyI6IFt7InJlcG9faWQiOiAi
-        c2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNS0zMFQx
-        NTozMzoxN1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
+        c2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wNi0wNFQy
+        MTozMTo1NloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmll
         cy9zY2VuYXJpb190ZXN0L2Rpc3RyaWJ1dG9ycy9zY2VuYXJpb190ZXN0X2Ns
         b25lLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJs
         aXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Nsb25l
         X2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRj
         aHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6
-        IHsiJG9pZCI6ICI1Y2VmZjc5MjA1ZjVlZTI5NjU5ZTBmYjAifSwgImNvbmZp
+        IHsiJG9pZCI6ICI1Y2Y2ZTMyMWIwMmU1MzRiYjU1MDRjNTgifSwgImNvbmZp
         ZyI6IHsiZGVzdGluYXRpb25fZGlzdHJpYnV0b3JfaWQiOiAic2NlbmFyaW9f
         dGVzdCJ9LCAiaWQiOiAic2NlbmFyaW9fdGVzdF9jbG9uZSJ9LCB7InJlcG9f
         aWQiOiAic2NlbmFyaW9fdGVzdCIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0w
-        NS0zMFQxNTozMzoxN1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9z
+        Ni0wNFQyMTozMTo1NloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9z
         aXRvcmllcy9zY2VuYXJpb190ZXN0L2Rpc3RyaWJ1dG9ycy9zY2VuYXJpb190
         ZXN0LyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJs
-        aXNoIjogIjIwMTktMDUtMzBUMTU6MzI6NTZaIiwgImRpc3RyaWJ1dG9yX3R5
+        aXNoIjogIjIwMTktMDYtMDRUMjE6MzE6MzVaIiwgImRpc3RyaWJ1dG9yX3R5
         cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IHRy
         dWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRv
-        cnMiLCAiX2lkIjogeyIkb2lkIjogIjVjZWZmNzkyMDVmNWVlMjk2NTllMGZh
-        ZiJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6IGZh
+        cnMiLCAiX2lkIjogeyIkb2lkIjogIjVjZjZlMzIxYjAyZTUzNGJiNTUwNGM1
+        NyJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6IGZh
         bHNlLCAicmVsYXRpdmVfdXJsIjogInNjZW5hcmlvX3Rlc3QiLCAiaHR0cHMi
         OiB0cnVlfSwgImlkIjogInNjZW5hcmlvX3Rlc3QifSwgeyJyZXBvX2lkIjog
-        InNjZW5hcmlvX3Rlc3QiLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDUtMzBU
-        MTU6MzM6MTdaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3Jp
+        InNjZW5hcmlvX3Rlc3QiLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDYtMDRU
+        MjE6MzE6NTZaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3Jp
         ZXMvc2NlbmFyaW9fdGVzdC9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3RyaWJ1
         dG9yLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJs
         aXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0X2Rp
         c3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBh
         ZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsi
-        JG9pZCI6ICI1Y2VmZjc5MjA1ZjVlZTI5NjU5ZTBmYjEifSwgImNvbmZpZyI6
+        JG9pZCI6ICI1Y2Y2ZTMyMWIwMmU1MzRiYjU1MDRjNTkifSwgImNvbmZpZyI6
         IHsiaHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogInNjZW5hcmlvX3Rl
         c3QiLCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6ICJleHBvcnRfZGlzdHJpYnV0
-        b3IifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAxOS0wNS0zMFQxNTozMjo1
-        NVoiLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwgImxh
+        b3IifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAxOS0wNi0wNFQyMTozMToz
+        NFoiLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwgImxh
         c3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3VudHMi
         OiB7InBhY2thZ2VfZ3JvdXAiOiAyLCAiZGlzdHJpYnV0aW9uIjogMSwgInBh
         Y2thZ2VfY2F0ZWdvcnkiOiAxLCAicnBtIjogOCwgImVycmF0dW0iOiAzfSwg
         Il9ucyI6ICJyZXBvcyIsICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lkIjogInNj
-        ZW5hcmlvX3Rlc3QiLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDUtMzBUMTU6
-        MzM6MTdaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
+        ZW5hcmlvX3Rlc3QiLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDYtMDRUMjE6
+        MzE6NTZaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
         c2NlbmFyaW9fdGVzdC9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMi
         OiAicmVwb19pbXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
         aW1wb3J0ZXIiLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rf
-        c3luYyI6ICIyMDE5LTA1LTMwVDE1OjMyOjU1WiIsICJzY3JhdGNocGFkIjog
+        c3luYyI6ICIyMDE5LTA2LTA0VDIxOjMxOjM0WiIsICJzY3JhdGNocGFkIjog
         eyJyZXBvbWRfcmV2aXNpb24iOiAxMzIxODkzODAwfSwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1Y2VmZjc5MjA1ZjVlZTI5NjU5ZTBmYWUifSwgImNvbmZpZyI6IHsi
+        ZCI6ICI1Y2Y2ZTMyMWIwMmU1MzRiYjU1MDRjNTYifSwgImNvbmZpZyI6IHsi
         ZmVlZCI6ICJmaWxlOi8vL3Zhci93d3cvdGVzdF9yZXBvcy96b28iLCAic3Ns
         X3ZhbGlkYXRpb24iOiB0cnVlLCAicmVtb3ZlX21pc3NpbmciOiBmYWxzZSwg
         ImRvd25sb2FkX3BvbGljeSI6ICJpbW1lZGlhdGUifSwgImlkIjogInl1bV9p
         bXBvcnRlciJ9XSwgImxvY2FsbHlfc3RvcmVkX3VuaXRzIjogMTUsICJfaWQi
-        OiB7IiRvaWQiOiAiNWNlZmY3OTIwNWY1ZWUyOTY1OWUwZmFkIn0sICJ0b3Rh
+        OiB7IiRvaWQiOiAiNWNmNmUzMjFiMDJlNTM0YmI1NTA0YzU1In0sICJ0b3Rh
         bF9yZXBvc2l0b3J5X3VuaXRzIjogMTUsICJpZCI6ICJzY2VuYXJpb190ZXN0
         IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvc2NlbmFy
         aW9fdGVzdC8ifQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:17 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:56 GMT
 - request:
     method: post
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/actions/publish/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/actions/publish/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2583,7 +801,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Content-Length:
@@ -2594,9 +812,9 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Thu, 30 May 2019 15:33:17 GMT
+      - Tue, 04 Jun 2019 21:31:56 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '172'
       Content-Type:
@@ -2605,14 +823,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzAwM2EzY2RkLWE1OWItNGVmYi05YmM2LTFiMjA4ZGM4MGM5ZS8iLCAi
-        dGFza19pZCI6ICIwMDNhM2NkZC1hNTliLTRlZmItOWJjNi0xYjIwOGRjODBj
-        OWUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzE2MWU2NmVhLThhYTItNDk0My1hYzRkLTVjNjMzODhiN2FlZi8iLCAi
+        dGFza19pZCI6ICIxNjFlNjZlYS04YWEyLTQ5NDMtYWM0ZC01YzYzMzg4Yjdh
+        ZWYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:17 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:56 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/003a3cdd-a59b-4efb-9bc6-1b208dc80c9e/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/161e66ea-8aa2-4943-ac4d-5c63388b7aef/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2622,7 +840,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -2631,15 +849,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:33:17 GMT
+      - Tue, 04 Jun 2019 21:31:56 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"f583d976d450a9aca72665d8e24e0663-gzip"'
+      - '"eb8dcc7c884764cb2a68803db9130384-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '673'
+      - '677'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2647,24 +865,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8wMDNhM2NkZC1hNTliLTRlZmItOWJjNi0xYjIw
-        OGRjODBjOWUvIiwgInRhc2tfaWQiOiAiMDAzYTNjZGQtYTU5Yi00ZWZiLTli
-        YzYtMWIyMDhkYzgwYzllIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy8xNjFlNjZlYS04YWEyLTQ5NDMtYWM0ZC01YzYz
+        Mzg4YjdhZWYvIiwgInRhc2tfaWQiOiAiMTYxZTY2ZWEtOGFhMi00OTQzLWFj
+        NGQtNWM2MzM4OGI3YWVmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogbnVsbCwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
-        IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4
-        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJ3YWl0aW5nIiwgIndvcmtlcl9u
-        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2
-        ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJv
-        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmY3YmRkZjk2OTRiYjE1
-        YjlmOTA3In0sICJpZCI6ICI1Y2VmZjdiZGRmOTY5NGJiMTViOWY5MDcifQ==
+        aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6NTZaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        fSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVs
+        LmJhbG1vcmEuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmci
+        LCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
+        ZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVjZjZlMzRjOWZhOTM0
+        ZjEwYTZkODYyZiJ9LCAiaWQiOiAiNWNmNmUzNGM5ZmE5MzRmMTBhNmQ4NjJm
+        In0=
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:17 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:56 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/003a3cdd-a59b-4efb-9bc6-1b208dc80c9e/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/161e66ea-8aa2-4943-ac4d-5c63388b7aef/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2674,7 +893,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -2683,15 +902,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:33:17 GMT
+      - Tue, 04 Jun 2019 21:31:56 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"175fbf1a231a5141c3383316511ee03f-gzip"'
+      - '"9f482a4140e823a5501de5e6279e22bc-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '4559'
+      - '4545'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2699,111 +918,110 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8wMDNhM2NkZC1hNTliLTRlZmItOWJjNi0xYjIw
-        OGRjODBjOWUvIiwgInRhc2tfaWQiOiAiMDAzYTNjZGQtYTU5Yi00ZWZiLTli
-        YzYtMWIyMDhkYzgwYzllIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy8xNjFlNjZlYS04YWEyLTQ5NDMtYWM0ZC01YzYz
+        Mzg4YjdhZWYvIiwgInRhc2tfaWQiOiAiMTYxZTY2ZWEtOGFhMi00OTQzLWFj
+        NGQtNWM2MzM4OGI3YWVmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDUtMzBUMTU6MzM6MTdaIiwgInRyYWNlYmFjayI6IG51
+        aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6NTZaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
         InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
         ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2MWM5N2ZhMy04OTUyLTQxNzItYTdk
-        NC1mNWExZGIzMTM2YjAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9z
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlZTM0OTAxZi04YjEwLTRkNTAtOWY1
+        YS03MTdjZWYwNWYxYzEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9z
         dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBv
         IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0
         YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
         RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjY5MmNlMjEtN2I1MS00M2Uy
-        LTk2YTgtM2Y2YjhhMmM4MGQwIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWU1NDg5ZmYtNjE2ZC00MmYx
+        LWI5Y2EtZDMzN2YxYTJjNzQ0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
         dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERp
         c3RyaWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9u
         IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImM2ZjExMDg4LWMzMDYtNGVlZS1iZGM0
-        LTYxZWVlOWI1ZTk0OCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImU2NWRjODM3LTQzZDktNDExNi05ZDY1
+        LTc4YmExYjM0NGQ4MyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
         Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwg
         InN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
         IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImViMDEz
-        MzIyLTBmZmMtNDQ5My1iYmJjLTRjMmE3ODEwODI4ZCIsICJudW1fcHJvY2Vz
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImMwNDdj
+        NjM4LTQ0MTMtNGUyMC04N2JjLTFkNjBiODYyNzI4YiIsICJudW1fcHJvY2Vz
         c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
         UHVibGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIs
         ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIxOGMzNmM1ZS1hMmFiLTQ0YjItYTRlNi1j
-        ZDliMjI3NTlmMjEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIyNTdjY2MxZC1mOWZkLTQ5ZjktYjVkMS1h
+        YjE5NzE1ZDk0Y2MiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
         ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwg
         InN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
         dGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTMz
-        ODZjNTAtZWMyZS00NTMzLWJjZDYtZjNmZWJjNTM2NjQyIiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjNl
+        YzVhZTItMTM2Yi00MGFkLThiYmEtMzJmNzc3ZDA5NjU0IiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
         ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMi
         LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZjljYWNlNzUtNmM4My00MWMzLThlODYt
-        YmM3ZmMyNzMwMjA4IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNDVhOTg3MTctZTcxZC00NDliLWFhNjEt
+        NjUwMDM3NTExMmI4IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZp
         bGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwg
         InN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
         ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjU3MDRjOWExLTE5M2QtNDQzYS05NjNlLTk5Y2RjNDU0NzlkYyIsICJudW1f
+        ImMyYjY4OTdjLWU4MmQtNGRkNC1iN2I2LWU2YWNiMGU3NWMyOCIsICJudW1f
         cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
         b24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1l
         dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFS
         VEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY5MTRkOWU4LTdjNzItNDEz
-        Ni05MTg5LTFmMjI1NjQxODk1MyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQyYmUwY2IxLWRhMmItNDc3
+        Ni1hMjRlLTIxMTU4ZDYxM2U2NCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
         bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBv
         IG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRh
         IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImE4OGNiZTE4LTdiZGEtNDFjMi1hOGQ0
-        LTIxMjEwYWI0MzdhMSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImQ0YWU2YjQxLTUwNzAtNDk3MS05NmRi
+        LTE0ZmU4ODk3YTdhMCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
         Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUg
         ZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVt
         c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI2MzMzMzJlOC1kMjQ0LTRjNjUtYWU2NC02NTI1OTRj
-        ODQ4OTciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICI0NGRiNTJiYy05NDMxLTRmOGUtOTFjMS1iZmViZGMx
+        YjM5YTQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
         MCwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJz
         dGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3Rh
         bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI5NmJmOTkwZS1jYjM0LTQxNGItYjNlMi1mYzg5MTI4MDNjOTEi
+        cF9pZCI6ICI3ZDUyNGJmYS1mMzYyLTQxOGMtOWEzYy1lN2Y5NDRjOWY5NzAi
         LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5
         cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
         Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjZlMTJiZGUt
-        OWNiZi00MDZlLWE4ODEtZTM4MjNiZDM5MjkzIiwgIm51bV9wcm9jZXNzZWQi
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjRjYzZhZjUt
+        ZTYxMC00Mjg0LTk4MTgtZTU3NmEzZGQ1YmIxIiwgIm51bV9wcm9jZXNzZWQi
         OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
         aXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9k
         aXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
         QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzNmOTdhZDgtMTMzOS00
-        MjBmLWFjMzEtYzM0M2Q4YzA2OTJkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjI0ZGEyNTYtN2IwNi00
+        MjM0LWIzNzctN2M5OWUzMTIxNmY2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
         eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
         c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
         ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RB
         UlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2NWE2MTRhOS02MDUyLTQw
-        MzAtOTQ2ZC1lYWJkYTBhYmEyZjYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0s
-        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3
-        LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVu
-        bmluZyIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
-        ZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVj
-        ZWZmN2JkZGY5Njk0YmIxNWI5ZjkwNyJ9LCAiaWQiOiAiNWNlZmY3YmRkZjk2
-        OTRiYjE1YjlmOTA3In0=
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyNzBjY2M5Zi00MTczLTRk
+        YjMtYmQ5My1hYjhiMmI3OWJlYzUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0s
+        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5i
+        YWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwg
+        Indvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRl
+        dmVsLmJhbG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2Y2ZTM0YzlmYTkzNGYx
+        MGE2ZDg2MmYifSwgImlkIjogIjVjZjZlMzRjOWZhOTM0ZjEwYTZkODYyZiJ9
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:17 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:56 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/003a3cdd-a59b-4efb-9bc6-1b208dc80c9e/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/161e66ea-8aa2-4943-ac4d-5c63388b7aef/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2813,7 +1031,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -2822,149 +1040,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:33:17 GMT
+      - Tue, 04 Jun 2019 21:31:56 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"b6171845efec1df7fd5ffe7b021b8032-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4543'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8wMDNhM2NkZC1hNTliLTRlZmItOWJjNi0xYjIw
-        OGRjODBjOWUvIiwgInRhc2tfaWQiOiAiMDAzYTNjZGQtYTU5Yi00ZWZiLTli
-        YzYtMWIyMDhkYzgwYzllIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
-        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDUtMzBUMTU6MzM6MTdaIiwgInRyYWNlYmFjayI6IG51
-        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
-        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
-        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
-        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI2MWM5N2ZhMy04OTUyLTQxNzItYTdkNC1m
-        NWExZGIzMTM2YjAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
-        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
-        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
-        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
-        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZjY5MmNlMjEtN2I1MS00M2UyLTk2YTgt
-        M2Y2YjhhMmM4MGQwIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
-        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
-        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
-        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImM2ZjExMDg4LWMzMDYtNGVlZS1iZGM0LTYxZWVlOWI1
-        ZTk0OCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
-        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImViMDEzMzIyLTBmZmMtNDQ5
-        My1iYmJjLTRjMmE3ODEwODI4ZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
-        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjE4YzM2YzVlLWEyYWItNDRiMi1hNGU2LWNkOWIyMjc1OWYyMSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
-        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVT
-        UyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5MzM4NmM1MC1lYzJlLTQ1MzMt
-        YmNkNi1mM2ZlYmM1MzY2NDIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
-        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9k
-        dWxlcyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICJmOWNhY2U3NS02YzgzLTQxYzMtOGU4Ni1iYzdmYzI3MzAyMDgiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUi
-        OiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
-        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNTcwNGM5YTEtMTkzZC00
-        NDNhLTk2M2UtOTljZGM0NTQ3OWRjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
-        IE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNf
-        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
-        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiZjkxNGQ5ZTgtN2M3Mi00MTM2LTkxODktMWYyMjU2NDE4
-        OTUzIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
-        ICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3Rl
-        cF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
-        OiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiYTg4Y2JlMTgtN2JkYS00MWMyLWE4ZDQtMjEyMTBhYjQzN2ExIiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5
-        cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
-        YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjYz
-        MzMzMmU4LWQyNDQtNGM2NS1hZTY0LTY1MjU5NGM4NDg5NyIsICJudW1fcHJv
-        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1v
-        dmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjk2YmY5OTBl
-        LWNiMzQtNDE0Yi1iM2UyLWZjODkxMjgwM2M5MSIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
-        ZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI2NmUxMmJkZS05Y2JmLTQwNmUtYTg4MS1l
-        MzgyM2JkMzkyOTMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8g
-        d2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVt
-        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJjM2Y5N2FkOC0xMzM5LTQyMGYtYWMzMS1jMzQzZDhj
-        MDY5MmQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJz
-        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
-        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjY1YTYxNGE5LTYwNTItNDAzMC05NDZkLWVhYmRhMGFi
-        YTJmNiIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4
-        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9u
-        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2
-        ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJv
-        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmY3YmRkZjk2OTRiYjE1
-        YjlmOTA3In0sICJpZCI6ICI1Y2VmZjdiZGRmOTY5NGJiMTViOWY5MDcifQ==
-    http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:17 GMT
-- request:
-    method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/003a3cdd-a59b-4efb-9bc6-1b208dc80c9e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 30 May 2019 15:33:17 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"341052ff40e47419fade8d188cb539ea-gzip"'
+      - '"37931b4d7d86f74cd59ec9a695803359-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -2976,110 +1056,110 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8wMDNhM2NkZC1hNTliLTRlZmItOWJjNi0xYjIw
-        OGRjODBjOWUvIiwgInRhc2tfaWQiOiAiMDAzYTNjZGQtYTU5Yi00ZWZiLTli
-        YzYtMWIyMDhkYzgwYzllIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy8xNjFlNjZlYS04YWEyLTQ5NDMtYWM0ZC01YzYz
+        Mzg4YjdhZWYvIiwgInRhc2tfaWQiOiAiMTYxZTY2ZWEtOGFhMi00OTQzLWFj
+        NGQtNWM2MzM4OGI3YWVmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDUtMzBUMTU6MzM6MTdaIiwgInRyYWNlYmFjayI6IG51
+        aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6NTZaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
         InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
         ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI2MWM5N2ZhMy04OTUyLTQxNzItYTdkNC1m
-        NWExZGIzMTM2YjAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJlZTM0OTAxZi04YjEwLTRkNTAtOWY1YS03
+        MTdjZWYwNWYxYzEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
         dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
         dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZjY5MmNlMjEtN2I1MS00M2UyLTk2YTgt
-        M2Y2YjhhMmM4MGQwIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiYWU1NDg5ZmYtNjE2ZC00MmYxLWI5Y2Et
+        ZDMzN2YxYTJjNzQ0IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
         Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
         dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
         ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImM2ZjExMDg4LWMzMDYtNGVlZS1iZGM0LTYxZWVlOWI1
-        ZTk0OCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        ICJzdGVwX2lkIjogImU2NWRjODM3LTQzZDktNDExNi05ZDY1LTc4YmExYjM0
+        NGQ4MyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
         LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
-        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
-        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImViMDEzMzIyLTBmZmMtNDQ5
-        My1iYmJjLTRjMmE3ODEwODI4ZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
-        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
-        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
-        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjE4YzM2YzVlLWEyYWItNDRiMi1hNGU2LWNkOWIyMjc1OWYyMSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
-        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
-        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5MzM4NmM1MC1lYzJlLTQ1MzMtYmNk
-        Ni1mM2ZlYmM1MzY2NDIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
-        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY5
-        Y2FjZTc1LTZjODMtNDFjMy04ZTg2LWJjN2ZjMjczMDIwOCIsICJudW1fcHJv
-        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1NzA0YzlhMS0xOTNkLTQ0M2EtOTYz
-        ZS05OWNkYzQ1NDc5ZGMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRh
-        dGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICJmOTE0ZDllOC03YzcyLTQxMzYtOTE4OS0xZjIyNTY0MTg5NTMiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
-        aXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUi
-        OiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJh
-        ODhjYmUxOC03YmRhLTQxYzItYThkNC0yMTIxMGFiNDM3YTEiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJn
-        ZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNjMzMzMyZTgt
-        ZDI0NC00YzY1LWFlNjQtNjUyNTk0Yzg0ODk3IiwgIm51bV9wcm9jZXNzZWQi
-        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJSZW1v
-        dmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRf
-        cmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
-        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTZiZjk5MGUtY2IzNC00
-        MTRiLWIzZTItZmM4OTEyODAzYzkxIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
-        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5n
-        IEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1z
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIklOX1BS
+        T0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImMwNDdjNjM4LTQ0MTMt
+        NGUyMC04N2JjLTFkNjBiODYyNzI4YiIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190
+        b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
+        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
+        c3RlcF9pZCI6ICIyNTdjY2MxZC1mOWZkLTQ5ZjktYjVkMS1hYjE5NzE1ZDk0
+        Y2MiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBfdHlw
+        ZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
+        X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjNlYzVhZTItMTM2
+        Yi00MGFkLThiYmEtMzJmNzc3ZDA5NjU0IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiNDVhOTg3MTctZTcxZC00NDliLWFhNjEtNjUwMDM3NTEx
+        MmI4IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3Rl
+        cF90eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImMyYjY4OTdj
+        LWU4MmQtNGRkNC1iN2I2LWU2YWNiMGU3NWMyOCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
+        bGlzaGluZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwg
+        Iml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVy
+        cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
+        cyI6IDAsICJzdGVwX2lkIjogIjQyYmUwY2IxLWRhMmItNDc3Ni1hMjRlLTIx
+        MTU4ZDYxM2U2NCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nl
+        c3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRh
+        IiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
         X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjY2ZTEyYmRlLTljYmYtNDA2ZS1hODgxLWUzODIzYmQz
-        OTI5MyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAi
-        c3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogImMzZjk3YWQ4LTEzMzktNDIwZi1hYzMxLWMzNDNkOGMwNjkyZCIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
-        Y3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlw
-        ZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
-        OiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6
-        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNjVhNjE0YTktNjA1Mi00MDMwLTk0NmQtZWFiZGEwYWJhMmY2Iiwg
-        Im51bV9wcm9jZXNzZWQiOiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5j
-        b20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAY2VudG9zNy1kZXZlbDIuc2Ft
-        aXIuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVs
-        bCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmZjdiZGRmOTY5NGJiMTViOWY5MDci
-        fSwgImlkIjogIjVjZWZmN2JkZGY5Njk0YmIxNWI5ZjkwNyJ9
+        ICJzdGVwX2lkIjogImQ0YWU2YjQxLTUwNzAtNDk3MS05NmRiLTE0ZmU4ODk3
+        YTdhMCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAi
+        c3RlcF90eXBlIjogImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICI0NGRiNTJiYy05NDMxLTRmOGUtOTFjMS1iZmViZGMxYjM5YTQiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUi
+        OiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
+        dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3
+        ZDUyNGJmYS1mMzYyLTQxOGMtOWEzYy1lN2Y5NDRjOWY5NzAiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
+        IjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVw
+        b3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJU
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjRjYzZhZjUtZTYxMC00Mjg0
+        LTk4MTgtZTU3NmEzZGQ1YmIxIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZp
+        bGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3Rvcnki
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiZjI0ZGEyNTYtN2IwNi00MjM0LWIzNzct
+        N2M5OWUzMTIxNmY2IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZp
+        bGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIyNzBjY2M5Zi00MTczLTRkYjMtYmQ5My1h
+        YjhiMmI3OWJlYzUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6
+        ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4
+        YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9u
+        YW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1v
+        cmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVs
+        bCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2Y2ZTM0YzlmYTkzNGYxMGE2ZDg2MmYi
+        fSwgImlkIjogIjVjZjZlMzRjOWZhOTM0ZjEwYTZkODYyZiJ9
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:17 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:56 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/003a3cdd-a59b-4efb-9bc6-1b208dc80c9e/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/161e66ea-8aa2-4943-ac4d-5c63388b7aef/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3089,7 +1169,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -3098,15 +1178,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:33:17 GMT
+      - Tue, 04 Jun 2019 21:31:56 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"16ed3584ab6431914768c71c463d64f0-gzip"'
+      - '"394eaa4c9e73cf3e945bc4f308fd55b5-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '4510'
+      - '4529'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3114,110 +1194,110 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8wMDNhM2NkZC1hNTliLTRlZmItOWJjNi0xYjIw
-        OGRjODBjOWUvIiwgInRhc2tfaWQiOiAiMDAzYTNjZGQtYTU5Yi00ZWZiLTli
-        YzYtMWIyMDhkYzgwYzllIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy8xNjFlNjZlYS04YWEyLTQ5NDMtYWM0ZC01YzYz
+        Mzg4YjdhZWYvIiwgInRhc2tfaWQiOiAiMTYxZTY2ZWEtOGFhMi00OTQzLWFj
+        NGQtNWM2MzM4OGI3YWVmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
         aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
-        aW1lIjogIjIwMTktMDUtMzBUMTU6MzM6MTdaIiwgInRyYWNlYmFjayI6IG51
+        aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6NTZaIiwgInRyYWNlYmFjayI6IG51
         bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
         InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
         dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
         ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI2MWM5N2ZhMy04OTUyLTQxNzItYTdkNC1m
-        NWExZGIzMTM2YjAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJlZTM0OTAxZi04YjEwLTRkNTAtOWY1YS03
+        MTdjZWYwNWYxYzEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
         dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
         dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiZjY5MmNlMjEtN2I1MS00M2UyLTk2YTgt
-        M2Y2YjhhMmM4MGQwIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiYWU1NDg5ZmYtNjE2ZC00MmYxLWI5Y2Et
+        ZDMzN2YxYTJjNzQ0IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
         Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
         dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
         ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogImM2ZjExMDg4LWMzMDYtNGVlZS1iZGM0LTYxZWVlOWI1
-        ZTk0OCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        ICJzdGVwX2lkIjogImU2NWRjODM3LTQzZDktNDExNi05ZDY1LTc4YmExYjM0
+        NGQ4MyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
         LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
         ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
         SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImViMDEzMzIyLTBmZmMtNDQ5
-        My1iYmJjLTRjMmE3ODEwODI4ZCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImMwNDdjNjM4LTQ0MTMtNGUy
+        MC04N2JjLTFkNjBiODYyNzI4YiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
         bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
         ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
         bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjE4YzM2YzVlLWEyYWItNDRiMi1hNGU2LWNkOWIyMjc1OWYyMSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
+        IjogIjI1N2NjYzFkLWY5ZmQtNDlmOS1iNWQxLWFiMTk3MTVkOTRjYyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAyLCAiZGVzY3Jp
         cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
-        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5MzM4NmM1MC1lYzJlLTQ1MzMtYmNk
-        Ni1mM2ZlYmM1MzY2NDIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
-        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDEs
-        ICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY5
-        Y2FjZTc1LTZjODMtNDFjMy04ZTg2LWJjN2ZjMjczMDIwOCIsICJudW1fcHJv
-        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24i
-        OiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21w
-        cyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJJTl9QUk9HUkVT
+        UyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyM2VjNWFlMi0xMzZiLTQwYWQt
+        OGJiYS0zMmY3NzdkMDk2NTQiLCAibnVtX3Byb2Nlc3NlZCI6IDJ9LCB7Im51
+        bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9k
+        dWxlcyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
+        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
+        ZCI6ICI0NWE5ODcxNy1lNzFkLTQ0OWItYWE2MS02NTAwMzc1MTEyYjgiLCAi
+        bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
+        aXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUi
+        OiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NU
+        QVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzJiNjg5N2MtZTgyZC00
+        ZGQ0LWI3YjYtZTZhY2IwZTc1YzI4IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwg
+        eyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
+        IE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiNDJiZTBjYjEtZGEyYi00Nzc2LWEyNGUtMjExNThkNjEz
+        ZTY0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3Rl
+        cF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiZDRhZTZiNDEtNTA3MC00OTcxLTk2ZGItMTRmZTg4OTdhN2EwIiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5
+        cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ0
+        ZGI1MmJjLTk0MzEtNGY4ZS05MWMxLWJmZWJkYzFiMzlhNCIsICJudW1fcHJv
+        Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
+        OiAiUmVtb3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1v
+        dmVfb2xkX3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdkNTI0YmZh
+        LWYzNjItNDE4Yy05YTNjLWU3Zjk0NGM5Zjk3MCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2Vu
+        ZXJhdGluZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI1NzA0YzlhMS0xOTNkLTQ0M2EtOTYzZS05
-        OWNkYzQ1NDc5ZGMiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
-        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEu
-        IiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJm
-        OTE0ZDllOC03YzcyLTQxMzYtOTE4OS0xZjIyNTY0MTg5NTMiLCAibnVtX3By
-        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9u
-        IjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xv
-        c2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhODhjYmUxOC03
-        YmRhLTQxYzItYThkNC0yMTIxMGFiNDM3YTEiLCAibnVtX3Byb2Nlc3NlZCI6
-        IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVy
-        YXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBz
-        cWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2MzMzMzJlOC1kMjQ0LTRjNjUtYWU2
-        NC02NTI1OTRjODQ4OTciLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBv
-        ZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIyNGNjNmFmNS1lNjEwLTQyODQtOTgxOC1l
+        NTc2YTNkZDViYjEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8g
+        d2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVt
+        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI5NmJmOTkwZS1jYjM0LTQxNGItYjNlMi1mYzg5MTI4
-        MDNjOTEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJz
-        dGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
-        dGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2NmUxMmJk
-        ZS05Y2JmLTQwNmUtYTg4MS1lMzgyM2JkMzkyOTMiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNo
-        X2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjM2Y5N2FkOC0xMzM5LTQy
-        MGYtYWMzMS1jMzQzZDhjMDY5MmQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
-        Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlz
-        dGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21l
-        dGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVE
-        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjY1YTYxNGE5LTYwNTItNDAzMC05
-        NDZkLWVhYmRhMGFiYTJmNiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1
-        ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGNlbnRvczctZGV2
-        ZWwyLnNhbWlyLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5n
-        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0w
-        QGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6
-        IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNlZmY3
-        YmRkZjk2OTRiYjE1YjlmOTA3In0sICJpZCI6ICI1Y2VmZjdiZGRmOTY5NGJi
-        MTViOWY5MDcifQ==
+        LCAic3RlcF9pZCI6ICJmMjRkYTI1Ni03YjA2LTQyMzQtYjM3Ny03Yzk5ZTMx
+        MjE2ZjYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJz
+        dGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogIjI3MGNjYzlmLTQxNzMtNGRiMy1iZDkzLWFiOGIyYjc5
+        YmVjNSIsICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2Vy
+        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5j
+        b20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAi
+        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFt
+        cGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjVjZjZlMzRjOWZhOTM0ZjEwYTZkODYyZiJ9LCAiaWQi
+        OiAiNWNmNmUzNGM5ZmE5MzRmMTBhNmQ4NjJmIn0=
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:18 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:56 GMT
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/tasks/003a3cdd-a59b-4efb-9bc6-1b208dc80c9e/
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/161e66ea-8aa2-4943-ac4d-5c63388b7aef/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3227,7 +1307,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -3236,15 +1316,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 30 May 2019 15:33:18 GMT
+      - Tue, 04 Jun 2019 21:31:56 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Etag:
-      - '"2fc143d8da93555908f634d8910eca87-gzip"'
+      - '"1c98cbf3b45b6499a2dc85775a0c2fd5-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '9054'
+      - '4523'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3252,206 +1332,618 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8wMDNhM2NkZC1hNTliLTRlZmItOWJjNi0xYjIw
-        OGRjODBjOWUvIiwgInRhc2tfaWQiOiAiMDAzYTNjZGQtYTU5Yi00ZWZiLTli
-        YzYtMWIyMDhkYzgwYzllIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        dWxwL2FwaS92Mi90YXNrcy8xNjFlNjZlYS04YWEyLTQ5NDMtYWM0ZC01YzYz
+        Mzg4YjdhZWYvIiwgInRhc2tfaWQiOiAiMTYxZTY2ZWEtOGFhMi00OTQzLWFj
+        NGQtNWM2MzM4OGI3YWVmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
         Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
-        aF90aW1lIjogIjIwMTktMDUtMzBUMTU6MzM6MThaIiwgIl9ucyI6ICJ0YXNr
-        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTktMDUtMzBUMTU6MzM6MTda
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6NTZaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJlZTM0OTAxZi04YjEwLTRkNTAtOWY1YS03
+        MTdjZWYwNWYxYzEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiYWU1NDg5ZmYtNjE2ZC00MmYxLWI5Y2Et
+        ZDMzN2YxYTJjNzQ0IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImU2NWRjODM3LTQzZDktNDExNi05ZDY1LTc4YmExYjM0
+        NGQ4MyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImMwNDdjNjM4LTQ0MTMtNGUy
+        MC04N2JjLTFkNjBiODYyNzI4YiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjI1N2NjYzFkLWY5ZmQtNDlmOS1iNWQxLWFiMTk3MTVkOTRjYyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
+        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyM2VjNWFlMi0xMzZiLTQwYWQtOGJi
+        YS0zMmY3NzdkMDk2NTQiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
+        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0
+        NWE5ODcxNy1lNzFkLTQ0OWItYWE2MS02NTAwMzc1MTEyYjgiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
+        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiSU5fUFJPR1JFU1Mi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzJiNjg5N2MtZTgyZC00ZGQ0LWI3
+        YjYtZTZhY2IwZTc1YzI4IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1f
+        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFk
+        YXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6
+        IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
+        aWQiOiAiNDJiZTBjYjEtZGEyYi00Nzc2LWEyNGUtMjExNThkNjEzZTY0Iiwg
+        Im51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
+        cmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBl
+        IjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAi
+        c3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        ZDRhZTZiNDEtNTA3MC00OTcxLTk2ZGItMTRmZTg4OTdhN2EwIiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlv
+        biI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
+        Z2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
+        Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjQ0ZGI1MmJj
+        LTk0MzEtNGY4ZS05MWMxLWJmZWJkYzFiMzlhNCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUmVt
+        b3Zpbmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xk
+        X3JlcG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdkNTI0YmZhLWYzNjIt
+        NDE4Yy05YTNjLWU3Zjk0NGM5Zjk3MCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGlu
+        ZyBIVE1MIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVt
+        c190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9k
+        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
+        LCAic3RlcF9pZCI6ICIyNGNjNmFmNS1lNjEwLTQyODQtOTgxOC1lNTc2YTNk
+        ZDViYjEiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        MCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwg
+        InN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
+        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
+        cF9pZCI6ICJmMjRkYTI1Ni03YjA2LTQyMzQtYjM3Ny03Yzk5ZTMxMjE2ZjYi
+        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
+        c2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5
+        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
+        IjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
+        X2lkIjogIjI3MGNjYzlmLTQxNzMtNGRiMy1iZDkzLWFiOGIyYjc5YmVjNSIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5jb20uZHEy
+        IiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2
+        ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5leGFtcGxlLmNv
+        bSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
+        b2lkIjogIjVjZjZlMzRjOWZhOTM0ZjEwYTZkODYyZiJ9LCAiaWQiOiAiNWNm
+        NmUzNGM5ZmE5MzRmMTBhNmQ4NjJmIn0=
+    http_version: 
+  recorded_at: Tue, 04 Jun 2019 21:31:57 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/161e66ea-8aa2-4943-ac4d-5c63388b7aef/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 04 Jun 2019 21:31:57 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"d52f111b043aaf24c9c5e5a8712e5f2c-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4503'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8xNjFlNjZlYS04YWEyLTQ5NDMtYWM0ZC01YzYz
+        Mzg4YjdhZWYvIiwgInRhc2tfaWQiOiAiMTYxZTY2ZWEtOGFhMi00OTQzLWFj
+        NGQtNWM2MzM4OGI3YWVmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6NTZaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJlZTM0OTAxZi04YjEwLTRkNTAtOWY1YS03
+        MTdjZWYwNWYxYzEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiYWU1NDg5ZmYtNjE2ZC00MmYxLWI5Y2Et
+        ZDMzN2YxYTJjNzQ0IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImU2NWRjODM3LTQzZDktNDExNi05ZDY1LTc4YmExYjM0
+        NGQ4MyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImMwNDdjNjM4LTQ0MTMtNGUy
+        MC04N2JjLTFkNjBiODYyNzI4YiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjI1N2NjYzFkLWY5ZmQtNDlmOS1iNWQxLWFiMTk3MTVkOTRjYyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
+        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyM2VjNWFlMi0xMzZiLTQwYWQtOGJi
+        YS0zMmY3NzdkMDk2NTQiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
+        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0
+        NWE5ODcxNy1lNzFkLTQ0OWItYWE2MS02NTAwMzc1MTEyYjgiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
+        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiYzJiNjg5N2MtZTgyZC00ZGQ0LWI3YjYt
+        ZTZhY2IwZTc1YzI4IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRh
+        LiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        NDJiZTBjYjEtZGEyYi00Nzc2LWEyNGUtMjExNThkNjEzZTY0IiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
+        biI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNs
+        b3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDRhZTZiNDEt
+        NTA3MC00OTcxLTk2ZGItMTRmZTg4OTdhN2EwIiwgIm51bV9wcm9jZXNzZWQi
+        OiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5l
+        cmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUg
+        c3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDRkYjUyYmMtOTQzMS00ZjhlLTkx
+        YzEtYmZlYmRjMWIzOWE0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVw
+        b2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAi
+        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiN2Q1MjRiZmEtZjM2Mi00MThjLTlhM2MtZTdmOTQ0
+        YzlmOTcwIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAi
+        c3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjRjYzZh
+        ZjUtZTYxMC00Mjg0LTk4MTgtZTU3NmEzZGQ1YmIxIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
+        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiSU5f
+        UFJPR1JFU1MiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjI0ZGEyNTYtN2Iw
+        Ni00MjM0LWIzNzctN2M5OWUzMTIxNmY2IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5n
+        IExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVw
+        b19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
+        U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyNzBjY2M5Zi00MTcz
+        LTRkYjMtYmQ5My1hYjhiMmI3OWJlYzUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZl
+        bC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5n
+        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0w
+        QGRldmVsLmJhbG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwg
+        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2Y2ZTM0YzlmYTkz
+        NGYxMGE2ZDg2MmYifSwgImlkIjogIjVjZjZlMzRjOWZhOTM0ZjEwYTZkODYy
+        ZiJ9
+    http_version: 
+  recorded_at: Tue, 04 Jun 2019 21:31:57 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/161e66ea-8aa2-4943-ac4d-5c63388b7aef/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 04 Jun 2019 21:31:57 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"a40cf5fb0f55af1cef92f13c7a9ab4a8-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4497'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8xNjFlNjZlYS04YWEyLTQ5NDMtYWM0ZC01YzYz
+        Mzg4YjdhZWYvIiwgInRhc2tfaWQiOiAiMTYxZTY2ZWEtOGFhMi00OTQzLWFj
+        NGQtNWM2MzM4OGI3YWVmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogbnVsbCwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90
+        aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6NTZaIiwgInRyYWNlYmFjayI6IG51
+        bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7
+        InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3Rh
+        ciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJlZTM0OTAxZi04YjEwLTRkNTAtOWY1YS03
+        MTdjZWYwNWYxYzEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1l
+        dGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiYWU1NDg5ZmYtNjE2ZC00MmYxLWI5Y2Et
+        ZDMzN2YxYTJjNzQ0IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1
+        dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2Rl
+        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
+        ICJzdGVwX2lkIjogImU2NWRjODM3LTQzZDktNDExNi05ZDY1LTc4YmExYjM0
+        NGQ4MyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlw
+        ZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImMwNDdjNjM4LTQ0MTMtNGUy
+        MC04N2JjLTFkNjBiODYyNzI4YiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        ZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
+        IjogIjI1N2NjYzFkLWY5ZmQtNDlmOS1iNWQxLWFiMTk3MTVkOTRjYyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVy
+        cmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyM2VjNWFlMi0xMzZiLTQwYWQtOGJi
+        YS0zMmY3NzdkMDk2NTQiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9z
+        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxl
+        cyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAs
+        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0
+        NWE5ODcxNy1lNzFkLTQ0OWItYWE2MS02NTAwMzc1MTEyYjgiLCAibnVtX3By
+        b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9u
+        IjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29t
+        cHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiYzJiNjg5N2MtZTgyZC00ZGQ0LWI3YjYt
+        ZTZhY2IwZTc1YzI4IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRh
+        LiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAw
+        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
+        ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
+        NDJiZTBjYjEtZGEyYi00Nzc2LWEyNGUtMjExNThkNjEzZTY0IiwgIm51bV9w
+        cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
+        biI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNs
+        b3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDRhZTZiNDEt
+        NTA3MC00OTcxLTk2ZGItMTRmZTg4OTdhN2EwIiwgIm51bV9wcm9jZXNzZWQi
+        OiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5l
+        cmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUg
+        c3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQi
+        LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDRkYjUyYmMtOTQzMS00ZjhlLTkx
+        YzEtYmZlYmRjMWIzOWE0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
+        c3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVw
+        b2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAi
+        aXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3Jf
+        ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
+        MCwgInN0ZXBfaWQiOiAiN2Q1MjRiZmEtZjM2Mi00MThjLTlhM2MtZTdmOTQ0
+        YzlmOTcwIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6
+        IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAi
+        c3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjRjYzZh
+        ZjUtZTYxMC00Mjg0LTk4MTgtZTU3NmEzZGQ1YmIxIiwgIm51bV9wcm9jZXNz
+        ZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlz
+        aF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklO
+        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
+        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjI0ZGEyNTYtN2IwNi00
+        MjM0LWIzNzctN2M5OWUzMTIxNmY2IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwg
+        eyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExp
+        c3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
+        ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
+        RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyNzBjY2M5Zi00MTczLTRkYjMt
+        YmQ5My1hYjhiMmI3OWJlYzUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9XX0sICJx
+        dWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5iYWxt
+        b3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVs
+        LmJhbG1vcmEuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwgImVycm9y
+        IjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2Y2ZTM0YzlmYTkzNGYxMGE2
+        ZDg2MmYifSwgImlkIjogIjVjZjZlMzRjOWZhOTM0ZjEwYTZkODYyZiJ9
+    http_version: 
+  recorded_at: Tue, 04 Jun 2019 21:31:57 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/161e66ea-8aa2-4943-ac4d-5c63388b7aef/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 04 Jun 2019 21:31:57 GMT
+      Server:
+      - Apache/2.4.6 (CentOS)
+      Etag:
+      - '"cd2c685ddefdf3260417a3bbd9bb9bf4-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '9043'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy8xNjFlNjZlYS04YWEyLTQ5NDMtYWM0ZC01YzYz
+        Mzg4YjdhZWYvIiwgInRhc2tfaWQiOiAiMTYxZTY2ZWEtOGFhMi00OTQzLWFj
+        NGQtNWM2MzM4OGI3YWVmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpz
+        Y2VuYXJpb190ZXN0IiwgInB1bHA6YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlz
+        aF90aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6NTdaIiwgIl9ucyI6ICJ0YXNr
+        X3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTktMDYtMDRUMjE6MzE6NTZa
         IiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10sICJw
         cm9ncmVzc19yZXBvcnQiOiB7InNjZW5hcmlvX3Rlc3QiOiBbeyJudW1fc3Vj
         Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0
         ZXBfdHlwZSI6ICJzYXZlX3RhciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2MWM5N2Zh
-        My04OTUyLTQxNzItYTdkNC1mNWExZGIzMTM2YjAiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlZTM0OTAx
+        Zi04YjEwLTRkNTAtOWY1YS03MTdjZWYwNWYxYzEiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIklu
         aXRpYWxpemluZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0
         aWFsaXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
         dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
-        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjY5MmNl
-        MjEtN2I1MS00M2UyLTk2YTgtM2Y2YjhhMmM4MGQwIiwgIm51bV9wcm9jZXNz
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWU1NDg5
+        ZmYtNjE2ZC00MmYxLWI5Y2EtZDMzN2YxYTJjNzQ0IiwgIm51bV9wcm9jZXNz
         ZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQ
         dWJsaXNoaW5nIERpc3RyaWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAi
         ZGlzdHJpYnV0aW9uIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJ
         TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM2ZjExMDg4LWMzMDYt
-        NGVlZS1iZGM0LTYxZWVlOWI1ZTk0OCIsICJudW1fcHJvY2Vzc2VkIjogMX0s
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImU2NWRjODM3LTQzZDkt
+        NDExNi05ZDY1LTc4YmExYjM0NGQ4MyIsICJudW1fcHJvY2Vzc2VkIjogMX0s
         IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
         ZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjog
         MCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
         ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImViMDEzMzIyLTBmZmMtNDQ5My1iYmJjLTRjMmE3ODEwODI4ZCIsICJudW1f
+        ImMwNDdjNjM4LTQ0MTMtNGUyMC04N2JjLTFkNjBiODYyNzI4YiIsICJudW1f
         cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
         b24iOiAiUHVibGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJk
         cnBtcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjE4YzM2YzVlLWEyYWItNDRiMi1hNGU2
-        LWNkOWIyMjc1OWYyMSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjI1N2NjYzFkLWY5ZmQtNDlmOS1iNWQx
+        LWFiMTk3MTVkOTRjYyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
         Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEi
         LCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5MzM4
-        NmM1MC1lYzJlLTQ1MzMtYmNkNi1mM2ZlYmM1MzY2NDIiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyM2Vj
+        NWFlMi0xMzZiLTQwYWQtOGJiYS0zMmY3NzdkMDk2NTQiLCAibnVtX3Byb2Nl
         c3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgTW9kdWxlcyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIs
-        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9y
-        X2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6
-        IDAsICJzdGVwX2lkIjogImY5Y2FjZTc1LTZjODMtNDFjMy04ZTg2LWJjN2Zj
-        MjczMDIwOCIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3Mi
-        OiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwg
-        InN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1NzA0Yzlh
-        MS0xOTNkLTQ0M2EtOTYzZS05OWNkYzQ1NDc5ZGMiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
-        Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJmOTE0ZDllOC03YzcyLTQxMzYtOTE4OS0xZjIy
-        NTY0MTg5NTMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIs
-        ICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJhODhjYmUxOC03YmRhLTQxYzItYThkNC0yMTIxMGFiNDM3YTEi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
-        c2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBf
-        dHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAi
-        c3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2MzMz
-        MzJlOC1kMjQ0LTRjNjUtYWU2NC02NTI1OTRjODQ4OTciLCAibnVtX3Byb2Nl
-        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3Zl
-        X29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5NmJmOTkwZS1jYjM0
-        LTQxNGItYjNlMi1mYzg5MTI4MDNjOTEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
-        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRp
-        bmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRl
-        bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRh
-        aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICI2NmUxMmJkZS05Y2JmLTQwNmUtYTg4MS1lMzgyM2JkMzky
-        OTMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwg
-        ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0
-        ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6
-        IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJjM2Y5N2FkOC0xMzM5LTQyMGYtYWMzMS1jMzQzZDhjMDY5MmQiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0
-        aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAi
-        aW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwg
-        InN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjY1
-        YTYxNGE5LTYwNTItNDAzMC05NDZkLWVhYmRhMGFiYTJmNiIsICJudW1fcHJv
-        Y2Vzc2VkIjogMX1dfSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dv
-        cmtlci0wQGNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tLmRxMiIs
-        ICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZl
-        ZF9yZXNvdXJjZV93b3JrZXItMEBjZW50b3M3LWRldmVsMi5zYW1pci5leGFt
-        cGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImV4
-        Y2VwdGlvbiI6IG51bGwsICJyZXBvX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAi
-        c3RhcnRlZCI6ICIyMDE5LTA1LTMwVDE1OjMzOjE3WiIsICJfbnMiOiAicmVw
-        b19wdWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTktMDUtMzBU
-        MTU6MzM6MTdaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90
-        eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5l
-        cmF0ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJycG1zIjogIkZJTklTSEVEIiwg
-        ImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJyZW1v
-        dmVfb2xkX3JlcG9kYXRhIjogIkZJTklTSEVEIiwgIm1vZHVsZXMiOiAiU0tJ
-        UFBFRCIsICJzYXZlX3RhciI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21l
-        dGFkYXRhIjogIkZJTklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29t
-        cHMiOiAiRklOSVNIRUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwg
-        InJlcG92aWV3IjogIlNLSVBQRUQiLCAicHVibGlzaF9kaXJlY3RvcnkiOiAi
-        RklOSVNIRUQiLCAiZXJyYXRhIjogIkZJTklTSEVEIiwgIm1ldGFkYXRhIjog
-        IkZJTklTSEVEIn0sICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1
-        dG9yX2lkIjogInNjZW5hcmlvX3Rlc3QiLCAiaWQiOiAiNWNlZmY3YmUwNWY1
-        ZWUyYWUwOTcwNGQ5IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEs
-        ICJkZXNjcmlwdGlvbiI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJzYXZlX3RhciIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2MWM5N2ZhMy04OTUyLTQx
-        NzItYTdkNC1mNWExZGIzMTM2YjAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7
-        Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemlu
-        ZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3Jl
-        cG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklO
-        SVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAi
-        bnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjY5MmNlMjEtN2I1MS00
-        M2UyLTk2YTgtM2Y2YjhhMmM4MGQwIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwg
-        eyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5n
-        IERpc3RyaWJ1dGlvbiBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0
-        aW9uIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImM2ZjExMDg4LWMzMDYtNGVlZS1iZGM0
-        LTYxZWVlOWI1ZTk0OCIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwg
-        InN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRl
-        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImViMDEzMzIy
-        LTBmZmMtNDQ5My1iYmJjLTRjMmE3ODEwODI4ZCIsICJudW1fcHJvY2Vzc2Vk
-        IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVi
-        bGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2Rl
-        dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjE4YzM2YzVlLWEyYWItNDRiMi1hNGU2LWNkOWIyMjc1
-        OWYyMSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAz
-        LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90
-        eXBlIjogImVycmF0YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5MzM4NmM1MC1lYzJl
-        LTQ1MzMtYmNkNi1mM2ZlYmM1MzY2NDIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9
-        LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
-        bmcgTW9kdWxlcyIsICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMi
-        OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogImY5Y2FjZTc1LTZjODMtNDFjMy04ZTg2LWJjN2ZjMjczMDIwOCIs
-        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVz
-        Y3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlw
-        ZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1NzA0YzlhMS0xOTNkLTQ0
-        M2EtOTYzZS05OWNkYzQ1NDc5ZGMiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7
-        Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
-        TWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190
-        b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJmOTE0ZDllOC03YzcyLTQxMzYtOTE4OS0xZjIyNTY0MTg5NTMi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
-        c2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
-        cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
+        OiAwLCAic3RlcF9pZCI6ICI0NWE5ODcxNy1lNzFkLTQ0OWItYWE2MS02NTAw
+        Mzc1MTEyYjgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
+        IjogMywgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIs
+        ICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRlbXNfdG90YWwiOiAzLCAic3Rh
+        dGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWls
+        cyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzJiNjg5
+        N2MtZTgyZC00ZGQ0LWI3YjYtZTZhY2IwZTc1YzI4IiwgIm51bV9wcm9jZXNz
+        ZWQiOiAzfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQ
+        dWJsaXNoaW5nIE1ldGFkYXRhLiIsICJzdGVwX3R5cGUiOiAibWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiNDJiZTBjYjEtZGEyYi00Nzc2LWEyNGUtMjEx
+        NThkNjEzZTY0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEi
+        LCAic3RlcF90eXBlIjogImNsb3NlX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNf
+        dG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiZDRhZTZiNDEtNTA3MC00OTcxLTk2ZGItMTRmZTg4OTdhN2Ew
+        IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVw
+        X3R5cGUiOiAiZ2VuZXJhdGUgc3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwg
+        InN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDRk
+        YjUyYmMtOTQzMS00ZjhlLTkxYzEtYmZlYmRjMWIzOWE0IiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
+        ICJSZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90eXBlIjogInJlbW92
+        ZV9vbGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiN2Q1MjRiZmEtZjM2
+        Mi00MThjLTlhM2MtZTdmOTQ0YzlmOTcwIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
+        aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0
+        ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiMjRjYzZhZjUtZTYxMC00Mjg0LTk4MTgtZTU3NmEzZGQ1
+        YmIxIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEs
+        ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJz
+        dGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwi
+        OiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiZjI0ZGEyNTYtN2IwNi00MjM0LWIzNzctN2M5OWUzMTIxNmY2IiwgIm51
+        bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlw
+        dGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjog
+        ImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
         ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJh
-        ODhjYmUxOC03YmRhLTQxYzItYThkNC0yMTIxMGFiNDM3YTEiLCAibnVtX3By
-        b2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
-        IjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJn
-        ZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2MzMzMzJlOC1kMjQ0
-        LTRjNjUtYWU2NC02NTI1OTRjODQ4OTciLCAibnVtX3Byb2Nlc3NlZCI6IDB9
-        LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5n
-        IG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBv
-        ZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIy
+        NzBjY2M5Zi00MTczLTRkYjMtYmQ5My1hYjhiMmI3OWJlYzUiLCAibnVtX3By
+        b2Nlc3NlZCI6IDF9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
+        b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0
+        ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJl
+        c3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVs
+        bCwgInJlcG9faWQiOiAic2NlbmFyaW9fdGVzdCIsICJzdGFydGVkIjogIjIw
+        MTktMDYtMDRUMjE6MzE6NTZaIiwgIl9ucyI6ICJyZXBvX3B1Ymxpc2hfcmVz
+        dWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0wNi0wNFQyMTozMTo1N1oiLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVt
+        X2Rpc3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7ImdlbmVyYXRlIHNxbGl0ZSI6
+        ICJTS0lQUEVEIiwgInJwbXMiOiAiRklOSVNIRUQiLCAiaW5pdGlhbGl6ZV9y
+        ZXBvX21ldGFkYXRhIjogIkZJTklTSEVEIiwgInJlbW92ZV9vbGRfcmVwb2Rh
+        dGEiOiAiRklOSVNIRUQiLCAibW9kdWxlcyI6ICJGSU5JU0hFRCIsICJzYXZl
+        X3RhciI6ICJGSU5JU0hFRCIsICJjbG9zZV9yZXBvX21ldGFkYXRhIjogIkZJ
+        TklTSEVEIiwgImRycG1zIjogIlNLSVBQRUQiLCAiY29tcHMiOiAiRklOSVNI
+        RUQiLCAiZGlzdHJpYnV0aW9uIjogIkZJTklTSEVEIiwgInJlcG92aWV3Ijog
+        IlNLSVBQRUQiLCAicHVibGlzaF9kaXJlY3RvcnkiOiAiRklOSVNIRUQiLCAi
+        ZXJyYXRhIjogIkZJTklTSEVEIiwgIm1ldGFkYXRhIjogIkZJTklTSEVEIn0s
+        ICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgImRpc3RyaWJ1dG9yX2lkIjogInNj
+        ZW5hcmlvX3Rlc3QiLCAiaWQiOiAiNWNmNmUzNGRiMDJlNTMwYWFhYTRmNDY1
+        IiwgImRldGFpbHMiOiBbeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlv
+        biI6ICJDb3B5aW5nIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJzYXZlX3RhciIs
+        ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJlZTM0OTAxZi04YjEwLTRkNTAtOWY1YS03MTdj
+        ZWYwNWYxYzEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
+        IjogMSwgImRlc2NyaXB0aW9uIjogIkluaXRpYWxpemluZyByZXBvIG1ldGFk
+        YXRhIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEi
+        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiYWU1NDg5ZmYtNjE2ZC00MmYxLWI5Y2EtZDMz
+        N2YxYTJjNzQ0IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2Vz
+        cyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERpc3RyaWJ1dGlv
+        biBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZGlzdHJpYnV0aW9uIiwgIml0ZW1z
+        X3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImU2NWRjODM3LTQzZDktNDExNi05ZDY1LTc4YmExYjM0NGQ4
+        MyIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAi
+        ZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6
+        ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImMwNDdjNjM4LTQ0MTMtNGUyMC04
+        N2JjLTFkNjBiODYyNzI4YiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBEZWx0
+        YSBSUE1zIiwgInN0ZXBfdHlwZSI6ICJkcnBtcyIsICJpdGVtc190b3RhbCI6
+        IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjI1N2NjYzFkLWY5ZmQtNDlmOS1iNWQxLWFiMTk3MTVkOTRjYyIsICJudW1f
+        cHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRp
+        b24iOiAiUHVibGlzaGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0
+        YSIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIyM2VjNWFlMi0xMzZiLTQwYWQtOGJiYS0z
+        MmY3NzdkMDk2NTQiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNj
+        ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxlcyIs
+        ICJzdGVwX3R5cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDAsICJz
+        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NWE5
+        ODcxNy1lNzFkLTQ0OWItYWE2MS02NTAwMzc1MTEyYjgiLCAibnVtX3Byb2Nl
+        c3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMywgImRlc2NyaXB0aW9uIjog
+        IlB1Ymxpc2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29tcHMi
+        LCAiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
+        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
+        IjogMCwgInN0ZXBfaWQiOiAiYzJiNjg5N2MtZTgyZC00ZGQ0LWI3YjYtZTZh
+        Y2IwZTc1YzI4IiwgIm51bV9wcm9jZXNzZWQiOiAzfSwgeyJudW1fc3VjY2Vz
+        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIs
+        ICJzdGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAwLCAi
+        c3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNDJi
+        ZTBjYjEtZGEyYi00Nzc2LWEyNGUtMjExNThkNjEzZTY0IiwgIm51bV9wcm9j
+        ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6
+        ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNsb3Nl
+        X3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDRhZTZiNDEtNTA3
+        MC00OTcxLTk2ZGItMTRmZTg4OTdhN2EwIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0
+        aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUgc3Fs
+        aXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiNDRkYjUyYmMtOTQzMS00ZjhlLTkxYzEt
+        YmZlYmRjMWIzOWE0IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        Y2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVwb2Rh
+        dGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAiaXRl
+        bXNfdG90YWwiOiAwLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0
+        YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
+        InN0ZXBfaWQiOiAiN2Q1MjRiZmEtZjM2Mi00MThjLTlhM2MtZTdmOTQ0Yzlm
+        OTcwIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        ICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAic3Rl
+        cF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
+        IjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjRjYzZhZjUt
+        ZTYxMC00Mjg0LTk4MTgtZTU3NmEzZGQ1YmIxIiwgIm51bV9wcm9jZXNzZWQi
+        OiAwfSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJs
+        aXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9k
+        aXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNI
+        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZjI0ZGEyNTYtN2IwNi00MjM0
+        LWIzNzctN2M5OWUzMTIxNmY2IiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJu
+        dW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3Rp
+        bmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRh
+        ZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5NmJmOTkwZS1jYjM0LTQxNGItYjNl
-        Mi1mYzg5MTI4MDNjOTEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9z
-        dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBm
-        aWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwi
-        OiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI2NmUxMmJkZS05Y2JmLTQwNmUtYTg4MS1lMzgyM2JkMzkyOTMiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0
-        aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6
-        ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjM2Y5N2Fk
-        OC0xMzM5LTQyMGYtYWMzMS1jMzQzZDhjMDY5MmQiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldy
-        aXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6
-        ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
-        IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjY1YTYxNGE5LTYw
-        NTItNDAzMC05NDZkLWVhYmRhMGFiYTJmNiIsICJudW1fcHJvY2Vzc2VkIjog
-        MX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1Y2VmZjdi
-        ZGRmOTY5NGJiMTViOWY5MDcifSwgImlkIjogIjVjZWZmN2JkZGY5Njk0YmIx
-        NWI5ZjkwNyJ9
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyNzBjY2M5Zi00MTczLTRkYjMtYmQ5
+        My1hYjhiMmI3OWJlYzUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9XX0sICJlcnJv
+        ciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWNmNmUzNGM5ZmE5MzRmMTBh
+        NmQ4NjJmIn0sICJpZCI6ICI1Y2Y2ZTM0YzlmYTkzNGYxMGE2ZDg2MmYifQ==
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:33:18 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:57 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/support/destroy_org_if_exists.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/support/destroy_org_if_exists.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com:8443/candlepin/owners/scenario_test
+    uri: https://devel.balmora.example.com:8443/candlepin/owners/scenario_test
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -12,11 +12,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Authorization:
-      - OAuth oauth_consumer_key="7AHaN3UJsZubdCVAxCja8wTLotxnwNG3", oauth_nonce="WOPHU2svRbtqVK1zXjDlAt0in047Aq01f1LgnHUUiM",
-        oauth_signature="otnCVg29cX3zznM%2FPOpGACLggFI%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1559230351", oauth_version="1.0"
+      - OAuth oauth_consumer_key="AE992kqHucTXo8KrGY9nA4HyiPVvHbYD", oauth_nonce="IZ5kJy86p726rAHvwH59Aba1iWBTrNfk8Z1xqw0LsQ",
+        oauth_signature="NJ14eq%2Fimx7N8KzIMHl3d14CDjs%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1559683869", oauth_version="1.0"
       Cp-User:
       - foreman_admin
   response:
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       X-Candlepin-Request-Uuid:
-      - f5da75b6-9bc6-46ef-a1d1-7d3ea276e3f1
+      - db251731-a791-4416-b2c5-51913ef9c245
       X-Version:
       - 2.6.5-1
       - 2.6.5-1
@@ -36,13 +36,13 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Thu, 30 May 2019 15:32:31 GMT
+      - Tue, 04 Jun 2019 21:31:09 GMT
     body:
       encoding: UTF-8
       base64_string: |
         eyJkaXNwbGF5TWVzc2FnZSI6Ik9yZ2FuaXphdGlvbiB3aXRoIGlkIHNjZW5h
         cmlvX3Rlc3QgY291bGQgbm90IGJlIGZvdW5kLiIsInJlcXVlc3RVdWlkIjoi
-        ZjVkYTc1YjYtOWJjNi00NmVmLWExZDEtN2QzZWEyNzZlM2YxIn0=
+        ZGIyNTE3MzEtYTc5MS00NDE2LWIyYzUtNTE5MTNlZjljMjQ1In0=
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:31 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:09 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/scenarios/support/destroy_repo_if_exists.yml
+++ b/test/fixtures/vcr_cassettes/scenarios/support/destroy_repo_if_exists.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos7-devel2.samir.example.com/pulp/api/v2/repositories/scenario_test/
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/scenario_test/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
   response:
@@ -21,9 +21,9 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Thu, 30 May 2019 15:32:33 GMT
+      - Tue, 04 Jun 2019 21:31:12 GMT
       Server:
-      - Apache
+      - Apache/2.4.6 (CentOS)
       Content-Length:
       - '422'
       Etag:
@@ -44,5 +44,5 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         InNjZW5hcmlvX3Rlc3QifX0=
     http_version: 
-  recorded_at: Thu, 30 May 2019 15:32:33 GMT
+  recorded_at: Tue, 04 Jun 2019 21:31:13 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
at some point in the past, either candlepin stopped
accepting nil as a valid value for a gpg key url
or katello started sending nil instead of empty string.

This starts sending empty string to properly unset a gpg
key url