### PR TITLE
Fixes #27066 - Corrects content source error message

### DIFF
--- a/app/lib/katello/validators/hostgroup_kickstart_repository_validator.rb
+++ b/app/lib/katello/validators/hostgroup_kickstart_repository_validator.rb
@@ -11,7 +11,7 @@ module Katello
         return unless hostgroup.kickstart_repository_id
 
         msg = if hostgroup.content_source.blank?
-                hostgroup.errors.add(:base, _("Please select a content source before assigning a kickstart repository"))
+                _("Please select a content source before assigning a kickstart repository")
               elsif hostgroup.operatingsystem.blank?
                 _("Please select an operating system before assigning a kickstart repository")
               elsif !hostgroup.operatingsystem.is_a?(Redhat)


### PR DESCRIPTION
Fixes #27066 - Clearing content source from hostgroup fails with error to 'unable to flatten recursive array'

On line 14, the error msg was defined to be the errors array itself, with the intended message added. When the msg gets added to the array on line 26, this caused the errors array to become a recursive array.

Thanks to @parthaa for the assistance with this issue!