### PR TITLE
Fixes #27079 - fixup subscription dashboard counts

### DIFF
--- a/app/helpers/katello/concerns/dashboard_helper_extensions.rb
+++ b/app/helpers/katello/concerns/dashboard_helper_extensions.rb
@@ -1,29 +1,32 @@
 module Katello
   module Concerns
     module DashboardHelperExtensions
+      def host_query
+        ::Host::Managed.authorized('view_hosts', ::Host::Managed).where(:organization => Organization.current)
+      end
+
       def total_host_count
-        total_host_count = ::Host::Managed.authorized('view_hosts', ::Host::Managed).where(:organization => Organization.current).size
-        return total_host_count || 0
+        host_query.size
       end
 
       def partial_consumer_count
-        partial_consumer_count = ::Host::Managed.authorized('view_hosts', ::Host::Managed).where(:organization => Organization.current).search_for("subscription_status = partial").size
-        return partial_consumer_count || 0
+        host_query.search_for("subscription_status = partial").size
       end
 
       def valid_consumer_count
-        valid_consumer_count = ::Host::Managed.authorized('view_hosts', ::Host::Managed).where(:organization => Organization.current).search_for("subscription_status = valid").size
-        return valid_consumer_count || 0
+        host_query.search_for("subscription_status = valid").size
       end
 
       def invalid_consumer_count
-        invalid_consumer_count = ::Host::Managed.authorized('view_hosts', ::Host::Managed).where(:organization => Organization.current).search_for("subscription_status = invalid").size
-        return invalid_consumer_count || 0
+        host_query.search_for("subscription_status = invalid").size
       end
 
       def unknown_consumer_count
-        unknown_consumer_count = ::Host::Managed.authorized('view_hosts', ::Host::Managed).where(:organization => Organization.current).search_for("subscription_status = unknown").size
-        return unknown_consumer_count || 0
+        host_query.search_for("subscription_status = unknown or (null? subscription_uuid)").size
+      end
+
+      def unsubscribed_hypervisor_count
+        host_query.search_for("subscription_status = unsubscribed_hypervisor").size
       end
     end
   end

--- a/app/views/dashboard/_subscription_widget.html.erb
+++ b/app/views/dashboard/_subscription_widget.html.erb
@@ -10,9 +10,9 @@
   <% valid_consumer_count = valid_consumer_count()%>
   <% invalid_consumer_count = invalid_consumer_count()%>
   <% unknown_consumer_count = unknown_consumer_count() %>
-  <% unregistered_consumer_count = total_count-partial_consumer_count-valid_consumer_count-invalid_consumer_count%>
   <% subscription_status_url = '/content_hosts?search='%>
   <% registered_subscription_url = subscription_status_url + ERB::Util.url_encode('subscription_status = ') %>
+  <% unknown_search_url = registered_subscription_url + 'unknown or (null? subscription_uuid)' %>
 
   <table class="table table-fixed table-striped table-bordered">
     <thead>
@@ -54,22 +54,22 @@
       </tr>
       <tr>
         <td>
-          <%= link_to("#{registered_subscription_url}" + 'unknown') do %>
-              <i class="label label-warning" style="margin-right: 6px">&nbsp;</i><%= _("Unknown") %>
+          <%= link_to("#{registered_subscription_url}" + 'unsubscribed_hypervisor') do %>
+              <i class="label label-warning" style="margin-right: 6px">&nbsp;</i><%= _("Unsubscribed Hypervisor") %>
           <% end %>
         </td>
         <td style="text-align:right">
-          <%= link_to( "#{unknown_consumer_count}", "#{registered_subscription_url}" + 'unknown')%>
+          <%= link_to( "#{unsubscribed_hypervisor_count}", "#{registered_subscription_url}" + 'unsubscribed_hypervisor')%>
         </td>
       </tr>
       <tr>
         <td>
-          <%= link_to("#{subscription_status_url}" + 'null? subscription_uuid') do %>
-              <i class="label label-danger" style="margin-right: 6px">&nbsp;</i><%= _("Unregistered") %>
+          <%= link_to(unknown_search_url) do %>
+              <i class="label label-warning" style="margin-right: 6px">&nbsp;</i><%= _("Unknown or Unregistered") %>
           <% end %>
         </td>
         <td style="text-align:right">
-          <%= link_to( "#{unregistered_consumer_count}", "#{subscription_status_url}" + 'null? subscription_uuid')%>
+          <%= link_to("#{unknown_consumer_count}", unknown_search_url)%>
         </td>
       </tr>
       <tr>

--- a/test/controllers/foreman/dashboard_controller_test.rb
+++ b/test/controllers/foreman/dashboard_controller_test.rb
@@ -1,0 +1,16 @@
+require 'katello_test_helper'
+class DashboardControllerTest < ActionController::TestCase
+  def setup
+    setup_controller_defaults(false, false)
+    login_user(User.find(users(:admin).id))
+    Dashboard::Manager.reset_user_to_default(User.current)
+    models
+  end
+
+  def test_show_subscription_widget
+    id = User.current.widgets.find_by(:template => 'subscription_widget').id
+    get :show, params: {id: id}
+
+    assert_response :success
+  end
+end

--- a/test/helpers/dashboard_helper_test.rb
+++ b/test/helpers/dashboard_helper_test.rb
@@ -46,6 +46,18 @@ class DashboardHelperTest < ActiveSupport::TestCase
     assert_equal 1, unknown
   end
 
+  def test_unregistered_consumer_count
+    @host.subscription_facet.update_attributes!(uuid: nil)
+    unknown = unknown_consumer_count
+    assert_equal 1, unknown
+  end
+
+  def test_unsubscribed_hypervisor_consumer_count
+    @host.subscription_facet.update_subscription_status('unsubscribed_hypervisor')
+    unknown = unsubscribed_hypervisor_count
+    assert_equal 1, unknown
+  end
+
   def test_partial_consumer_count_nil
     partial = partial_consumer_count
     assert !partial.nil?


### PR DESCRIPTION
The subscription dashboard widget was created prior
to the unsubscribed_hypervisor status being added.
This lead to confusing behavior where the counts did not
add up to the total.  To fix this, a row was added
for unsubscribed_hypervisors as well as combining
the unknown and unsubscribed rows into one