### PR TITLE
Fixes #27242 - Update CDN url might break feed url.

### DIFF
--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -279,16 +279,20 @@ module Katello
       self.content.content_url
     end
 
+    def repo_mapper
+      Katello::Candlepin::RepositoryMapper.new(self.product, self.content, self.substitutions)
+    end
+
     def calculate_updated_name
       fail _("Cannot calculate name for custom repos") if custom?
-      Katello::Candlepin::RepositoryMapper.new(self.product, self.content, self.substitutions).name
+      repo_mapper.name
     end
 
     def substitutions
       {
         :releasever => self.minor,
         :basearch => self.arch
-      }
+      }.compact
     end
 
     class Jail < ::Safemode::Jail

--- a/test/fixtures/models/katello_contents.yml
+++ b/test/fixtures/models/katello_contents.yml
@@ -4,10 +4,11 @@ some_content:
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
   label:        fedora
   cp_content_id: 1
+  content_url: /pub/fedora/linux/releases/$releasever/Everything/$basearch/os
 
 rhel_content:
   name:         rhel
   label:        rhel
   cp_content_id: 69
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
-
+  content_url: /content/dist/rhel/server/$releasever/$basearch/os


### PR DESCRIPTION
When updating the CDN url, some repositories' url are updating
multiple times in a single foreman task if they are used in any
content view. This causes the url path to replace by an empty
string due to a bug in the code that can't handle url update
multiple time safely. This commit fixed the issue.