### PR TITLE
Fixes #27062 - Fail to delete subscriptions from UI

### DIFF
--- a/app/lib/actions/katello/upstream_subscriptions/remove_entitlement.rb
+++ b/app/lib/actions/katello/upstream_subscriptions/remove_entitlement.rb
@@ -6,10 +6,13 @@ module Actions
 
         input_format do
           param :entitlement_id
+          param :sub_name
         end
 
         def run
           output[:response] = ::Katello::Resources::Candlepin::UpstreamConsumer.remove_entitlement(input[:entitlement_id])
+        rescue ::Katello::Errors::UpstreamEntitlementGone
+          output[:response] = _("%s has already been deleted" % input[:sub_name])
         end
 
         def run_progress_weight

--- a/app/lib/actions/katello/upstream_subscriptions/remove_entitlements.rb
+++ b/app/lib/actions/katello/upstream_subscriptions/remove_entitlements.rb
@@ -3,6 +3,7 @@ module Actions
     module UpstreamSubscriptions
       class RemoveEntitlements < Actions::Base
         def plan(pool_ids = [])
+          ::Katello::Resources::Candlepin::UpstreamConsumer.get(:include_only => [:uuid])
           ids = pool_ids.uniq.compact
           fail _("No pool IDs were provided.") if ids.blank?
           fail _("Current organization is not set.") unless ::Organization.current
@@ -13,7 +14,9 @@ module Actions
 
               fail _("Provided pool with id %s has no upstream entitlement" % pid) if pool.upstream_entitlement_id.nil?
 
-              plan_action(::Actions::Katello::UpstreamSubscriptions::RemoveEntitlement, entitlement_id: pool.upstream_entitlement_id)
+              sub_name = pool.subscription.name
+
+              plan_action(::Actions::Katello::UpstreamSubscriptions::RemoveEntitlement, entitlement_id: pool.upstream_entitlement_id, sub_name: sub_name)
             end
 
             plan_action(::Actions::Katello::Organization::ManifestRefresh, ::Organization.current)

--- a/app/lib/katello/errors.rb
+++ b/app/lib/katello/errors.rb
@@ -123,5 +123,7 @@ module Katello
           "Please create a new Subscription Allocation and import the new manifest.")
       end
     end
+
+    class UpstreamEntitlementGone < StandardError; end
   end
 end

--- a/test/actions/katello/upstream_subscriptions/remove_entitlement_test.rb
+++ b/test/actions/katello/upstream_subscriptions/remove_entitlement_test.rb
@@ -8,11 +8,16 @@ describe ::Actions::Katello::UpstreamSubscriptions::RemoveEntitlement do
   before :all do
     @org = FactoryBot.create(:katello_organization)
     set_organization(@org)
-    @planned_action = create_and_plan_action(subject, org_id: @org.id, entitlement_id: 'foo')
+    @planned_action = create_and_plan_action(subject, org_id: @org.id, entitlement_id: 'foo', sub_name: 'Test Sub')
   end
 
   it 'runs' do
     ::Katello::Resources::Candlepin::UpstreamConsumer.expects(:remove_entitlement).with('foo')
     run_action @planned_action
+  end
+
+  it 'outputs a message if entitlement is gone' do
+    ::Katello::Resources::Candlepin::UpstreamConsumer.expects(:remove_entitlement).with('foo').raises(::Katello::Errors::UpstreamEntitlementGone)
+    assert_equal("Test Sub has already been deleted", run_action(@planned_action).output[:response])
   end
 end

--- a/test/actions/katello/upstream_subscriptions/remove_entitlements_test.rb
+++ b/test/actions/katello/upstream_subscriptions/remove_entitlements_test.rb
@@ -23,10 +23,12 @@ describe ::Actions::Katello::UpstreamSubscriptions::RemoveEntitlements do
     ::Katello::Pool.expects(:find).with(pool1.id).returns(pool1)
     ::Katello::Pool.expects(:find).with(pool2.id).returns(pool2)
 
+    ::Katello::Resources::Candlepin::UpstreamConsumer.expects(:get).returns(true)
+
     plan_action(@action, [pool1.id, pool2.id])
 
-    assert_action_planned_with(@action, @remove_action_class, entitlement_id: 'a')
-    assert_action_planned_with(@action, @remove_action_class, entitlement_id: 'b')
+    assert_action_planned_with(@action, @remove_action_class, entitlement_id: 'a', sub_name: 'basic subscription')
+    assert_action_planned_with(@action, @remove_action_class, entitlement_id: 'b', sub_name: 'other subscription')
     assert_action_planned_with(@action, @manifest_action_class, @org)
   end
 
@@ -34,17 +36,27 @@ describe ::Actions::Katello::UpstreamSubscriptions::RemoveEntitlements do
     pool1 = katello_pools(:pool_one)
     pool1.expects(:upstream_entitlement_id).returns(nil)
     ::Katello::Pool.expects(:find).with(pool1.id).returns(pool1)
+    ::Katello::Resources::Candlepin::UpstreamConsumer.expects(:get).returns(true)
 
     error = proc { plan_action(@action, [pool1.id]) }.must_raise RuntimeError
     error.message.must_match(/upstream/)
   end
 
+  it 'raises an error when the pool has no upstream allocation' do
+    pool1 = katello_pools(:pool_one)
+    ::Katello::HttpResource.expects(:get).raises(::Katello::Errors::UpstreamConsumerGone)
+
+    proc { plan_action(@action, [pool1.id]) }.must_raise ::Katello::Errors::UpstreamConsumerGone
+  end
+
   it 'raises an error when given no pool ids' do
+    ::Katello::Resources::Candlepin::UpstreamConsumer.expects(:get).returns(true)
     error = proc { plan_action(@action, []) }.must_raise RuntimeError
     error.message.must_match(/provided/)
   end
 
   it 'raises an error when no organization is set' do
+    ::Katello::Resources::Candlepin::UpstreamConsumer.expects(:get).returns(true)
     set_organization(nil)
     error = proc { plan_action(@action, [:foo]) }.must_raise RuntimeError
     error.message.must_match(/is not set/)


### PR DESCRIPTION
Two issues are being solved here:  
- Firstly, the bug described in [#27062](https://projects.theforeman.org/issues/27062) occurred because the upstream consumer was deleted sometime before trying to delete the subscription in the UI.  The issue here was the ambiguous error messages in the task.  Now, the upstream consumer is checked and the error messaged introduced [here](https://github.com/Katello/katello/commit/444db0c5d3d91182c1873c6f1deb5281b7d58a23) is displayed.
    - To reproduce the issue, import a fresh manifest and delete the upstream consumer (subscription allocation).  Then try to delete a subscription that belongs to that manifest.
- Secondly, during testing, it was discovered that there was another ambiguous error message in the task when trying to delete a subscription that had previously been deleted.  The fix is to hide the error, refresh the manifest, and log the missing subscription in the task Dynflow.
  - To reproduce the issue, import a fresh manifest and delete one of the subscriptions.  Delete the manifest and re-upload it.  Try to delete the subscription again.