### PR TITLE
Fixes #27014 - Smart Proxy set initial loc and org

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -151,12 +151,11 @@ module Katello
       end
 
       def pulp_mirror?
-        self.features.map(&:name).include?(PULP_NODE_FEATURE)
+        self.has_feature? PULP_NODE_FEATURE
       end
 
       def pulp_master?
-        # use map instead of pluck in case the features aren't saved yet during create
-        self.features.map(&:name).include?(PULP_FEATURE)
+        self.has_feature? PULP_FEATURE
       end
 
       #deprecated methods
@@ -168,7 +167,7 @@ module Katello
       end
 
       def associate_default_locations
-        return unless pulp_master?
+        return unless self.pulp_master?
         ['puppet_content', 'subscribed_hosts'].each do |type|
           default_location = ::Location.unscoped.find_by_title(
             ::Setting[:"default_location_#{type}"])

--- a/app/views/overrides/smart_proxies/_environment_tab.html.erb
+++ b/app/views/overrides/smart_proxies/_environment_tab.html.erb
@@ -1,4 +1,4 @@
-<% if !@smart_proxy.new_record? && @smart_proxy.features.pluck(:name).include?(SmartProxy::PULP_NODE_FEATURE) -%>
+<% if !@smart_proxy.new_record? && @smart_proxy.has_feature?(SmartProxy::PULP_NODE_FEATURE) -%>
   <li id="kt_environments_tab">
     <a href="#kt_environments" data-toggle="tab"><%= _('Lifecycle Environments') %></a>
   </li>

--- a/app/views/overrides/smart_proxies/_environment_tab_pane.html.erb
+++ b/app/views/overrides/smart_proxies/_environment_tab_pane.html.erb
@@ -1,4 +1,4 @@
-<% if !@smart_proxy.new_record? && @smart_proxy.features.pluck(:name).include?(SmartProxy::PULP_NODE_FEATURE) -%>
+<% if !@smart_proxy.new_record? && @smart_proxy.has_feature?(SmartProxy::PULP_NODE_FEATURE) -%>
   <div class="tab-pane" id="kt_environments">
     <%= multiple_selects f, :lifecycle_environments, Katello::KTEnvironment.completer_scope(:organization_id => ::Organization.current.try(:id)), @smart_proxy.lifecycle_environment_ids, {:label => _('Lifecycle Environments')}, @smart_proxy.default_capsule? ? {:disabled => :disabled } : {}  %>
 

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "runcible", ">= 2.11.0", "< 3.0.0"
   gem.add_dependency "anemone"
   gem.add_dependency "pulpcore_client"
-  gem.add_dependency "pulp_file_client", "3.0.0rc2.dev.1558441126"
+  gem.add_dependency "pulp_file_client", "< 1.0"
 
   # UI
   gem.add_dependency "deface", '>= 1.0.2', '< 2.0.0'

--- a/test/factories/smart_proxy_factory.rb
+++ b/test/factories/smart_proxy_factory.rb
@@ -9,6 +9,7 @@ FactoryBot.modify do
         proxy.features << Feature.find_or_create_by(:name => 'Pulp')
         proxy.url = "https://#{Socket.gethostname}:9090"
         proxy.puppet_path = '/etc/puppet/environments'
+        proxy.locations = proxy.organizations = proxy.lifecycle_environments = []
       end
     end
 
@@ -27,6 +28,7 @@ FactoryBot.modify do
 
     trait :pulp_mirror do
       after(:build) do |proxy, _evaluator|
+        proxy.locations = proxy.organizations = proxy.lifecycle_environments = []
         proxy.features << Feature.find_or_create_by(:name => 'Pulp Node')
       end
     end


### PR DESCRIPTION
The way I tested this was to run `bundle exec rails katello:reset` in my foreman dir. Another way is to spin up a new dev box and check the smart proxy created.
**Issue**: The default smart proxy created was not assigned the default location and org.
**Expected**: The default smart proxy should be assigned thye default org and location on create. 