### PR TITLE
Fixes #27194 - Run CV auto-publish serially

### DIFF
--- a/app/models/katello/content_view.rb
+++ b/app/models/katello/content_view.rb
@@ -318,6 +318,10 @@ module Katello
       components.select { |component| component.repositories.where(:library_instance => library_instance).any? }
     end
 
+    def auto_publish_components
+      component_composites.where(latest: true).joins(:composite_content_view).where(self.class.table_name => {auto_publish: true})
+    end
+
     def publish_repositories
       repositories = composite? ? repositories_to_publish_by_library_instance.values : repositories_to_publish
       repositories.each do |repos|

--- a/app/models/katello/event.rb
+++ b/app/models/katello/event.rb
@@ -4,6 +4,8 @@ module Katello
     # Note: Do not use active record call backs or dependent references on this class
     # Direct deletes are made in EventQueue#clear_events (instead of destroys).
 
+    serialize :metadata, Hash
+
     def validate_event_type
       unless EventQueue.supported_event_types.include?(self.event_type)
         errors.add(:event_type, _("Unsupported event type %{type}. Supported: %{types}") %

--- a/app/models/katello/events/auto_publish_composite_view.rb
+++ b/app/models/katello/events/auto_publish_composite_view.rb
@@ -1,0 +1,41 @@
+module Katello
+  module Events
+    class AutoPublishCompositeView
+      EVENT_TYPE = 'auto_publish_composite_view'.freeze
+
+      attr_reader :composite_view
+      attr_accessor :metadata, :retry
+
+      def self.retry_seconds
+        180
+      end
+
+      def initialize(composite_view_id)
+        @composite_view = ::Katello::ContentView.find_by_id(composite_view_id)
+        Rails.logger.warn "Content View not found for ID #{object_id}" if @composite_view.nil?
+        yield(self) if block_given?
+      end
+
+      def run
+        return unless composite_view
+
+        begin
+          ForemanTasks.async_task(::Actions::Katello::ContentView::Publish,
+                              composite_view,
+                              metadata[:description],
+                              triggered_by: metadata[:version_id])
+        rescue => e
+          self.retry = true if e.is_a?(ForemanTasks::Lock::LockConflict)
+          deliver_failure_notification
+          raise e
+        end
+      end
+
+      private
+
+      def deliver_failure_notification
+        ::Katello::UINotifications::ContentView::AutoPublishFailure.deliver!(composite_view)
+      end
+    end
+  end
+end

--- a/app/services/katello/event_queue.rb
+++ b/app/services/katello/event_queue.rb
@@ -50,7 +50,7 @@ module Katello
     end
 
     def self.reschedule_event(event)
-      return if event.created_at <= MAX_RETRY_AGE.ago
+      return :expired if event.created_at <= MAX_RETRY_AGE.ago
 
       retry_seconds = event_class(event.event_type).try(:retry_seconds)
       if retry_seconds

--- a/db/migrate/20190702182118_add_metadata_process_after_to_katello_event.rb
+++ b/db/migrate/20190702182118_add_metadata_process_after_to_katello_event.rb
@@ -1,0 +1,6 @@
+class AddMetadataProcessAfterToKatelloEvent < ActiveRecord::Migration[5.2]
+  def change
+    add_column :katello_events, :metadata, :text
+    add_column :katello_events, :process_after, :datetime
+  end
+end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -196,6 +196,7 @@ module Katello
 
       Katello::EventQueue.register_event(Katello::Events::ImportHostApplicability::EVENT_TYPE, Katello::Events::ImportHostApplicability)
       Katello::EventQueue.register_event(Katello::Events::ImportPool::EVENT_TYPE, Katello::Events::ImportPool)
+      Katello::EventQueue.register_event(Katello::Events::AutoPublishCompositeView::EVENT_TYPE, Katello::Events::AutoPublishCompositeView)
 
       ::HostsController.class_eval do
         helper Katello::Concerns::HostsAndHostgroupsHelperExtensions

--- a/test/factories/content_view_component_factory.rb
+++ b/test/factories/content_view_component_factory.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :katello_content_view_component, :class => Katello::ContentViewComponent do
+  end
+end

--- a/test/fixtures/models/katello_content_views.yml
+++ b/test/fixtures/models/katello_content_views.yml
@@ -90,6 +90,7 @@ composite_view:
   label:          composite_view
   composite:      true
   default:        false
+  auto_publish:   true
   next_version:   2
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>

--- a/test/models/events/auto_publish_composite_view_test.rb
+++ b/test/models/events/auto_publish_composite_view_test.rb
@@ -1,0 +1,37 @@
+require 'katello_test_helper'
+
+module Katello
+  module Events
+    class AutoPublishCompositeViewTest < ActiveSupport::TestCase
+      let(:composite_view) { katello_content_views(:composite_view) }
+
+      def test_run_with_publish
+        ForemanTasks.expects(:async_task)
+
+        event = AutoPublishCompositeView.new(composite_view.id) do |instance|
+          instance.metadata = {}
+        end
+
+        event.run
+      end
+
+      def test_run_with_error
+        instance = AutoPublishCompositeView.new(composite_view.id)
+
+        assert_raises(StandardError) { instance.run }
+        refute instance.retry
+      end
+
+      def test_run_with_lock_error
+        ForemanTasks.expects(:async_task).raises(ForemanTasks::Lock::LockConflict.new(mock(name: 'foo'), []))
+
+        instance = AutoPublishCompositeView.new(composite_view.id) do |event|
+          event.metadata = {}
+        end
+
+        assert_raises(ForemanTasks::Lock::LockConflict) { instance.run }
+        assert instance.retry
+      end
+    end
+  end
+end

--- a/test/services/katello/event_queue_test.rb
+++ b/test/services/katello/event_queue_test.rb
@@ -170,7 +170,7 @@ module Katello
       event = EventQueue.next_event
 
       MockEvent.stubs(:retry_seconds)
-      refute Katello::EventQueue.reschedule_event(event)
+      assert_nil Katello::EventQueue.reschedule_event(event)
       event.reload
 
       assert event.in_progress
@@ -181,7 +181,7 @@ module Katello
       event = EventQueue.push_event(@type, 1)
 
       travel_to 7.hours.from_now do
-        refute Katello::EventQueue.reschedule_event(event)
+        assert_equal :expired, Katello::EventQueue.reschedule_event(event)
       end
     end
   end

--- a/test/services/katello/event_queue_test.rb
+++ b/test/services/katello/event_queue_test.rb
@@ -93,20 +93,6 @@ module Katello
       assert_empty Event.all
     end
 
-    def test_clear_events_expired
-      event = EventQueue.push_event(@type, 1)
-
-      EventQueue.clear_events(@type, 1, event.created_at)
-
-      assert Katello::Event.find(event.id)
-
-      travel_to 7.hours.from_now do
-        EventQueue.clear_events(@type, 1, event.created_at)
-
-        refute Katello::Event.find_by_id(event.id)
-      end
-    end
-
     def test_event_class
       assert_equal MockEvent, EventQueue.event_class(@type)
     end
@@ -189,6 +175,14 @@ module Katello
 
       assert event.in_progress
       refute event.process_after
+    end
+
+    def test_reschedule_event_expired
+      event = EventQueue.push_event(@type, 1)
+
+      travel_to 7.hours.from_now do
+        refute Katello::EventQueue.reschedule_event(event)
+      end
     end
   end
 end

--- a/test/services/katello/event_queue_test.rb
+++ b/test/services/katello/event_queue_test.rb
@@ -2,8 +2,49 @@ require 'katello_test_helper'
 
 module Katello
   class EventQueueTest < ActiveSupport::TestCase
+    class MockEvent
+      EVENT_TYPE = 'mock_event'.freeze
+      def initialize(*)
+      end
+
+      def self.retry_seconds
+        300
+      end
+    end
+
+    class MockEventWithMetadata
+      EVENT_TYPE = 'mock_event_with_metadata'.freeze
+      attr_accessor :metadata
+
+      def initialize(*)
+        yield(self) if block_given?
+      end
+    end
+
     def setup
-      @type = Katello::Events::ImportHostApplicability::EVENT_TYPE
+      @type = MockEvent::EVENT_TYPE
+      EventQueue.register_event(@type, MockEvent)
+      EventQueue.register_event(MockEventWithMetadata::EVENT_TYPE, MockEventWithMetadata)
+    end
+
+    def test_create_instance
+      event = EventQueue.push_event(@type, 1)
+
+      instance = EventQueue.create_instance(event)
+
+      assert instance.is_a?(MockEvent)
+    end
+
+    def test_create_instance_with_metadata
+      metadata = { admin_password: 'sekret' }
+      event = EventQueue.push_event(MockEventWithMetadata::EVENT_TYPE, 1) do |attrs|
+        attrs[:metadata] = metadata
+      end
+
+      instance = EventQueue.create_instance(event)
+
+      assert instance.is_a?(MockEventWithMetadata)
+      assert_equal metadata, instance.metadata
     end
 
     def test_clear_events_only_deletes_last
@@ -34,8 +75,40 @@ module Katello
       assert_empty Event.all
     end
 
+    def test_clear_events_delete_process_after
+      # Given 2 events E1, E2
+      # E1 fails and is rescheduled for later
+      # E2 is received, runs successfully
+      # E1 should also be removed to avoid redundant run
+
+      EventQueue.push_event(@type, 1)
+      failed_event = EventQueue.next_event
+      EventQueue.reschedule_event(failed_event)
+
+      EventQueue.push_event(@type, 1)
+      success_event = EventQueue.next_event
+
+      EventQueue.clear_events(@type, 1, success_event.created_at)
+
+      assert_empty Event.all
+    end
+
+    def test_clear_events_expired
+      event = EventQueue.push_event(@type, 1)
+
+      EventQueue.clear_events(@type, 1, event.created_at)
+
+      assert Katello::Event.find(event.id)
+
+      travel_to 7.hours.from_now do
+        EventQueue.clear_events(@type, 1, event.created_at)
+
+        refute Katello::Event.find_by_id(event.id)
+      end
+    end
+
     def test_event_class
-      assert_equal Katello::Events::ImportHostApplicability, EventQueue.event_class(@type)
+      assert_equal MockEvent, EventQueue.event_class(@type)
     end
 
     def test_supported_event_types
@@ -63,6 +136,59 @@ module Katello
 
       EventQueue.push_event('foo', 1)
       refute_nil EventQueue.next_event
+    end
+
+    def test_next_event_process_after
+      event = EventQueue.push_event(@type, 1) do |attrs|
+        attrs[:process_after] = Time.zone.now + 5.minutes
+      end
+
+      # next event should not return an event with a process_after date > now
+      assert_nil EventQueue.next_event
+
+      # event will be returned when it is time to run it
+      travel_to 6.minutes.from_now do
+        assert_equal event, EventQueue.next_event
+      end
+    end
+
+    def test_mark_in_progress
+      # marking a new event received while there are rescheduled
+      # events for the same will mark both in progress
+      urgent_event = EventQueue.push_event(@type, 1)
+      deferred_event = EventQueue.push_event(@type, 1) do |attrs|
+        attrs[:process_after] = Time.zone.now + 5.minutes
+      end
+
+      EventQueue.mark_in_progress(urgent_event)
+      urgent_event.reload
+      deferred_event.reload
+
+      assert urgent_event.in_progress
+      assert deferred_event.in_progress
+    end
+
+    def test_reschedule_event
+      EventQueue.push_event(@type, 1)
+      event = Katello::EventQueue.next_event
+
+      assert Katello::EventQueue.reschedule_event(event)
+      event.reload
+
+      refute event.in_progress
+      assert event.process_after
+    end
+
+    def test_reschedule_event_no_retry
+      EventQueue.push_event(@type, 1)
+      event = EventQueue.next_event
+
+      MockEvent.stubs(:retry_seconds)
+      refute Katello::EventQueue.reschedule_event(event)
+      event.reload
+
+      assert event.in_progress
+      refute event.process_after
     end
   end
 end


### PR DESCRIPTION
This PR fixes the locking problems that occur when component content view publish result in multiple publishes for the same composite view coming in at/around the same time.

I would have liked to go with a more dynflow-y or foreman-tasks focused solution but what I came up with using Polling module brought in a race condition coming out of ContentView#create_new_version that was not very natural to fix:

```
PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "version_index"
DETAIL:  Key (content_view_id, major, minor)=(19, 1, 0) already exists.
: INSERT INTO "katello_content_view_versions" ("content_view_id", "major", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"
PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "version_index"
DETAIL:  Key (content_view_id, major, minor)=(19, 1, 0) already exists.
: INSERT INTO "katello_content_view_versions" ("content_view_id", "major", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"
```


**To test:**

- Create an auto-publishable  composite content view with two components (select 'Latest') each having a single empty repo
- Publish the component repos at the same time
- Observe one of the auto-publishes for the composite will fail with a locking issue

Applying this PR will fix that by serially running the auto-publishes thru the event queue (thanks for the suggestion @jlsherrill !)

For future note I think it would be cool to be able to chain actions serially based on the input of other actions something like :
```
class MyAction < Actions::BaseAction
  chain_on_input do
    :content_view_id
   end
   def plan
     ...
    end
end
```

TODO:

- [x] decide on how to remove events that never seen to complete. purge by age? max retry attempts?