### PR TITLE
Fixes #27241 - duplicate content view CCV message is misleading

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-publish.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/views/content-view-publish.html
@@ -26,8 +26,7 @@
         </li>
       </ul>
       <p translate>
-        For the duplicate repositories, the packages in each Content View Version will combine regardless of the filters that 
-        were applied to the individual Content View Version.
+		    Duplicate repositories between the selected Content View Versions will merge, resulting in a Composite Content View with all packages that exist among the duplicates.
       </p>
     </div>
 


### PR DESCRIPTION
The mention of filters is a bit misleading here since it can be interpreted that the CCV undoes the filtering.