### PR TITLE
Fixes #27288 - CCV environment repo shouldn't be a master

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -643,7 +643,7 @@ module Katello
       !self.yum? || # non-yum repos
           self.in_default_view? || # default content view repos
           (self.archive? && !self.content_view.composite) || # non-composite content view archive repos
-          (self.content_view.composite? && self.component_source_repositories.count > 1) # composite archive repo with more than 1 source repository
+          (self.archive? && self.content_view.composite? && self.component_source_repositories.count > 1) # composite archive repo with more than 1 source repository
     end
 
     # a link repository has no content in the pulp repository and serves as a shell.  It will always be empty.  Only the YumCloneDistributor can be used

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -7,6 +7,10 @@ module Katello
       super
       User.current = @admin
       @repo = katello_repositories(:rhel_6_x86_64)
+      @rpm_one = katello_rpms(:one)
+      @rpm_two = katello_rpms(:two)
+      @errata_security = katello_errata(:security)
+      @errata_bugfix = katello_errata(:bugfix)
     end
 
     def test_create
@@ -144,6 +148,17 @@ module Katello
       #now add a 2nd component to make the archive a "master", due to 'conflicting' repos
       version.components << katello_content_view_versions(:library_view_version_2)
       assert version_archive_repo.master?
+
+      # composite environment repo should stay as a linked repo
+      assert version_env_repo.link?
+
+      version_archive_repo.rpms = [@rpm_one, @rpm_two]
+      version_archive_repo.errata = [@errata_security, @errata_bugfix]
+      version_archive_repo.save!
+
+      version_env_repo.index_content
+      assert_equal version_archive_repo.rpms.sort, version_env_repo.rpms.sort
+      assert_equal version_archive_repo.errata.sort, version_env_repo.errata.sort
     end
   end
 


### PR DESCRIPTION
An environment repository in a composite content view may
mistakenly be considered as a master repository when its
archived repository has more than 1 source repositories.
This causes the environment repository to fetch the contents
from Pulp instead of its archived repository while doing the
"index_content". Since no contents are associated to the
enviroment repository in Pulp so nothing will be indexed.
This causes the content hosts to get 0 installable content.