### PR TITLE
[WIP] Add cypress test for content credentials page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ node_modules
 npm-debug.log
 /foreman/
 package-lock.json
+test/cypress/videos
+test/cypress/screenshots

--- a/cypress.json
+++ b/cypress.json
@@ -1,0 +1,11 @@
+{
+  "baseUrl": "https://localhost",
+  "fixturesFolder": "test/cypress/fixtures",
+  "integrationFolder": "test/cypress/integration",
+  "pluginsFile": "test/cypress/plugins/index.js",
+  "screenshotsFolder": "test/cypress/screenshots",
+  "videosFolder": "test/cypress/videos",
+  "supportFile": "test/cypress/support/index.js",
+  "defaultCommandTimeout": 10000,
+  "watchForFileChanges": false
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.24.1",
     "coveralls": "^3.0.0",
+    "cypress": "^3.3.1",
     "enzyme": "^3.4.0",
     "enzyme-adapter-react-16": "^1.4.0",
     "enzyme-to-json": "^3.1.2",

--- a/test/cypress/fixtures/content_credentials/details.json
+++ b/test/cypress/fixtures/content_credentials/details.json
@@ -1,0 +1,27 @@
+{
+  "name": "my gpg key",
+  "content_type": "gpg_key",
+  "content": "super secure key",
+  "id": 29,
+  "organization_id": 2,
+  "organization": {
+    "name": "Default Organization",
+    "label": "Default_Organization",
+    "id": 2
+  },
+  "created_at": "2019-06-24 15:42:14 -0400",
+  "updated_at": "2019-06-24 15:42:14 -0400",
+  "gpg_key_products": [],
+  "gpg_key_repos": [],
+  "ssl_ca_products": [],
+  "ssl_ca_root_repos": [],
+  "ssl_client_products": [],
+  "ssl_client_root_repos": [],
+  "ssl_key_products": [],
+  "ssl_key_root_repos": [],
+  "permissions": {
+    "view_content_credenials": true,
+    "edit_content_credenials": true,
+    "destroy_content_credenials": true
+  }
+}

--- a/test/cypress/fixtures/content_credentials/list.json
+++ b/test/cypress/fixtures/content_credentials/list.json
@@ -1,0 +1,41 @@
+{
+  "total": 1,
+  "subtotal": 1,
+  "page": 1,
+  "per_page": 20,
+  "error": null,
+  "search": null,
+  "sort": {
+    "by": "name",
+    "order": "asc"
+  },
+  "results": [
+    {
+      "name": "my gpg key",
+      "content_type": "gpg_key",
+      "content": "super secure key",
+      "id": 35,
+      "organization_id": 2,
+      "organization": {
+        "name": "Default Organization",
+        "label": "Default_Organization",
+        "id": 2
+      },
+      "created_at": "2019-06-25 01:23:41 UTC",
+      "updated_at": "2019-06-25 01:23:41 UTC",
+      "gpg_key_products": [],
+      "gpg_key_repos": [],
+      "ssl_ca_products": [],
+      "ssl_ca_root_repos": [],
+      "ssl_client_products": [],
+      "ssl_client_root_repos": [],
+      "ssl_key_products": [],
+      "ssl_key_root_repos": [],
+      "permissions": {
+        "view_content_credenials": true,
+        "edit_content_credenials": true,
+        "destroy_content_credenials": true
+      }
+    }
+  ]
+}

--- a/test/cypress/fixtures/example.json
+++ b/test/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/test/cypress/integration/content_credentials_spec.js
+++ b/test/cypress/integration/content_credentials_spec.js
@@ -1,0 +1,81 @@
+describe('Content Credentials', () => {
+  before(() => {
+    cy.login();
+  })
+
+  beforeEach(() => {
+    cy.fixture('content_credentials/details').as('contentCredDetails')
+    Cypress.Cookies.preserveOnce('_session_id', 'remember_token')
+  })
+
+  // using function() in order to use aliased variables
+  it('Visits top level page', function() {
+    cy.visit("/content_credentials");
+    cy.get('h2').contains('Content Credentials');
+  })
+
+  it('Can create new content credential', function() {
+   cy.visit("/content_credentials/new");
+   cy.get("@contentCredDetails").then(details => {
+      cy.get('[name="name"]').type(details.name);
+      cy.get('[name="content"]').type(details.content);
+    });
+    cy.get('[name="content_type"]').select("GPG Key");
+    // We don't actually submit the form because it doesn't submit as an XHR request.
+    // Only XHR requests are able to be stubbed in cypress.
+    cy.contains('Save').should('be.visible');
+  })
+
+  it('Can view the details for a content credential', function() {
+    // to re-record the response, use the following, adjusting the ids as necessary:
+    // cy.request("katello/api/v2/content_credentials/29?organization_id=2").then(response => {
+    //   cy.writeFile("test/cypress/fixtures/content_credentials/details.json", response.body);
+    // })
+
+    cy.server();
+    cy.route(/katello\/api\/v2\/content_credentials\/\d+/, "@contentCredDetails")
+    cy.visit(`/content_credentials/29`);
+
+    cy.contains('Details').should('be.visible');
+    cy.contains('GPG Key').should('be.visible');
+    cy.get("@contentCredDetails").then(details => {
+      cy.contains(details.name).should('be.visible');
+      cy.contains(details.content).should('be.visible');
+    });
+
+    // Products tab
+    cy.get('a').get('[ui-sref="content-credential.products"]')
+               .contains("Products")
+               .click();
+
+    cy.get('table').within(() => {
+      cy.get('span').contains('Name').should('be.visible');
+      cy.get('span').contains('Used as').should('be.visible');
+      cy.get('span').contains('Repositories').should('be.visible');
+    });
+    
+    // Repositories tab
+    cy.get('a').get('[ui-sref="content-credential.repositories"]')
+               .contains("Repositories")
+               .click();
+
+    cy.get('table').within(() => {
+      cy.get('span').contains('Name').should('be.visible');
+      cy.get('span').contains('Product').should('be.visible');
+      cy.get('span').contains('Used as').should('be.visible');
+    });
+  })
+
+  it('Can view and delete content credential', function() {
+    cy.server();
+    cy.route("delete", /katello\/api\/v2\/content_credentials\/\d+/, {});
+    cy.route("katello/api/v2/content_credentials", "fixture:content_credentials/list");
+
+    cy.visit("/content_credentials");
+    cy.get("@contentCredDetails").then(details => {
+      cy.contains(details.name).click();
+    });
+    cy.contains("Remove Content Credential").click();
+    cy.get("button").contains("Remove").click();
+  })
+})

--- a/test/cypress/integration/login_spec.js
+++ b/test/cypress/integration/login_spec.js
@@ -1,0 +1,13 @@
+describe('Login', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('User is logged in', () => {
+    cy.visit("/")
+    cy.contains("Welcome").should("not.be.visible");
+    cy.contains("Default Organization").should('be.visible');
+    cy.contains("Default Location").should('be.visible');
+  });
+});
+

