### PR TITLE
Fixes #27100 - Organization and location assginment to global default http proxy.

### DIFF
--- a/app/models/katello/concerns/location_extensions.rb
+++ b/app/models/katello/concerns/location_extensions.rb
@@ -60,10 +60,10 @@ module Katello
       end
 
       def associate_default_http_proxy
-        setting = Setting::Content.where(name: 'content_default_http_proxy').first
+        setting = Setting::Content.find_by(name: 'content_default_http_proxy')
 
         if setting
-          default_proxy = HttpProxy.where(name: setting.value).first
+          default_proxy = HttpProxy.find_by(name: setting.value)
 
           if default_proxy
             default_proxy.locations << self

--- a/app/models/katello/concerns/location_extensions.rb
+++ b/app/models/katello/concerns/location_extensions.rb
@@ -7,6 +7,7 @@ module Katello
         after_initialize :set_default_overrides, :if => :new_record?
         after_save :reset_settings
         before_destroy :assert_deletable
+        after_create :associate_default_http_proxy
       end
 
       def set_default_overrides
@@ -55,6 +56,19 @@ module Katello
           false
         else
           true
+        end
+      end
+
+      def associate_default_http_proxy
+        setting = Setting::Content.where(name: 'content_default_http_proxy').first
+
+        if setting
+          default_proxy = HttpProxy.where(name: setting.value).first
+
+          if default_proxy
+            default_proxy.locations << self
+            default_proxy.save
+          end
         end
       end
 

--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -41,6 +41,8 @@ module Katello
         scoped_search :on => :label, :complete_value => :true
 
         after_create :associate_default_capsule
+        after_create :associate_default_http_proxy
+
         validates_with Validators::KatelloLabelFormatValidator, :attributes => :label
         validates :label, :uniqueness => true
 
@@ -94,6 +96,19 @@ module Katello
         def associate_default_capsule
           smart_proxy = SmartProxy.pulp_master
           smart_proxy.organizations << self if smart_proxy
+        end
+
+        def associate_default_http_proxy
+          setting = Setting::Content.where(name: 'content_default_http_proxy').first
+
+          if setting
+            default_proxy = HttpProxy.where(name: setting.value).first
+
+            if default_proxy
+              default_proxy.organizations << self
+              default_proxy.save
+            end
+          end
         end
 
         def create_anonymous_provider

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -2,6 +2,8 @@ class Setting::Content < Setting
   #rubocop:disable Metrics/MethodLength
   #rubocop:disable Metrics/AbcSize
 
+  after_save :add_organizations_and_locations_if_global_http_proxy
+
   def self.hashify_parameters(parameters)
     Hash[parameters.map { |p| [p, p] }]
   end
@@ -137,6 +139,17 @@ class Setting::Content < Setting
   def self.katello_template_setting_values(name)
     templates = ProvisioningTemplate.where(:template_kind => TemplateKind.where(:name => name))
     templates.each_with_object({}) { |tmpl, hash| hash[tmpl.name] = tmpl.name }
+  end
+
+  def add_organizations_and_locations_if_global_http_proxy
+    if name == 'content_default_http_proxy'
+      proxy = HttpProxy.where(name: value).first
+
+      if proxy
+        proxy.update_attribute(:organizations, Organization.all)
+        proxy.update_attribute(:locations, Location.all)
+      end
+    end
   end
 end
 

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -146,8 +146,8 @@ class Setting::Content < Setting
       proxy = HttpProxy.where(name: value).first
 
       if proxy
-        proxy.update_attribute(:organizations, Organization.all)
-        proxy.update_attribute(:locations, Location.all)
+        proxy.update_attribute(:organizations, Organization.unscoped.all)
+        proxy.update_attribute(:locations, Location.unscoped.all)
       end
     end
   end

--- a/test/models/setting/default_http_proxy_setting_test.rb
+++ b/test/models/setting/default_http_proxy_setting_test.rb
@@ -63,5 +63,31 @@ module Katello
       assert_equal proxy.name, setting.reload.value
       refute_equal new_proxy.name, setting.reload.value
     end
