### PR TITLE
fixes #27050 - Activation Keys to support System Purpose

### DIFF
--- a/app/lib/actions/candlepin/activation_key/create.rb
+++ b/app/lib/actions/candlepin/activation_key/create.rb
@@ -4,12 +4,18 @@ module Actions
       input_format do
         param :organization_label
         param :auto_attach
+        param :purpose_role
+        param :purpose_usage
+        param :purpse_addons
       end
 
       def run
         output[:response] = ::Katello::Resources::Candlepin::ActivationKey.create(::Katello::Util::Model.uuid,
                                                                                   input[:organization_label],
-                                                                                  input[:auto_attach])
+                                                                                  input[:auto_attach],
+                                                                                  input[:purpose_role],
+                                                                                  input[:purpose_usage],
+                                                                                  input[:purpose_addons])
       end
     end
   end

--- a/app/lib/actions/candlepin/activation_key/update.rb
+++ b/app/lib/actions/candlepin/activation_key/update.rb
@@ -7,6 +7,9 @@ module Actions
           param :release_version
           param :service_level
           param :auto_attach
+          param :purpose_role
+          param :purpose_usage
+          param :purpose_addons
         end
 
         def run
@@ -14,7 +17,10 @@ module Actions
                                                                 input[:cp_id],
                                                                 input[:release_version],
                                                                 input[:service_level],
-                                                                input[:auto_attach])
+                                                                input[:auto_attach],
+                                                                input[:purpose_role],
+                                                                input[:purpose_usage],
+                                                                input[:purpose_addons])
         end
       end
     end

--- a/app/lib/actions/katello/activation_key/create.rb
+++ b/app/lib/actions/katello/activation_key/create.rb
@@ -7,7 +7,10 @@ module Actions
           if ::SETTINGS[:katello][:use_cp]
             cp_create = plan_action(Candlepin::ActivationKey::Create,
                                     organization_label: activation_key.organization.label,
-                                    auto_attach: activation_key.auto_attach)
+                                    auto_attach: activation_key.auto_attach,
+                                    purpose_role: activation_key.purpose_role,
+                                    purpose_usage: activation_key.purpose_usage,
+                                    purpose_addons: activation_key.purpose_addons.pluck(:name))
             cp_id = cp_create.output[:response][:id]
           end
           action_subject(activation_key, :cp_id => cp_id)

--- a/app/lib/actions/katello/activation_key/update.rb
+++ b/app/lib/actions/katello/activation_key/update.rb
@@ -12,14 +12,20 @@ module Actions
                         cp_id: activation_key.cp_id,
                         release_version: activation_key.release_version,
                         service_level: activation_key.service_level,
-                        auto_attach: activation_key.auto_attach)
+                        auto_attach: activation_key.auto_attach,
+                        purpose_role: activation_key.purpose_role,
+                        purpose_usage: activation_key.purpose_usage,
+                        purpose_addons: activation_key.purpose_addons.pluck(:name))
           end
         end
 
         def update_candlepin?(activation_key, activation_key_params)
           cp_changed?(activation_key.auto_attach, activation_key_params[:auto_attach]) ||
           cp_changed?(activation_key.service_level, activation_key_params[:service_level]) ||
-          cp_changed?(activation_key.release_version, activation_key_params[:release_version])
+          cp_changed?(activation_key.release_version, activation_key_params[:release_version]) ||
+          cp_changed?(activation_key.purpose_role, activation_key_params[:purpose_role]) ||
+          cp_changed?(activation_key.purpose_usage, activation_key_params[:purpose_usage]) ||
+          cp_changed?(activation_key.purpose_addon_ids, activation_key_params[:purpose_addon_ids])
         end
 
         def cp_changed?(activation_key, activation_key_params)

--- a/app/lib/katello/resources/candlepin/activation_key.rb
+++ b/app/lib/katello/resources/candlepin/activation_key.rb
@@ -10,13 +10,14 @@ module Katello
             ::Katello::Util::Data.array_with_indifferent_access akeys
           end
 
-          def create(name, owner_key, auto_attach)
+          def create(name, owner_key, auto_attach, purpose_role, purpose_usage, purpose_addons)
             url = "/candlepin/owners/#{owner_key}/activation_keys"
-            JSON.parse(self.post(url, {:name => name, :autoAttach => auto_attach}.to_json, self.default_headers).body).with_indifferent_access
+            JSON.parse(self.post(url, {:name => name, :autoAttach => auto_attach, :role => purpose_role, :usage => purpose_usage, :addOns => purpose_addons}.to_json, self.default_headers).body).with_indifferent_access
           end
 
