### PR TITLE
Fixes #26821 - move cp owner delete to finalize phase

### DIFF
--- a/app/lib/actions/candlepin/owner/destroy.rb
+++ b/app/lib/actions/candlepin/owner/destroy.rb
@@ -6,7 +6,7 @@ module Actions
           param :label
         end
 
-        def run
+        def finalize
           output[:response] = ::Katello::Resources::Candlepin::Owner.destroy(input[:label])
         end
       end

--- a/app/lib/actions/katello/organization/destroy.rb
+++ b/app/lib/actions/katello/organization/destroy.rb
@@ -16,7 +16,6 @@ module Actions
             remove_products(organization)
             remove_providers(organization)
             remove_environments(organization)
-            destroy_contents(organization)
             plan_self
             plan_action(Candlepin::Owner::Destroy, label: organization.label) if ::SETTINGS[:katello][:use_cp]
           end
@@ -89,16 +88,6 @@ module Actions
           organization.default_content_view.tap do |view|
             view.content_view_environments.each { |cve| remove_content_view_environment(cve) }
             plan_action(ContentView::Destroy, organization.default_content_view, :check_ready_to_destroy => false, :organization_destroy => true)
-          end
-        end
-
-        def destroy_contents(organization)
-          repositories = organization.products.map(&:repositories).flatten
-          content_ids = repositories.map(&:content_id).uniq
-          content_ids.each do |content_id|
-            plan_action(Candlepin::Product::ContentDestroy,
-                        owner: organization.label,
-                        content_id: content_id)
           end
         end
       end

--- a/test/actions/katello/organization_test.rb
+++ b/test/actions/katello/organization_test.rb
@@ -72,7 +72,7 @@ module ::Actions::Katello::Organization
 
       organization.expects(:label).returns("ACME_Corporation")
       organization.expects(:validate_destroy).returns([])
-      organization.expects(:products).twice.returns([])
+      organization.expects(:products).returns([])
       where_clause = mock
       where_clause.expects(:where).returns([])
       ::Host.expects(:unscoped).returns(where_clause)


### PR DESCRIPTION
We are currently hitting a deadlock sometimes while
deleting an organization.  The current understanding is that
the following is occuring:

1. in run phase: delete org in candlepin
2. in finalize: delete product AR models and all their associations
3. in finalize: delete the org AR model and all their associations

As part of 1), messages are sent to the candlepin event queue that are
picked up and handled asyncronously.  This asyncronous task will
try to delete a specific pool and if that pools product is being deleted
in 2) there is the possibility of a deadlock.

To work around this, lets reorder things a little to be like this:

1.  in finalize phase: delete the org in katello
2.  in finalize phase delete the org in candlepin

this delays all the messages about pool deletion until after
the AR relations are destroyed

In addition i hit an error trying to delete RH content in candlepin
'content ID is locked'.  This happens when trying to delete rh content
from manifests.  With candlepin 2.0 we don't need to remove the content
since the owner delete will handle it