### PR TITLE
fixes #26531 - Search Purpose Addons

### DIFF
--- a/app/models/katello/purpose_addon.rb
+++ b/app/models/katello/purpose_addon.rb
@@ -1,0 +1,9 @@
+module Katello
+  class PurposeAddon < Katello::Model
+    self.table_name = 'katello_purpose_addons'
+
+    has_many :subscription_facet_purpose_addons, :class_name => "Katello::SubscriptionFacetPurposeAddon", :dependent => :destroy, :inverse_of => :purpose_addon
+
+    has_many :subscription_facets, :through => :subscription_facet_purpose_addons, :class_name => "Katello::Host::SubscriptionFacet"
+  end
+end

--- a/app/models/katello/subscription_facet_purpose_addon.rb
+++ b/app/models/katello/subscription_facet_purpose_addon.rb
@@ -1,0 +1,6 @@
+module Katello
+  class SubscriptionFacetPurposeAddon < Katello::Model
+    belongs_to :subscription_facet, inverse_of: :subscription_facet_purpose_addons, class_name: 'Katello::Host::SubscriptionFacet'
+    belongs_to :purpose_addon, inverse_of: :subscription_facet_purpose_addons, class_name: 'Katello::PurposeAddon'
+  end
+end

--- a/app/views/katello/api/v2/subscription_facet/base.json.rabl
+++ b/app/views/katello/api/v2/subscription_facet/base.json.rabl
@@ -1,5 +1,9 @@
-attributes :id, :uuid, :last_checkin, :service_level, :release_version, :autoheal, :registered_at, :registered_through, :purpose_role, :purpose_usage, :purpose_addons
+attributes :id, :uuid, :last_checkin, :service_level, :release_version, :autoheal, :registered_at, :registered_through, :purpose_role, :purpose_usage
 
 child :user => :user do
   attributes :id, :login
+end
+
+node :purpose_addons do |sub|
+  sub.purpose_addons.pluck(:name)
 end

--- a/db/migrate/20190605014649_add_purpose_addons.rb
+++ b/db/migrate/20190605014649_add_purpose_addons.rb
@@ -1,0 +1,29 @@
+class AddPurposeAddons < ActiveRecord::Migration[5.2]
+  def change
+    create_table :katello_purpose_addons do |t|
+      t.string :name, null: false
+    end
+
+    create_table :katello_subscription_facet_purpose_addons do |t|
+      t.references :purpose_addon, index: { name: :katello_sub_facet_purpose_addons_paid }
+      t.references :subscription_facet, index: { name: :katello_sub_facet_purpose_addons_sfid }
+    end
+
+    add_foreign_key :katello_subscription_facet_purpose_addons, :katello_subscription_facets, column: :subscription_facet_id, name: :katello_sub_facet_purpose_addon_facet_id
+    add_foreign_key :katello_subscription_facet_purpose_addons, :katello_purpose_addons, column: :purpose_addon_id, name: :katello_sub_facet_purpose_addon_purpose_addon_id
+
+    Katello::Host::SubscriptionFacet.pluck(:id, :purpose_addons).each do |facet|
+      yaml_string = facet[1]
+      next if yaml_string.nil?
+
+      parsed = YAML.parse(yaml_string)
+      addon_names = parsed.root.children.map(&:value)
+      addon_names.each do |addon|
+        purpose_addon = Katello::PurposeAddon.find_or_create_by(name: addon)
+        Katello::SubscriptionFacetPurposeAddon.create(purpose_addon_id: purpose_addon.id, subscription_facet_id: facet[0])
+      end
+    end
+
+    remove_column :katello_subscription_facets, :purpose_addons, :text
+  end
+end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -211,7 +211,7 @@ Foreman::Plugin.register :katello do
     :content_facet_attributes => [:content_view_id, :lifecycle_environment_id, :content_source_id,
                                   :host, :kickstart_repository_id],
     :subscription_facet_attributes => [:release_version, :autoheal, :purpose_usage, :purpose_role, :service_level, :host,
-                                       {:installed_products => [:product_id, :product_name, :arch, :version]}, :facts, :hypervisor_guest_uuids => [], :purpose_addons => []]
+                                       {:installed_products => [:product_id, :product_name, :arch, :version]}, :facts, :hypervisor_guest_uuids => [], :purpose_addon_ids => []]
   parameter_filter Hostgroup, :content_view_id, :lifecycle_environment_id, :content_source_id,
     :kickstart_repository_id
   parameter_filter Organization, :label, :service_level

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -75,7 +75,8 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
 
   def test_create_with_permitted_attributes
     cf_attrs = {:content_view_id => @content_view.id, :lifecycle_environment_id => @environment.id}
-    attrs = @host.clone.attributes.merge("name" => "contenthost", "content_facet_attributes" => cf_attrs).compact!
+    sf_attrs = {:purpose_addons => ["Addon"]}
+    attrs = @host.clone.attributes.merge("name" => "contenthost", "content_facet_attributes" => cf_attrs, "subscription_facet_attributes" => sf_attrs).compact!
 
     assert_difference('Host.unscoped.count') do
       post :create, params: attrs
@@ -93,5 +94,19 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     post :create, params: attrs
     assert_response :success # the uuid is simply filtered out which allows the host to be still saved
     refute Katello::Host::ContentFacet.where(:uuid => cf_attrs[:uuid]).exists?
+  end
+
+  def test_create_purpose_addons
+    sf_attrs = {:purpose_addons => ["Addon", katello_purpose_addons(:addon).name]}
+    attrs = @host.clone.attributes.merge("name" => "host", "subscription_facet_attributes" => sf_attrs)
+
+    post :create, params: attrs
+
+    host_id = JSON.parse(response.body)["id"]
+    host = Host.find(host_id)
+    addon_names = host.subscription_facet.purpose_addons.pluck(:name)
+
+    assert_equal addon_names.sort, sf_attrs[:purpose_addons].sort
+    assert_response :success
   end
 end

--- a/test/fixtures/models/katello_purpose_addons.yml
+++ b/test/fixtures/models/katello_purpose_addons.yml
@@ -1,0 +1,2 @@
+addon:
+  name: "Test Addon"

--- a/test/support/fixtures_support.rb
+++ b/test/support/fixtures_support.rb
@@ -25,6 +25,7 @@ module Katello
       :katello_product_contents => Katello::ProductContent,
       :katello_providers => Katello::Provider,
       :katello_puppet_modules => Katello::PuppetModule,
+      :katello_purpose_addons => Katello::PurposeAddon,
       :katello_repository_puppet_modules => Katello::RepositoryPuppetModule,
       :katello_root_repositories => Katello::RootRepository,
       :katello_repositories => Katello::Repository,


### PR DESCRIPTION
This PR is created to search for hosts using purpose addons. Addons can be viewed under System Purpose inside Host's content.
**To test this PR:**
-  Create a Custom Product
-  Set some addons on it by connecting to your local postgres candlepin db
```
select uuid from cp2_products where name = 'CustomProduct';
insert into cp2_product_attributes(name, value, product_uuid) values ('addons', 'Test Addon1,Test Addon2', 'REPLACEME');
```

- Restart the tomcat service to refresh the product cache ` systemctl restart tomcat`

Now you should be able to see these addons under System Purpose. Add these addons to the host by selecting them and clicking on save.
To perform search on addons, go to Hosts and in the search box, type -
`addon = "Name of the addon you have added to the host" `and press enter. 
You should be able to see the hosts which have the addon that you have searched for. Also while performing a search, the text should be auto completed.``