+
+    def test_assigning_setting_associates_all_organizations
+      3.times.each { FactoryBot.create(:organization) }
+      organization_count = Organization.count
+      refute_equal 0, organization_count
+
+      proxy = FactoryBot.create(:http_proxy)
+      assert_equal 0, proxy.organizations.count
+
+      setting = Setting.where(name: @name).first
+      setting.update_attribute(:value, proxy.name)
+      assert_equal organization_count, proxy.organizations.count
+    end
+
+    def test_assigning_setting_associates_all_locations
+      3.times.each { FactoryBot.create(:location) }
+      location_count = Location.count
+      refute_equal 0, location_count
+
+      proxy = FactoryBot.create(:http_proxy)
+      assert_equal 0, proxy.locations.count
+
+      setting = Setting.where(name: @name).first
+      setting.update_attribute(:value, proxy.name)
+      assert_equal location_count, proxy.locations.count
+    end
   end
 end

--- a/test/models/setting/default_http_proxy_setting_test.rb
+++ b/test/models/setting/default_http_proxy_setting_test.rb
@@ -89,5 +89,37 @@ module Katello
       setting.update_attribute(:value, proxy.name)
       assert_equal location_count, proxy.locations.count
     end
+
+    def test_new_organization_is_added_to_current_global_http_proxy
+      proxy = FactoryBot.create(:http_proxy)
+      other_proxy = FactoryBot.create(:http_proxy, name: 'another_proxy')
+      organization = FactoryBot.build(:organization)
+
+      refute_includes proxy.organizations, organization
+      refute_includes other_proxy.organizations, organization
+
+      setting = Setting.where(name: @name).first
+      setting.update_attribute(:value, proxy.name)
+      organization.save
+
+      assert_includes proxy.reload.organizations, organization
+      refute_includes other_proxy.reload.organizations, organization
+    end
+
+    def test_new_location_is_added_to_current_global_http_proxy
+      proxy = FactoryBot.create(:http_proxy)
+      other_proxy = FactoryBot.create(:http_proxy, name: 'another_proxy')
+      location = FactoryBot.build(:location)
+
+      refute_includes proxy.locations, location
+      refute_includes other_proxy.locations, location
+
+      setting = Setting.where(name: @name).first
+      setting.update_attribute(:value, proxy.name)
+      location.save
+
+      assert_includes proxy.reload.locations, location
+      refute_includes other_proxy.reload.locations, location
+    end
   end
 end


### PR DESCRIPTION
This PR adds model AR hooks to assign all organizations and locations to the HttpProxy indicated by the global http proxy Setting value. Additionally, after creating a new Organization or Location, that record is associated with the global default HttpProxy.