--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -1,0 +1,17 @@
+// ***********************************************************
+// This example plugins/index.js can be used to load plugins
+//
+// You can change the location of this file or turn off loading
+// the plugins file with the 'pluginsFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/plugins-guide
+// ***********************************************************
+
+// This function is called when a project is opened or re-opened (e.g. due to
+// the project's config changing)
+
+module.exports = (on, config) => {
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
+}

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -1,0 +1,51 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add("login", (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This is will overwrite an existing command --
+// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+Cypress.Commands.add('login', (username = "admin", password = "changeme") => {
+  let authToken;
+
+  // Prevent issues during repeat test runs
+  cy.clearCookies();
+  // Can't get auth token as JSON so we visit the page and grab from the meta tag
+  cy.visit("/");
+  cy.get('head meta[name="csrf-token"]').then(meta_tag => {
+    authToken = meta_tag[0].content;
+
+    // Submit the login as network request to save time
+    cy.request({
+      url: "users/login",
+      method: "POST",
+      form: true,
+      body: {
+        authenticity_token: authToken,
+        login: {
+          login: username,
+          password, password
+        }
+     }
+    });
+  });
+});

--- a/test/cypress/support/index.js
+++ b/test/cypress/support/index.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')


### PR DESCRIPTION
Adds [cypress](cypress.io) to do end to end UI testing on Katello. This commit starts out with the content credentials page.

We'll use it in headless mode so it can run in the VM, but it can be used with the GUI too.

[link to community post explaining more about cypress and my proposal](https://community.theforeman.org/t/rfc-integration-tests-end-to-end-tests/12142/17?u=john_mitsch)

To use, do the following on a Katello VM:
- `npm install --save-dev cypress`
- `yum install xorg-x11-server-Xvfb.x86_64 gtk3 libXScrnSaver-devel GConf2-devel`
- `./node_modules/.bin/cypress run`
- see test output for video and screenshot location

You will need to start the server that it runs against. It runs fastest with [assets precompiled](https://github.com/theforeman/forklift/blob/master/docs/development.md#run-the-rails-server-without-a-webpack-server-running)

Best practices and tips for using cypress (I'll add this to docs somewhere)
- Stub all server requests, use cypress for front-end testing only
- Log in once in `before()` block and then store the session for each test. Cypress.Cookies.preserveOnce('_session_id', 'remember_token')
- You can debug cypress by using `DEBUG=cypress:*` prepended before the cypress command