### PR TITLE
Fixes #27037 - update proxy task

### DIFF
--- a/app/models/katello/concerns/http_proxy_extensions.rb
+++ b/app/models/katello/concerns/http_proxy_extensions.rb
@@ -22,7 +22,10 @@ module Katello
       end
 
       def name_and_url
-        "#{name} (#{url})"
+        uri = URI(url)
+        uri.password = nil
+        uri.user = nil
+        "#{name} (#{uri})"
       end
     end
   end

--- a/lib/katello/tasks/update_content_default_http_proxy.rake
+++ b/lib/katello/tasks/update_content_default_http_proxy.rake
@@ -33,15 +33,15 @@ namespace :katello do
     User.current = User.anonymous_api_admin
     http_proxy = HttpProxy.where(name: options[:name]).first
 
+    uri = URI(options[:url])
+    username = uri.user
+    password = uri.password
+
     if http_proxy
       setting.update_attribute(:value, http_proxy.name)
-      http_proxy.update_attribute(:url, options[:url])
+      http_proxy.update_attributes(url: options[:url], username: username, password: password)
       puts "Content default http proxy set to #{http_proxy.name_and_url}."
     else
-
-      uri = URI(options[:url])
-      username = uri.user
-      password = uri.password
       new_proxy = ::HttpProxy.new(name: options[:name], url: options[:url],
                                 username: username, password: password,
                                 organizations: Organization.all,

--- a/lib/katello/tasks/update_content_default_http_proxy.rake
+++ b/lib/katello/tasks/update_content_default_http_proxy.rake
@@ -33,7 +33,6 @@ namespace :katello do
     User.current = User.anonymous_api_admin
     http_proxy = HttpProxy.where(name: options[:name]).first
 
-
     if http_proxy
       setting.update_attribute(:value, http_proxy.name)
       http_proxy.update_attribute(:url, options[:url])

--- a/lib/katello/tasks/update_content_default_http_proxy.rake
+++ b/lib/katello/tasks/update_content_default_http_proxy.rake
@@ -1,0 +1,22 @@
+require File.expand_path("../engine", File.dirname(__FILE__))
+
+namespace :katello do
+  desc "Sets the content default http proxy to an existing http proxy based on supplied URL."
+  task :update_default_http_proxy, [:proxy_name] => [ :environment] do |task, args|
+    setting = ::Setting::Content.where(name: 'content_default_http_proxy').first
+
+    http_proxy = HttpProxy.where(name: args[:proxy_name]).first
+
+    if http_proxy
+      setting.update_attribute(:value, http_proxy.name)
+      puts "Content default http proxy set to #{http_proxy.name_and_url}."
+    else
+      $stderr.print "No http proxy found with name \"#{args[:proxy_name]}\"."
+    end
+  end
+
+  task http_proxy_list: [:environment] do
+    ::HttpProxy.all.each { |proxy| puts "#{proxy.name_and_url}" }
+  end
+end
+

--- a/lib/katello/tasks/update_content_default_http_proxy.rake
+++ b/lib/katello/tasks/update_content_default_http_proxy.rake
@@ -2,7 +2,7 @@ require File.expand_path("../engine", File.dirname(__FILE__))
 
 namespace :katello do
   desc "Sets the content default http proxy to an existing http proxy based on supplied URL."
-  task :update_default_http_proxy => :environment do |_task, args|
+  task :update_default_http_proxy => :environment do
     setting = ::Setting::Content.where(name: 'content_default_http_proxy').first
     options = {}
     o = OptionParser.new
@@ -17,7 +17,7 @@ namespace :katello do
       puts o
       exit
     end
-    ordered_args = o.order!(args.to_a) {}
+    ordered_args = o.order!(ARGV) {}
     o.parse!(ordered_args)
 
     unless options.key?(:name)

--- a/lib/katello/tasks/update_content_default_http_proxy.rake
+++ b/lib/katello/tasks/update_content_default_http_proxy.rake
@@ -48,7 +48,7 @@ namespace :katello do
                                 locations: Location.all)
       if new_proxy.save!
         setting.update_attribute(:value, new_proxy.name)
-        puts "Default content http proxy set to \"#{new_proxy.name_and_url}\"."
+        puts "Default content http proxy set to #{new_proxy.name_and_url}."
       end
     end
 

--- a/lib/katello/tasks/update_content_default_http_proxy.rake
+++ b/lib/katello/tasks/update_content_default_http_proxy.rake
@@ -2,7 +2,7 @@ require File.expand_path("../engine", File.dirname(__FILE__))
 
 namespace :katello do
   desc "Sets the content default http proxy to an existing http proxy based on supplied URL."