Example of how to verify this change from the console:
```[vagrant@centos7-katello-devel foreman]$ bundle exec rails console
...
Loading development environment (Rails 5.2.1)
Failed to load console gems, starting anyway
irb(main):002:0> Setting::Content.where(name: 'content_default_http_proxy').first
=> #<Setting::Content id: 11, name: "content_default_http_proxy", value: "--- a_new_proxy\n...\n", description: "Default HTTP Proxy for syncing content", category: "Setting::Content", settings_type: nil, default: "--- \n...", created_at: "2019-06-18 18:17:15", updated_at: "2019-06-24 14:53:21", full_name: "Default http proxy", encrypted: false>
irb(main):003:0> setting = Setting::Content.where(name: 'content_default_http_proxy').first
=> #<Setting::Content id: 11, name: "content_default_http_proxy", value: "--- a_new_proxy\n...\n", description: "Default HTTP Proxy for syncing content", category: "Setting::Content", settings_type: nil, default: "--- \n...", created_at: "2019-06-18 18:17:15", updated_at: "2019-06-24 14:53:21", full_name: "Default http proxy", encrypted: false>
irb(main):008:0> default_proxy = HttpProxy.where(name: setting.value).first
=> #<HttpProxy id: 52, name: "a_new_proxy", url: "http://192.168.23.131", username: "admin", password: "redhat">
=> #<ActiveRecord::Associations::CollectionProxy [#<Organization id: 1, name: "Default Organization", type: "Organization", created_at: "2019-06-18 18:17:27", updated_at: "2019-06-18 18:17:27", ignore_types: [], description: nil, label: "Default_Organization", ancestry: nil, title: "Default Organization", manifest_refreshed_at: nil>]>
```
Then, create a new Organization, and reload that default proxy.
```
irb(main):010:0> default_proxy.organizations
=> #<ActiveRecord::Associations::CollectionProxy [#<Organization id: 1, name: "Default Organization", type: "Organization", created_at: "2019-06-18 18:17:27", updated_at: "2019-06-18 18:17:27", ignore_types: [], description: nil, label: "Default_Organization", ancestry: nil, title: "Default Organization", manifest_refreshed_at: nil>, #<Organization id: 6, name: "Test4155", type: "Organization", created_at: "2019-06-25 13:28:56", updated_at: "2019-06-25 13:28:56", ignore_types: [], description: "", label: "Test4155", ancestry: nil, title: "Test4155", manifest_refreshed_at: nil>]>
```
Note that the new organization is added by default to the global default HttpProxy.

Now, look at an HttpProxy that is not the global default http proxy.
```
irb(main):011:0> HttpProxy.first
=> #<HttpProxy id: 1, name: "testXX", url: "http://192.168.121.245:8888", username: "admin", password: "">
irb(main):012:0> HttpProxy.first.organizations
=> #<ActiveRecord::Associations::CollectionProxy [#<Organization id: 1, name: "Default Organization", type: "Organization", created_at: "2019-06-18 18:17:27", updated_at: "2019-06-18 18:17:27", ignore_types: [], description: nil, label: "Default_Organization", ancestry: nil, title: "Default Organization", manifest_refreshed_at: nil>]>
irb(main):013:0> HttpProxy.first.locations
=> #<ActiveRecord::Associations::CollectionProxy [#<Location id: 2, name: "Default Location", type: "Location", created_at: "2019-06-18 18:17:27", updated_at: "2019-06-18 18:17:27", ignore_types: ["ProvisioningTemplate", "Hostgroup"], description: nil, label: nil, ancestry: nil, title: "Default Location", manifest_refreshed_at: nil>]>
```
Assign the global default http proxy setting to that proxy, and then observe the organizations and locations.
```
irb(main):014:0> HttpProxy.first.organizations
=> #<ActiveRecord::Associations::CollectionProxy [#<Organization id: 1, name: "Default Organization", type: "Organization", created_at: "2019-06-18 18:17:27", updated_at: "2019-06-18 18:17:27", ignore_types: [], description: nil, label: "Default_Organization", ancestry: nil, title: "Default Organization", manifest_refreshed_at: nil>, #<Organization id: 6, name: "Test4155", type: "Organization", created_at: "2019-06-25 13:28:56", updated_at: "2019-06-25 13:28:56", ignore_types: [], description: "", label: "Test4155", ancestry: nil, title: "Test4155", manifest_refreshed_at: nil>]>
irb(main):015:0> HttpProxy.first.locations
=> #<ActiveRecord::Associations::CollectionProxy [#<Location id: 2, name: "Default Location", type: "Location", created_at: "2019-06-18 18:17:27", updated_at: "2019-06-18 18:17:27", ignore_types: ["ProvisioningTemplate", "Hostgroup"], description: nil, label: nil, ancestry: nil, title: "Default Location", manifest_refreshed_at: nil>, #<Location id: 7, name: "Test4155", type: "Location", created_at: "2019-06-25 13:36:18", updated_at: "2019-06-25 13:36:18", ignore_types: ["ProvisioningTemplate", "Hostgroup"], description: "", label: nil, ancestry: nil, title: "Test4155", manifest_refreshed_at: nil>]>
irb(main):016:0> 
```