### PR TITLE
Fixes #26973 - include pagination helper in app

### DIFF
--- a/app/controllers/katello/application_controller.rb
+++ b/app/controllers/katello/application_controller.rb
@@ -9,6 +9,7 @@ module Katello
 
     helper ::TaxonomyHelper
     helper ::ApplicationHelper
+    helper ::PaginationHelper
 
     before_action :set_gettext_locale
     helper_method :current_organization_object


### PR DESCRIPTION
A recent change in foreman meant that the application
helper now requires the pagination helper.  In foreman
this gets included automatically in controllers, but not in
katello