### PR TITLE
Fixes #26947 - correct metadata gen logic

### DIFF
--- a/app/lib/actions/katello/repository/metadata_generate.rb
+++ b/app/lib/actions/katello/repository/metadata_generate.rb
@@ -8,9 +8,13 @@ module Actions
           dependency = options.fetch(:dependency, nil)
           force = options.fetch(:force, false)
           repository_creation = options.fetch(:repository_creation, false)
-          matching_content = options.fetch(:matching_content, false) && !repository_creation
           source_repository = options.fetch(:source_repository, nil)
           source_repository ||= repository.target_repository if repository.link?
+          if repository_creation
+            matching_content = false
+          else
+            matching_content = options.fetch(:matching_content, false)
+          end
 
           plan_pulp_action([Pulp::Repository::DistributorPublish, Pulp3::Orchestration::Repository::GenerateMetadata],
                         repository, SmartProxy.pulp_master,

--- a/test/actions/katello/repository/metadata_generate_test.rb
+++ b/test/actions/katello/repository/metadata_generate_test.rb
@@ -72,5 +72,29 @@ module Actions
       assert_action_planed_with(action, pulp_publish_class, yum_repo, SmartProxy.pulp_master,
                                 yum_action_options)
     end
+
+    it 'plans a yum refresh with matching content set to some deferred object' do
+      action = create_action(action_class)
+      not_falsey = Object.new
+      plan_action(action, yum_repo, :matching_content => not_falsey, :repository_creation => false)
+
+      yum_action_options = action_options.clone
+      yum_action_options[:matching_content] = not_falsey
+      yum_action_options[:repository_creation] = false
+      assert_action_planed_with(action, pulp_publish_class, yum_repo, SmartProxy.pulp_master,
+                                yum_action_options)
+    end
+
+    it 'plans a yum refresh, but ignores matching content during repository_creation' do
+      action = create_action(action_class)
+      not_falsey = Object.new
+      plan_action(action, yum_repo, :matching_content => not_falsey, :repository_creation => true)
+
+      yum_action_options = action_options.clone
+      yum_action_options[:matching_content] = false
+      yum_action_options[:repository_creation] = true
+      assert_action_planed_with(action, pulp_publish_class, yum_repo, SmartProxy.pulp_master,
+                                yum_action_options)
+    end
   end
 end


### PR DESCRIPTION
a logic check was introduced, but during the
planning phase, the value is actually unresolved
output from a previous step which is always truthy
during the plan phase