### PR TITLE
Fixes #26991 - Add Ansible Collections

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -54,6 +54,7 @@ module Katello
       param :deb_architectures, String, :desc => N_("comma separated list of architectures to be synched from deb-archive")
       param :ignore_global_proxy, :bool, :desc => N_("if true, will ignore the globally configured proxy when syncing")
       param :ignorable_content, Array, :desc => N_("List of content units to ignore while syncing a yum repository. Must be subset of %s") % RootRepository::IGNORABLE_CONTENT_UNIT_TYPES.join(",")
+      param :ansible_collection_whitelist, String, :desc => N_("Name of collection to sync from URL")
     end
 
     def_param_group :repo_create do
@@ -451,6 +452,7 @@ module Katello
              ]
 
       keys += [{:docker_tags_whitelist => []}, :docker_upstream_name] if params[:action] == 'create' || @repository&.docker?
+      keys += [:ansible_collection_whitelist] if params[:action] == 'create' || @repository&.ansible_collection?
       keys += [:label, :content_type] if params[:action] == "create"
       if params[:action] == 'create' || @repository.custom?
         keys += [:url, :gpg_key_id, :ssl_ca_cert_id, :ssl_client_cert_id, :ssl_client_key_id, :unprotected, :name,
@@ -482,6 +484,7 @@ module Katello
       root.upstream_username = repo_params[:upstream_username] if repo_params.key?(:upstream_username)
       root.upstream_password = repo_params[:upstream_password] if repo_params.key?(:upstream_password)
       root.ignorable_content = repo_params[:ignorable_content] if root.yum? && repo_params.key?(:ignorable_content)
+      root.ansible_collection_whitelist = repo_params[:ansible_collection_whitelist] if root.ansible_collection?
 
       if root.ostree?
         root.ostree_upstream_sync_policy = repo_params[:ostree_upstream_sync_policy]

--- a/app/lib/actions/pulp3/orchestration/repository/generate_metadata.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/generate_metadata.rb
@@ -5,11 +5,12 @@ module Actions
         class GenerateMetadata < Pulp3::Abstract
           def plan(repository, smart_proxy, options = {})
             options[:contents_changed] = (options && options.key?(:contents_changed)) ? options[:contents_changed] : true
+            publication_content_type = !::Katello::RepositoryTypeManager.find(repository.content_type).pulp3_skip_publication
             sequence do
               plan_action(Actions::Pulp3::Repository::CreateVersion, repository, smart_proxy) if options[:repository_creation]
-              if options[:source_repository]
+              if options[:source_repository] && publication_content_type
                 repository.update_attributes!(publication_href: options[:source_repository].publication_href)
-              else
+              elsif publication_content_type
                 plan_action(Actions::Pulp3::Repository::CreatePublication, repository, smart_proxy, options)
               end
 

--- a/app/lib/pulp/v3/api.rb
+++ b/app/lib/pulp/v3/api.rb
@@ -1,11 +1,12 @@
 require 'pulpcore_client'
 require 'pulp_file_client'
+require 'pulp_ansible_client'
 
 module Pulp
   module V3
     class Api
       def configure(opts)
-        [PulpcoreClient.configure, PulpFileClient.configure].each do |config|
+        [PulpcoreClient.configure, PulpFileClient.configure, PulpAnsibleClient.configure].each do |config|
           opts.each { |option, value| config.send("#{option}=", value) }
         end
       end
@@ -30,21 +31,48 @@ module Pulp
       delegate :remotes_file_file_partial_update, to: :file_remotes_api
       delegate :remotes_file_file_sync, to: :file_remotes_api
 
+      delegate :remotes_ansible_collection_create, to: :ansible_remotes_api
+      delegate :remotes_ansible_collection_list, to: :ansible_remotes_api
+      delegate :remotes_ansible_collection_read, to: :ansible_remotes_api
+      delegate :remotes_ansible_collection_sync, to: :ansible_remotes_api
+      delegate :remotes_ansible_collection_partial_update, to: :ansible_remotes_api
+      delegate :remotes_ansible_collection_update, to: :ansible_remotes_api
+      delegate :remotes_ansible_collection_delete, to: :ansible_remotes_api
+
       delegate :distributions_file_file_create, to: :file_distributions_api
       delegate :distributions_file_file_list, to: :file_distributions_api
       delegate :distributions_file_file_read, to: :file_distributions_api
       delegate :distributions_file_file_delete, to: :file_distributions_api
       delegate :distributions_file_file_partial_update, to: :file_distributions_api
 
+      delegate :distributions_ansible_ansible_create, to: :ansible_distributions_api
+      delegate :distributions_ansible_ansible_list, to: :ansible_distributions_api
+      delegate :distributions_ansible_ansible_read, to: :ansible_distributions_api
+      delegate :distributions_ansible_ansible_delete, to: :ansible_distributions_api
+      delegate :distributions_ansible_ansible_partial_update, to: :ansible_distributions_api
+
       delegate :content_file_files_create, to: :file_content_api
       delegate :content_file_files_list, to: :file_content_api
       delegate :content_file_files_read, to: :file_content_api
+
+      delegate :content_ansible_collections_create, to: :ansible_content_api
+      delegate :content_ansible_collections_list, to: :ansible_content_api
 
       delegate :tasks_read, to: :tasks_api
 
       def repositories_api
         @repositories_api ||= PulpcoreClient::RepositoriesApi.new
       end
+
+      def artifacts_api
+        @artifacts_api ||= PulpcoreClient::ArtifactsApi.new
+      end
+
+      def tasks_api
+        @tasks_api ||= PulpcoreClient::TasksApi.new
+      end
+
+      ### File Client API
 
       def file_distributions_api
         @file_distributions_api ||= PulpFileClient::DistributionsApi.new
@@ -62,12 +90,18 @@ module Pulp
         @file_content_api ||= PulpFileClient::ContentApi.new
       end
 
-      def artifacts_api
-        @artifacts_api ||= PulpcoreClient::ArtifactsApi.new
+      ### Ansible Collection API
+
+      def ansible_distributions_api
+        @ansible_distributions_api ||= PulpAnsibleClient::DistributionsApi.new
       end
 
-      def tasks_api
-        @tasks_api ||= PulpcoreClient::TasksApi.new
+      def ansible_remotes_api
+        @ansible_remotes_api ||= PulpAnsibleClient::RemotesApi.new
+      end
+
+      def ansible_content_api
+        @ansible_content_api ||= PulpAnsibleClient::ContentApi.new
       end
     end
   end

--- a/app/models/katello/ansible_collection.rb
+++ b/app/models/katello/ansible_collection.rb
@@ -11,7 +11,7 @@ module Katello
 
     scoped_search :on => :name, :complete_value => true
     scoped_search :on => :namespace, :complete_value => true
-    scoped_search :on => :checksum
+    scoped_search :on => :version, :complete_value => true
 
     def self.default_sort
       order(:name)

--- a/app/models/katello/ansible_collection.rb
+++ b/app/models/katello/ansible_collection.rb
@@ -1,0 +1,32 @@
+module Katello
+  class AnsibleCollection < ApplicationRecord
+    include Concerns::PulpDatabaseUnit
+
+    self.table_name = 'katello_ansible_collections'
+
+    CONTENT_TYPE = 'ansible collection'.freeze
+
+    has_many :repository_ansible_collections, :class_name => "Katello::RepositoryAnsibleCollection", :dependent => :destroy, :inverse_of => :ansible_collection, :foreign_key => :ansible_collection_id
+    has_many :repositories, :through => :repository_ansible_collections, :class_name => "Katello::Repository"
+
+    scoped_search :on => :name, :complete_value => true
+    scoped_search :on => :namespace, :complete_value => true
+    scoped_search :on => :checksum
+
+    def self.default_sort
+      order(:name)
+    end
+
+    def self.repository_association_class
+      RepositoryAnsibleCollection
+    end
+
+    def self.unit_id_field
+      'ansible_collection_id'
+    end
+
+    def self.total_for_repositories(repos)
+      self.in_repositories(repos).count
+    end
+  end
+end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -25,6 +25,7 @@ module Katello
     PUPPET_TYPE = 'puppet'.freeze
     DOCKER_TYPE = 'docker'.freeze
     OSTREE_TYPE = 'ostree'.freeze
+    ANSIBLE_COLLECTION_TYPE = 'ansible_collection'.freeze
 
     define_model_callbacks :sync, :only => :after
 
@@ -90,6 +91,9 @@ module Katello
     has_many :repository_module_streams, class_name: "Katello::RepositoryModuleStream", dependent: :delete_all
     has_many :module_streams, through: :repository_module_streams
 
+    has_many :repository_ansible_collections, :class_name => "Katello::RepositoryAnsibleCollection", :dependent => :delete_all
+    has_many :ansible_collections, :through => :repository_ansible_collections
+
     # rubocop:disable HasAndBelongsToMany
     # TODO: change this into has_many :through association
     has_and_belongs_to_many :filters, :class_name => "Katello::ContentViewFilter",
@@ -116,6 +120,7 @@ module Katello
     scope :puppet_type, -> { with_type(PUPPET_TYPE) }
     scope :docker_type, -> { with_type(DOCKER_TYPE) }
     scope :ostree_type, -> { with_type(OSTREE_TYPE) }
+    scope :ansible_collection_type, -> { with_type(ANSIBLE_COLLECTION_TYPE) }
     scope :non_puppet, -> { with_type(RepositoryTypeManager.repository_types.keys - [PUPPET_TYPE]) }
     scope :non_archived, -> { where('environment_id is not NULL') }
     scope :archived, -> { where('environment_id is NULL') }
@@ -145,7 +150,7 @@ module Katello
     scoped_search :on => :content_label, :ext_method => :search_by_content_label
 
     delegate :product, :redhat?, :custom?, :to => :root
-    delegate :yum?, :docker?, :puppet?, :deb?, :file?, :ostree?, :to => :root
+    delegate :yum?, :docker?, :puppet?, :deb?, :file?, :ostree?, :ansible_collection?, :to => :root
     delegate :name, :label, :docker_upstream_name, :url, :to => :root
 
     delegate :name, :created_at, :updated_at, :major, :minor, :gpg_key_id, :gpg_key, :content_id, :arch, :label, :url, :unprotected,
@@ -153,7 +158,7 @@ module Katello
              :download_policy, :verify_ssl_on_sync, :"verify_ssl_on_sync?", :upstream_username, :upstream_password,
              :ostree_upstream_sync_policy, :ostree_upstream_sync_depth, :deb_releases, :deb_components, :deb_architectures,
              :ignore_global_proxy, :ssl_ca_cert_id, :ssl_ca_cert, :ssl_client_cert, :ssl_client_cert_id, :ssl_client_key_id,
-             :ssl_client_key, :ignorable_content, :description, :docker_tags_whitelist, :to => :root
+             :ssl_client_key, :ignorable_content, :description, :docker_tags_whitelist, :ansible_collection_whitelist, :to => :root
 
     def self.with_type(content_type)
       joins(:root).where("#{RootRepository.table_name}.content_type" => content_type)

--- a/app/models/katello/repository_ansible_collection.rb
+++ b/app/models/katello/repository_ansible_collection.rb
@@ -1,0 +1,6 @@
+module Katello
+  class RepositoryAnsibleCollection < Katello::Model
+    belongs_to :repository, inverse_of: :repository_ansible_collections, class_name: 'Katello::Repository'
+    belongs_to :ansible_collection, inverse_of: :repository_ansible_collections, class_name: 'Katello::AnsibleCollection'
+  end
+end

--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -82,6 +82,7 @@ module Katello
     scope :puppet_type, -> { where(:content_type => Repository::PUPPET_TYPE) }
     scope :docker_type, -> { where(:content_type => Repository::DOCKER_TYPE) }
     scope :ostree_type, -> { where(:content_type => Repository::OSTREE_TYPE) }
+    scope :ansible_collection_type, -> { where(:content_type => Repository::ANSIBLE_COLLECTION_TYPE) }
     delegate :redhat?, :provider, :organization, to: :product
 
     def library_instance
@@ -247,6 +248,10 @@ module Katello
       self.content_type == Repository::DEB_TYPE
     end
 
+    def ansible_collection?
+      self.content_type == Repository::ANSIBLE_COLLECTION_TYPE
+    end
+
     def metadata_generate_needed?
       (%w(unprotected checksum_type container_repsoitory_name) & previous_changes.keys).any?
     end
@@ -261,6 +266,7 @@ module Katello
                                  ssl_ca_cert_id ssl_client_cert_id ssl_client_key_id)
       changeable_attributes += %w(name container_repository_name docker_tags_whitelist) if docker?
       changeable_attributes += %w(deb_releases deb_components deb_architectures gpg_key_id) if deb?
