### PR TITLE
Fixes #26767 - Custom products on bulk content host manage page

### DIFF
--- a/app/controllers/katello/api/v2/repository_sets_controller.rb
+++ b/app/controllers/katello/api/v2/repository_sets_controller.rb
@@ -19,6 +19,7 @@ module Katello
     param :enabled, :bool, :required => false, :desc => N_("If true, only return repository sets that have been enabled. Defaults to false")
     param :with_active_subscription, :bool, :required => false, :desc => N_("If true, only return repository sets that are associated with an active subscriptions")
     param :organization_id, :number, :desc => N_("organization identifier"), :required => false
+    param :with_custom, :bool, :required => false, :desc => N_("If true, return custom repository sets along with redhat repos")
     param_group :search, Api::V2::ApiController
     add_scoped_search_description_for(Katello::ProductContent)
     def index
@@ -116,7 +117,8 @@ module Katello
       end
 
       relation = relation.where(Katello::Content.table_name => {:name => params[:name]}) if params[:name].present?
-      relation.redhat
+      relation = relation.redhat unless ::Foreman::Cast.to_bool(params[:with_custom])
+      relation
     end
 
     def find_product_content

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-repository-sets-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-repository-sets-modal.controller.js
@@ -29,7 +29,8 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkRepositorySe
             'organization_id': CurrentOrganization,
             'offset': 0,
             'paged': true,
-            'enabled': true
+            'enabled': true,
+            'with_custom': true
         };
 
         nutupane = new Nutupane(RepositorySet, nutupaneParams,

--- a/test/controllers/api/v2/repository_sets_controller_test.rb
+++ b/test/controllers/api/v2/repository_sets_controller_test.rb
@@ -74,6 +74,15 @@ module Katello
       assert_response :success
     end
 
+    def test_index_org_with_custom
+      get :index, params: { :organization_id => @organization.id, :with_custom => true }
+
+      body = JSON.parse(response.body)
+
+      assert_empty body['error']
+      assert_response :success
+    end
+
     def test_index_org
       get :index, params: { :organization_id => @organization.id}
 


### PR DESCRIPTION
**Steps to Reproduce:**
1. Create a custom product
2. Create a repository in a custom product
3. Register content host(s) to your box
4. Goto Hosts -> Content Hosts
5. Select one or more hosts with checkbox
6. Select Action (Dropdown) -> Manage Repository Sets

Actual results:
Repository list is empty (in case you don't have any redhat products) with the message 'No enabled Repository Sets provided through subscriptions.'
This list only shows redhat products.

Expected results:
Ability to change Repository Sets for hosts selected, like in Host -> Content Hosts ->host -> Repository Sets