### PR TITLE
Fixes #27258 - Install errata only to selected hosts

### DIFF
--- a/app/controllers/katello/remote_execution_controller.rb
+++ b/app/controllers/katello/remote_execution_controller.rb
@@ -31,13 +31,15 @@ module Katello
 
       def hosts
         host_ids = params[:host_ids].is_a?(String) ? params[:host_ids].split(',') : params[:host_ids]
-        find_bulk_hosts('edit_hosts',
+
+        bulk_params = {
           included: {
             ids: host_ids,
-            search: params[:scoped_search],
-            excluded: params[:excluded]
+            search: params[:scoped_search]
           }
-                       )
+        }
+
+        find_bulk_hosts('edit_hosts', bulk_params)
       end
 
       def inputs

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.js
@@ -50,8 +50,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkErrataModalC
         $scope.remoteExecutionByDefault = BastionConfig.remoteExecutionByDefault;
 
         $scope.errataActionFormValues = {
-            authenticityToken: $window.AUTH_TOKEN.replace(/&quot;/g, ''),
-            search: hostIds.included.search
+            authenticityToken: $window.AUTH_TOKEN.replace(/&quot;/g, '')
         };
 
         if (hostIds.included.ids) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-module-streams-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-module-streams-modal.controller.js
@@ -38,8 +38,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkModuleStream
 
         $scope.moduleStreamActionFormValues = {
             authenticityToken: $window.AUTH_TOKEN.replace(/&quot;/g, ''),
-            remoteAction: 'module_stream_action',
-            search: hostIds.included.search
+            remoteAction: 'module_stream_action'
         };
 
         if (hostIds.included.ids) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-packages-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-packages-modal.controller.js
@@ -138,8 +138,6 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkPackagesModa
                 $scope.packageActionFormValues.hostIds = selectedHosts.included.ids.join(',');
             }
 
-            $scope.packageActionFormValues.search = selectedHosts.included.search;
-
             $timeout(function () {
                 angular.element('#packageActionForm').submit();
             }, 0);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-host-bulk-module-streams-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-host-bulk-module-streams-modal.html
@@ -9,7 +9,6 @@
       <input type="hidden" name="remote_action" ng-value="moduleStreamActionFormValues.remoteAction"/>
       <input type="hidden" name="module_stream_action" ng-value="moduleStreamActionFormValues.moduleStreamAction"/>
       <input type="hidden" name="module_spec" ng-value="moduleStreamActionFormValues.moduleSpec"/>
-      <input type="hidden" name="scoped_search" ng-value="moduleStreamActionFormValues.search"/>
       <input type="hidden" name="host_ids" ng-value="moduleStreamActionFormValues.hostIds"/>
       <input type="hidden" name="customize" ng-value="moduleStreamActionFormValues.customize"/>
       <input type="hidden" name="authenticity_token" ng-value="moduleStreamActionFormValues.authenticityToken"/>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
@@ -5,7 +5,6 @@
     <form id="errataActionForm" name="errataActionForm" class="form" method="post" action="/katello/remote_execution">
       <input type="hidden" name="name" ng-value="errataActionFormValues.errata"/>
       <input type="hidden" name="remote_action" ng-value="errataActionFormValues.remoteAction"/>
-      <input type="hidden" name="scoped_search" ng-value="errataActionFormValues.search"/>
       <input type="hidden" name="host_ids" ng-value="errataActionFormValues.hostIds"/>
       <input type="hidden" name="authenticity_token" ng-value="errataActionFormValues.authenticityToken"/>
       <input type="hidden" name="customize" ng-value="errataActionFormValues.customize"/>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-packages-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-packages-modal.html
@@ -33,7 +33,6 @@
     <form id="packageActionForm" name="packageActionForm" class="form" method="post" action="/katello/remote_execution">
       <input type="hidden" name="name" ng-value="content.content"/>
       <input type="hidden" name="remote_action" ng-value="packageActionFormValues.remoteAction"/>
-      <input type="hidden" name="scoped_search" ng-value="packageActionFormValues.search"/>
       <input type="hidden" name="host_ids" ng-value="packageActionFormValues.hostIds"/>
       <input type="hidden" name="authenticity_token" ng-value="packageActionFormValues.authenticityToken"/>
       <input type="hidden" name="customize" ng-value="packageActionFormValues.customize"/>

--- a/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-module-streams-modal.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/bulk/content-hosts-bulk-module-streams-modal.controller.test.js
@@ -62,7 +62,6 @@ describe('Controller: ContentHostsBulkModuleStreamsModalController', function() 
         formValues = {
             authenticityToken: 'secret_token', 
             remoteAction: 'module_stream_action', 
-            search: undefined, 
             hostIds: '1,2,3', 
             moduleSpec: 'django:1.9', 
             moduleStreamAction: 'enable'


### PR DESCRIPTION
From Hosts -> Content Hosts, selecting a subset of hosts for errata installation via REX initiates the action for all hosts in the lists - not just the selected ones. The root cause is that the form was sending an empty string for the `scoped_search` param which matches all hosts in BulkHostsExtensions. I think that's the correct behavior so I did this:

- removed the scoped_search param from errata and modularity bulk actions form submissions (looks like they were unused)
- adjusted remote_execution_controller to remove the 'excluded' option - it doesn't appear to be used by any REX action and was not in the proper location in the hash anyway


To test with this PR applied:

- Set up a content host w/ some applicable errata(Host A), and one or more other content hosts
- From the Content Hosts lists select HostA 
- Select Action -> Manage Errata -> select some errata -> install via remove execution

The following page should indicate that the errata will be installed only on HostA and not all of them