### PR TITLE
Fixes #27222 - Add minitest reporter for slow tests

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -54,6 +54,7 @@ Gem::Specification.new do |gem|
   # Testing
   gem.add_development_dependency "factory_bot_rails", "~> 4.5"
   gem.add_development_dependency "minitest-tags"
+  gem.add_development_dependency "minitest-reporters"
   gem.add_development_dependency "mocha"
   gem.add_development_dependency "vcr", "< 4.0.0"
   gem.add_development_dependency "webmock"

--- a/lib/katello/tasks/jenkins.rake
+++ b/lib/katello/tasks/jenkins.rake
@@ -2,6 +2,8 @@ require File.expand_path("../engine", File.dirname(__FILE__))
 
 begin
   namespace :jenkins do
+    ENV['USE_MEAN_TIME_REPORTER'] = '1' unless ENV['USE_MEAN_TIME_REPORTER'] == '0'
+
     task :katello do
       Rake::Task['jenkins:setup:minitest'].invoke
       Rake::Task['rake:test:katello'].invoke

--- a/test/katello_test_helper.rb
+++ b/test/katello_test_helper.rb
@@ -7,6 +7,11 @@ require "webmock/minitest"
 require "mocha/setup"
 require 'set'
 require 'robottelo/reporter/attributes'
+require 'minitest/reporters'
+
+if ENV['USE_MEAN_TIME_REPORTER'] == '1'
+  Minitest::Reporters.use!(Minitest::Reporters::MeanTimeReporter.new)
+end
 
 SimpleCov.formatters = [
   SimpleCov::Formatter::RcovFormatter,


### PR DESCRIPTION
This generates an output like this:

```
USE_MEAN_TIME_REPORTER=1 bundle exec ktest ~/katello/test/services/katello/event_queue_test.rb

[vagrant@centos7-devel foreman]$ USE_MEAN_TIME_REPORTER=1 bundle exec ktest ~/katello/test/services/katello/event_queue_test.rb

# Running tests with run options --seed 44705:

...........

Finished tests in 1.734594s, 6.3415 tests/s, 17.8716 assertions/s.


11 tests, 31 assertions, 0 failures, 0 errors, 0 skips

Minitest Reporters: Mean Time Report (Samples: 1, Order: :avg :desc)
Avg: 1.731855869  Min: 1.731855869  Max: 1.731855869  Last: 1.731855869  Description: Katello::EventQueueTest
Coverage report Rcov style generated for Unit Tests to /home/vagrant/foreman/coverage/rcov
Coverage report generated for Unit Tests to /home/vagrant/foreman/coverage. 0.0 / 0.0 LOC (100.0%) covered.

```

For the whole suite we'll see which test files took the longest and from there we can isolate the slow tests individually.