### PR TITLE
Fixes #26763 - Pass string representation of time in host info [3.12 Cherry Pick]

### DIFF
--- a/app/models/katello/host/info_provider.rb
+++ b/app/models/katello/host/info_provider.rb
@@ -28,7 +28,7 @@ module Katello
           'label' => host.content_view.try(:label),
           'latest-version' => host.content_view.try(:latest_version),
           'version' => content_version.try(:version),
-          'published' => content_version.try(:created_at).try(:time),
+          'published' => content_version.try(:created_at).try(:time).to_s,
           'components' => content_view_components
         }
 
@@ -43,7 +43,7 @@ module Katello
           cv_label = cv.component_version.content_view.label
           components[cv_label] = {}
           components[cv_label]['version'] = cv.component_version.try(:version)
-          components[cv_label]['published'] = cv.component_version.try(:created_at).try(:time)
+          components[cv_label]['published'] = cv.component_version.try(:created_at).try(:time).to_s
         end
         components
       end


### PR DESCRIPTION
This is simply a cherry pick of #8147 into the 3.12 branch.  The [original issue](https://projects.theforeman.org/issues/26763) was closed with that PR and the comments note that the fix was made in 3.13, 3.11, and 3.10, but the back port into 3.12 was still needed.