### PR TITLE
fixes #26848 - Add System Purpose tooltip

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -89,7 +89,8 @@
 
       <div class="divider"></div>
 
-      <h4 translate>System Purpose</h4>
+      <div style="display: inline-block"><h4 translate>System Purpose</h4></div>
+      <div style="display: inline-block"><i class="pficon-info" title="{{ 'System Purpose allows you to set the system\'s intended use on your network and improves the accuracy of auto attaching subscriptions.' | translate }}"></i></div>
 
       <dl class="dl-horizontal dl-horizontal-left">
         <dt translate>System Purpose Status</dt>


### PR DESCRIPTION
This PR was created to add a System Purpose tool tip (explaining what System Purpose is) under content host details.