### PR TITLE
Fixes #27256 - JS error on REX errata install

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-errata.controller.js
@@ -133,7 +133,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostErrataController'
 
         $scope.performViaRemoteExecution = function(customize) {
             var errataIds = $scope.selectedErrataIds();
-            $scope.errataActionFormValues.errata = errataIds.join(',');
+            $scope.errataActionFormValues.errata = errataIds.included.ids.join(',');
             $scope.errataActionFormValues.hostIds = $scope.host.id;
             $scope.errataActionFormValues.customize = customize;
 

--- a/engines/bastion_katello/test/content-hosts/content/content-host-errata.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content/content-host-errata.controller.test.js
@@ -48,7 +48,11 @@ describe('Controller: ContentHostErrataController', function() {
             this.refresh = function() {nutupaneMock.refresh()};
             this.load = function () {nutupaneMock.load()};
             this.enableSelectAllResults = function () {};
-            this.getAllSelectedResults = function() {return [mockErratum];}
+            this.getAllSelectedResults = function() {
+                return {
+                    included: { ids: [mockErratum.errata_id] }
+                };
+            };
         };
         HostErratum = {
             get: function() {return []},
@@ -99,10 +103,20 @@ describe('Controller: ContentHostErrataController', function() {
         spyOn($scope.table, "selectAll");
         spyOn($scope, "transitionTo");
         $scope.applySelected();
-        expect(HostErratum.apply).toHaveBeenCalledWith({id: host.id, bulk_errata_ids: [{errata_id: mockErratum.errata_id}]},
+        expect(HostErratum.apply).toHaveBeenCalledWith({id: host.id, bulk_errata_ids: {included: { ids: [mockErratum.errata_id]}}},
                                                          jasmine.any(Function));
         expect($scope.transitionTo).toHaveBeenCalledWith('content-host.tasks.details', {taskId: mockTask.id});
         expect($scope.table.selectAll).toHaveBeenCalledWith(false);
+    });
+
+    it("can apply errata with remote execution", function() {
+        $scope.remoteExecutionByDefault = true;
+
+        $scope.applySelected();
+
+        expect($scope.errataActionFormValues.hostIds).toEqual(host.id);
+        expect($scope.errataActionFormValues.customize).toEqual(false);
+        expect($scope.errataActionFormValues.errata).toEqual(mockErratum.errata_id);
     });
 
     it("provide a way to regenerate applicability", function() {


### PR DESCRIPTION
Looks like this was introduced by the changes in #8117 

To reproduce the problem just set up a content host with some applicable errata. From the content host details, attempt to install one of the selected errata via remote execution and you'll see an error in the js console regarding `errataIds.join`. This patch fixes that. I don't think it's necessary to test the whole REX errata install flow. It's evident that with the patch REX is getting all the necessary bits of info in the UI (mainly the errata IDs)

You can use a config like this to get remote execution installed to verify:

```
centos7-devel:                                                                                                                                                                                                     
  primary: true                                                                                                                                                                                                    
  box: centos7                                                                                                                                                                                                     
  memory: 9000                                                                                                                                                                                                     
  ansible:                                                                                                                                                                                                         
    playbook: 'playbooks/katello_devel.yml'                                                                                                                                                                        
    group: 'devel'                                                                                                                                                                                                 
    variables:                                                                                                                                                                                                     
      ssh_forward_agent: true                                                                                                                                                                                      
      foreman_devel_github_push_ssh: True                                                                                                                                                                          
      katello_devel_github_username: 'yourname'                                                                                                                                                                      
      foreman_installer_options:                                                                                                                                                                                   
        - "--katello-devel-extra-plugins theforeman/foreman_remote_execution"                                                                                                                                      
        - "--enable-foreman-proxy-plugin-remote-execution-ssh"                                                                                                                                                     
                                                               

```