### PR TITLE
Fixes #27229 - add message attribute to ping api

### DIFF
--- a/app/views/katello/api/v2/ping/show.json.rabl
+++ b/app/views/katello/api/v2/ping/show.json.rabl
@@ -5,6 +5,7 @@ child :services => :services do
   Katello::Ping::SERVICES.each do |service|
     child service => service do
       attribute :status
+      attribute :message
       attribute :duration_ms
     end
   end


### PR DESCRIPTION
_Related to https://github.com/Katello/katello/pull/8039_

`ping` API call doesn't return  messages, so
```ruby
Katello::Ping.ping[:services]
```
 returns:

```ruby
{:pulp=>{:status=>"FAIL", :message=>"Not all necessary pulp workers running at https://centos7-devel.tlv-fedora25.example.com/pulp/api/v2/."},
 :pulp_auth=>{:status=>"FAIL", :message=>"Skipped pulp_auth check after failed pulp check"}, 
:candlepin=>{:status=>"ok", :duration_ms=>"56"},
 :candlepin_auth=>{:status=>"ok", :duration_ms=>"26"}, 
:foreman_tasks=>{:status=>"ok", :duration_ms=>"18373"}}
```
while the api (`/api/ping`) returns:
```json
  {"status":"FAIL","services":{"pulp":{"status":"FAIL"},"pulp_auth":{"status":"FAIL"},
"candlepin":{"status":"ok","duration_ms":"19"},
"candlepin_auth":{"status":"ok","duration_ms":"14"},
"foreman_tasks":{"status":"FAIL"}}}
```