-  task :update_default_http_proxy, [:proxy_name] => [ :environment] do |task, args|
+  task :update_default_http_proxy, [:proxy_name] => [ :environment] do |_task, args|
     setting = ::Setting::Content.where(name: 'content_default_http_proxy').first
 
     http_proxy = HttpProxy.where(name: args[:proxy_name]).first
@@ -19,4 +19,3 @@ namespace :katello do
     ::HttpProxy.all.each { |proxy| puts "#{proxy.name_and_url}" }
   end
 end
-

--- a/lib/katello/tasks/update_content_default_http_proxy.rake
+++ b/lib/katello/tasks/update_content_default_http_proxy.rake
@@ -15,6 +15,7 @@ namespace :katello do
     end
   end
 
+  desc "Displays the current defined http proxies."
   task http_proxy_list: [:environment] do
     ::HttpProxy.all.each { |proxy| puts "#{proxy.name_and_url}" }
   end

--- a/lib/katello/tasks/update_content_default_http_proxy.rake
+++ b/lib/katello/tasks/update_content_default_http_proxy.rake
@@ -2,16 +2,49 @@ require File.expand_path("../engine", File.dirname(__FILE__))
 
 namespace :katello do
   desc "Sets the content default http proxy to an existing http proxy based on supplied URL."
-  task :update_default_http_proxy, [:proxy_name] => [ :environment] do |_task, args|
+  task :update_default_http_proxy => :environment do |_task, args|
     setting = ::Setting::Content.where(name: 'content_default_http_proxy').first
+    options = {}
 
-    http_proxy = HttpProxy.where(name: args[:proxy_name]).first
+    o = OptionParser.new
+    o.banner = "Usage: rake katello:update_content_default_http_proxy [options]"
+    o.on("-n", "--name HTTP_PROXY_NAME") { |name|
+      options[:name] = name
+    }
+    o.on("-u", "--url HTTP_PROXY_URL") { |url|
+      options[:url] = url
+    }
+    o.on("-h, --help", "Prints this help") do
+      puts o
+      exit
+    end
+    args = o.order!(ARGV) {}
+    o.parse!(args)
+
+    if !options.key?(:name)
+      $stderr.print("ERROR: Missing required option for --name HTTP_PROXY_NAME")
+      exit 2
+    end
+
+    http_proxy = HttpProxy.where(name: options[:name]).first
 
     if http_proxy
       setting.update_attribute(:value, http_proxy.name)
       puts "Content default http proxy set to #{http_proxy.name_and_url}."
     else
-      $stderr.print "No http proxy found with name \"#{args[:proxy_name]}\"."
+      if options.key?(:url)
+        uri = URI(options[:url])
+        username = uri.user
+        password = uri.password
+        new_proxy = ::HttpProxy.new(name: options[:name], url: options[:url],
+                                  username: username, password: password)
+        setting.update_attribute(:value, new_proxy.name) if new_proxy.save!
+        puts "Default content http proxy set to \"#{setting.value}\"."
+      else
+        $stderr.print("ERROR: No http proxy found with name \"#{options[:name]}\".")
+        exit 1
+      end
+      exit
     end
   end
 

--- a/lib/katello/tasks/update_content_default_http_proxy.rake
+++ b/lib/katello/tasks/update_content_default_http_proxy.rake
@@ -25,35 +25,34 @@ namespace :katello do
       exit 2
     end
 
+    unless options.key?(:url)
+      $stderr.print("ERROR: Missing required option for --url HTTP_PROXY_URL")
+      exit 2
+    end
+
     User.current = User.anonymous_api_admin
     http_proxy = HttpProxy.where(name: options[:name]).first
 
+
     if http_proxy
       setting.update_attribute(:value, http_proxy.name)
+      http_proxy.update_attribute(:url, options[:url])
       puts "Content default http proxy set to #{http_proxy.name_and_url}."
     else
-      if options.key?(:url)
-        uri = URI(options[:url])
-        username = uri.user
-        password = uri.password
-        new_proxy = ::HttpProxy.new(name: options[:name], url: options[:url],
-                                  username: username, password: password,
-                                  organizations: Organization.all,
-                                  locations: Location.all)
-        if new_proxy.save!
-          setting.update_attribute(:value, new_proxy.name)
-          puts "Default content http proxy set to \"#{new_proxy.name_and_url}\"."
-        end
-      else
-        $stderr.print("ERROR: No http proxy found with name \"#{options[:name]}\".")
-        exit 1
+
+      uri = URI(options[:url])
+      username = uri.user
+      password = uri.password
+      new_proxy = ::HttpProxy.new(name: options[:name], url: options[:url],
+                                username: username, password: password,
+                                organizations: Organization.all,
+                                locations: Location.all)
+      if new_proxy.save!
+        setting.update_attribute(:value, new_proxy.name)
+        puts "Default content http proxy set to \"#{new_proxy.name_and_url}\"."
       end
     end
