### PR TITLE
Fixes #27213 - Expose description to update filter api call

### DIFF
--- a/app/controllers/katello/api/v2/content_view_filters_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_filters_controller.rb
@@ -62,6 +62,8 @@ module Katello
                                                        "(package filter only)")
     param :inclusion, :bool, :desc => N_("specifies if content should be included or excluded, default: inclusion=false")
     param :repository_ids, Array, :desc => N_("list of repository ids")
+    param :description, String, :desc => N_("description of the filter"), :required => false
+
     def update
       @filter.update_attributes!(filter_params)
       respond :resource => @filter

--- a/test/controllers/api/v2/content_view_filters_controller_test.rb
+++ b/test/controllers/api/v2/content_view_filters_controller_test.rb
@@ -112,6 +112,13 @@ module Katello
       assert_equal @filter.reload.name, "New Filter Name"
     end
 
+    def test_update_description
+      put :update, params: { :content_view_id => @filter.content_view_id, :id => @filter, :description => "New Description" }
+      assert_response :success
+      assert_template 'api/v2/common/update'
+      assert_equal @filter.reload.description, "New Description"
+    end
+
     def test_update_repositories
       repository = Repository.find(katello_repositories(:fedora_17_x86_64).id)
       assert_includes @content_view.repositories.map(&:id), repository.id


### PR DESCRIPTION
Screenshot of it being updated in the UI:

https://nimb.ws/RX7tKb

Update with hammer and new api cache. Adding a pr to hammer to expose the description in list but not required for this.

```bash
[vagrant@centos7-katello-devel katello]$ hammer -d content-view filter update --id 1 --description pizza

[ INFO 2019-07-02T17:27:27 HammerCLIKatello::Filter::UpdateCommand] Called with options: {"option_id"=>1, "option_description"=>"pizza"}
[ INFO 2019-07-02T17:27:27 API] Server: https://centos7-katello-devel.area51.example.com
[ INFO 2019-07-02T17:27:27 API] PUT /katello/api/content_view_filters/1
[DEBUG 2019-07-02T17:27:27 API] Params: {
    "description" => "pizza"
}
[DEBUG 2019-07-02T17:27:27 API] Headers: {}
[DEBUG 2019-07-02T17:27:27 API] Using authenticator: HammerCLIForeman::Api::InteractiveBasicAuth
[DEBUG 2019-07-02T17:27:28 API] Cache expired. (57d51c2c52f2196de21c4156e27dade4160a6f2d -> 815e172ce92b238c8435c0cc491ec4d19044ead8)
[DEBUG 2019-07-02T17:27:28 API] Response: {
            "inclusion" => false,
    "original_packages" => false,
                   "id" => 1,
                 "name" => "nofox",
          "description" => "pizza",
}
Filter updated.

----------|-------|-------------|------|----------
FILTER ID | NAME  | DESCRIPTION | TYPE | INCLUSION
----------|-------|-------------|------|----------
1         | nofox | pizza       | rpm  |          
----------|-------|-------------|------|----------
```