+      changeable_attributes += %w(ansible_collection_whitelist) if ansible_collection?
       changeable_attributes.any? { |key| previous_changes.key?(key) }
     end
 

--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -48,6 +48,7 @@ module Katello
     validates_with Validators::ContainerImageNameValidator, :attributes => :docker_upstream_name, :allow_blank => true, :if => :docker?
 
     validate :ensure_valid_docker_attributes, :if => :docker?
+    validate :ensure_valid_ansible_collection_attributes, :if => :ansible_collection?
     validate :ensure_docker_repo_unprotected, :if => :docker?
     validate :ensure_ostree_repo_protected, :if => :ostree?
     validate :ensure_compatible_download_policy, :if => :yum?
@@ -192,6 +193,10 @@ module Katello
       unless docker_tags_whitelist.is_a?(Array)
         errors.add(:docker_tags_whitelist, N_("Invalid value specified for Container Image repositories."))
       end
+    end
+
+    def ensure_valid_ansible_collection_attributes
+      errors.add(:base, N_("Whitelist cannot be blank.")) if ansible_collection_whitelist.blank?
     end
 
     def ensure_valid_upstream_authorization

--- a/app/services/katello/pulp3/ansible_collection.rb
+++ b/app/services/katello/pulp3/ansible_collection.rb
@@ -1,0 +1,34 @@
+module Katello
+  module Pulp3
+    class AnsibleCollection < PulpContentUnit
+      include LazyAccessor
+      CONTENT_TYPE = "ansible collection".freeze
+
+      lazy_accessor :pulp_facts, :initializer => :backend_data
+
+      def self.ids_for_repository(repo_id)
+        repo = Katello::Pulp3::Repository::AnsibleCollection.new(Katello::Repository.find(repo_id), SmartProxy.pulp_master)
+        repo_content_list = repo.content_list
+        repo_content_list.map { |content| content.try(:_href) }
+      end
+
+      def self.pulp_data(_href)
+        #No content read method
+        fail NotImplementedError
+      end
+
+      def update_model(model)
+        custom_json = {}
+        custom_json['checksum'] = backend_data['sha256']
+        custom_json['namespace'] = backend_data['namespace']
+        custom_json['version'] = backend_data['version']
+        custom_json['name'] = backend_data['name']
+        model.update_attributes!(custom_json)
+      end
+
+      def self.content_unit_list(page_opts)
+        SmartProxy.pulp_master!.pulp3_api.content_ansible_collections_list page_opts
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/file_unit.rb
+++ b/app/services/katello/pulp3/file_unit.rb
@@ -25,20 +25,8 @@ module Katello
         model.update_attributes!(custom_json)
       end
 
-      def self.pulp_units_batch_for_repo(repository, page_size = SETTINGS[:katello][:pulp][:bulk_load_size])
-        repository_version_href = repository.version_href
-        page_opts = { "page" => 1, repository_version: repository_version_href, page_size: page_size}
-        response = {}
-        Enumerator.new do |yielder|
-          loop do
-            page_opts = page_opts.with_indifferent_access
-            break unless (response["next"] || page_opts["page"] == 1)
-            response = SmartProxy.pulp_master!.pulp3_api.content_file_files_list page_opts
-            response = response.as_json.with_indifferent_access
-            yielder.yield response[:results]
-            page_opts[:page] += 1
-          end
-        end
+      def self.content_unit_list(page_opts)
+        SmartProxy.pulp_master!.pulp3_api.content_file_files_list page_opts
       end
     end
   end

--- a/app/services/katello/pulp3/pulp_content_unit.rb
+++ b/app/services/katello/pulp3/pulp_content_unit.rb
@@ -27,6 +27,22 @@ module Katello
         "_href"
       end
 
+      def self.pulp_units_batch_for_repo(repository, page_size = SETTINGS[:katello][:pulp][:bulk_load_size])
+        repository_version_href = repository.version_href
+        page_opts = { "page" => 1, repository_version: repository_version_href, page_size: page_size}
+        response = {}
+        Enumerator.new do |yielder|
+          loop do
+            page_opts = page_opts.with_indifferent_access
+            break unless (response["next"] || page_opts["page"] == 1)
+            response = fetch_content_list page_opts
+            response = response.as_json.with_indifferent_access
+            yielder.yield response[:results]
+            page_opts[:page] += 1
+          end
+        end
+      end
+
       def self.pulp_data(_href)
         fail NotImplementedError
       end
@@ -46,6 +62,10 @@ module Katello
 
       def fetch_backend_data
         self.class.pulp_data(self.uuid)
+      end
+
+      def self.fetch_content_list(page_opts)
+        content_unit_list page_opts
       end
     end
   end

--- a/app/services/katello/pulp3/repository/ansible_collection.rb
+++ b/app/services/katello/pulp3/repository/ansible_collection.rb
@@ -1,0 +1,74 @@
+require 'pulp_file_client'
+require 'pulp_ansible_client'
+
+module Katello
+  module Pulp3
+    class Repository
+      class AnsibleCollection < ::Katello::Pulp3::Repository
+        def create_content_remote
+          remote_collection_data = PulpAnsibleClient::CollectionRemote.new(remote_options)
+          response = pulp3_api.remotes_ansible_collection_create(remote_collection_data)
+          response._href
+        end
+
+        def remote_options
+          if root.url.blank?
+            super
+          else
+            common_remote_options.merge(url: root.url, whitelist: root.ansible_collection_whitelist || "testing.ansible_testing_content")
+          end
+        end
+
+        def remote_partial_update
+          pulp3_api.remotes_ansible_collection_partial_update(repo.remote_href, remote_options)
+        end
+
+        def delete_remote(href = repo.remote_href)
+          pulp3_api.remotes_ansible_collection_delete(href) if href
+        end
+
+        def list_remotes(args)
+          pulp3_api.remotes_ansible_collection_list(args).results
+        end
+
+        def sync
+          [pulp3_api.remotes_ansible_collection_sync(repo.remote_href, repository: repository_reference.repository_href)]
+        end
+
+        def create_distribution(path)
+          distribution_data = PulpAnsibleClient::AnsibleDistribution.new(
+              base_path: path,
+              repository_version: repo.version_href,
+              name: "#{backend_object_name}")
+          pulp3_api.distributions_ansible_ansible_create(distribution_data)
+        end
+
+        def delete_distribution(href)
+          pulp3_api.distributions_ansible_ansible_delete(href)
+        end
+
+        def lookup_distributions(args)
+          pulp3_api.distributions_ansible_ansible_list(args).results
+        end
+
+        def update_distribution(path)
+          distribution_reference = distribution_reference(path)
+          if distribution_reference
+            distribution_data = PulpAnsibleClient::AnsibleDistribution.new(
+                base_path: path,
+                repository_version: repo.version_href,
+                name: "#{backend_object_name}")
+            pulp3_api.distributions_ansible_ansible_partial_update(distribution_reference.href, distribution_data)
+          end
+        end
+
+        def get_distribution(href)
+          pulp3_api.distributions_ansible_ansible_read(href)
+        rescue PulpAnsibleClient::ApiError => e
+          raise e if e.code != 404
+          nil
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/repository/file.rb
+++ b/app/services/katello/pulp3/repository/file.rb
@@ -4,36 +4,23 @@ module Katello
   module Pulp3
     class Repository
       class File < ::Katello::Pulp3::Repository
-        def create_remote
+        def create_content_remote
           remote_file_data = PulpFileClient::FileRemote.new(remote_options)
           response = pulp3_api.remotes_file_file_create(remote_file_data)
-          repo.update_attributes!(:remote_href => response._href)
+          response._href
         end
 
         def remote_options
           #TODO: move to user specifying PULP_MANIFEST
           if root.url.blank?
-            common_remote_options.delete(:url)
-            common_remote_options
+            super
           else
             common_remote_options.merge(url: root.url + '/PULP_MANIFEST')
           end
         end
 
-        def update_remote
-          if remote_options[:url].blank?
-            if repo.remote_href
-              href = repo.remote_href
-              repo.update_attributes(remote_href: nil)
-              pulp3_api.remotes_file_file_delete(href)
-            end
-          else
-            if repo.remote_href?
-              pulp3_api.remotes_file_file_partial_update(repo.remote_href, remote_options)
-            else
-              create_remote
-            end
-          end
+        def remote_partial_update
+          pulp3_api.remotes_file_file_partial_update(repo.remote_href, remote_options)
         end
 
         def delete_remote(href = repo.remote_href)
@@ -62,14 +49,6 @@ module Katello
           pulp3_api.distributions_file_file_create(distribution_data)
         end
 
-        def delete_distributions
-          path = repo.relative_path.sub(/^\//, '')
-          dists = lookup_distributions(base_path: path)
-          delete_distribution(dists.first._href) if dists.first
-          dist_ref = distribution_reference(path)
-          dist_ref.destroy! if dist_ref
-        end
-
         def delete_distribution(href)
           pulp3_api.distributions_file_file_delete(href)
         end
@@ -87,13 +66,6 @@ module Katello
 
         def get_distribution(href)
           pulp3_api.distributions_file_file_read(href)
-        rescue PulpFileClient::ApiError => e
-          raise e if e.code != 404
-          nil
-        end
-
-        def version_details
-          pulp3_api.repositories_versions_read(repo.version_href)
         rescue PulpFileClient::ApiError => e
           raise e if e.code != 404
           nil

--- a/app/services/katello/repository_type.rb
+++ b/app/services/katello/repository_type.rb
@@ -12,7 +12,7 @@ module Katello
       end
     end
 
-    def_field :allow_creation_by_user, :service_class, :pulp3_service_class, :pulp3_plugin
+    def_field :allow_creation_by_user, :service_class, :pulp3_service_class, :pulp3_plugin, :pulp3_skip_publication
     attr_accessor :metadata_publish_matching_check, :index_additional_data_proc
     attr_reader :id
 

--- a/app/views/katello/api/v2/repositories/base.json.rabl
+++ b/app/views/katello/api/v2/repositories/base.json.rabl
@@ -37,7 +37,8 @@ node :content_counts do |repo|
     :puppet_module => repo.puppet_modules.count,
     :file => repo.files.count,
     :deb => repo.debs.count,
-    :module_stream => repo.module_streams.count
+    :module_stream => repo.module_streams.count,
+    :ansible_collection => repo.ansible_collections.count
   }
 end
 

--- a/app/views/katello/api/v2/repositories/show.json.rabl
+++ b/app/views/katello/api/v2/repositories/show.json.rabl
@@ -13,6 +13,7 @@ glue(@resource.root) do
   attributes :container_repository_name
   attributes :download_policy
   attributes :url
+  attributes :ansible_collection_whitelist
   attributes :gpg_key_id
   attributes :ssl_ca_cert_id
   attributes :ssl_client_cert_id

--- a/config/katello.yaml.example
+++ b/config/katello.yaml.example
@@ -8,6 +8,7 @@
     :puppet: true
     :docker: true
     :ostree: true
