### PR TITLE
Fixes #26930 - support multi-repo composite publishing

### DIFF
--- a/app/lib/actions/katello/repository/clone_contents.rb
+++ b/app/lib/actions/katello/repository/clone_contents.rb
@@ -13,13 +13,11 @@ module Actions
 
           sequence do
             if copy_contents
-              source_repositories.each do |repository|
-                plan_pulp_action([Pulp3::Orchestration::Repository::CopyAllUnits, Pulp::Repository::CopyAllUnits],
-                            repository,
-                            SmartProxy.pulp_master,
-                            new_repository,
-                            filters: filters, rpm_filenames: rpm_filenames, solve_dependencies: solve_dependencies)
-              end
+              plan_pulp_action([Pulp3::Orchestration::Repository::CopyAllUnits, Pulp::Orchestration::Repository::CopyAllUnits],
+                          new_repository,
+                          SmartProxy.pulp_master,
+                          source_repositories,
+                          filters: filters, rpm_filenames: rpm_filenames, solve_dependencies: solve_dependencies)
             end
 
             metadata_generate(source_repositories, new_repository, filters, rpm_filenames) if generate_metadata

--- a/app/lib/actions/pulp/orchestration/repository/copy_all_units.rb
+++ b/app/lib/actions/pulp/orchestration/repository/copy_all_units.rb
@@ -1,0 +1,19 @@
+module Actions
+  module Pulp
+    module Orchestration
+      module Repository
+        class CopyAllUnits < Pulp::Abstract
+          def plan(target_repo, smart_proxy, source_repos, options = {})
+            source_repos.each do |source_repo|
+              plan_action(Pulp::Repository::CopyAllUnits,
+                          target_repo,
+                          smart_proxy,
+                          source_repo,
+                          options)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp/repository/copy_all_units.rb
+++ b/app/lib/actions/pulp/repository/copy_all_units.rb
@@ -2,7 +2,7 @@ module Actions
   module Pulp
     module Repository
       class CopyAllUnits < Pulp::AbstractAsyncTask
-        def plan(source_repo, _smart_proxy, target_repo, options = {})
+        def plan(target_repo, _smart_proxy, source_repo, options = {})
           filter_ids = options.fetch(:filters, nil)&.map(&:id)
           rpm_filenames = options.fetch(:rpm_filenames, nil)
           solve_dependencies = options.fetch(:solve_dependencies, false)

--- a/app/lib/actions/pulp3/abstract.rb
+++ b/app/lib/actions/pulp3/abstract.rb
@@ -11,7 +11,7 @@ module Actions
       end
 
       def smart_proxy
-        SmartProxy.find(input[:smart_proxy_id])
+        SmartProxy.unscoped.find(input[:smart_proxy_id])
       end
     end
   end

--- a/app/lib/actions/pulp3/orchestration/repository/copy_all_units.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/copy_all_units.rb
@@ -2,27 +2,51 @@ module Actions
   module Pulp3
     module Orchestration
       module Repository
-        class CopyAllUnits < Pulp3::AbstractAsyncTask
+        class CopyAllUnits < Pulp3::Abstract
           # Copying all the units from the source repository version to the destination katello repository
           # if there are no filters, we can just reference the repository version and publication
-          def plan(source_repo, _smart_proxy, target_repo, options = {})
+          def plan(target_repo, smart_proxy, source_repositories, options = {})
             filter_ids = options.fetch(:filters, nil)&.map(&:id)
             rpm_filenames = options.fetch(:rpm_filenames, nil)
             solve_dependencies = options.fetch(:solve_dependencies, false)
 
