### PR TITLE
Fixes #27121 - migrate proxy usage to global content proxy

### DIFF
--- a/app/lib/actions/katello/repository/discover.rb
+++ b/app/lib/actions/katello/repository/discover.rb
@@ -53,16 +53,16 @@ module Actions
         end
 
         def proxy
-          proxy = {}
-
-          if (config = SETTINGS[:katello][:cdn_proxy])
-            proxy[:proxy_host] = URI.parse(config[:host]).host if config.key?(:host)
-            proxy[:proxy_port] = config[:port] if config.key?(:port)
-            proxy[:proxy_user] = config[:user] if config.key?(:user)
-            proxy[:proxy_password] = config[:password] if config.key?(:password)
+          proxy_details = {}
+          if (proxy = ::HttpProxy.default_global_content_proxy)
+            uri = URI(proxy.url)
+            proxy_details[:proxy_host] = "#{uri.host}#{uri.path}"
+            proxy_details[:proxy_port] = uri.port
+            proxy_details[:proxy_user] = proxy.username
+            proxy_details[:proxy_password] = proxy.password
           end
 
-          proxy
+          proxy_details
         end
       end
     end

--- a/app/lib/katello/util/cdn_var_substitutor.rb
+++ b/app/lib/katello/util/cdn_var_substitutor.rb
@@ -68,9 +68,6 @@ module Katello
         futures.each do |future|
           begin
             resolved << future.value
-          rescue StandardError => e
-            Rails.logger.error("Error Recieved: #{e.to_s}")
-            Rails.logger.error("Error Recieved: #{e.backtrace.join("\n")}")
           end
         end
 

--- a/app/lib/katello/util/http_proxy.rb
+++ b/app/lib/katello/util/http_proxy.rb
@@ -11,29 +11,29 @@ module Katello
           scheme = 'proxys' if proxy_scheme == 'https'
 
           uri = URI("#{scheme}://#{proxy_host}:#{proxy_port}")
-          if proxy_config && proxy_config[:user]
-            uri.user = CGI.escape(proxy_config[:user])
-            uri.password = CGI.escape(proxy_config[:password])
+          if proxy && proxy.username.present?
+            uri.user = CGI.escape(proxy.username)
+            uri.password = CGI.escape(proxy.password)
           end
 
           uri.to_s
         end
       end
 
-      def proxy_config
-        SETTINGS[:katello][:cdn_proxy]
+      def proxy
+        ::HttpProxy.default_global_content_proxy
       end
 
       def proxy_host
-        proxy_config && URI.parse(proxy_config[:host]).host
+        URI(proxy.url).host
       end
 
       def proxy_scheme
-        proxy_config && URI.parse(proxy_config[:host]).scheme
+        URI(proxy.url).scheme
       end
 
       def proxy_port
-        proxy_config && proxy_config[:port]
+        URI(proxy.url).port
       end
     end # HttpProxy
   end # Util

--- a/app/models/katello/concerns/http_proxy_extensions.rb
+++ b/app/models/katello/concerns/http_proxy_extensions.rb
@@ -5,6 +5,12 @@ module Katello
 
       included do
         after_save :update_default_proxy_setting
+
+        def self.default_global_content_proxy
+          if Setting[:content_default_http_proxy]
+            HttpProxy.unscoped.find_by(name: Setting[:content_default_http_proxy])
+          end
+        end
       end
 
       def update_default_proxy_setting

--- a/app/models/katello/concerns/location_extensions.rb
+++ b/app/models/katello/concerns/location_extensions.rb
@@ -60,15 +60,9 @@ module Katello
       end
 
       def associate_default_http_proxy
-        setting = Setting::Content.find_by(name: 'content_default_http_proxy')
-
-        if setting
-          default_proxy = HttpProxy.find_by(name: setting.value)
-
-          if default_proxy
-            default_proxy.locations << self
-            default_proxy.save
-          end
+        if (default_proxy = ::HttpProxy.default_global_content_proxy)
+          default_proxy.locations << self
+          default_proxy.save
         end
       end
 

--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -99,15 +99,9 @@ module Katello
         end
 
         def associate_default_http_proxy
-          setting = Setting::Content.where(name: 'content_default_http_proxy').first
-
-          if setting
-            default_proxy = HttpProxy.where(name: setting.value).first
-
-            if default_proxy
-              default_proxy.organizations << self
-              default_proxy.save
-            end
+          if (default_proxy = ::HttpProxy.default_global_content_proxy)
+            default_proxy.organizations << self
+            default_proxy.save
           end
         end
 

--- a/test/lib/util/http_proxy_test.rb
+++ b/test/lib/util/http_proxy_test.rb
@@ -5,21 +5,20 @@ module Katello
     class HttpProxyTest < ActiveSupport::TestCase
       include Katello::Util::HttpProxy
 
+      def setup_default_proxy(url, user, pass)
+        proxy = ::HttpProxy.create!(:url => url, :username => user, :password => pass, :name => url)
+        Setting[:content_default_http_proxy] = proxy.name
+      end
+
       def test_handles_no_username_test
-        SETTINGS[:katello][:cdn_proxy] = {
-          host: 'http://foobar.com',
-          username: nil,
-          password: nil
-        }
+        setup_default_proxy('http://foobar.com', nil, nil)
+
         assert_equal 'proxy://foobar.com', proxy_uri
       end
 
       def test_properly_escapes_username
-        SETTINGS[:katello][:cdn_proxy] = {
-          host: 'http://foobar.com',
-          user: 'red!hat',
-          password: 'red@hat'
-        }
+        setup_default_proxy('http://foobar.com', 'red!hat', 'red@hat')
+
         assert_equal 'proxy://red%21hat:red%40hat@foobar.com', proxy_uri
 
         uri = URI.parse(proxy_uri)


### PR DESCRIPTION
This migrates the following to use the globally set
contetn proxy:

* Repository Discovery
* Manifest actions (refresh, entitlement change)
* Redhat Repository enablement