-    exit
-  end
 
-  desc "Displays the current defined http proxies."
-  task http_proxy_list: [:environment] do
-    ::HttpProxy.all.each { |proxy| puts "#{proxy.name_and_url}" }
+    exit
   end
 end

--- a/lib/katello/tasks/update_content_default_http_proxy.rake
+++ b/lib/katello/tasks/update_content_default_http_proxy.rake
@@ -6,7 +6,7 @@ namespace :katello do
     setting = ::Setting::Content.where(name: 'content_default_http_proxy').first
     options = {}
     o = OptionParser.new
-    o.banner = "Usage: rake katello:update_content_default_http_proxy [options]"
+    o.banner = "Usage: rake katello:update_content_default_http_proxy -- --name HTTP_PROXY_NAME --url HTTP_PROXY_URL"
     o.on("-n", "--name HTTP_PROXY_NAME") do |name|
       options[:name] = name
     end

--- a/test/lib/tasks/http_proxy_tasks_test.rb
+++ b/test/lib/tasks/http_proxy_tasks_test.rb
@@ -87,6 +87,5 @@ module Katello
       assert_equal 'new_proxy', HttpProxy.last.name
       assert_equal 'http://someurl', HttpProxy.last.url
     end
-
   end
 end

--- a/test/lib/tasks/http_proxy_tasks_test.rb
+++ b/test/lib/tasks/http_proxy_tasks_test.rb
@@ -67,13 +67,17 @@ module Katello
       assert_equal 'http://someurl', HttpProxy.last.url
     end
 
-    def test_update_proxy_by_proxy_name_and_url_set_default_proxy
-      assert_nil @setting.value
+    def test_update_proxy_by_proxy_name_and_short_url_opton_creates_new_proxy
+      assert 0, HttpProxy.all.count
+
       assert_raises SystemExit do
-        ARGV.concat(['--', '--name', 'new_proxy', '--url', 'http://someurl'])
+        ARGV.concat(['--', '--name', 'new_proxy', '-u', 'http://someurl'])
         Rake::Task['katello:update_default_http_proxy'].invoke
       end
-      assert_equal 'new_proxy', @setting.reload.value
+
+      assert_equal 1, HttpProxy.count
+      assert_equal 'new_proxy', HttpProxy.last.name
+      assert_equal 'http://someurl', HttpProxy.last.url
     end
 
     def test_proxy_list_when_no_proxies

--- a/test/lib/tasks/http_proxy_tasks_test.rb
+++ b/test/lib/tasks/http_proxy_tasks_test.rb
@@ -105,5 +105,15 @@ module Katello
       assert_equal 'new_proxy', HttpProxy.last.name
       assert_equal 'http://someurl', HttpProxy.last.url
     end
+
+    def test_password_is_not_displayed_when_part_of_url
+      proxy = FactoryBot.build(:http_proxy, url: 'http://admin:redhat@http://someurl.com:8888')
+      refute_match /redhat/, proxy.name_and_url, "Name and url included password in displayed string."
+    end
+
+    def test_password_is_not_display_when_specified_in_model
+      proxy = FactoryBot.build(:http_proxy, url: 'http://someurl.com:8888', password: 'redhat')
+      refute_match /redhat/, proxy.name_and_url, "Name and url included password in displayed string."
+    end
   end
 end

--- a/test/lib/tasks/http_proxy_tasks_test.rb
+++ b/test/lib/tasks/http_proxy_tasks_test.rb
@@ -12,7 +12,10 @@ module Katello
     end
 
     def test_update_proxy_with_missing_proxy
-      Rake.application.invoke_task('katello:update_default_http_proxy[some proxy]')
+      exit_code = assert_raises SystemExit do
+        Rake::Task['katello:update_default_http_proxy'].invoke('--', '--name', 'foobar')
+      end
+      assert_equal 1, exit_code.status, "Task didn't exit with expected exit code."
       refute_equal "some proxy", @setting.reload.value
     end
 
@@ -20,7 +23,10 @@ module Katello
       current_default_proxy = FactoryBot.create(:http_proxy)
       @setting.update_attribute(:value, current_default_proxy.name)
       proxy = FactoryBot.create(:http_proxy)