-            if filter_ids.present? || rpm_filenames.present?
-              plan_self(source_repo_id: source_repo.id,
-                                    target_repo_id: target_repo.id,
-                                    filter_ids: filter_ids,
-                                    solve_dependencies: solve_dependencies,
-                                    rpm_filenames: rpm_filenames)
-              fail 'not supported yet in pulp3'
+            if filter_ids.present? || rpm_filenames.present? || source_repositories.length > 1
+              sequence do
+                if filter_ids.present? || rpm_filenames.present?
+                  #if we are filtering, we need to copy from each repo with filters in place.  We also need to clear out everything in the repo
+                  # which will be easier with https://pulp.plan.io/issues/4901
+                  start_copying_from = 0
+                  fail "Publish with filters are not currently supported"
+                else
+                  #if we are not filtering, copy the version to the cv repository, and the units for each additional repo
+                  action = plan_action(Actions::Pulp3::Repository::CopyVersion, source_repositories.first, smart_proxy, target_repo)
+                  plan_action(Actions::Pulp3::Repository::SaveVersion, target_repo, action.output[:pulp_tasks])
+                  start_copying_from = 1 #since we're creating a new version from the first repo, start copying at the 2nd
+                end
+
+                copy_actions = []
+                source_repositories[start_copying_from..-1].each do |source_repo|
+                  copy_actions << plan_action(Actions::Pulp3::Repository::CopyContent,
+                                              source_repo, smart_proxy, target_repo,
+                                              filter_ids: filter_ids,
+                                              solve_dependencies: solve_dependencies,
+                                              rpm_filenames: rpm_filenames)
+                end
+
+                plan_action(Actions::Pulp3::Repository::SaveVersion, target_repo, copy_actions.last.output[:pulp_tasks])
+              end
             else
-              target_repo.update_attributes!(version_href: source_repo.version_href)
+              plan_self(source_version_repo_id: source_repositories.first.id,
+                        target_repo_id: target_repo.id)
+              target_repo.update_attributes!(version_href: source_repositories.first.version_href)
             end
           end
 
-          def invoke_external_task
+          def run
+            #this is a 'simple' copy, so just reference version_href
+            target_repo = ::Katello::Repository.find(input[:target_repo_id])
+            source_repo = ::Katello::Repository.find(input[:source_version_repo_id])
+            target_repo.update_attributes!(version_href: source_repo.version_href)
           end
         end
       end

--- a/app/lib/actions/pulp3/repository/copy_content.rb
+++ b/app/lib/actions/pulp3/repository/copy_content.rb
@@ -1,0 +1,19 @@
+module Actions
+  module Pulp3
+    module Repository
+      class CopyContent < Pulp3::AbstractAsyncTask
+        def plan(source_repository, smart_proxy, target_repository, options)
+          plan_self(options.merge(:source_repository_id => source_repository.id,
+                                  :target_repository_id => target_repository.id,
+                                  :smart_proxy_id => smart_proxy.id))
+        end
+
+        def invoke_external_task
+          source = ::Katello::Repository.find(input[:source_repository_id])
+          target = ::Katello::Repository.find(input[:target_repository_id] || input[:target_repository])
+          output[:pulp_tasks] = target.backend_service(smart_proxy).copy_content_for_source(source, input)
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/repository/copy_version.rb
+++ b/app/lib/actions/pulp3/repository/copy_version.rb
@@ -1,0 +1,19 @@
+module Actions
+  module Pulp3
+    module Repository
+      class CopyVersion < Pulp3::AbstractAsyncTask
+        def plan(source_repository, smart_proxy, target_repository)
+          plan_self(:source_repository_id => source_repository.id,
+                    :target_repository_id => target_repository.id,
+                    :smart_proxy_id => smart_proxy.id)
+        end
+
+        def invoke_external_task
+          source = ::Katello::Repository.find(input[:source_repository_id])
+          target = ::Katello::Repository.find(input[:target_repository_id] || input[:target_repository])
+          output[:pulp_tasks] = target.backend_service(smart_proxy).copy_version(source)
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/repository/create_publication.rb
+++ b/app/lib/actions/pulp3/repository/create_publication.rb
@@ -12,7 +12,6 @@ module Actions
 
         def invoke_external_task
           repository = ::Katello::Repository.find(input[:repository_id])
-          smart_proxy = ::SmartProxy.find(input[:smart_proxy_id])
           if repository.publication_href.nil? || input[:options][:force]
             output[:response] = repository.backend_service(smart_proxy).create_publication
           else

--- a/app/lib/actions/pulp3/repository/save_version.rb
+++ b/app/lib/actions/pulp3/repository/save_version.rb
@@ -7,7 +7,7 @@ module Actions
         end
 
         def run
-          version_href = input[:tasks].first[:created_resources].first
+          version_href = input[:tasks].last[:created_resources].first
           repo = ::Katello::Repository.find(input[:repository_id])
           repo_version = repo.backend_service(::SmartProxy.pulp_master).lookup_version version_href
           content_summary = send(:eval, repo_version.content_summary)