+    :ansible_collection: true
 
   :use_cp: true # set to true/false if you want to override default
   :use_pulp: true # set to true/false if you want to override default

--- a/db/migrate/20190617142328_create_katello_ansible_collections.rb
+++ b/db/migrate/20190617142328_create_katello_ansible_collections.rb
@@ -1,0 +1,26 @@
+class CreateKatelloAnsibleCollections < ActiveRecord::Migration[5.2]
+  def change
+    create_table :katello_ansible_collections do |t|
+      t.string :pulp_id, :null => false, :limit => 255
+      t.string :checksum
+      t.string :name
+      t.string :namespace
+      t.string :version
+      t.timestamps
+    end
+
+    add_index :katello_ansible_collections, :pulp_id, :unique => true, :name => 'katello_ansible_collections_pulp_id_index'
+    add_index :katello_ansible_collections, [:id, :pulp_id, :name, :version, :namespace], :name => 'katello_ansible_collections_fields_index'
+
+    create_table "katello_repository_ansible_collections" do |t|
+      t.references :ansible_collection, :null => false, index: { :name => 'index_katello_repo_ansible_collections' }
+      t.references :repository, :null => false
+      t.timestamps
+    end
+
+    add_index :katello_repository_ansible_collections, [:ansible_collection_id, :repository_id], :unique => true, :name => 'repository_ansible_collection_ids'
+
+    add_foreign_key "katello_repository_ansible_collections", "katello_ansible_collections", :column => "ansible_collection_id"
+    add_foreign_key "katello_repository_ansible_collections", "katello_repositories", :column => "repository_id"
+  end
+end

--- a/db/migrate/20190617142328_create_katello_ansible_collections.rb
+++ b/db/migrate/20190617142328_create_katello_ansible_collections.rb
@@ -10,7 +10,6 @@ class CreateKatelloAnsibleCollections < ActiveRecord::Migration[5.2]
     end
 
     add_index :katello_ansible_collections, :pulp_id, :unique => true, :name => 'katello_ansible_collections_pulp_id_index'
-    add_index :katello_ansible_collections, [:id, :pulp_id, :name, :version, :namespace], :name => 'katello_ansible_collections_fields_index'
 
     create_table "katello_repository_ansible_collections" do |t|
       t.references :ansible_collection, :null => false, index: { :name => 'index_katello_repo_ansible_collections' }

--- a/db/migrate/20190618034438_add_ansible_collection_whitelist_to_katello_root_repositories.rb
+++ b/db/migrate/20190618034438_add_ansible_collection_whitelist_to_katello_root_repositories.rb
@@ -1,0 +1,5 @@
+class AddAnsibleCollectionWhitelistToKatelloRootRepositories < ActiveRecord::Migration[5.2]
+  def change
+    add_column :katello_root_repositories, :ansible_collection_whitelist, :string
+  end
+end

--- a/db/migrate/20190618034438_add_ansible_collection_whitelist_to_katello_root_repositories.rb
+++ b/db/migrate/20190618034438_add_ansible_collection_whitelist_to_katello_root_repositories.rb
@@ -1,5 +1,5 @@
 class AddAnsibleCollectionWhitelistToKatelloRootRepositories < ActiveRecord::Migration[5.2]
   def change
-    add_column :katello_root_repositories, :ansible_collection_whitelist, :string
+    add_column :katello_root_repositories, :ansible_collection_whitelist, :text
   end
 end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -77,7 +77,7 @@
 
       <span ng-if="repository.content_type == 'ansible_collection'">
         <dt translate>Whitelist</dt>
-        <dd bst-edit-text="repository.ansible_collection_whitelist"
+        <dd bst-edit-textarea="repository.ansible_collection_whitelist"
             on-save="save(repository)"
             readonly="denied('edit_products', product)">
         </dd>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -75,6 +75,14 @@
         </dd>
       </span>
 
+      <span ng-if="repository.content_type == 'ansible_collection'">
+        <dt translate>Whitelist</dt>
+        <dd bst-edit-text="repository.ansible_collection_whitelist"
+            on-save="save(repository)"
+            readonly="denied('edit_products', product)">
+        </dd>
+      </span>
+
       <dt translate>Verify SSL</dt>
       <dd bst-edit-checkbox="repository.verify_ssl_on_sync"
           formatter="booleanToYesNo"
@@ -380,6 +388,14 @@
           <td class="align-center">
             <a ui-sref="product.repository.manage-content.debs({productId: product.id, repositoryId: repository.id})">
               {{ repository.content_counts.deb || 0 }}
+            </a>
+          </td>
+        </tr>
+        <tr ng-show="repository.content_type === 'ansible_collection'">
+          <td translate>Ansible Collections</td>
+          <td class="align-center">
+            <a ui-sref="product.repository.manage-content.ansible-collections({productId: product.id, repositoryId: repository.id})">
+              {{ repository.content_counts.ansible_collection || 0 }}
             </a>
           </td>
         </tr>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -60,16 +60,19 @@
         <p class="help-block" ng-show="repository.content_type === 'docker'" translate>
           URL of the registry you want to sync. Example: https://registry-1.docker.io/
         </p>
+        <p class="help-block" ng-show="repository.content_type === 'ansible_collection'" translate>
+          URL of the ansible content sharing hub you want to sync. Example: https://galaxy.ansible.com
+        </p>
 
       </div>
 
       <div ng-show="repository.content_type === 'ansible_collection'" bst-form-group label="{{ 'Whitelist' | translate }}">
-        <input id="collection_whitelist"
+        <textarea id="collection_whitelist"
                name="collection_whitelists"
                ng-model="repository.ansible_collection_whitelist"
                type="text"/>
         <p class="help-block" translate>
-          Name of ansible collection you want to sync. ex: testing.ansible_testing_content
+          Name / Comma-separated names of ansible collection(s) you want to sync from the galaxy. ex: newswangerd.collection_demo, devoperate.base
         </p>
       </div>
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -62,6 +62,17 @@
         </p>
 
       </div>
+
+      <div ng-show="repository.content_type === 'ansible_collection'" bst-form-group label="{{ 'Whitelist' | translate }}">
+        <input id="collection_whitelist"
+               name="collection_whitelists"
+               ng-model="repository.ansible_collection_whitelist"
+               type="text"/>
+        <p class="help-block" translate>
+          Name of ansible collection you want to sync. ex: testing.ansible_testing_content
+        </p>
+      </div>
+
       <div ng-show="repository.content_type === 'deb'" bst-form-group label="{{ 'Releases' | translate }}">
         <input id="deb_releases"
                name="deb_releases"

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/views/product-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/views/product-repositories.html
@@ -181,6 +181,13 @@
               </div>
             </span>
 
+            <span ng-show="repository.content_type == 'ansible_collection'">
+              <div>
+                <a translate ui-sref="product.repository.manage-content.ansible-collections({productId: product.id, repositoryId: repository.id})">
+                  {{ repository.content_counts.ansible_collection || 0 }}
+                </a>
+              </div>
+            </span>
           </td>
         </tr>
       </tbody>

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "anemone"
   gem.add_dependency "pulpcore_client", "<= 3.0.0rc3.dev0.1561038430"
   gem.add_dependency "pulp_file_client", "<= 0.1.0b1.dev.1560792388"
-  gem.add_dependency "pulp_ansible_client", "0.2.0b1.dev0.1560866833"
+  gem.add_dependency "pulp_ansible_client", "<= 0.2.0b1.dev0.1561386170"
 
   # UI
   gem.add_dependency "deface", '>= 1.0.2', '< 2.0.0'

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "anemone"
   gem.add_dependency "pulpcore_client", "<= 3.0.0rc3.dev0.1561038430"
   gem.add_dependency "pulp_file_client", "<= 0.1.0b1.dev.1560792388"
+  gem.add_dependency "pulp_ansible_client", "0.2.0b1.dev0.1560866833"
 
   # UI
   gem.add_dependency "deface", '>= 1.0.2', '< 2.0.0'

--- a/lib/katello/repository_types/ansible_collection.rb
+++ b/lib/katello/repository_types/ansible_collection.rb
@@ -1,0 +1,8 @@
+Katello::RepositoryTypeManager.register(::Katello::Repository::ANSIBLE_COLLECTION_TYPE) do
+  allow_creation_by_user true
+  pulp3_skip_publication true
+  pulp3_service_class Katello::Pulp3::Repository::AnsibleCollection
+  pulp3_plugin 'pulp_ansible'
+
+  content_type Katello::AnsibleCollection, :pulp3_service_class => ::Katello::Pulp3::AnsibleCollection, :user_removable => true
+end

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -13,6 +13,7 @@ module ::Actions::Katello::Repository
     let(:action) { create_action action_class }
     let(:repository) { katello_repositories(:rhel_6_x86_64) }
     let(:repository_pulp3) { katello_repositories(:pulp3_file_1) }
+    let(:repository_ansible_collection_pulp3) { katello_repositories(:pulp3_ansible_collection_1) }
     let(:custom_repository) { katello_repositories(:fedora_17_x86_64) }
     let(:puppet_repository) { katello_repositories(:p_forge) }
     let(:docker_repository) { katello_repositories(:redis) }
@@ -408,6 +409,15 @@ module ::Actions::Katello::Repository
       refute_action_planed action, ::Actions::Pulp3::Repository::CreateVersion
       assert_action_planed_with(action, ::Actions::Pulp3::Repository::CreatePublication, repository_pulp3, proxy, :contents_changed => true)
       assert_action_planed_with(action, ::Actions::Pulp3::Repository::RefreshDistribution, repository_pulp3, proxy, :contents_changed => true)
+    end
+
+    it 'plans pulp3 ansible collection metadata generate without publication ' do
+      action = create_action pulp3_metadata_generate_action_class
+      action.stubs(:action_subject).with(repository_ansible_collection_pulp3)
+      plan_action action, repository_ansible_collection_pulp3, proxy, :contents_changed => true
+      refute_action_planed action, ::Actions::Pulp3::Repository::CreateVersion
+      refute_action_planed action, ::Actions::Pulp3::Repository::CreatePublication
+      assert_action_planed_with(action, ::Actions::Pulp3::Repository::RefreshDistribution, repository_ansible_collection_pulp3, proxy, :contents_changed => true)
     end
 
     describe 'progress' do

--- a/test/actions/pulp3/orchestration/ansible_collection_create_test.rb
+++ b/test/actions/pulp3/orchestration/ansible_collection_create_test.rb
@@ -1,0 +1,27 @@
+require 'katello_test_helper'
+
+module ::Actions::Pulp3
+  class AnsibleCollectionCreateTest < ActiveSupport::TestCase
+    include Katello::Pulp3Support
+
+    def setup
+      @master = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+      @repo = katello_repositories(:pulp3_ansible_collection_1)
+      # @repo.root.update_attributes(:url => 'http://test/test/')
+      ensure_creatable(@repo, @master)
+    end
+
+    def test_create
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Create, @repo, @master)
+      @repo.reload
+
+      assert @repo.remote_href
+      refute @repo.version_href
+
+      repo_reference = Katello::Pulp3::RepositoryReference.find_by(:root_repository_id => @repo.root.id,
+                                                                   :content_view_id => @repo.content_view.id)
+      assert repo_reference
+      assert repo_reference.repository_href
+    end
+  end
+end