-      Rake.application.invoke_task("katello:update_default_http_proxy[#{proxy.url}]")
+      exit_code = assert_raises SystemExit do
+        Rake::Task['katello:update_default_http_proxy'].invoke('--', '-u', proxy.url)
+      end
+      assert_equal 2, exit_code.status, "Task didn't exit with expected exit code."
       assert_equal current_default_proxy.name, @setting.reload.value
     end
 
@@ -28,7 +34,9 @@ module Katello
       current_default_proxy = FactoryBot.create(:http_proxy)
       @setting.update_attribute(:value, current_default_proxy.name)
       proxy = FactoryBot.create(:http_proxy)
-      Rake.application.invoke_task("katello:update_default_http_proxy[#{proxy.name}]")
+      assert_raises SystemExit do
+        Rake::Task['katello:update_default_http_proxy'].invoke('--', '--name', proxy.name)
+      end
       assert_equal proxy.name, @setting.reload.value
     end
 

--- a/test/lib/tasks/http_proxy_tasks_test.rb
+++ b/test/lib/tasks/http_proxy_tasks_test.rb
@@ -12,7 +12,7 @@ module Katello
     end
 
     def test_update_proxy_with_missing_proxy
-      result = Rake.application.invoke_task('katello:update_default_http_proxy[some proxy]')
+      Rake.application.invoke_task('katello:update_default_http_proxy[some proxy]')
       refute_equal "some proxy", @setting.reload.value
     end
 
@@ -20,7 +20,7 @@ module Katello
       current_default_proxy = FactoryBot.create(:http_proxy)
       @setting.update_attribute(:value, current_default_proxy.name)
       proxy = FactoryBot.create(:http_proxy)
-      result = Rake.application.invoke_task("katello:update_default_http_proxy[#{proxy.url}]")
+      Rake.application.invoke_task("katello:update_default_http_proxy[#{proxy.url}]")
       assert_equal current_default_proxy.name, @setting.reload.value
     end
 
@@ -28,7 +28,7 @@ module Katello
       current_default_proxy = FactoryBot.create(:http_proxy)
       @setting.update_attribute(:value, current_default_proxy.name)
       proxy = FactoryBot.create(:http_proxy)
-      result = Rake.application.invoke_task("katello:update_default_http_proxy[#{proxy.name}]")
+      Rake.application.invoke_task("katello:update_default_http_proxy[#{proxy.name}]")
       assert_equal proxy.name, @setting.reload.value
     end
 
@@ -43,4 +43,3 @@ module Katello
     end
   end
 end
-

--- a/test/lib/tasks/http_proxy_tasks_test.rb
+++ b/test/lib/tasks/http_proxy_tasks_test.rb
@@ -13,7 +13,8 @@ module Katello
 
     def test_update_proxy_with_missing_proxy
       exit_code = assert_raises SystemExit do
-        Rake::Task['katello:update_default_http_proxy'].invoke('--', '--name', 'foobar')
+        ARGV.concat(['--', '--name', 'foobar'])
+        Rake::Task['katello:update_default_http_proxy'].invoke
       end
       assert_equal 1, exit_code.status, "Task didn't exit with expected exit code."
       refute_equal "some proxy", @setting.reload.value
@@ -24,7 +25,8 @@ module Katello
       @setting.update_attribute(:value, current_default_proxy.name)
       proxy = FactoryBot.create(:http_proxy)
       exit_code = assert_raises SystemExit do
-        Rake::Task['katello:update_default_http_proxy'].invoke('--', '-u', proxy.url)
+        ARGV.concat(['--', '-u', proxy.url])
+        Rake::Task['katello:update_default_http_proxy'].invoke
       end
       assert_equal 2, exit_code.status, "Task didn't exit with expected exit code."
       assert_equal current_default_proxy.name, @setting.reload.value
@@ -35,7 +37,8 @@ module Katello
       @setting.update_attribute(:value, current_default_proxy.name)
       proxy = FactoryBot.create(:http_proxy)
       assert_raises SystemExit do
-        Rake::Task['katello:update_default_http_proxy'].invoke('--', '--name', proxy.name)
+        ARGV.concat(['--', '--name', proxy.name])
+        Rake::Task['katello:update_default_http_proxy'].invoke
       end
       assert_equal proxy.name, @setting.reload.value
     end

--- a/test/lib/tasks/http_proxy_tasks_test.rb
+++ b/test/lib/tasks/http_proxy_tasks_test.rb
@@ -82,12 +82,22 @@ module Katello
 
     def test_proxy_list_when_no_proxies
       assert_empty HttpProxy.all.to_a
