### PR TITLE
Fixes #26159 - Activation Key Repository set label

### DIFF
--- a/app/lib/actions/katello/repository/update.rb
+++ b/app/lib/actions/katello/repository/update.rb
@@ -17,14 +17,14 @@ module Actions
             plan_action(::Actions::Candlepin::Product::ContentUpdate,
                         :owner => repository.organization.label,
                         :content_id => root.content_id,
-                        :name => content.name,
+                        :name => root.name,
                         :content_url => root.custom_content_path,
                         :gpg_key_url => repository.yum_gpg_key_url,
                         :label => content.label,
                         :type => root.content_type,
                         :arches => root.arch == "noarch" ? nil : root.arch)
 
-            content.update_attributes!(name: content.name,
+            content.update_attributes!(name: root.name,
                                        content_url: root.custom_content_path,
                                        content_type: repository.content_type,
                                        label: content.label,


### PR DESCRIPTION
**To test:**
1. Create a content view and add a repository to it.
2. Add the cv to an activattion key.
3. Add subscription for the product to the activation key.
4. See the repository sets tab and you should be able to view the repository in the content view.
5. Update name of the repository.
6. GO back to the repository sets tab on activation key. You should see the updated name of the repo.