-          def update(id, release_version, service_level, auto_attach)
-            attrs = { :releaseVer => release_version, :serviceLevel => service_level, :autoAttach => auto_attach }.delete_if { |_k, v| v.nil? }
+          # rubocop:disable Metrics/ParameterLists
+          def update(id, release_version, service_level, auto_attach, purpose_role, purpose_usage, purpose_addons)
+            attrs = { :releaseVer => release_version, :serviceLevel => service_level, :autoAttach => auto_attach, :role => purpose_role, :usage => purpose_usage, :addOns => purpose_addons }.delete_if { |_k, v| v.nil? }
             JSON.parse(self.put(path(id), attrs.to_json, self.default_headers).body).with_indifferent_access
           end
 

--- a/app/models/katello/activation_key_purpose_addon.rb
+++ b/app/models/katello/activation_key_purpose_addon.rb
@@ -1,0 +1,6 @@
+module Katello
+  class ActivationKeyPurposeAddon < Katello::Model
+    belongs_to :activation_key, inverse_of: :activation_key_purpose_addons, class_name: 'Katello::ActivationKey'
+    belongs_to :purpose_addon, inverse_of: :activation_key_purpose_addons, class_name: 'Katello::PurposeAddon'
+  end
+end

--- a/app/models/katello/purpose_addon.rb
+++ b/app/models/katello/purpose_addon.rb
@@ -3,7 +3,9 @@ module Katello
     self.table_name = 'katello_purpose_addons'
 
     has_many :subscription_facet_purpose_addons, :class_name => "Katello::SubscriptionFacetPurposeAddon", :dependent => :destroy, :inverse_of => :purpose_addon
-
     has_many :subscription_facets, :through => :subscription_facet_purpose_addons, :class_name => "Katello::Host::SubscriptionFacet"
+
+    has_many :activation_key_purpose_addons, :class_name => "Katello::ActivationKeyPurposeAddon", :dependent => :destroy, :inverse_of => :purpose_addon
+    has_many :activation_keys, :through => :activation_key_purpose_addons, :class_name => "Katello::ActivationKey"
   end
 end

--- a/app/views/katello/api/v2/activation_keys/base.json.rabl
+++ b/app/views/katello/api/v2/activation_keys/base.json.rabl
@@ -14,7 +14,11 @@ child :environment => :environment do
 end
 attributes :environment_id
 