--- a/test/actions/pulp3/orchestration/ansible_collection_delete_test.rb
+++ b/test/actions/pulp3/orchestration/ansible_collection_delete_test.rb
@@ -1,0 +1,42 @@
+require 'katello_test_helper'
+
+module ::Actions::Pulp3
+  class AnsibleCollectionDeleteTest < ActiveSupport::TestCase
+    include ::Katello::Pulp3Support
+
+    def setup
+      @master = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+      @repo = katello_repositories(:pulp3_ansible_collection_1)
+      create_repo(@repo, @master)
+      ForemanTasks.sync_task(
+          ::Actions::Katello::Repository::MetadataGenerate, @repo,
+          repository_creation: true)
+
+      assert Katello::Pulp3::RepositoryReference.find_by(
+          :root_repository_id => @repo.root.id,
+          :content_view_id => @repo.content_view.id)
+
+      refute_empty Katello::Pulp3::DistributionReference.where(
+          root_repository_id: @repo.root.id)
+
+      ForemanTasks.sync_task(
+          ::Actions::Pulp3::Orchestration::Repository::Delete, @repo, @master)
+      @repo.reload
+    end
+
+    def test_repository_reference_is_deleted
+      repo_reference = Katello::Pulp3::RepositoryReference.find_by(
+          :root_repository_id => @repo.root.id,
+          :content_view_id => @repo.content_view.id)
+
+      assert_nil repo_reference
+    end
+
+    def test_distribution_references_are_deleted
+      distribution_references = Katello::Pulp3::DistributionReference.where(
+          root_repository_id: @repo.root.id)
+
+      assert_empty distribution_references
+    end
+  end
+end

--- a/test/actions/pulp3/orchestration/ansible_collection_sync_test.rb
+++ b/test/actions/pulp3/orchestration/ansible_collection_sync_test.rb
@@ -1,0 +1,44 @@
+require 'katello_test_helper'
+
+module ::Actions::Pulp3
+  class AnsibleCollectionSyncTest < ActiveSupport::TestCase
+    include Katello::Pulp3Support
+
+    def setup
+      @master = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+      @repo = katello_repositories(:pulp3_ansible_collection_1)
+      create_repo(@repo, @master)
+      ForemanTasks.sync_task(
+          ::Actions::Katello::Repository::MetadataGenerate, @repo,
+          repository_creation: true)
+
+      repository_reference = Katello::Pulp3::RepositoryReference.find_by(
+          :root_repository_id => @repo.root.id,
+          :content_view_id => @repo.content_view.id)
+
+      assert repository_reference
+      refute_empty repository_reference.repository_href
+      refute_empty Katello::Pulp3::DistributionReference.where(
+          root_repository_id: @repo.root.id)
+      @repo_version_href = @repo.version_href
+    end
+
+    def teardown
+      ForemanTasks.sync_task(
+          ::Actions::Pulp3::Orchestration::Repository::Delete, @repo, @master)
+      @repo.reload
+    end
+
+    def test_sync
+      sync_args = {:smart_proxy_id => @master.id, :repo_id => @repo.id}
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @master, sync_args)
+      @repo.reload
+      refute_equal @repo.version_href, @repo_version_href
+      repository_reference = Katello::Pulp3::RepositoryReference.find_by(
+          :root_repository_id => @repo.root.id,
+          :content_view_id => @repo.content_view.id)
+
+      assert_equal repository_reference.repository_href + "versions/2/", @repo.version_href
+    end
+  end
+end

--- a/test/controllers/api/v2/products_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/products_bulk_actions_controller_test.rb
@@ -55,7 +55,7 @@ module Katello
     def test_sync
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
         action_class.must_equal ::Actions::Katello::Repository::Sync
-        repos.size.must_equal 7
+        repos.size.must_equal 8
       end
 
       put :sync_products, params: { :ids => @products.collect(&:id), :organization_id => @organization.id }

--- a/test/fixtures/katello/ansible_collections.yml
+++ b/test/fixtures/katello/ansible_collections.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -345,3 +345,10 @@ pulp3_file_1:
   relative_path:        '/Default_Organization/library/pulp3_File_1'
   environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
+
+pulp3_ansible_collection_1:
+  root_id:              <%= ActiveRecord::FixtureSet.identify(:pulp3_ansible_collection_root_1) %>
+  pulp_id:              "Default_Organization-Cabinet-pulp3_Ansible_collection_1"
+  relative_path:        '/Default_Organization/library/pulp3_Ansible_collection_1'
+  environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
+  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>

--- a/test/fixtures/models/katello_root_repositories.yml
+++ b/test/fixtures/models/katello_root_repositories.yml
@@ -180,3 +180,15 @@ pulp3_file_root_1:
   gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
   unprotected:           <%= true %>
   url:                  "https://repos.fedorapeople.org/pulp/pulp/demo_repos/test_file_repo/"
+
+pulp3_ansible_collection_root_1:
+  name:                 Pulp3 Ansible Collection 1
+  content_id:           12
+  content_type:         ansible_collection
+  label:                Pulp3_Ansible Collection 1
+  product_id:           <%= ActiveRecord::FixtureSet.identify(:fedora) %>
+  gpg_key_id:           <%= ActiveRecord::FixtureSet.identify(:fedora_gpg_key) %>
+  unprotected:           <%= true %>
+  url:                  "https://galaxy.ansible.com"
+  ansible_collection_whitelist: "robertdebock.rundeck_collection"
+

