### PR TITLE
Fixes #27108 - Show hostname in Tasks for Host actions

### DIFF
--- a/app/lib/actions/katello/host/erratum/install.rb
+++ b/app/lib/actions/katello/host/erratum/install.rb
@@ -8,7 +8,7 @@ module Actions
           def plan(host, errata_ids)
             Type! host, ::Host::Managed
 
-            action_subject(host, :errata => errata_ids)
+            action_subject(host, :hostname => host.name, :errata => errata_ids)
             if Setting['erratum_install_batch_size'] && Setting['erratum_install_batch_size'] > 0
               errata_ids.each_slice(Setting['erratum_install_batch_size']) do |errata_ids_batch|
                 plan_action(Pulp::Consumer::ContentInstall,
@@ -26,7 +26,11 @@ module Actions
           end
 
           def humanized_name
-            _("Install erratum")
+            if input.try(:[], :hostname)
+              _("Install erratum for %s") % input[:hostname]
+            else
+              _("Install erratum")
+            end
           end
 
           def humanized_input

--- a/app/lib/actions/katello/host/package/install.rb
+++ b/app/lib/actions/katello/host/package/install.rb
@@ -8,7 +8,7 @@ module Actions
           def plan(host, packages)
             Type! host, ::Host::Managed
 
-            action_subject(host, :packages => packages)
+            action_subject(host, :hostname => host.name, :packages => packages)
             plan_action(Pulp::Consumer::ContentInstall,
                         consumer_uuid: host.content_facet.uuid,
                         type:          'rpm',
@@ -17,7 +17,11 @@ module Actions
           end
 
           def humanized_name
-            _("Install package")
+            if input.try(:[], :hostname)
+              _("Install package for %s") % input[:hostname]
+            else
+              _("Install package")
+            end
           end
 
           def humanized_input

--- a/app/lib/actions/katello/host/package/remove.rb
+++ b/app/lib/actions/katello/host/package/remove.rb
@@ -6,7 +6,7 @@ module Actions
           include Helpers::Presenter
 
           def plan(host, packages)
-            action_subject(host, :packages => packages)
+            action_subject(host, :hostname => host.name, :packages => packages)
             plan_action(Pulp::Consumer::ContentUninstall,
                         consumer_uuid: host.content_facet.uuid,
                         type:          'rpm',
@@ -15,7 +15,11 @@ module Actions
           end
 
           def humanized_name
-            _("Remove package")
+            if input.try(:[], :hostname)
+              _("Remove package for %s") % input[:hostname]
+            else
+              _("Remove package")
+            end
           end
 
           def humanized_input

--- a/app/lib/actions/katello/host/package/update.rb
+++ b/app/lib/actions/katello/host/package/update.rb
@@ -8,7 +8,7 @@ module Actions
           def plan(host, packages)
             Type! host, ::Host::Managed
 
-            action_subject(host, :packages => packages)
+            action_subject(host, :hostname => host.name, :packages => packages)
             plan_action(Pulp::Consumer::ContentUpdate,
                         consumer_uuid: host.content_facet.uuid,
                         type:          'rpm',
@@ -17,7 +17,11 @@ module Actions
           end
 
           def humanized_name
-            _("Update package")
+            if input.try(:[], :hostname)
+              _("Update package for %s") % input[:hostname]
+            else
+              _("Update package")
+            end
           end
 
           def humanized_input

--- a/test/actions/katello/host/erratum_test.rb
+++ b/test/actions/katello/host/erratum_test.rb
@@ -7,12 +7,16 @@ module ::Actions::Katello::Host::Erratum
 
     let(:uuid) { 'uuid' }
     let(:content_facet) { mock('a_system', uuid: uuid).mimic!(::Katello::Host::ContentFacet) }
-    let(:host) { mock('a_host', content_facet: content_facet, id: 42).mimic!(::Host::Managed) }
+    let(:host) do
+      host_mock = mock('a_host', content_facet: content_facet, id: 42).mimic!(::Host::Managed)
+      host_mock.stubs('name').returns('foobar')
+      host_mock
+    end
     let(:errata_ids) { %w(RHBA-2014-1234 RHBA-2014-1235 RHBA-2014-1236 RHBA-2014-1237) }
     let(:action) do
       action = create_action action_class
       action.expects(:plan_self)
-      action.stubs(:action_subject).with(host, :errata => errata = %w(RHBA-2014-1234))
+      action.stubs(:action_subject).with(host, :hostname => host.name, :errata => errata = %w(RHBA-2014-1234))
       plan_action action, host, errata
     end
   end
@@ -55,7 +59,7 @@ module ::Actions::Katello::Host::Erratum
 
     it 'plans installs with batching' do
       Setting.stubs(:[]).returns(2)
-      action.stubs(:action_subject).with(host, :errata => errata_ids)
+      action.stubs(:action_subject).with(host, :hostname => host.name, :errata => errata_ids)
       host.stubs(:id).returns(42)
       host.stubs(:content_facet).returns(content_facet)
       content_facet.stubs(:uuid).returns(uuid)

--- a/test/actions/katello/host/package_test.rb
+++ b/test/actions/katello/host/package_test.rb
@@ -6,12 +6,16 @@ module ::Actions::Katello::Host::Package
     include Support::Actions::Fixtures
 
     let(:content_facet) { mock('a_system', uuid: 'uuid').mimic!(::Katello::Host::ContentFacet) }
-    let(:host) { mock('a_host', content_facet: content_facet, id: 42).mimic!(::Host::Managed) }
+    let(:host) do
+      host_mock = mock('a_host', content_facet: content_facet, id: 42).mimic!(::Host::Managed)
+      host_mock.stubs('name').returns('foobar')
+      host_mock
+    end
 
     let(:action) do
       action = create_action action_class
       action.expects(:plan_self)
-      action.stubs(:action_subject).with(host, :packages => packages = %w(vim vi))
+      action.stubs(:action_subject).with(host, :hostname => host.name, :packages => packages = %w(vim vi))
       plan_action action, host, packages
     end
   end


### PR DESCRIPTION
No hostname was logged under **Monitor** > **Tasks** page where Host Actions such as Erratum, Package, Package Group. Task doesn't show on which host the action was excuted. 

With this patch hostname now shows up with an associated action.