-attributes :usage_count, :user_id, :max_hosts, :system_template_id, :release_version
+attributes :usage_count, :user_id, :max_hosts, :system_template_id, :release_version, :purpose_usage, :purpose_role
+
+node :purpose_addons do |key|
+  key.purpose_addons.pluck(:name)
+end
 
 node :permissions do |activation_key|
   {

--- a/db/migrate/20190619192151_add_activation_key_system_purpose_attributes.rb
+++ b/db/migrate/20190619192151_add_activation_key_system_purpose_attributes.rb
@@ -1,0 +1,14 @@
+class AddActivationKeySystemPurposeAttributes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :katello_activation_key_purpose_addons do |t|
+      t.references :purpose_addon, index: { name: :katello_activation_key_purpose_addons_paid }
+      t.references :activation_key, index: { name: :katello_activation_key_purpose_addons_akid }
+    end
+
+    add_column :katello_activation_keys, :purpose_role, :string
+    add_column :katello_activation_keys, :purpose_usage, :string
+
+    add_foreign_key :katello_activation_key_purpose_addons, :katello_activation_keys, column: :activation_key_id, name: :katello_act_key_purpose_addon_act_key_id
+    add_foreign_key :katello_activation_key_purpose_addons, :katello_purpose_addons, column: :purpose_addon_id, name: :katello_act_key_purpose_addon_purpose_addon_id
+  end
+end

--- a/test/actions/candlepin/activation_key_test.rb
+++ b/test/actions/candlepin/activation_key_test.rb
@@ -11,11 +11,12 @@ class Actions::Candlepin::ActivationKey::CreateTest < ActiveSupport::TestCase
   describe 'Create' do
     let(:action_class) { ::Actions::Candlepin::ActivationKey::Create }
     let(:planned_action) do
-      create_and_plan_action(action_class, uuid: 123)
+      create_and_plan_action action_class, organization_label: nil, auto_attach: true, purpose_role: "role", purpose_usage: "usage", purpose_addons: ["Test"]
     end
 
     it 'runs' do
-      ::Katello::Resources::Candlepin::ActivationKey.expects(:create)
+      ::Katello::Util::Model.stubs(:uuid).returns(123)
+      ::Katello::Resources::Candlepin::ActivationKey.expects(:create).with(123, nil, true, "role", "usage", ["Test"])
       run_action planned_action
     end
   end
@@ -31,14 +32,13 @@ class Actions::Candlepin::ActivationKey::UpdateTest < ActiveSupport::TestCase
 
   describe 'Update' do
     let(:action_class) { ::Actions::Candlepin::ActivationKey::Update }
-    let(:input) { { :cp_id => 'foo_boo', :auto_attach => 'false' } }
 
     let(:planned_action) do
-      create_and_plan_action(action_class, input)
+      create_and_plan_action(action_class, cp_id: "foo", :release_version => 1, :service_level => "Premium", :auto_attach => true, :purpose_role => "test role", :purpose_usage => "test usage", :purpose_addons => ["test1"])
     end
 
     it 'runs' do
-      ::Katello::Resources::Candlepin::ActivationKey.expects(:update)
+      ::Katello::Resources::Candlepin::ActivationKey.expects(:update).with("foo", 1, "Premium", true, "test role", "test usage", ["test1"])
       run_action planned_action
     end
   end

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -44,7 +44,7 @@ module Katello
       assert_template 'api/v2/activation_keys/index'
 
       assert_equal results.keys.sort, ['error', 'page', 'per_page', 'results', 'search', 'sort', 'subtotal', 'total']
-      assert_equal results['results'].size, 6
+      assert_equal results['results'].size, 7
       assert_includes results['results'].collect { |item| item['id'] }, @activation_key.id
     end
 
@@ -61,7 +61,7 @@ module Katello
       results = JSON.parse(get(:index, params: { :organization_id => @organization.id, :content_view_id => @acme_view.id }).body)
 
       assert_response :success
-      assert_equal results["results"].size, 4
+      assert_equal results["results"].size, 5
     end
 
     def test_show

--- a/test/fixtures/models/katello_activation_key_purpose_addons.yml
+++ b/test/fixtures/models/katello_activation_key_purpose_addons.yml
@@ -1,0 +1,3 @@
+relation:
+  purpose_addon_id: <%= ActiveRecord::FixtureSet.identify(:addon) %>
+  activation_key_id: <%= ActiveRecord::FixtureSet.identify(:purpose_attributes_key) %>

--- a/test/fixtures/models/katello_activation_keys.yml
+++ b/test/fixtures/models/katello_activation_keys.yml
@@ -45,3 +45,14 @@ library_dev_staging_view_key:
   environment_id: <%= ActiveRecord::FixtureSet.identify(:dev) %>
   content_view_id: <%= ActiveRecord::FixtureSet.identify(:library_dev_staging_view) %>
   auto_attach: true
+
+purpose_attributes_key:
+  name: Activation Key
+  description: A simple activation key.
+  organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
+  environment_id: <%= ActiveRecord::FixtureSet.identify(:library) %>
+  content_view_id: <%= ActiveRecord::FixtureSet.identify(:acme_default) %>
+  auto_attach: true
+  purpose_role: role name
+  purpose_usage: usage name
+

--- a/test/models/activation_key_test.rb
+++ b/test/models/activation_key_test.rb
@@ -8,6 +8,7 @@ module Katello
       @dev_view = katello_content_views(:library_dev_view)
       @lib_view = katello_content_views(:library_view)
       @pool_one = katello_pools(:pool_one)
+      @purpose_key = katello_activation_keys(:purpose_attributes_key)
     end
 
     should allow_values(*valid_name_list).for(:name)
@@ -187,6 +188,22 @@ module Katello
       assert @dev_key.available_subscriptions.include? pool_one
       assert @dev_key.available_subscriptions.include? pool_two
       assert_equal @dev_key.available_subscriptions.length, 2
+    end
+
+    def test_search_role
+      activation_keys = ActivationKey.search_for("role = \"#{@purpose_key.purpose_role}\"")
+      assert_includes activation_keys, @purpose_key
+    end
+
+    def test_search_addon
+      @purpose_key.purpose_addons << katello_purpose_addons(:addon)
+      activation_keys = ActivationKey.search_for("addon = \"Test Addon\"")
+      assert_includes activation_keys, @purpose_key
+    end
+
+    def test_search_usage
+      activation_keys = ActivationKey.search_for("usage = \"#{@purpose_key.purpose_usage}\"")
+      assert_includes activation_keys, @purpose_key
     end
 
     context 'host_collection' do

--- a/test/support/fixtures_support.rb
+++ b/test/support/fixtures_support.rb
@@ -2,6 +2,7 @@ module Katello
   module FixturesSupport
     FIXTURE_CLASSES = {
       :katello_activation_keys => Katello::ActivationKey,
+      :katello_activation_key_purpose_addons => Katello::ActivationKeyPurposeAddon,
       :katello_contents => Katello::Content,
       :katello_content_views => Katello::ContentView,
       :katello_content_view_environments => Katello::ContentViewEnvironment,


### PR DESCRIPTION
This PR was created to use the functionality of Candlepin to support System Purpose on Activation Keys.
Since the UI isn't set up yet for the System Purpose under Activation Key, please use the api  **/katello/api/v2/activation_keys/1?** to test the update and create functionality.

**To test this PR:**
Create and update purpose_role, purpose_usage and purpose_addons in an activation key using the api endpoint. This change should reflect in both Katello and Candlepin db.

View Katello::ActivationKey to see changes in the Katello db.
View Katello::Resources::Candlepin::ActivationKey.get to see changes made to Candlepin.