### PR TITLE
Fixes #27009 - adds a default http proxy setting for content

### DIFF
--- a/app/models/katello/concerns/http_proxy_extensions.rb
+++ b/app/models/katello/concerns/http_proxy_extensions.rb
@@ -11,13 +11,11 @@ module Katello
         changes = self.previous_changes
         if changes.key?(:name)
           previous_name = changes[:name].first
-          content_settings = Setting::Content.arel_table
           setting = Setting::Content.unscoped.
             where(name: "content_default_http_proxy").
-            where(content_settings[:value].matches("%#{previous_name}%")).
             first
 
-          if setting && !previous_name.blank?
+          if setting && setting.value == previous_name && !previous_name.blank?
             setting.update_attribute(:value, self.name)
           end
         end

--- a/app/models/katello/concerns/http_proxy_extensions.rb
+++ b/app/models/katello/concerns/http_proxy_extensions.rb
@@ -1,0 +1,19 @@
+module Katello
+  module Concerns
+    module HttpProxyExtensions
+      extend ActiveSupport::Concern
+
+      included do
+        after_save :update_default_proxy_setting
+      end
+
+      def update_default_proxy_setting
+        setting = Setting.where(name: "content_default_http_proxy").first
+
+        if setting
+          setting.update_attribute(:value, self.name)
+        end
+      end
+    end
+  end
+end

--- a/app/models/katello/concerns/http_proxy_extensions.rb
+++ b/app/models/katello/concerns/http_proxy_extensions.rb
@@ -16,7 +16,7 @@ module Katello
             where(value: previous_name.to_yaml).
             first
 
-          if setting and not previous_name.blank?
+          if setting && !previous_name.blank?
             setting.update_attribute(:value, self.name)
           end
         end

--- a/app/models/katello/concerns/http_proxy_extensions.rb
+++ b/app/models/katello/concerns/http_proxy_extensions.rb
@@ -14,6 +14,10 @@ module Katello
           setting.update_attribute(:value, self.name)
         end
       end
+
+      def name_and_url
+        "#{name} (#{url})"
+      end
     end
   end
 end

--- a/app/models/katello/concerns/http_proxy_extensions.rb
+++ b/app/models/katello/concerns/http_proxy_extensions.rb
@@ -11,9 +11,10 @@ module Katello
         changes = self.previous_changes
         if changes.key?(:name)
           previous_name = changes[:name].first
-          setting = Setting.
+          content_settings = Setting::Content.arel_table
+          setting = Setting::Content.unscoped.
             where(name: "content_default_http_proxy").
-            where(value: previous_name.to_yaml).
+            where(content_settings[:value].matches("%#{previous_name}%")).
             first
 
           if setting && !previous_name.blank?

--- a/app/models/katello/concerns/http_proxy_extensions.rb
+++ b/app/models/katello/concerns/http_proxy_extensions.rb
@@ -8,10 +8,17 @@ module Katello
       end
 
       def update_default_proxy_setting
-        setting = Setting.where(name: "content_default_http_proxy").first
+        changes = self.previous_changes
+        if changes.key?(:name)
+          previous_name = changes[:name].first
+          setting = Setting.
+            where(name: "content_default_http_proxy").
+            where(value: previous_name.to_yaml).
+            first
 
-        if setting
-          setting.update_attribute(:value, self.name)
+          if setting and not previous_name.blank?
+            setting.update_attribute(:value, self.name)
+          end
         end
       end
 

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -15,7 +15,7 @@ class Setting::Content < Setting
     download_policies = proc { hashify_parameters(::Runcible::Models::YumImporter::DOWNLOAD_POLICIES) }
     proxy_download_policies = proc { hashify_parameters(::SmartProxy::DOWNLOAD_POLICIES) }
     dependency_solving_options = proc { hashify_parameters(['conservative', 'greedy']) }
