### PR TITLE
Fixes #26981 -  /katello/api/repository_sets/:id returns too many repositories

### DIFF
--- a/app/models/katello/product_content.rb
+++ b/app/models/katello/product_content.rb
@@ -36,7 +36,7 @@ module Katello
 
     # used by Katello::Api::V2::RepositorySetsController#index
     def repositories
-      Katello::Repository.where(:root_id => product.root_repositories.has_url.where(:content_id => content.cp_content_id))
+      Katello::Repository.in_default_view.where(:root_id => product.root_repositories.has_url.where(:content_id => content.cp_content_id))
     end
   end
 end

--- a/test/models/product_content_test.rb
+++ b/test/models/product_content_test.rb
@@ -33,9 +33,12 @@ module Katello
       repo = katello_repositories(:fedora_17_x86_64)
       repo.root.update_attributes!(product: @product, content_id: @content_id)
 
-      assert_equal repo.clones.count + 1, @product_content.repositories.size
-
       assert_includes @product_content.repositories, repo
+
+      @product_content.repositories.each do |repository|
+        assert repository.in_default_view?
+        assert_equal @product_content.product, repository.product
+      end
     end
 
     def test_enabled


### PR DESCRIPTION
To reproduce:

- Import a manifest with Red Hat content.
- Check the katello/api/v2/repository_sets endpoint and pick one set that exists there.  Note that "repositories" in the set should be empty.
- Enable the chosen RH repo in Foreman.
- Create two Content Views, with each being in a different Lifecycle Environment.
- Add the same enabled repo to each of the two Content Views and publish.
- Check the chosen product in the repository_sets API endpoint again.  "repositories" under that product should now be populated and have duplicates with only different IDs.
- Apply this PR to Katello.
- Check the repository_sets API endpoint again.  This time, under the chosen product's repositories list, there should no longer be any duplicate repositories.