--- a/test/fixtures/vcr_cassettes/actions/pulp3/ansible_collection_create/create.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/ansible_collection_create/create.yml
@@ -1,0 +1,300 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_Ansible_collection_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:19:40 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:19:40 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/ansible/collection/?name=Default_Organization-Cabinet-pulp3_Ansible_collection_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:19:40 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:19:40 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/ansible/ansible/?name=Default_Organization-Cabinet-pulp3_Ansible_collection_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:19:40 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:19:40 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/ansible/ansible/?base_path=Default_Organization/library/pulp3_Ansible_collection_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:19:41 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:19:41 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19B
+        bnNpYmxlX2NvbGxlY3Rpb25fMSJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:19:41 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/9f2a69a0-65a4-409f-b78b-ee784f4f7b1f/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '320'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOWYyYTY5YTAt
+        NjVhNC00MDlmLWI3OGItZWU3ODRmNGY3YjFmLyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wNi0yNFQxODoxOTo0MS40ODMwMTBaIiwiX3ZlcnNpb25zX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzlmMmE2OWEwLTY1YTQtNDA5Zi1i
+        NzhiLWVlNzg0ZjRmN2IxZi92ZXJzaW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25f
+        aHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfQW5zaWJsZV9jb2xsZWN0aW9uXzEiLCJkZXNjcmlwdGlvbiI6
+        bnVsbH0=
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:19:41 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/ansible/collection/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19B
+        bnNpYmxlX2NvbGxlY3Rpb25fMSIsInVybCI6Imh0dHBzOi8vZ2FsYXh5LmFu
+        c2libGUuY29tIiwidmFsaWRhdGUiOnRydWUsInNzbF92YWxpZGF0aW9uIjp0
+        cnVlLCJwb2xpY3kiOiJpbW1lZGlhdGUiLCJ3aGl0ZWxpc3QiOiJyb2JlcnRk
+        ZWJvY2sucnVuZGVja19jb2xsZWN0aW9uIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:19:41 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/ansible/collection/d36d7171-a662-4a00-bb7e-95e8d49f4364/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '531'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2Fuc2libGUvY29sbGVj
+        dGlvbi9kMzZkNzE3MS1hNjYyLTRhMDAtYmI3ZS05NWU4ZDQ5ZjQzNjQvIiwi
+        X2NyZWF0ZWQiOiIyMDE5LTA2LTI0VDE4OjE5OjQxLjc1MzQ4MVoiLCJfdHlw
+        ZSI6ImFuc2libGUuY29sbGVjdGlvbiIsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
+        aXphdGlvbi1DYWJpbmV0LXB1bHAzX0Fuc2libGVfY29sbGVjdGlvbl8xIiwi
+        dXJsIjoiaHR0cHM6Ly9nYWxheHkuYW5zaWJsZS5jb20iLCJ2YWxpZGF0ZSI6
+        dHJ1ZSwic3NsX2NhX2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2Nl
+        cnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3NsX3Zh
+        bGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwiX2xhc3RfdXBkYXRl
+        ZCI6IjIwMTktMDYtMjRUMTg6MTk6NDEuNzUzNTAzWiIsImRvd25sb2FkX2Nv
+        bmN1cnJlbmN5IjoyMCwicG9saWN5IjoiaW1tZWRpYXRlIiwid2hpdGVsaXN0
+        Ijoicm9iZXJ0ZGVib2NrLnJ1bmRlY2tfY29sbGVjdGlvbiJ9
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:19:41 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/ansible_collection_delete/distribution_references_are_deleted.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/ansible_collection_delete/distribution_references_are_deleted.yml
@@ -1,0 +1,1232 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_Ansible_collection_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '372'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85ZjJh
+        NjlhMC02NWE0LTQwOWYtYjc4Yi1lZTc4NGY0ZjdiMWYvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA2LTI0VDE4OjE5OjQxLjQ4MzAxMFoiLCJfdmVyc2lvbnNfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOWYyYTY5YTAtNjVhNC00
+        MDlmLWI3OGItZWU3ODRmNGY3YjFmL3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVy
+        c2lvbl9ocmVmIjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24t
+        Q2FiaW5ldC1wdWxwM19BbnNpYmxlX2NvbGxlY3Rpb25fMSIsImRlc2NyaXB0
+        aW9uIjpudWxsfV19
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:02 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/9f2a69a0-65a4-409f-b78b-ee784f4f7b1f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E0YmJkZTg0LThhM2YtNDA0
+        Mi05ZWQwLTc5NDI2ZTg2MmI2YS8ifQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:02 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/ansible/collection/?name=Default_Organization-Cabinet-pulp3_Ansible_collection_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '583'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlbW90ZXMvYW5zaWJsZS9j
+        b2xsZWN0aW9uL2QzNmQ3MTcxLWE2NjItNGEwMC1iYjdlLTk1ZThkNDlmNDM2
+        NC8iLCJfY3JlYXRlZCI6IjIwMTktMDYtMjRUMTg6MTk6NDEuNzUzNDgxWiIs
+        Il90eXBlIjoiYW5zaWJsZS5jb2xsZWN0aW9uIiwibmFtZSI6IkRlZmF1bHRf
+        T3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfQW5zaWJsZV9jb2xsZWN0aW9u
+        XzEiLCJ1cmwiOiJodHRwczovL2dhbGF4eS5hbnNpYmxlLmNvbSIsInZhbGlk
+        YXRlIjp0cnVlLCJzc2xfY2FfY2VydGlmaWNhdGUiOm51bGwsInNzbF9jbGll
+        bnRfY2VydGlmaWNhdGUiOm51bGwsInNzbF9jbGllbnRfa2V5IjpudWxsLCJz
+        c2xfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJfbGFzdF91
+        cGRhdGVkIjoiMjAxOS0wNi0yNFQxODoxOTo0MS43NTM1MDNaIiwiZG93bmxv
+        YWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJpbW1lZGlhdGUiLCJ3aGl0
+        ZWxpc3QiOiJyb2JlcnRkZWJvY2sucnVuZGVja19jb2xsZWN0aW9uIn1dfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:03 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/ansible/collection/d36d7171-a662-4a00-bb7e-95e8d49f4364/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E4OGY3NTZjLTBhY2YtNGEy
+        YS1hOTYwLTI4YTE1M2IxZTU2ZC8ifQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:03 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/ansible/ansible/?name=Default_Organization-Cabinet-pulp3_Ansible_collection_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:03 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/ansible/ansible/?base_path=Default_Organization/library/pulp3_Ansible_collection_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:03 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19B
+        bnNpYmxlX2NvbGxlY3Rpb25fMSJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/37bb616d-8b65-4a11-ab77-8de96a3624b6/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '320'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvMzdiYjYxNmQt
+        OGI2NS00YTExLWFiNzctOGRlOTZhMzYyNGI2LyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wNi0yNFQxODoyMjowNC4zMzE0NTFaIiwiX3ZlcnNpb25zX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzM3YmI2MTZkLThiNjUtNGExMS1h
+        Yjc3LThkZTk2YTM2MjRiNi92ZXJzaW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25f
+        aHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfQW5zaWJsZV9jb2xsZWN0aW9uXzEiLCJkZXNjcmlwdGlvbiI6
+        bnVsbH0=
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:04 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/ansible/collection/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19B
+        bnNpYmxlX2NvbGxlY3Rpb25fMSIsInVybCI6Imh0dHBzOi8vZ2FsYXh5LmFu
+        c2libGUuY29tIiwidmFsaWRhdGUiOnRydWUsInNzbF92YWxpZGF0aW9uIjp0
+        cnVlLCJwb2xpY3kiOiJpbW1lZGlhdGUiLCJ3aGl0ZWxpc3QiOiJyb2JlcnRk
+        ZWJvY2sucnVuZGVja19jb2xsZWN0aW9uIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/ansible/collection/b84b3868-49fe-4c1e-b95e-48dae964a263/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '531'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2Fuc2libGUvY29sbGVj
+        dGlvbi9iODRiMzg2OC00OWZlLTRjMWUtYjk1ZS00OGRhZTk2NGEyNjMvIiwi
+        X2NyZWF0ZWQiOiIyMDE5LTA2LTI0VDE4OjIyOjA0LjU5Njc0MVoiLCJfdHlw
+        ZSI6ImFuc2libGUuY29sbGVjdGlvbiIsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
+        aXphdGlvbi1DYWJpbmV0LXB1bHAzX0Fuc2libGVfY29sbGVjdGlvbl8xIiwi
+        dXJsIjoiaHR0cHM6Ly9nYWxheHkuYW5zaWJsZS5jb20iLCJ2YWxpZGF0ZSI6
+        dHJ1ZSwic3NsX2NhX2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2Nl
+        cnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3NsX3Zh
+        bGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwiX2xhc3RfdXBkYXRl
+        ZCI6IjIwMTktMDYtMjRUMTg6MjI6MDQuNTk2Nzg0WiIsImRvd25sb2FkX2Nv
+        bmN1cnJlbmN5IjoyMCwicG9saWN5IjoiaW1tZWRpYXRlIiwid2hpdGVsaXN0
+        Ijoicm9iZXJ0ZGVib2NrLnJ1bmRlY2tfY29sbGVjdGlvbiJ9
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:04 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/37bb616d-8b65-4a11-ab77-8de96a3624b6/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:05 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI4NzM0NmY4LTMzNGYtNDFj
+        ZS04NGY4LTQyNzAyZGU3YzQ2Yy8ifQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:05 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/287346f8-334f-41ce-84f8-42702de7c46c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:05 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '502'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yODczNDZmOC0zMzRmLTQx
+        Y2UtODRmOC00MjcwMmRlN2M0NmMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjIyOjA1LjA1NTE1M1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLnJlcG9zaXRvcnkuYWRkX2FuZF9yZW1vdmUi
+        LCJzdGFydGVkX2F0IjoiMjAxOS0wNi0yNFQxODoyMjowNS4yMjIzNzlaIiwi
+        ZmluaXNoZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJv
+        ciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGQ0MTI4
+        YjAtNmEyNC00Y2NjLWFkMDMtODMyZjIwOGRlMThjLyIsInBhcmVudCI6bnVs
+        bCwic3Bhd25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJj
+        cmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        LzM3YmI2MTZkLThiNjUtNGExMS1hYjc3LThkZTk2YTM2MjRiNi92ZXJzaW9u
+        cy8xLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:05 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/287346f8-334f-41ce-84f8-42702de7c46c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:05 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yODczNDZmOC0zMzRmLTQx
+        Y2UtODRmOC00MjcwMmRlN2M0NmMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjIyOjA1LjA1NTE1M1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA2LTI0VDE4OjIyOjA1LjIyMjM3OVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDYtMjRUMTg6MjI6MDUuMzAxMzUwWiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvMGQ0MTI4YjAtNmEyNC00Y2NjLWFkMDMt
+        ODMyZjIwOGRlMThjLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzM3YmI2MTZkLThiNjUtNGEx
+        MS1hYjc3LThkZTk2YTM2MjRiNi92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:05 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/37bb616d-8b65-4a11-ab77-8de96a3624b6/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:05 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvMzdiYjYxNmQt
+        OGI2NS00YTExLWFiNzctOGRlOTZhMzYyNGI2L3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA2LTI0VDE4OjIyOjA1LjI3MjMwN1oiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:05 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/ansible/ansible/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0Fuc2libGVfY29sbGVjdGlvbl8xIiwibmFtZSI6IkRlZmF1bHRfT3Jn
+        YW5pemF0aW9uLUNhYmluZXQtcHVscDNfQW5zaWJsZV9jb2xsZWN0aW9uXzEi
+        LCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzM3YmI2MTZkLThiNjUtNGExMS1hYjc3LThkZTk2YTM2MjRiNi92ZXJz
+        aW9ucy8xLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:06 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IzZjZkMTU1LTc4ODUtNGU1
+        Zi05MzM3LWMyYTM1ZWM3ZTRlYy8ifQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:06 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/b3f6d155-7885-4e5f-9337-c2a35ec7e4ec/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:06 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9iM2Y2ZDE1NS03ODg1LTRl
+        NWYtOTMzNy1jMmEzNWVjN2U0ZWMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjIyOjA2LjAwNDQ5N1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNi0yNFQxODoyMjowNi4yNDc5MTJaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGQ0MTI4YjAtNmEy
+        NC00Y2NjLWFkMDMtODMyZjIwOGRlMThjLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:06 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/b3f6d155-7885-4e5f-9337-c2a35ec7e4ec/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:06 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '502'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9iM2Y2ZDE1NS03ODg1LTRl
+        NWYtOTMzNy1jMmEzNWVjN2U0ZWMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjIyOjA2LjAwNDQ5N1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNi0yNFQxODoyMjowNi4yNDc5MTJaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGQ0MTI4YjAtNmEy
+        NC00Y2NjLWFkMDMtODMyZjIwOGRlMThjLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9hbnNp
+        YmxlL2Fuc2libGUvYjE0OTM3OTAtZThiYS00ZGQzLTk1MjctMGQ5ZjU1YjA1
+        ZTBkLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:06 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/b3f6d155-7885-4e5f-9337-c2a35ec7e4ec/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:06 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9iM2Y2ZDE1NS03ODg1LTRl
+        NWYtOTMzNy1jMmEzNWVjN2U0ZWMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjIyOjA2LjAwNDQ5N1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA2LTI0VDE4OjIyOjA2LjI0NzkxMloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDYtMjRUMTg6MjI6MDYuNTUzOTgyWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMGQ0MTI4YjAtNmEyNC00Y2NjLWFkMDMtODMyZjIw
+        OGRlMThjLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9hbnNpYmxlL2Fuc2libGUvYjE0OTM3
+        OTAtZThiYS00ZGQzLTk1MjctMGQ5ZjU1YjA1ZTBkLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:06 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/ansible/ansible/b1493790-e8ba-4dd3-9527-0d9f55b05e0d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:07 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '520'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2Fuc2libGUv
+        YW5zaWJsZS9iMTQ5Mzc5MC1lOGJhLTRkZDMtOTUyNy0wZDlmNTViMDVlMGQv
+        IiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0VDE4OjIyOjA2LjU0MDIyMVoiLCJi
+        YXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAz
+        X0Fuc2libGVfY29sbGVjdGlvbl8xIiwiYmFzZV91cmwiOiJjZW50b3M3LWRl
+        dmVsNC5zYW1pci5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9P
+        cmdhbml6YXRpb24vbGlicmFyeS9wdWxwM19BbnNpYmxlX2NvbGxlY3Rpb25f
+        MSIsImNvbnRlbnRfZ3VhcmQiOm51bGwsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
+        aXphdGlvbi1DYWJpbmV0LXB1bHAzX0Fuc2libGVfY29sbGVjdGlvbl8xIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAv
+        YXBpL3YzL3JlcG9zaXRvcmllcy8zN2JiNjE2ZC04YjY1LTRhMTEtYWI3Ny04
+        ZGU5NmEzNjI0YjYvdmVyc2lvbnMvMS8ifQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:07 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/ansible/collection/b84b3868-49fe-4c1e-b95e-48dae964a263/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:07 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhmODgxMzU5LWY5ZWQtNDZi
+        MC04ZWE2LTUzYWZhOWIwMjYyNy8ifQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:07 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/8f881359-f9ed-46b0-8ea6-53afa9b02627/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:07 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84Zjg4MTM1OS1mOWVkLTQ2
+        YjAtOGVhNi01M2FmYTliMDI2MjcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjIyOjA3LjU0NjYxOFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA2LTI0VDE4OjIyOjA3LjcyNjk2OVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDYtMjRUMTg6MjI6MDcuNzc4NTE1WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvOWRhYTAzMGUtMzY3Ny00NmFkLWIyYWEtMjBiODU4
+        YmJmZjU1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:07 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/ansible/ansible/?base_path=Default_Organization/library/pulp3_Ansible_collection_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:08 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '572'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvYW5z
+        aWJsZS9hbnNpYmxlL2IxNDkzNzkwLWU4YmEtNGRkMy05NTI3LTBkOWY1NWIw
+        NWUwZC8iLCJfY3JlYXRlZCI6IjIwMTktMDYtMjRUMTg6MjI6MDYuNTQwMjIx
+        WiIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkv
+        cHVscDNfQW5zaWJsZV9jb2xsZWN0aW9uXzEiLCJiYXNlX3VybCI6ImNlbnRv
+        czctZGV2ZWw0LnNhbWlyLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZh
+        dWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0Fuc2libGVfY29sbGVj
+        dGlvbl8xIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6IkRlZmF1bHRf
+        T3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfQW5zaWJsZV9jb2xsZWN0aW9u
+        XzEiLCJyZXBvc2l0b3J5IjpudWxsLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzM3YmI2MTZkLThiNjUtNGExMS1h
+        Yjc3LThkZTk2YTM2MjRiNi92ZXJzaW9ucy8xLyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:08 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/ansible/ansible/b1493790-e8ba-4dd3-9527-0d9f55b05e0d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:08 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY5ODMxNWMxLTljNDgtNGU5
+        Yi04NDVlLWE3ZWVlYmM4Y2E3ZS8ifQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:08 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/37bb616d-8b65-4a11-ab77-8de96a3624b6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:08 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzljMGM1MmZkLTAxYmYtNGQ1
+        Yi1iZDg1LTRmZGRmZjhiOWRlOS8ifQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:08 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/9c0c52fd-01bf-4d5b-bd85-4fddff8b9de9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:08 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '418'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85YzBjNTJmZC0wMWJmLTRk
+        NWItYmQ4NS00ZmRkZmY4YjlkZTkvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjIyOjA4LjUxNjIwMloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwic3RhcnRl
+        ZF9hdCI6IjIwMTktMDYtMjRUMTg6MjI6MDguODQ0MDI2WiIsImZpbmlzaGVk
+        X2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGws
+        IndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzlkYWEwMzBlLTM2Nzct
+        NDZhZC1iMmFhLTIwYjg1OGJiZmY1NS8iLCJwYXJlbnQiOm51bGwsInNwYXdu
+        ZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9y
+        ZXNvdXJjZXMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:08 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/9c0c52fd-01bf-4d5b-bd85-4fddff8b9de9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:09 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '445'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85YzBjNTJmZC0wMWJmLTRk
+        NWItYmQ4NS00ZmRkZmY4YjlkZTkvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjIyOjA4LjUxNjIwMloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5kZWxldGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNi0yNFQxODoyMjowOC44NDQwMjZaIiwiZmluaXNo
+        ZWRfYXQiOiIyMDE5LTA2LTI0VDE4OjIyOjA4Ljk2NzI0NVoiLCJub25fZmF0
+        YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2Fw
+        aS92My93b3JrZXJzLzlkYWEwMzBlLTM2NzctNDZhZC1iMmFhLTIwYjg1OGJi
+        ZmY1NS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9n
+        cmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:09 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/ansible_collection_delete/repository_reference_is_deleted.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/ansible_collection_delete/repository_reference_is_deleted.yml
@@ -1,0 +1,1014 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_Ansible_collection_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:10 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:10 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/ansible/collection/?name=Default_Organization-Cabinet-pulp3_Ansible_collection_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:10 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:10 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/ansible/ansible/?name=Default_Organization-Cabinet-pulp3_Ansible_collection_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:10 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:10 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/ansible/ansible/?base_path=Default_Organization/library/pulp3_Ansible_collection_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:11 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:11 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19B
+        bnNpYmxlX2NvbGxlY3Rpb25fMSJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:11 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/c3680626-0d70-42b6-8bc5-762083cd7508/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '320'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYzM2ODA2MjYt
+        MGQ3MC00MmI2LThiYzUtNzYyMDgzY2Q3NTA4LyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wNi0yNFQxODoyMjoxMS41MDUyMjJaIiwiX3ZlcnNpb25zX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2MzNjgwNjI2LTBkNzAtNDJiNi04
+        YmM1LTc2MjA4M2NkNzUwOC92ZXJzaW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25f
+        aHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfQW5zaWJsZV9jb2xsZWN0aW9uXzEiLCJkZXNjcmlwdGlvbiI6
+        bnVsbH0=
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:11 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/ansible/collection/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19B
+        bnNpYmxlX2NvbGxlY3Rpb25fMSIsInVybCI6Imh0dHBzOi8vZ2FsYXh5LmFu
+        c2libGUuY29tIiwidmFsaWRhdGUiOnRydWUsInNzbF92YWxpZGF0aW9uIjp0
+        cnVlLCJwb2xpY3kiOiJpbW1lZGlhdGUiLCJ3aGl0ZWxpc3QiOiJyb2JlcnRk
+        ZWJvY2sucnVuZGVja19jb2xsZWN0aW9uIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:11 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/ansible/collection/01b406d1-1f51-418d-9f8a-c5de29bbbbdd/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '531'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2Fuc2libGUvY29sbGVj
+        dGlvbi8wMWI0MDZkMS0xZjUxLTQxOGQtOWY4YS1jNWRlMjliYmJiZGQvIiwi
+        X2NyZWF0ZWQiOiIyMDE5LTA2LTI0VDE4OjIyOjExLjczMjMxM1oiLCJfdHlw
+        ZSI6ImFuc2libGUuY29sbGVjdGlvbiIsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
+        aXphdGlvbi1DYWJpbmV0LXB1bHAzX0Fuc2libGVfY29sbGVjdGlvbl8xIiwi
+        dXJsIjoiaHR0cHM6Ly9nYWxheHkuYW5zaWJsZS5jb20iLCJ2YWxpZGF0ZSI6
+        dHJ1ZSwic3NsX2NhX2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2Nl
+        cnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3NsX3Zh
+        bGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwiX2xhc3RfdXBkYXRl
+        ZCI6IjIwMTktMDYtMjRUMTg6MjI6MTEuNzMyMzI4WiIsImRvd25sb2FkX2Nv
+        bmN1cnJlbmN5IjoyMCwicG9saWN5IjoiaW1tZWRpYXRlIiwid2hpdGVsaXN0
+        Ijoicm9iZXJ0ZGVib2NrLnJ1bmRlY2tfY29sbGVjdGlvbiJ9
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:11 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/c3680626-0d70-42b6-8bc5-762083cd7508/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FkZWUyYmM1LTE0ZDUtNDVi
+        ZS05MTMxLWNiYWIyM2IzYTBjMy8ifQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:12 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/adee2bc5-14d5-45be-9131-cbab23b3a0c3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hZGVlMmJjNS0xNGQ1LTQ1
+        YmUtOTEzMS1jYmFiMjNiM2EwYzMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjIyOjEyLjIyMzIxN1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA2LTI0VDE4OjIyOjEyLjM5NTkxNFoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDYtMjRUMTg6MjI6MTIuNDY4MzYzWiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvMGQ0MTI4YjAtNmEyNC00Y2NjLWFkMDMt
+        ODMyZjIwOGRlMThjLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2MzNjgwNjI2LTBkNzAtNDJi
+        Ni04YmM1LTc2MjA4M2NkNzUwOC92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:12 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/c3680626-0d70-42b6-8bc5-762083cd7508/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYzM2ODA2MjYt
+        MGQ3MC00MmI2LThiYzUtNzYyMDgzY2Q3NTA4L3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA2LTI0VDE4OjIyOjEyLjQzMzQzNFoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:12 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/ansible/ansible/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0Fuc2libGVfY29sbGVjdGlvbl8xIiwibmFtZSI6IkRlZmF1bHRfT3Jn
+        YW5pemF0aW9uLUNhYmluZXQtcHVscDNfQW5zaWJsZV9jb2xsZWN0aW9uXzEi
+        LCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2MzNjgwNjI2LTBkNzAtNDJiNi04YmM1LTc2MjA4M2NkNzUwOC92ZXJz
+        aW9ucy8xLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMwMjI1Mzk1LWY3MTQtNDE3
+        Yy1hYzgxLWQxMTI5ZTg2ZjlhMS8ifQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:12 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/30225395-f714-417c-ac81-d1129e86f9a1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:13 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zMDIyNTM5NS1mNzE0LTQx
+        N2MtYWM4MS1kMTEyOWU4NmY5YTEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjIyOjEyLjk4Njg4OFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNi0yNFQxODoyMjoxMy4yMDc2MDlaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGQ0MTI4YjAtNmEy
+        NC00Y2NjLWFkMDMtODMyZjIwOGRlMThjLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:13 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/30225395-f714-417c-ac81-d1129e86f9a1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:13 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zMDIyNTM5NS1mNzE0LTQx
+        N2MtYWM4MS1kMTEyOWU4NmY5YTEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjIyOjEyLjk4Njg4OFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA2LTI0VDE4OjIyOjEzLjIwNzYwOVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDYtMjRUMTg6MjI6MTMuNTM0MjI0WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMGQ0MTI4YjAtNmEyNC00Y2NjLWFkMDMtODMyZjIw
+        OGRlMThjLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9hbnNpYmxlL2Fuc2libGUvNWE5ZDY2
+        M2UtMDdhNS00OTdmLWFhNjktOWEzZDE1MzQ5YjMyLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:13 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/ansible/ansible/5a9d663e-07a5-497f-aa69-9a3d15349b32/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:13 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '520'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2Fuc2libGUv
+        YW5zaWJsZS81YTlkNjYzZS0wN2E1LTQ5N2YtYWE2OS05YTNkMTUzNDliMzIv
+        IiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0VDE4OjIyOjEzLjUyMDI1MFoiLCJi
+        YXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAz
+        X0Fuc2libGVfY29sbGVjdGlvbl8xIiwiYmFzZV91cmwiOiJjZW50b3M3LWRl
+        dmVsNC5zYW1pci5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9P
+        cmdhbml6YXRpb24vbGlicmFyeS9wdWxwM19BbnNpYmxlX2NvbGxlY3Rpb25f
+        MSIsImNvbnRlbnRfZ3VhcmQiOm51bGwsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
+        aXphdGlvbi1DYWJpbmV0LXB1bHAzX0Fuc2libGVfY29sbGVjdGlvbl8xIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAv
+        YXBpL3YzL3JlcG9zaXRvcmllcy9jMzY4MDYyNi0wZDcwLTQyYjYtOGJjNS03
+        NjIwODNjZDc1MDgvdmVyc2lvbnMvMS8ifQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:13 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/ansible/collection/01b406d1-1f51-418d-9f8a-c5de29bbbbdd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:14 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNhMGIxNjI1LTE5ZDYtNDc0
+        MS04MzVlLTViYTJlYzhjM2EyNy8ifQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:14 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/3a0b1625-19d6-4741-835e-5ba2ec8c3a27/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:14 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zYTBiMTYyNS0xOWQ2LTQ3
+        NDEtODM1ZS01YmEyZWM4YzNhMjcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjIyOjE0LjM2NjU4NFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA2LTI0VDE4OjIyOjE0LjU0MjYxN1oiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDYtMjRUMTg6MjI6MTQuNjAzMDc4WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvOWRhYTAzMGUtMzY3Ny00NmFkLWIyYWEtMjBiODU4
+        YmJmZjU1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:14 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/ansible/ansible/?base_path=Default_Organization/library/pulp3_Ansible_collection_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:14 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '572'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvYW5z
+        aWJsZS9hbnNpYmxlLzVhOWQ2NjNlLTA3YTUtNDk3Zi1hYTY5LTlhM2QxNTM0
+        OWIzMi8iLCJfY3JlYXRlZCI6IjIwMTktMDYtMjRUMTg6MjI6MTMuNTIwMjUw
+        WiIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkv
+        cHVscDNfQW5zaWJsZV9jb2xsZWN0aW9uXzEiLCJiYXNlX3VybCI6ImNlbnRv
+        czctZGV2ZWw0LnNhbWlyLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZh
+        dWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0Fuc2libGVfY29sbGVj
+        dGlvbl8xIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6IkRlZmF1bHRf
+        T3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfQW5zaWJsZV9jb2xsZWN0aW9u
+        XzEiLCJyZXBvc2l0b3J5IjpudWxsLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2MzNjgwNjI2LTBkNzAtNDJiNi04
+        YmM1LTc2MjA4M2NkNzUwOC92ZXJzaW9ucy8xLyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:14 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/ansible/ansible/5a9d663e-07a5-497f-aa69-9a3d15349b32/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E5NGYxMTAyLTRhOGEtNDI1
+        MS1hYmU5LTc4YThhYmJiMTg2OC8ifQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:15 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/c3680626-0d70-42b6-8bc5-762083cd7508/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI3ZGI0Yjc4LWNlMDItNDY3
+        NS1iYTc4LWJiOWEwYmZmNjVjMC8ifQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:15 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/27db4b78-ce02-4675-ba78-bb9a0bff65c0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '418'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yN2RiNGI3OC1jZTAyLTQ2
+        NzUtYmE3OC1iYjlhMGJmZjY1YzAvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjIyOjE1LjM1MTA4MFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwic3RhcnRl
+        ZF9hdCI6IjIwMTktMDYtMjRUMTg6MjI6MTUuNTU3MjM2WiIsImZpbmlzaGVk
+        X2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGws
+        IndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBkNDEyOGIwLTZhMjQt
+        NGNjYy1hZDAzLTgzMmYyMDhkZTE4Yy8iLCJwYXJlbnQiOm51bGwsInNwYXdu
+        ZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9y
+        ZXNvdXJjZXMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:15 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/27db4b78-ce02-4675-ba78-bb9a0bff65c0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:22:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '445'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yN2RiNGI3OC1jZTAyLTQ2
+        NzUtYmE3OC1iYjlhMGJmZjY1YzAvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjIyOjE1LjM1MTA4MFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5kZWxldGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNi0yNFQxODoyMjoxNS41NTcyMzZaIiwiZmluaXNo
+        ZWRfYXQiOiIyMDE5LTA2LTI0VDE4OjIyOjE1LjY1MzkyOVoiLCJub25fZmF0
+        YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2Fw
+        aS92My93b3JrZXJzLzBkNDEyOGIwLTZhMjQtNGNjYy1hZDAzLTgzMmYyMDhk
+        ZTE4Yy8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9n
+        cmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:22:15 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/actions/pulp3/ansible_collection_sync/sync.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/ansible_collection_sync/sync.yml
@@ -1,0 +1,1806 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_Ansible_collection_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:15 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/ansible/collection/?name=Default_Organization-Cabinet-pulp3_Ansible_collection_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:15 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/ansible/ansible/?name=Default_Organization-Cabinet-pulp3_Ansible_collection_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:15 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/ansible/ansible/?base_path=Default_Organization/library/pulp3_Ansible_collection_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:15 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19B
+        bnNpYmxlX2NvbGxlY3Rpb25fMSJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:16 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/0457c87b-fd2e-40e5-b6e7-440df0bc5ad2/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '320'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvMDQ1N2M4N2It
+        ZmQyZS00MGU1LWI2ZTctNDQwZGYwYmM1YWQyLyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wNi0yNFQxODoyNDoxNi4yOTMxOTBaIiwiX3ZlcnNpb25zX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzA0NTdjODdiLWZkMmUtNDBlNS1i
+        NmU3LTQ0MGRmMGJjNWFkMi92ZXJzaW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25f
+        aHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfQW5zaWJsZV9jb2xsZWN0aW9uXzEiLCJkZXNjcmlwdGlvbiI6
+        bnVsbH0=
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:16 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/ansible/collection/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19B
+        bnNpYmxlX2NvbGxlY3Rpb25fMSIsInVybCI6Imh0dHBzOi8vZ2FsYXh5LmFu
+        c2libGUuY29tIiwidmFsaWRhdGUiOnRydWUsInNzbF92YWxpZGF0aW9uIjp0
+        cnVlLCJwb2xpY3kiOiJpbW1lZGlhdGUiLCJ3aGl0ZWxpc3QiOiJyb2JlcnRk
+        ZWJvY2sucnVuZGVja19jb2xsZWN0aW9uIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:16 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/ansible/collection/7db91151-4d00-4e4b-8afb-ff463fa85fc5/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '531'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2Fuc2libGUvY29sbGVj
+        dGlvbi83ZGI5MTE1MS00ZDAwLTRlNGItOGFmYi1mZjQ2M2ZhODVmYzUvIiwi
+        X2NyZWF0ZWQiOiIyMDE5LTA2LTI0VDE4OjI0OjE2LjU2MTAyMFoiLCJfdHlw
+        ZSI6ImFuc2libGUuY29sbGVjdGlvbiIsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
+        aXphdGlvbi1DYWJpbmV0LXB1bHAzX0Fuc2libGVfY29sbGVjdGlvbl8xIiwi
+        dXJsIjoiaHR0cHM6Ly9nYWxheHkuYW5zaWJsZS5jb20iLCJ2YWxpZGF0ZSI6
+        dHJ1ZSwic3NsX2NhX2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2Nl
+        cnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3NsX3Zh
+        bGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwiX2xhc3RfdXBkYXRl
+        ZCI6IjIwMTktMDYtMjRUMTg6MjQ6MTYuNTYxMDM2WiIsImRvd25sb2FkX2Nv
+        bmN1cnJlbmN5IjoyMCwicG9saWN5IjoiaW1tZWRpYXRlIiwid2hpdGVsaXN0
+        Ijoicm9iZXJ0ZGVib2NrLnJ1bmRlY2tfY29sbGVjdGlvbiJ9
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:16 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/0457c87b-fd2e-40e5-b6e7-440df0bc5ad2/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E3MWRhMjk3LThjYzgtNDQ0
+        Ny1iZjgxLTliZTM4MzVhM2MxZC8ifQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/a71da297-8cc8-4447-bf81-9be3835a3c1d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hNzFkYTI5Ny04Y2M4LTQ0
+        NDctYmY4MS05YmUzODM1YTNjMWQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjI0OjE3LjE4Mzk1MFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA2LTI0VDE4OjI0OjE3LjM2MDA4NFoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDYtMjRUMTg6MjQ6MTcuNDMzOTAwWiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvMGQ0MTI4YjAtNmEyNC00Y2NjLWFkMDMt
+        ODMyZjIwOGRlMThjLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzA0NTdjODdiLWZkMmUtNDBl
+        NS1iNmU3LTQ0MGRmMGJjNWFkMi92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:17 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/0457c87b-fd2e-40e5-b6e7-440df0bc5ad2/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvMDQ1N2M4N2It
+        ZmQyZS00MGU1LWI2ZTctNDQwZGYwYmM1YWQyL3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA2LTI0VDE4OjI0OjE3LjM5NzI0M1oiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:17 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/ansible/ansible/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0Fuc2libGVfY29sbGVjdGlvbl8xIiwibmFtZSI6IkRlZmF1bHRfT3Jn
+        YW5pemF0aW9uLUNhYmluZXQtcHVscDNfQW5zaWJsZV9jb2xsZWN0aW9uXzEi
+        LCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzA0NTdjODdiLWZkMmUtNDBlNS1iNmU3LTQ0MGRmMGJjNWFkMi92ZXJz
+        aW9ucy8xLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:18 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E0YjUzYWUwLTUzMmYtNDkx
+        OS04YTEwLTNjNGY0N2Q4OWNkZS8ifQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:18 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/a4b53ae0-532f-4919-8a10-3c4f47d89cde/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:18 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hNGI1M2FlMC01MzJmLTQ5
+        MTktOGExMC0zYzRmNDdkODljZGUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjI0OjE4LjEyMDE0MFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNi0yNFQxODoyNDoxOC4zMzM0NTRaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGQ0MTI4YjAtNmEy
+        NC00Y2NjLWFkMDMtODMyZjIwOGRlMThjLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:18 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/a4b53ae0-532f-4919-8a10-3c4f47d89cde/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:18 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hNGI1M2FlMC01MzJmLTQ5
+        MTktOGExMC0zYzRmNDdkODljZGUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjI0OjE4LjEyMDE0MFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNi0yNFQxODoyNDoxOC4zMzM0NTRaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGQ0MTI4YjAtNmEy
+        NC00Y2NjLWFkMDMtODMyZjIwOGRlMThjLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:18 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/a4b53ae0-532f-4919-8a10-3c4f47d89cde/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:18 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hNGI1M2FlMC01MzJmLTQ5
+        MTktOGExMC0zYzRmNDdkODljZGUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjI0OjE4LjEyMDE0MFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA2LTI0VDE4OjI0OjE4LjMzMzQ1NFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDYtMjRUMTg6MjQ6MTguNzA5MDM3WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMGQ0MTI4YjAtNmEyNC00Y2NjLWFkMDMtODMyZjIw
+        OGRlMThjLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9hbnNpYmxlL2Fuc2libGUvOWU0NmVk
+        NzItNWE5MC00MjkzLTg0OGMtMWYyMzZjMDkyODViLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:18 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/ansible/ansible/9e46ed72-5a90-4293-848c-1f236c09285b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:19 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '520'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2Fuc2libGUv
+        YW5zaWJsZS85ZTQ2ZWQ3Mi01YTkwLTQyOTMtODQ4Yy0xZjIzNmMwOTI4NWIv
+        IiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0VDE4OjI0OjE4LjY2ODQ0NloiLCJi
+        YXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAz
+        X0Fuc2libGVfY29sbGVjdGlvbl8xIiwiYmFzZV91cmwiOiJjZW50b3M3LWRl
+        dmVsNC5zYW1pci5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9P
+        cmdhbml6YXRpb24vbGlicmFyeS9wdWxwM19BbnNpYmxlX2NvbGxlY3Rpb25f
+        MSIsImNvbnRlbnRfZ3VhcmQiOm51bGwsIm5hbWUiOiJEZWZhdWx0X09yZ2Fu
+        aXphdGlvbi1DYWJpbmV0LXB1bHAzX0Fuc2libGVfY29sbGVjdGlvbl8xIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicmVwb3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAv
+        YXBpL3YzL3JlcG9zaXRvcmllcy8wNDU3Yzg3Yi1mZDJlLTQwZTUtYjZlNy00
+        NDBkZjBiYzVhZDIvdmVyc2lvbnMvMS8ifQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:19 GMT
+- request:
+    method: post
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/ansible/collection/7db91151-4d00-4e4b-8afb-ff463fa85fc5/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy8wNDU3
+        Yzg3Yi1mZDJlLTQwZTUtYjZlNy00NDBkZjBiYzVhZDIvIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:19 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UyMGIxZmE5LTJiZWYtNGQx
+        Zi04ODUzLTZkZTM1ZjEyYzM2Ny8ifQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:19 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/e20b1fa9-2bef-4d1f-8853-6de35f12c367/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:19 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '425'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lMjBiMWZhOS0yYmVmLTRk
+        MWYtODg1My02ZGUzNWYxMmMzNjcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjI0OjE5LjY3NDU0OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9hbnNpYmxlLmFwcC50YXNrcy5jb2xsZWN0aW9ucy5zeW5jIiwic3Rh
+        cnRlZF9hdCI6IjIwMTktMDYtMjRUMTg6MjQ6MTkuODgxNDI5WiIsImZpbmlz
+        aGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51
+        bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzlkYWEwMzBlLTM2
+        NzctNDZhZC1iMmFhLTIwYjg1OGJiZmY1NS8iLCJwYXJlbnQiOm51bGwsInNw
+        YXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRl
+        ZF9yZXNvdXJjZXMiOltudWxsXX0=
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:19 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/e20b1fa9-2bef-4d1f-8853-6de35f12c367/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:20 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '425'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lMjBiMWZhOS0yYmVmLTRk
+        MWYtODg1My02ZGUzNWYxMmMzNjcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjI0OjE5LjY3NDU0OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9hbnNpYmxlLmFwcC50YXNrcy5jb2xsZWN0aW9ucy5zeW5jIiwic3Rh
+        cnRlZF9hdCI6IjIwMTktMDYtMjRUMTg6MjQ6MTkuODgxNDI5WiIsImZpbmlz
+        aGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51
+        bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzlkYWEwMzBlLTM2
+        NzctNDZhZC1iMmFhLTIwYjg1OGJiZmY1NS8iLCJwYXJlbnQiOm51bGwsInNw
+        YXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRl
+        ZF9yZXNvdXJjZXMiOltudWxsXX0=
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:20 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/e20b1fa9-2bef-4d1f-8853-6de35f12c367/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:20 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '425'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lMjBiMWZhOS0yYmVmLTRk
+        MWYtODg1My02ZGUzNWYxMmMzNjcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjI0OjE5LjY3NDU0OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9hbnNpYmxlLmFwcC50YXNrcy5jb2xsZWN0aW9ucy5zeW5jIiwic3Rh
+        cnRlZF9hdCI6IjIwMTktMDYtMjRUMTg6MjQ6MTkuODgxNDI5WiIsImZpbmlz
+        aGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51
+        bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzlkYWEwMzBlLTM2
+        NzctNDZhZC1iMmFhLTIwYjg1OGJiZmY1NS8iLCJwYXJlbnQiOm51bGwsInNw
+        YXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRl
+        ZF9yZXNvdXJjZXMiOltudWxsXX0=
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:20 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/e20b1fa9-2bef-4d1f-8853-6de35f12c367/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:20 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '425'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lMjBiMWZhOS0yYmVmLTRk
+        MWYtODg1My02ZGUzNWYxMmMzNjcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjI0OjE5LjY3NDU0OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9hbnNpYmxlLmFwcC50YXNrcy5jb2xsZWN0aW9ucy5zeW5jIiwic3Rh
+        cnRlZF9hdCI6IjIwMTktMDYtMjRUMTg6MjQ6MTkuODgxNDI5WiIsImZpbmlz
+        aGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51
+        bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzlkYWEwMzBlLTM2
+        NzctNDZhZC1iMmFhLTIwYjg1OGJiZmY1NS8iLCJwYXJlbnQiOm51bGwsInNw
+        YXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRl
+        ZF9yZXNvdXJjZXMiOltudWxsXX0=
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:20 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/e20b1fa9-2bef-4d1f-8853-6de35f12c367/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:20 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '425'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lMjBiMWZhOS0yYmVmLTRk
+        MWYtODg1My02ZGUzNWYxMmMzNjcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjI0OjE5LjY3NDU0OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9hbnNpYmxlLmFwcC50YXNrcy5jb2xsZWN0aW9ucy5zeW5jIiwic3Rh
+        cnRlZF9hdCI6IjIwMTktMDYtMjRUMTg6MjQ6MTkuODgxNDI5WiIsImZpbmlz
+        aGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51
+        bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzlkYWEwMzBlLTM2
+        NzctNDZhZC1iMmFhLTIwYjg1OGJiZmY1NS8iLCJwYXJlbnQiOm51bGwsInNw
+        YXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRl
+        ZF9yZXNvdXJjZXMiOltudWxsXX0=
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:20 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/e20b1fa9-2bef-4d1f-8853-6de35f12c367/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '425'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lMjBiMWZhOS0yYmVmLTRk
+        MWYtODg1My02ZGUzNWYxMmMzNjcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjI0OjE5LjY3NDU0OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9hbnNpYmxlLmFwcC50YXNrcy5jb2xsZWN0aW9ucy5zeW5jIiwic3Rh
+        cnRlZF9hdCI6IjIwMTktMDYtMjRUMTg6MjQ6MTkuODgxNDI5WiIsImZpbmlz
+        aGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51
+        bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzlkYWEwMzBlLTM2
+        NzctNDZhZC1iMmFhLTIwYjg1OGJiZmY1NS8iLCJwYXJlbnQiOm51bGwsInNw
+        YXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRl
+        ZF9yZXNvdXJjZXMiOltudWxsXX0=
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:21 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/e20b1fa9-2bef-4d1f-8853-6de35f12c367/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '425'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lMjBiMWZhOS0yYmVmLTRk
+        MWYtODg1My02ZGUzNWYxMmMzNjcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjI0OjE5LjY3NDU0OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9hbnNpYmxlLmFwcC50YXNrcy5jb2xsZWN0aW9ucy5zeW5jIiwic3Rh
+        cnRlZF9hdCI6IjIwMTktMDYtMjRUMTg6MjQ6MTkuODgxNDI5WiIsImZpbmlz
+        aGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51
+        bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzlkYWEwMzBlLTM2
+        NzctNDZhZC1iMmFhLTIwYjg1OGJiZmY1NS8iLCJwYXJlbnQiOm51bGwsInNw
+        YXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRl
+        ZF9yZXNvdXJjZXMiOltudWxsXX0=
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:21 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/e20b1fa9-2bef-4d1f-8853-6de35f12c367/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '425'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lMjBiMWZhOS0yYmVmLTRk
+        MWYtODg1My02ZGUzNWYxMmMzNjcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjI0OjE5LjY3NDU0OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9hbnNpYmxlLmFwcC50YXNrcy5jb2xsZWN0aW9ucy5zeW5jIiwic3Rh
+        cnRlZF9hdCI6IjIwMTktMDYtMjRUMTg6MjQ6MTkuODgxNDI5WiIsImZpbmlz
+        aGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51
+        bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzlkYWEwMzBlLTM2
+        NzctNDZhZC1iMmFhLTIwYjg1OGJiZmY1NS8iLCJwYXJlbnQiOm51bGwsInNw
+        YXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRl
+        ZF9yZXNvdXJjZXMiOltudWxsXX0=
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:21 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/e20b1fa9-2bef-4d1f-8853-6de35f12c367/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '524'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lMjBiMWZhOS0yYmVmLTRk
+        MWYtODg1My02ZGUzNWYxMmMzNjcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjI0OjE5LjY3NDU0OVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2Fuc2libGUuYXBwLnRhc2tzLmNvbGxlY3Rpb25zLnN5bmMiLCJz
+        dGFydGVkX2F0IjoiMjAxOS0wNi0yNFQxODoyNDoxOS44ODE0MjlaIiwiZmlu
+        aXNoZWRfYXQiOiIyMDE5LTA2LTI0VDE4OjI0OjIxLjcxMTA1N1oiLCJub25f
+        ZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzlkYWEwMzBlLTM2NzctNDZhZC1iMmFhLTIwYjg1
+        OGJiZmY1NS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJw
+        cm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy8wNDU3Yzg3Yi1mZDJlLTQwZTUtYjZl
+        Ny00NDBkZjBiYzVhZDIvdmVyc2lvbnMvMi8iXX0=
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:21 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/0457c87b-fd2e-40e5-b6e7-440df0bc5ad2/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '575'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvMDQ1N2M4N2It
+        ZmQyZS00MGU1LWI2ZTctNDQwZGYwYmM1YWQyL3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA2LTI0VDE4OjI0OjE5LjkxODg0M1oiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImFuc2libGUuY29sbGVjdGlvbiI6eyJjb3VudCI6MSwiaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L2Fuc2libGUvY29sbGVjdGlvbnMvP3Jl
+        cG9zaXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzA0NTdjODdiLWZkMmUtNDBlNS1iNmU3LTQ0MGRmMGJjNWFkMi92ZXJz
+        aW9ucy8yLyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnsiYW5zaWJsZS5j
+        b2xsZWN0aW9uIjp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvYW5zaWJsZS9jb2xsZWN0aW9ucy8/cmVwb3NpdG9yeV92ZXJzaW9u
+        PS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvMDQ1N2M4N2ItZmQyZS00MGU1
+        LWI2ZTctNDQwZGYwYmM1YWQyL3ZlcnNpb25zLzIvIn19fX0=
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:22 GMT
+- request:
+    method: patch
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/ansible/ansible/9e46ed72-5a90-4293-848c-1f236c09285b/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0Fuc2libGVfY29sbGVjdGlvbl8xIiwibmFtZSI6IkRlZmF1bHRfT3Jn
+        YW5pemF0aW9uLUNhYmluZXQtcHVscDNfQW5zaWJsZV9jb2xsZWN0aW9uXzEi
+        LCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzA0NTdjODdiLWZkMmUtNDBlNS1iNmU3LTQ0MGRmMGJjNWFkMi92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM5ZWUxY2JlLTE0MDctNDJh
+        MS05ZDA4LTc5NmQxOTVkZTlmYS8ifQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:22 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/39ee1cbe-1407-42a1-9d08-796d195de9fa/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zOWVlMWNiZS0xNDA3LTQy
+        YTEtOWQwOC03OTZkMTk1ZGU5ZmEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjI0OjIyLjM3MzIzMloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNi0yNFQxODoyNDoyMi41ODgyNDJaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGQ0MTI4YjAtNmEy
+        NC00Y2NjLWFkMDMtODMyZjIwOGRlMThjLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:22 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/39ee1cbe-1407-42a1-9d08-796d195de9fa/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zOWVlMWNiZS0xNDA3LTQy
+        YTEtOWQwOC03OTZkMTk1ZGU5ZmEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjI0OjIyLjM3MzIzMloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNi0yNFQxODoyNDoyMi41ODgyNDJaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGQ0MTI4YjAtNmEy
+        NC00Y2NjLWFkMDMtODMyZjIwOGRlMThjLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:22 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/39ee1cbe-1407-42a1-9d08-796d195de9fa/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zOWVlMWNiZS0xNDA3LTQy
+        YTEtOWQwOC03OTZkMTk1ZGU5ZmEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjI0OjIyLjM3MzIzMloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA2LTI0VDE4OjI0OjIyLjU4ODI0MloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDYtMjRUMTg6MjQ6MjIuOTg3ODc3WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMGQ0MTI4YjAtNmEyNC00Y2NjLWFkMDMtODMyZjIw
+        OGRlMThjLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:23 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/remotes/ansible/collection/7db91151-4d00-4e4b-8afb-ff463fa85fc5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RjMTAyMWFhLTcyMTItNGFl
+        Mi1hNzk3LTE4Y2YwOWJjYzg5ZC8ifQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:23 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/dc1021aa-7212-4ae2-a797-18cf09bcc89d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kYzEwMjFhYS03MjEyLTRh
+        ZTItYTc5Ny0xOGNmMDliY2M4OWQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjI0OjIzLjc3MDU2NVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA2LTI0VDE4OjI0OjIzLjkzMzI0N1oiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDYtMjRUMTg6MjQ6MjQuMDA3NTM0WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvOWRhYTAzMGUtMzY3Ny00NmFkLWIyYWEtMjBiODU4
+        YmJmZjU1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:24 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/ansible/ansible/?base_path=Default_Organization/library/pulp3_Ansible_collection_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '572'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvYW5z
+        aWJsZS9hbnNpYmxlLzllNDZlZDcyLTVhOTAtNDI5My04NDhjLTFmMjM2YzA5
+        Mjg1Yi8iLCJfY3JlYXRlZCI6IjIwMTktMDYtMjRUMTg6MjQ6MTguNjY4NDQ2
+        WiIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkv
+        cHVscDNfQW5zaWJsZV9jb2xsZWN0aW9uXzEiLCJiYXNlX3VybCI6ImNlbnRv
+        czctZGV2ZWw0LnNhbWlyLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZh
+        dWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0Fuc2libGVfY29sbGVj
+        dGlvbl8xIiwiY29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6IkRlZmF1bHRf
+        T3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfQW5zaWJsZV9jb2xsZWN0aW9u
+        XzEiLCJyZXBvc2l0b3J5IjpudWxsLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzA0NTdjODdiLWZkMmUtNDBlNS1i
+        NmU3LTQ0MGRmMGJjNWFkMi92ZXJzaW9ucy8yLyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:24 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/distributions/ansible/ansible/9e46ed72-5a90-4293-848c-1f236c09285b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.2.0b1.dev0.1560866833/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdhMzQzZjU0LTdkNDItNDQ5
+        Ny05OTZkLWZlZDA0NjliM2M3Ny8ifQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:24 GMT
+- request:
+    method: delete
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/repositories/0457c87b-fd2e-40e5-b6e7-440df0bc5ad2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc5MDRlYzQyLWY2YTYtNGNi
+        ZC05MjRkLTRmODUyZWJmN2RjOC8ifQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:24 GMT
+- request:
+    method: get
+    uri: https://centos7-devel4.samir.example.com/pulp/api/v3/tasks/7904ec42-f6a6-4cbd-924d-4f852ebf7dc8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc3.dev0.1561038430/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 24 Jun 2019 18:24:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '445'
+      Via:
+      - 1.1 centos7-devel4.samir.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy83OTA0ZWM0Mi1mNmE2LTRj
+        YmQtOTI0ZC00Zjg1MmViZjdkYzgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA2LTI0
+        VDE4OjI0OjI0Ljc0NjgwNVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5kZWxldGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNi0yNFQxODoyNDoyNS4wMDQxNTVaIiwiZmluaXNo
+        ZWRfYXQiOiIyMDE5LTA2LTI0VDE4OjI0OjI1LjA5MzE0NloiLCJub25fZmF0
+        YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2Fw
+        aS92My93b3JrZXJzLzBkNDEyOGIwLTZhMjQtNGNjYy1hZDAzLTgzMmYyMDhk
+        ZTE4Yy8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9n
+        cmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 24 Jun 2019 18:24:25 GMT
+recorded_with: VCR 3.0.3

--- a/test/models/katello/ansible_collection_test.rb
+++ b/test/models/katello/ansible_collection_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+module Katello
+  class AnsibleCollectionTest < ActiveSupport::TestCase
+    # test "the truth" do
+    #   assert true
+    # end
+  end
+end


### PR DESCRIPTION
To test, copy the change in katello.yaml.example to foreman/config/settings.plugins.d/katello.yaml and restart server after installing the binding gem. The one-VM setup for Pulp3 has the pulp_ansible enabled.

- Read documentation for the pulp-ansible plugin here : https://pulp-ansible.readthedocs.io/en/latest/
- Read API documentation for the plugin here: https://pulp-ansible.readthedocs.io/en/latest/restapi.html
- Ruby binding gem for pulp_ansible can be found here: https://rubygems.org/gems/pulp_ansible_client