-    http_proxy_select = [{:name => _("HTTP Proxies"), :class => 'HttpProxy', :scope => 'all', :value_method => 'url', :text_method => 'url'}]
+    http_proxy_select = [{ name: _("HTTP Proxies"), class: 'HttpProxy', scope: 'all', value_method: 'name', text_method: 'name'}]
 
     self.transaction do
       [

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -10,14 +10,23 @@ class Setting::Content < Setting
     return unless super
 
     BLANK_ATTRS.concat %w(register_hostname_fact default_location_subscribed_hosts
-                          default_location_puppet_content)
+                          default_location_puppet_content content_default_http_proxy)
 
     download_policies = proc { hashify_parameters(::Runcible::Models::YumImporter::DOWNLOAD_POLICIES) }
     proxy_download_policies = proc { hashify_parameters(::SmartProxy::DOWNLOAD_POLICIES) }
     dependency_solving_options = proc { hashify_parameters(['conservative', 'greedy']) }
+    http_proxy_select = [{:name => _("HTTP Proxies"), :class => 'HttpProxy', :scope => 'all', :value_method => 'url', :text_method => 'url'}]
 
     self.transaction do
       [
+        self.set('content_default_http_proxy', N_("Default HTTP Proxy for syncing content"),
+                        nil, N_('Default http proxy'),
+                        nil,
+                        {
+                          collection: proc { http_proxy_select },
+                          include_blank: "no global default"
+                        }
+                ),
         self.set('katello_default_provision', N_("Default provisioning template for Operating Systems created from synced content"),
                  'Kickstart default', N_('Default synced OS provisioning template'),
                  nil, :collection => proc { katello_template_setting_values("provision") }
@@ -50,9 +59,7 @@ class Setting::Content < Setting
         self.set('katello_default_ptable', N_("Default partitioning table for new Operating Systems created from synced content"),
                  'Kickstart default', N_('Default synced OS partition table'),
                  nil, :collection => proc { Hash[Template.all.where(:type => "Ptable").map { |tmp| [tmp[:name], tmp[:name]] }] }
-                ),
-        self.set('katello_default_kexec', N_("Default kexec template for new Operating Systems created from synced content"),
-                 'Discovery Red Hat kexec', N_('Default synced OS kexec template'),
+                ), self.set('katello_default_kexec', N_("Default kexec template for new Operating Systems created from synced content"), 'Discovery Red Hat kexec', N_('Default synced OS kexec template'),
                  nil, :collection => proc { katello_template_setting_values("kexec") }
                 ),
         self.set('katello_default_atomic_provision', N_("Default provisioning template for new Atomic Operating Systems created from synced content"),

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -28,7 +28,7 @@ class Setting::Content < Setting
         self.set('content_default_http_proxy', N_("Default HTTP Proxy for syncing content"),
                         nil, N_('Default http proxy'),
                         nil,
-                        collection: proc { http_proxy_select }, include_blank: "no global default"
+                        collection: proc { http_proxy_select }, include_blank: N_("no global default")
                 ),
         self.set('katello_default_provision', N_("Default provisioning template for Operating Systems created from synced content"),
                  'Kickstart default', N_('Default synced OS provisioning template'),

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -22,10 +22,7 @@ class Setting::Content < Setting
         self.set('content_default_http_proxy', N_("Default HTTP Proxy for syncing content"),
                         nil, N_('Default http proxy'),
                         nil,
-                        {
-                          collection: proc { http_proxy_select },
-                          include_blank: "no global default"
-                        }
+                        collection: proc { http_proxy_select }, include_blank: "no global default"
                 ),
         self.set('katello_default_provision', N_("Default provisioning template for Operating Systems created from synced content"),
                  'Kickstart default', N_('Default synced OS provisioning template'),

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -15,7 +15,13 @@ class Setting::Content < Setting
     download_policies = proc { hashify_parameters(::Runcible::Models::YumImporter::DOWNLOAD_POLICIES) }
     proxy_download_policies = proc { hashify_parameters(::SmartProxy::DOWNLOAD_POLICIES) }
     dependency_solving_options = proc { hashify_parameters(['conservative', 'greedy']) }
-    http_proxy_select = [{ name: _("HTTP Proxies"), class: 'HttpProxy', scope: 'all', value_method: 'name', text_method: 'name'}]
+    http_proxy_select = [{
+      name: _("HTTP Proxies"),
+      class: 'HttpProxy',
+      scope: 'all',
+      value_method: 'name',
+      text_method: 'name_and_url'
+    }]
 
     self.transaction do
       [

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -146,6 +146,7 @@ module Katello
       ::Organization.send :include, Katello::Concerns::OrganizationExtensions
       ::User.send :include, Katello::Concerns::UserExtensions
       ::Setting.send :include, Katello::Concerns::SettingExtensions
+      ::HttpProxy.send :include, Katello::Concerns::HttpProxyExtensions
       ForemanTasks::RecurringLogic.send :include, Katello::Concerns::RecurringLogicExtensions
 
       #Controller extensions

--- a/test/models/setting/default_http_proxy_setting_test.rb
+++ b/test/models/setting/default_http_proxy_setting_test.rb
@@ -35,5 +35,15 @@ module Katello
       proxy.update_attribute(:name, "Some other proxy name")
       assert_equal "Some other proxy name", setting.reload.value
     end
+
+    def test_adding_new_proxy_does_not_change_setting
+      proxy = FactoryBot.create(:http_proxy)
+      setting = Setting.where(name: @name).first
+      setting.update_attribute(:value, proxy.name)
+
+      new_proxy = FactoryBot.create(:http_proxy, name: "second proxy")
+      assert_equal proxy.name, setting.reload.value
+      refute_equal new_proxy.name, setting.reload.value
+    end
   end
 end

--- a/test/models/setting/default_http_proxy_setting_test.rb
+++ b/test/models/setting/default_http_proxy_setting_test.rb
@@ -2,7 +2,6 @@ require 'katello_test_helper'
 
 module Katello
   class DefaultHTTPProxySettingTest < ActiveSupport::TestCase
-
     class TestAppController < ApplicationController
     end
 

--- a/test/models/setting/default_http_proxy_setting_test.rb
+++ b/test/models/setting/default_http_proxy_setting_test.rb
@@ -1,0 +1,30 @@
+require 'katello_test_helper'
+
+module Katello
+  class DefaultHTTPProxySettingTest < ActiveSupport::TestCase
+
+    class TestAppController < ApplicationController
+    end
+
+    def setup
+      @name = 'content_default_http_proxy'
+    end
+
+    def test_default_setting_accepts_proxy_url
+      setting = Setting.where(name: @name).first
+      FactoryBot.create(:http_proxy)
+      assert setting.valid?
+    end
+
+    def test_collection_children_empty_when_no_proxies_defined
+      children = TestAppController.helpers.send("#{@name}_collection").last[:children]
+      assert_empty children
+    end
+
+    def test_collection_includes_defined_proxy
+      proxy = FactoryBot.create(:http_proxy)
+      children = TestAppController.helpers.send("#{@name}_collection").last[:children]
+      assert_includes children, proxy.url
+    end
+  end
+end

--- a/test/models/setting/default_http_proxy_setting_test.rb
+++ b/test/models/setting/default_http_proxy_setting_test.rb
@@ -9,9 +9,10 @@ module Katello
       @name = 'content_default_http_proxy'
     end
 
-    def test_default_setting_accepts_proxy_url
+    def test_default_setting_accepts_proxy_name
       setting = Setting.where(name: @name).first
-      FactoryBot.create(:http_proxy)
+      proxy = FactoryBot.create(:http_proxy)
+      setting.value = proxy.name
       assert setting.valid?
     end
 
@@ -23,7 +24,7 @@ module Katello
     def test_collection_includes_defined_proxy
       proxy = FactoryBot.create(:http_proxy)
       children = TestAppController.helpers.send("#{@name}_collection").last[:children]
-      assert_includes children, proxy.url
+      assert_includes children, proxy.name
     end
   end
 end

--- a/test/models/setting/default_http_proxy_setting_test.rb
+++ b/test/models/setting/default_http_proxy_setting_test.rb
@@ -33,7 +33,7 @@ module Katello
       setting.update_attribute(:value, proxy.name)
 
       proxy.update_attribute(:name, "Some other proxy name")
-      assert_equal "Some other proxy name", setting.reload.name
+      assert_equal "Some other proxy name", setting.reload.value
     end
 
   end

--- a/test/models/setting/default_http_proxy_setting_test.rb
+++ b/test/models/setting/default_http_proxy_setting_test.rb
@@ -35,6 +35,5 @@ module Katello
       proxy.update_attribute(:name, "Some other proxy name")
       assert_equal "Some other proxy name", setting.reload.value
     end
-
   end
 end

--- a/test/models/setting/default_http_proxy_setting_test.rb
+++ b/test/models/setting/default_http_proxy_setting_test.rb
@@ -33,7 +33,25 @@ module Katello
       setting.update_attribute(:value, proxy.name)
 
       proxy.update_attribute(:name, "Some other proxy name")
-      assert_equal "Some other proxy name", setting.reload.value
+      assert_equal "Some other proxy name", Setting.where(name: @name).first.value
+    end
+
+    def test_proxy_name_partial_match_does_not_update_setting
+      proxy = FactoryBot.create(:http_proxy, 'foo')
+      setting = Setting.where(name: @name).first
+      setting.update_attribute(:value, proxy.name)
+
+      new_poxy = FactoryBot.create(:http_proxy, name: 'foobar')
+      assert_equal proxy.name, Setting.where(name: @name).first.value
+    end
+
+    def test_adding_first_proxy_does_not_change_setting
+      setting = Setting.where(name: @name).first
+      assert_nil setting.value
+
+      first_proxy = FactoryBot.create(:http_proxy)
+      assert_nil setting.reload.value
+      refute_equal first_proxy.name, setting.reload.value
     end
 
     def test_adding_new_proxy_does_not_change_setting

--- a/test/models/setting/default_http_proxy_setting_test.rb
+++ b/test/models/setting/default_http_proxy_setting_test.rb
@@ -37,11 +37,11 @@ module Katello
     end
 
     def test_proxy_name_partial_match_does_not_update_setting
-      proxy = FactoryBot.create(:http_proxy, 'foo')
+      proxy = FactoryBot.create(:http_proxy, name: 'foo')
       setting = Setting.where(name: @name).first
       setting.update_attribute(:value, proxy.name)
 
-      new_poxy = FactoryBot.create(:http_proxy, name: 'foobar')
+      FactoryBot.create(:http_proxy, name: 'foobar')
       assert_equal proxy.name, Setting.where(name: @name).first.value
     end
 

--- a/test/models/setting/default_http_proxy_setting_test.rb
+++ b/test/models/setting/default_http_proxy_setting_test.rb
@@ -26,5 +26,15 @@ module Katello
       children = TestAppController.helpers.send("#{@name}_collection").last[:children]
       assert_includes children, proxy.name
     end
+
+    def test_changing_proxy_name_updates_setting
+      proxy = FactoryBot.create(:http_proxy)
+      setting = Setting.where(name: @name).first
+      setting.update_attribute(:value, proxy.name)
+
+      proxy.update_attribute(:name, "Some other proxy name")
+      assert_equal "Some other proxy name", setting.reload.name
+    end
+
   end
 end


### PR DESCRIPTION
This PR creates a new Setting in the "Content" section under Administer->Settings in the UI.

The default is an empty value, meaning no global default value for content syncing will be set for organizations or repositories (remotes).

When clicked, the input will include any http proxies defined in the application. The value use is the proxy url. It's possible to set the setting value to a "nil" value by selecting "no global default".