--- a/app/services/katello/pulp/pulp_content_unit.rb
+++ b/app/services/katello/pulp/pulp_content_unit.rb
@@ -45,7 +45,9 @@ module Katello
         end
       end
 
-      def self.pulp_units_batch_for_repo(repository, page_size = SETTINGS[:katello][:pulp][:bulk_load_size])
+      def self.pulp_units_batch_for_repo(repository, options = {})
+        page_size = options.fetch(:page_size, SETTINGS[:katello][:pulp][:bulk_load_size])
+
         fields = self.const_get(:PULP_INDEXED_FIELDS) if self.constants.include?(:PULP_INDEXED_FIELDS)
         criteria = {:type_ids => [const_get(:CONTENT_TYPE)], :limit => page_size, :skip => 0}
         criteria[:fields] = {:unit => fields} if fields

--- a/app/services/katello/pulp3/pulp_content_unit.rb
+++ b/app/services/katello/pulp3/pulp_content_unit.rb
@@ -30,9 +30,12 @@ module Katello
         "_href"
       end
 
-      def self.pulp_units_batch_for_repo(repository, page_size = SETTINGS[:katello][:pulp][:bulk_load_size])
+      def self.pulp_units_batch_for_repo(repository, options = {})
+        fetch_identifiers = options.fetch(:fetch_identifiers, false)
+        page_size = options.fetch(:page_size, SETTINGS[:katello][:pulp][:bulk_load_size])
         repository_version_href = repository.version_href
         page_opts = { "page" => 1, repository_version: repository_version_href, page_size: page_size}
+        page_opts[:fields] = '_href' if fetch_identifiers
         response = {}
         Enumerator.new do |yielder|
           loop do

--- a/app/services/katello/pulp3/repository/file.rb
+++ b/app/services/katello/pulp3/repository/file.rb
@@ -36,6 +36,10 @@ module Katello
           PulpFileClient::DistributionsFileApi.new(api_client)
         end
 
+        def copy_content_for_source(source_repository, _options = {})
+          copy_units_by_href(source_repository.files.pluck(:pulp_id))
+        end
+
         def distribution_options(path)
           {
             base_path: path,

--- a/test/actions/pulp3/orchestration/copy_all_units_test.rb
+++ b/test/actions/pulp3/orchestration/copy_all_units_test.rb
@@ -12,7 +12,7 @@ module ::Actions::Pulp3
 
     def test_create
       @repo.update_attributes(:version_href => "my/custom/path")
-      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::CopyAllUnits, @repo, @master, @clone)
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::CopyAllUnits, @repo, @master, [@clone])
       assert_equal @repo.version_href, @clone.version_href
     end
   end

--- a/test/actions/pulp3/orchestration/generate_metadata_test.rb
+++ b/test/actions/pulp3/orchestration/generate_metadata_test.rb
@@ -35,7 +35,7 @@ module ::Actions::Pulp3
       assert_equal 1, Katello::Pulp3::DistributionReference.where(root_repository_id: @clone.root.id).count
       ensure_creatable(@clone, @master)
       ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::GenerateMetadata, @clone, @master, source_repository: @repo)
-      assert_equal @repo.publication_href, @clone.publication_href
+      assert_equal @repo.publication_href, @clone.reload.publication_href
       assert_equal 2, Katello::Pulp3::DistributionReference.where(root_repository_id: @clone.root.id).count
     end
   end

--- a/test/models/docker_tag_test.rb
+++ b/test/models/docker_tag_test.rb
@@ -22,6 +22,7 @@ module Katello
     end
 
     def test_with_uuid
+      @tag.update_attributes(:pulp_id => 'ksdjfkdjkfjdk')
       tag = DockerTag.with_pulp_id(@tag.pulp_id).first
       refute_nil tag
     end

--- a/test/models/file_unit_test.rb
+++ b/test/models/file_unit_test.rb
@@ -38,5 +38,10 @@ module Katello
       assert_includes FileUnit.with_identifiers([@file_one.id]), @file_one
       assert_includes FileUnit.with_identifiers(@file_one.pulp_id), @file_one
     end
+
+    def test_large_query
+      ids = ['href'] * 70_000 + [@file_one.pulp_id]
+      assert_equal 1, FileUnit.with_pulp_id(ids).count
+    end
   end
 end


### PR DESCRIPTION
this adds support for pulp3 for publishing a composite repo
with multiple components that contain the same repository