-      Rake.application.invoke_task("katello:http_proxy_list")
+      assert_output('') do
+        Rake.application.invoke_task("katello:http_proxy_list")
+      end
     end
 
     def test_proxy_list_with_defined_proxies
       3.times { FactoryBot.create(:http_proxy) }
-      Rake.application.invoke_task("katello:http_proxy_list")
+      assert 3, HttpProxy.count
+      expected_output = ""
+      HttpProxy.all.each do |proxy|
+        expected_output += "#{proxy.name_and_url}\n"
+      end
+
+      assert_output(expected_output) do
+        Rake.application.invoke_task("katello:http_proxy_list")
+      end
     end
   end
 end

--- a/test/lib/tasks/http_proxy_tasks_test.rb
+++ b/test/lib/tasks/http_proxy_tasks_test.rb
@@ -1,0 +1,46 @@
+require 'katello_test_helper'
+require 'rake'
+
+module Katello
+  class UpdateContentHttpProxyTest < ActiveSupport::TestCase
+    def setup
+      Rake.application.rake_require 'katello/tasks/update_content_default_http_proxy'
+      Rake::Task['katello:update_default_http_proxy'].reenable
+      Rake::Task.define_task(:environment)
+      @setting = Setting::Content.where(name: 'content_default_http_proxy').first
+      assert @setting
+    end
+
+    def test_update_proxy_with_missing_proxy
+      result = Rake.application.invoke_task('katello:update_default_http_proxy[some proxy]')
+      refute_equal "some proxy", @setting.reload.value
+    end
+
+    def test_update_proxy_by_proxy_url_fails
+      current_default_proxy = FactoryBot.create(:http_proxy)
+      @setting.update_attribute(:value, current_default_proxy.name)
+      proxy = FactoryBot.create(:http_proxy)
+      result = Rake.application.invoke_task("katello:update_default_http_proxy[#{proxy.url}]")
+      assert_equal current_default_proxy.name, @setting.reload.value
+    end
+
+    def test_update_proxy_by_proxy_name_sets_default
+      current_default_proxy = FactoryBot.create(:http_proxy)
+      @setting.update_attribute(:value, current_default_proxy.name)
+      proxy = FactoryBot.create(:http_proxy)
+      result = Rake.application.invoke_task("katello:update_default_http_proxy[#{proxy.name}]")
+      assert_equal proxy.name, @setting.reload.value
+    end
+
+    def test_proxy_list_when_no_proxies
+      assert_empty HttpProxy.all.to_a
+      Rake.application.invoke_task("katello:http_proxy_list")
+    end
+
+    def test_proxy_list_with_defined_proxies
+      3.times { FactoryBot.create(:http_proxy) }
+      Rake.application.invoke_task("katello:http_proxy_list")
+    end
+  end
+end
+

--- a/test/lib/tasks/http_proxy_tasks_test.rb
+++ b/test/lib/tasks/http_proxy_tasks_test.rb
@@ -51,6 +51,24 @@ module Katello
       assert_equal 'http://someotherurl', proxy.reload.url
     end
 
+    def test_update_proxy_updates_username
+      proxy = FactoryBot.create(:http_proxy, url: 'http://someurl')
+      assert_raises SystemExit do
+        ARGV.concat(['--', '--name', proxy.name, '--url', 'http://admin:redhat@someotherurl'])
+        Rake::Task['katello:update_default_http_proxy'].invoke
+      end
+      assert_equal 'admin', proxy.reload.username
+    end
+
+    def test_update_proxy_updates_password
+      proxy = FactoryBot.create(:http_proxy, url: 'http://someurl')
+      assert_raises SystemExit do
+        ARGV.concat(['--', '--name', proxy.name, '--url', 'http://admin:redhat@someotherurl'])
+        Rake::Task['katello:update_default_http_proxy'].invoke
+      end
+      assert_equal 'redhat', proxy.reload.password
+    end
+
     def test_update_proxy_by_short_option_name_sets_default
       current_default_proxy = FactoryBot.create(:http_proxy)
       @setting.update_attribute(:value, current_default_proxy.name)


### PR DESCRIPTION
This PR creates a new rake task for katello. The task "update_default_http_proxy" takes a http proxy name as defined under the Infrastructure->Http Proxies. 

Example:
```
[vagrant@centos7-katello-devel foreman]$ bundle exec rails katello:update_default_http_proxy -- -n a_new_proxy -u http://192.168.23.131 -s admin -p redhat
...
Content default http proxy set to a_new_proxy (http://192.168.23.131).
```