### PR TITLE
Fixes #27248 - intorduce separate queue for host-related tasks

### DIFF
--- a/app/lib/actions/katello/host/attach_subscriptions.rb
+++ b/app/lib/actions/katello/host/attach_subscriptions.rb
@@ -2,6 +2,10 @@ module Actions
   module Katello
     module Host
       class AttachSubscriptions < Actions::EntryAction
+        def queue
+          ::Katello::HOST_TASKS_QUEUE
+        end
+
         def plan(host, pools_with_quantities_params)
           action_subject(host)
           sequence do

--- a/app/lib/actions/katello/host/destroy.rb
+++ b/app/lib/actions/katello/host/destroy.rb
@@ -4,6 +4,10 @@ module Actions
       class Destroy < Actions::EntryAction
         middleware.use ::Actions::Middleware::RemoteAction
 
+        def queue
+          ::Katello::HOST_TASKS_QUEUE
+        end
+
         def plan(host, options = {})
           action_subject(host)
           # normalize options before passing through to run phase

--- a/app/lib/actions/katello/host/generate_applicability.rb
+++ b/app/lib/actions/katello/host/generate_applicability.rb
@@ -2,6 +2,10 @@ module Actions
   module Katello
     module Host
       class GenerateApplicability < Actions::Base
+        def queue
+          ::Katello::HOST_TASKS_QUEUE
+        end
+
         def plan(hosts, use_queue = true)
           uuids = hosts.map { |host| host.content_facet.try(:uuid) }.compact
           unless uuids.empty?

--- a/app/lib/actions/katello/host/update.rb
+++ b/app/lib/actions/katello/host/update.rb
@@ -4,6 +4,10 @@ module Actions
       class Update < Actions::EntryAction
         middleware.use ::Actions::Middleware::RemoteAction
 
+        def queue
+          ::Katello::HOST_TASKS_QUEUE
+        end
+
         def plan(host, consumer_params = nil)
           input[:hostname] = host.name
           action_subject host

--- a/app/lib/actions/katello/host/upload_package_profile.rb
+++ b/app/lib/actions/katello/host/upload_package_profile.rb
@@ -2,6 +2,10 @@ module Actions
   module Katello
     module Host
       class UploadPackageProfile < Actions::EntryAction
+        def queue
+          ::Katello::HOST_TASKS_QUEUE
+        end
+
         def plan(host, profile_string)
           action_subject host
 

--- a/app/lib/actions/katello/host/upload_profiles.rb
+++ b/app/lib/actions/katello/host/upload_profiles.rb
@@ -4,6 +4,10 @@ module Actions
       class UploadProfiles < Actions::EntryAction
         middleware.use Actions::Middleware::KeepCurrentUser
 
+        def queue
+          ::Katello::HOST_TASKS_QUEUE
+        end
+
         def plan(host, profile_string)
           action_subject host
 

--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -130,7 +130,9 @@ class Setting::Content < Setting
                  "packages to solve the dependencies if the package needed doesn't exist. Greedy will pull in the " \
                  "latest package to solve a dependency even if it already does exist in the repository."),
                  'conservative', N_('Content View Dependency Solving Algorithm'), nil,
-                 :collection => dependency_solving_options)
+                 :collection => dependency_solving_options),
+        self.set('host_tasks_workers_pool_size', N_("Amount of workers in the pool to handle the execution of host-related tasks. When set to 0, the default queue will be used instead. Restart of the dynflowd/foreman-tasks service is required."),
+                 5, N_('Host Tasks Workers Pool Size'))
       ].each { |s| self.create! s.update(:category => "Setting::Content") }
     end
     true

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -1,4 +1,6 @@
 module Katello
+  HOST_TASKS_QUEUE = :hosts_queue
+
   class Engine < ::Rails::Engine
     isolate_namespace Katello
 
@@ -63,6 +65,10 @@ module Katello
 
     initializer "katello.register_actions", :before => :finisher_hook do |_app|
       ForemanTasks.dynflow.require!
+      if (Setting.table_exists? rescue(false)) && Setting['host_tasks_workers_pool_size'].to_i > 0
+        ForemanTasks.dynflow.config.queues.add(HOST_TASKS_QUEUE, :pool_size => Setting['host_tasks_workers_pool_size'])
+      end
+
       action_paths = %W(#{Katello::Engine.root}/app/lib/actions
                         #{Katello::Engine.root}/app/lib/headpin/actions
                         #{Katello::Engine.root}/app/lib/katello/actions)


### PR DESCRIPTION
To prevent the user-related actions to be highly influenced by the
hosts-related tasks (such as errata applicability calculations), the
work for the hosts should be put on dedicated queue with independent set
of worker threads to process, so if the host-workers get starved, the
non-host work could still flow.

This PR is introducing new queue `hosts_queue` to be assigned to
host-related tasks and setting `host_tasks_workers_pool_size` to set how
many workers should be in the queue.

To achieve the old behaviour of one shared queue, one can set
`host_tasks_workers_pool_size` to 0.