### PR TITLE
Fixes #26999 - support syncing docker repositories in pulp3 

### DIFF
--- a/app/models/katello/docker_tag.rb
+++ b/app/models/katello/docker_tag.rb
@@ -66,7 +66,7 @@ module Katello
       end
     end
 
-    def self.manage_repository_association
+    def self.many_repository_associations
       false
     end
 

--- a/app/models/katello/yum_metadata_file.rb
+++ b/app/models/katello/yum_metadata_file.rb
@@ -10,7 +10,7 @@ module Katello
       super(repository)
     end
 
-    def self.manage_repository_association
+    def self.many_repository_associations
       false
     end
 

--- a/app/services/katello/pulp3/docker_blob.rb
+++ b/app/services/katello/pulp3/docker_blob.rb
@@ -1,0 +1,17 @@
+module Katello
+  module Pulp3
+    class DockerBlob < PulpContentUnit
+      include LazyAccessor
+
+      def self.content_api
+        PulpDockerClient::ContentBlobsApi.new(Katello::Pulp3::Repository::Docker.api_client(SmartProxy.pulp_master!))
+      end
+
+      def self.ids_for_repository(repo_id)
+        repo = Katello::Pulp3::Repository::Docker.new(Katello::Repository.find(repo_id), SmartProxy.pulp_master)
+        repo_content_list = repo.content_list
+        repo_content_list.map { |content| content.try(:_href) }
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/docker_manifest.rb
+++ b/app/services/katello/pulp3/docker_manifest.rb
@@ -1,0 +1,36 @@
+module Katello
+  module Pulp3
+    class DockerManifest < PulpContentUnit
+      include LazyAccessor
+
+      def self.content_api
+        PulpDockerClient::ContentManifestsApi.new(Katello::Pulp3::Repository::Docker.api_client(SmartProxy.pulp_master!))
+      end
+
+      def self.ids_for_repository(repo_id)
+        repo = Katello::Pulp3::Repository::Docker.new(Katello::Repository.find(repo_id), SmartProxy.pulp_master)
+        repo_content_list = repo.content_list
+        repo_content_list.map { |content| content.try(:_href) }
+      end
+
+      def self.content_unit_list(page_opts)
+        page_opts[:media_type] = "application/vnd.docker.distribution.manifest.v1+json"
+        data_v1 = self.content_api.list(page_opts)
+        page_opts[:media_type] = "application/vnd.docker.distribution.manifest.v2+json"
+        data_v2 = self.content_api.list(page_opts)
+
+        filtered = {}
+        filtered["count"] = data_v1.count + data_v2.count
+        filtered["results"] = data_v1.results + data_v2.results
+        filtered
+      end
+
+      def update_model(model)
+        custom_json = {}
+        custom_json['schema_version'], = backend_data['schema_version']
+        custom_json['digest'], = backend_data['digest']
+        model.update_attributes!(custom_json)
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/docker_manifest_list.rb
+++ b/app/services/katello/pulp3/docker_manifest_list.rb
@@ -1,0 +1,30 @@
+module Katello
+  module Pulp3
+    class DockerManifestList < PulpContentUnit
+      include LazyAccessor
+
+      def self.content_api
+        PulpDockerClient::ContentManifestsApi.new(Katello::Pulp3::Repository::Docker.api_client(SmartProxy.pulp_master!))
+      end
+
+      def self.ids_for_repository(repo_id)
+        repo = Katello::Pulp3::Repository::Docker.new(Katello::Repository.find(repo_id), SmartProxy.pulp_master)
+        repo_content_list = repo.content_list
+        repo_content_list.map { |content| content.try(:_href) }
+      end
+
+      def self.content_unit_list(page_opts)
+        page_opts[:media_type] = "application/vnd.docker.distribution.manifest.list.v2+json"
+        self.content_api.list(page_opts)
+      end
+
+      def update_model(model)
+        custom_json = {}
+        custom_json['schema_version'], = backend_data['schema_version']
+        custom_json['digest'], = backend_data['digest']
+        custom_json['docker_manifests'] = ::Katello::DockerManifest.where(:pulp_id => backend_data[:listed_manifests])
+        model.update_attributes!(custom_json)
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/docker_tag.rb
+++ b/app/services/katello/pulp3/docker_tag.rb
@@ -1,0 +1,28 @@
+module Katello
+  module Pulp3
+    class DockerTag < PulpContentUnit
+      include LazyAccessor
+
+      def self.content_api
+        PulpDockerClient::ContentManifestTagsApi.new(Katello::Pulp3::Repository::Docker.api_client(SmartProxy.pulp_master!))
+      end
+
+      def self.ids_for_repository(repo_id)
+        repo = Katello::Pulp3::Repository::Docker.new(Katello::Repository.find(repo_id), SmartProxy.pulp_master)
+        repo_content_list = repo.content_list
+        repo_content_list.map { |content| content.try(:_href) }
+      end
+
+      def update_model(model)
+        custom_json = {}
+        taggable = ::Katello::DockerManifest.find_by(:pulp_id => backend_data['tagged_manifest'])
+        if taggable.nil?
+          taggable = ::Katello::DockerManifestList.find_by(:pulp_id => backend_data['tagged_manifest'])
+        end
+        custom_json['docker_taggable'] = taggable
+        custom_json['name'] = backend_data['name']
+        model.update_attributes!(custom_json)
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/repository/docker.rb
+++ b/app/services/katello/pulp3/repository/docker.rb
@@ -4,7 +4,7 @@ module Katello
   module Pulp3
     class Repository
       class Docker < ::Katello::Pulp3::Repository
-        def api_client
+        def self.api_client(smart_proxy)
           PulpDockerClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpDockerClient::Configuration))
         end
 

--- a/lib/katello/repository_types/docker.rb
+++ b/lib/katello/repository_types/docker.rb
@@ -4,8 +4,22 @@ Katello::RepositoryTypeManager.register(::Katello::Repository::DOCKER_TYPE) do
   pulp3_skip_publication true
   pulp3_plugin 'pulp_docker'
 
-  content_type Katello::DockerManifest, :priority => 1, :pulp2_service_class => ::Katello::Pulp::DockerManifest, :user_removable => true
-  content_type Katello::DockerManifestList, :priority => 2, :pulp2_service_class => ::Katello::Pulp::DockerManifestList
-  content_type Katello::DockerTag, :priority => 3, :pulp2_service_class => ::Katello::Pulp::DockerTag
-  content_type Katello::DockerBlob, :priority => 4, :pulp2_service_class => ::Katello::Pulp::DockerBlob, :index => false
+  content_type Katello::DockerManifest,
+               :priority => 1,
+               :pulp2_service_class => ::Katello::Pulp::DockerManifest,
+               :pulp3_service_class => ::Katello::Pulp3::DockerManifest,
+               :user_removable => true
+  content_type Katello::DockerManifestList,
+               :priority => 2,
+               :pulp2_service_class => ::Katello::Pulp::DockerManifestList,
+               :pulp3_service_class => ::Katello::Pulp3::DockerManifestList
+  content_type Katello::DockerTag,
+               :priority => 3,
+               :pulp2_service_class => ::Katello::Pulp::DockerTag,
+               :pulp3_service_class => ::Katello::Pulp3::DockerTag
+  content_type Katello::DockerBlob,
+               :priority => 4,
+               :pulp2_service_class => ::Katello::Pulp::DockerBlob,
+               :pulp3_service_class => ::Katello::Pulp3::DockerBlob,
+               :index => false
 end

--- a/test/actions/pulp3/orchestration/docker_sync_test.rb
+++ b/test/actions/pulp3/orchestration/docker_sync_test.rb
@@ -1,0 +1,44 @@
+require 'katello_test_helper'
+
+module ::Actions::Pulp3
+  class DockerSyncTest < ActiveSupport::TestCase
+    include Katello::Pulp3Support
+
+    def setup
+      @master = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+      @repo = katello_repositories(:pulp3_docker_1)
+      create_repo(@repo, @master)
+      ForemanTasks.sync_task(
+          ::Actions::Katello::Repository::MetadataGenerate, @repo,
+          repository_creation: true)
+
+      repository_reference = Katello::Pulp3::RepositoryReference.find_by(
+          :root_repository_id => @repo.root.id,
+          :content_view_id => @repo.content_view.id)
+
+      assert repository_reference
+      refute_empty repository_reference.repository_href
+      refute_empty Katello::Pulp3::DistributionReference.where(
+          root_repository_id: @repo.root.id)
+      @repo_version_href = @repo.version_href
+    end
+
+    def teardown
+      ForemanTasks.sync_task(
+          ::Actions::Pulp3::Orchestration::Repository::Delete, @repo, @master)
+      @repo.reload
+    end
+
+    def test_sync
+      sync_args = {:smart_proxy_id => @master.id, :repo_id => @repo.id}
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @master, sync_args)
+      @repo.reload
+      refute_equal @repo.version_href, @repo_version_href
+      repository_reference = Katello::Pulp3::RepositoryReference.find_by(
+          :root_repository_id => @repo.root.id,
+          :content_view_id => @repo.content_view.id)
+
+      assert_equal repository_reference.repository_href + "versions/2/", @repo.version_href
+    end
+  end
+end

--- a/test/controllers/api/v2/products_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/products_bulk_actions_controller_test.rb
@@ -55,7 +55,7 @@ module Katello
     def test_sync
       assert_async_task(::Actions::BulkAction) do |action_class, repos|
         action_class.must_equal ::Actions::Katello::Repository::Sync
-        repos.size.must_equal 8
+        repos.size.must_equal 9
       end
 
       put :sync_products, params: { :ids => @products.collect(&:id), :organization_id => @organization.id }

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -199,7 +199,7 @@ module Katello
     def test_index_with_library
       ids = @organization.default_content_view.versions.first.repositories.pluck(:id)
 
-      response = get :index, params: { :library => true, :organization_id => @organization.id }
+      response = get :index, params: { :library => true, :organization_id => @organization.id, :per_page => 100 }
 
       assert_response :success
       assert_template 'api/v2/repositories/index'

--- a/test/fixtures/models/katello_repositories.yml
+++ b/test/fixtures/models/katello_repositories.yml
@@ -352,3 +352,10 @@ pulp3_ansible_collection_1:
   relative_path:        '/Default_Organization/library/pulp3_Ansible_collection_1'
   environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
   content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>
+
+pulp3_docker_1:
+  root_id:              <%= ActiveRecord::FixtureSet.identify(:pulp3_docker_root_1) %>
+  pulp_id:              "Default_Organization-Cabinet-pulp3_Docker_1"
+  relative_path:        '/Default_Organization/library/pulp3_Docker_1'
+  environment_id:       <%= ActiveRecord::FixtureSet.identify(:library) %>
+  content_view_version_id: <%= ActiveRecord::FixtureSet.identify(:library_default_version) %>

--- a/test/fixtures/models/katello_root_repositories.yml
+++ b/test/fixtures/models/katello_root_repositories.yml
@@ -192,3 +192,13 @@ pulp3_ansible_collection_root_1:
   url:                  "https://galaxy.ansible.com"
   ansible_collection_whitelist: "robertdebock.rundeck_collection"
 
+pulp3_docker_root_1:
+  name:                 Pulp3 Docker 1
+  content_id:           13
+  content_type:         docker
+  label:                Pulp3_Docker 1
+  product_id:           <%= ActiveRecord::FixtureSet.identify(:fedora) %>
+  gpg_key_id:           null
+  unprotected:           <%= true %>
+  url:                  "https://registry-1.docker.io/"
+  docker_upstream_name: "fedora/ssh"

--- a/test/fixtures/vcr_cassettes/actions/pulp3/docker_sync/sync.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/docker_sync/sync.yml
@@ -1,0 +1,5998 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/repositories/?name=Default_Organization-Test-busybox-library
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:45 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/remotes/docker/docker/?name=Default_Organization-Test-busybox-library
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563368915/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:45 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/docker/docker/?name=Default_Organization-Test-busybox-library
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563368915/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:45 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/docker/docker/?base_path=ACME_Corporation/library/busybox
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563368915/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:45 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94LWxp
+        YnJhcnkifQ==
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/bcfe5b61-b3a5-4fdd-b83f-7ac53822b338/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '306'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYmNmZTViNjEt
+        YjNhNS00ZmRkLWI4M2YtN2FjNTM4MjJiMzM4LyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wNy0xN1QyMTowNjo0Ni4wNjU0OThaIiwiX3ZlcnNpb25zX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2JjZmU1YjYxLWIzYTUtNGZkZC1i
+        ODNmLTdhYzUzODIyYjMzOC92ZXJzaW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25f
+        aHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3Qt
+        YnVzeWJveC1saWJyYXJ5IiwiZGVzY3JpcHRpb24iOm51bGx9
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:46 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/remotes/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94LWxp
+        YnJhcnkiLCJ1cmwiOiJodHRwOi8vZG9ja2VyLmlvIiwic3NsX3ZhbGlkYXRp
+        b24iOnRydWUsInBvbGljeSI6ImltbWVkaWF0ZSIsInVwc3RyZWFtX25hbWUi
+        OiJidXN5Ym94In0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563368915/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/docker/docker/519a9cac-87e2-4bc7-a6df-bc8206420dac/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '483'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2RvY2tlci9kb2NrZXIv
+        NTE5YTljYWMtODdlMi00YmM3LWE2ZGYtYmM4MjA2NDIwZGFjLyIsIl9jcmVh
+        dGVkIjoiMjAxOS0wNy0xN1QyMTowNjo0Ni4yNzM4NzlaIiwiX3R5cGUiOiJk
+        b2NrZXIuZG9ja2VyIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLVRl
+        c3QtYnVzeWJveC1saWJyYXJ5IiwidXJsIjoiaHR0cDovL2RvY2tlci5pbyIs
+        InNzbF9jYV9jZXJ0aWZpY2F0ZSI6bnVsbCwic3NsX2NsaWVudF9jZXJ0aWZp
+        Y2F0ZSI6bnVsbCwic3NsX2NsaWVudF9rZXkiOm51bGwsInNzbF92YWxpZGF0
+        aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsIl9sYXN0X3VwZGF0ZWQiOiIy
+        MDE5LTA3LTE3VDIxOjA2OjQ2LjI3MzkyMFoiLCJkb3dubG9hZF9jb25jdXJy
+        ZW5jeSI6MjAsInBvbGljeSI6ImltbWVkaWF0ZSIsInVwc3RyZWFtX25hbWUi
+        OiJidXN5Ym94Iiwid2hpdGVsaXN0X3RhZ3MiOm51bGx9
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:46 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/repositories/bcfe5b61-b3a5-4fdd-b83f-7ac53822b338/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q2YzYyNGNjLWUyMmItNGZj
+        Yy05ODEyLWJmOTNlNzZmMTQ3OC8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:46 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/d6c624cc-e22b-4fcc-9812-bf93e76f1478/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kNmM2MjRjYy1lMjJiLTRm
+        Y2MtOTgxMi1iZjkzZTc2ZjE0NzgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjA2OjQ2LjU5MjYwN1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTE3VDIxOjA2OjQ2LjY4MjQ1Nloi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMTdUMjE6MDY6NDYuNzE0OTYxWiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvMzU1NWRkNTYtNzZlNy00NTY0LThlOGMt
+        ZDhkYzM5N2IyMDE2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2JjZmU1YjYxLWIzYTUtNGZk
+        ZC1iODNmLTdhYzUzODIyYjMzOC92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:46 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/repositories/bcfe5b61-b3a5-4fdd-b83f-7ac53822b338/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYmNmZTViNjEt
+        YjNhNS00ZmRkLWI4M2YtN2FjNTM4MjJiMzM4L3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTE3VDIxOjA2OjQ2LjY5NzcwMloiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:46 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVzeWJv
+        eCIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gt
+        bGlicmFyeSIsInJlcG9zaXRvcnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvYmNmZTViNjEtYjNhNS00ZmRkLWI4M2YtN2FjNTM4MjJi
+        MzM4L3ZlcnNpb25zLzEvIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563368915/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EzM2U1YmYwLTgyOWUtNDhh
+        OC1iZDIwLTJlNzQwMjViNTZlNC8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:47 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/a33e5bf0-829e-48a8-bd20-2e74025b56e4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '395'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hMzNlNWJmMC04MjllLTQ4
+        YTgtYmQyMC0yZTc0MDI1YjU2ZTQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjA2OjQ3LjAyMjc4M1oiLCJzdGF0ZSI6IndhaXRpbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjpudWxsLCJmaW5pc2hlZF9hdCI6bnVsbCwibm9uX2ZhdGFsX2Vy
+        cm9ycyI6W10sImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
+        d29ya2Vycy8xNjAyMWZkMS05NDZlLTQzMTItODM0NS02MjAxMWVmZTBiMDUv
+        IiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jlc3Nf
+        cmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpbXX0=
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:47 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/a33e5bf0-829e-48a8-bd20-2e74025b56e4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hMzNlNWJmMC04MjllLTQ4
+        YTgtYmQyMC0yZTc0MDI1YjU2ZTQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjA2OjQ3LjAyMjc4M1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0xN1QyMTowNjo0Ny4xNTg4NDJaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMTYwMjFmZDEtOTQ2
+        ZS00MzEyLTgzNDUtNjIwMTFlZmUwYjA1LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:47 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/a33e5bf0-829e-48a8-bd20-2e74025b56e4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '527'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hMzNlNWJmMC04MjllLTQ4
+        YTgtYmQyMC0yZTc0MDI1YjU2ZTQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjA2OjQ3LjAyMjc4M1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTE3VDIxOjA2OjQ3LjE1ODg0MloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMTdUMjE6MDY6NDcuMzIxMDAxWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMTYwMjFmZDEtOTQ2ZS00MzEyLTgzNDUtNjIwMTFl
+        ZmUwYjA1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzE2MDNkOWYx
+        LWQzNzAtNDliNy1hYWM4LWMxZjRiY2IxNDVmZi8iXX0=
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:47 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/docker/docker/1603d9f1-d370-49b7-aac8-c1f4bcb145ff/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563368915/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '451'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfY3JlYXRlZCI6IjIwMTktMDctMTdUMjE6MDY6NDcuMzEzNDI3WiIsIl9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZG9ja2VyL2RvY2tl
+        ci8xNjAzZDlmMS1kMzcwLTQ5YjctYWFjOC1jMWY0YmNiMTQ1ZmYvIiwicmVw
+        b3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9i
+        Y2ZlNWI2MS1iM2E1LTRmZGQtYjgzZi03YWM1MzgyMmIzMzgvdmVyc2lvbnMv
+        MS8iLCJyZXBvc2l0b3J5IjpudWxsLCJjb250ZW50X2d1YXJkIjpudWxsLCJu
+        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tVGVzdC1idXN5Ym94LWxpYnJh
+        cnkiLCJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVz
+        eWJveCIsInJlZ2lzdHJ5X3BhdGgiOiJwdWxwMy1kZXZlbC0yLmNhbm5vbG8u
+        ZXhhbXBsZS5jb20vQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5L2J1c3lib3gi
+        fQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:47 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/remotes/docker/docker/519a9cac-87e2-4bc7-a6df-bc8206420dac/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iY2Zl
+        NWI2MS1iM2E1LTRmZGQtYjgzZi03YWM1MzgyMmIzMzgvIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563368915/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgwNGI0NjhlLWJhZmEtNDJi
+        My1hOWY1LTE4YjRmZGRmM2RiZS8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:47 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/804b468e-bafa-42b3-a9f5-18b4fddf3dbe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:48 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84MDRiNDY4ZS1iYWZhLTQy
+        YjMtYTlmNS0xOGI0ZmRkZjNkYmUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjA2OjQ3Ljg1ODEyOVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMTdUMjE6MDY6NDcuOTU2MDkzWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzM1NTVk
+        ZDU2LTc2ZTctNDU2NC04ZThjLWQ4ZGMzOTdiMjAxNi8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:48 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/804b468e-bafa-42b3-a9f5-18b4fddf3dbe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:48 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84MDRiNDY4ZS1iYWZhLTQy
+        YjMtYTlmNS0xOGI0ZmRkZjNkYmUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjA2OjQ3Ljg1ODEyOVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMTdUMjE6MDY6NDcuOTU2MDkzWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzM1NTVk
+        ZDU2LTc2ZTctNDU2NC04ZThjLWQ4ZGMzOTdiMjAxNi8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:48 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/804b468e-bafa-42b3-a9f5-18b4fddf3dbe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:48 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84MDRiNDY4ZS1iYWZhLTQy
+        YjMtYTlmNS0xOGI0ZmRkZjNkYmUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjA2OjQ3Ljg1ODEyOVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMTdUMjE6MDY6NDcuOTU2MDkzWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzM1NTVk
+        ZDU2LTc2ZTctNDU2NC04ZThjLWQ4ZGMzOTdiMjAxNi8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:48 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/804b468e-bafa-42b3-a9f5-18b4fddf3dbe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:48 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84MDRiNDY4ZS1iYWZhLTQy
+        YjMtYTlmNS0xOGI0ZmRkZjNkYmUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjA2OjQ3Ljg1ODEyOVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMTdUMjE6MDY6NDcuOTU2MDkzWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzM1NTVk
+        ZDU2LTc2ZTctNDU2NC04ZThjLWQ4ZGMzOTdiMjAxNi8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:48 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/804b468e-bafa-42b3-a9f5-18b4fddf3dbe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:48 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84MDRiNDY4ZS1iYWZhLTQy
+        YjMtYTlmNS0xOGI0ZmRkZjNkYmUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjA2OjQ3Ljg1ODEyOVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMTdUMjE6MDY6NDcuOTU2MDkzWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzM1NTVk
+        ZDU2LTc2ZTctNDU2NC04ZThjLWQ4ZGMzOTdiMjAxNi8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:48 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/804b468e-bafa-42b3-a9f5-18b4fddf3dbe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:48 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84MDRiNDY4ZS1iYWZhLTQy
+        YjMtYTlmNS0xOGI0ZmRkZjNkYmUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjA2OjQ3Ljg1ODEyOVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMTdUMjE6MDY6NDcuOTU2MDkzWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzM1NTVk
+        ZDU2LTc2ZTctNDU2NC04ZThjLWQ4ZGMzOTdiMjAxNi8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:48 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/804b468e-bafa-42b3-a9f5-18b4fddf3dbe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:48 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '2595'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84MDRiNDY4ZS1iYWZhLTQy
+        YjMtYTlmNS0xOGI0ZmRkZjNkYmUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjA2OjQ3Ljg1ODEyOVoiLCJzdGF0ZSI6ImZhaWxlZCIsIm5hbWUiOiJw
+        dWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25pemUi
+        LCJzdGFydGVkX2F0IjoiMjAxOS0wNy0xN1QyMTowNjo0Ny45NTYwOTNaIiwi
+        ZmluaXNoZWRfYXQiOiIyMDE5LTA3LTE3VDIxOjA2OjQ4Ljg1MTQ2MFoiLCJu
+        b25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOnsiY29kZSI6bnVsbCwiZGVz
+        Y3JpcHRpb24iOiI0MDQsIG1lc3NhZ2U9J05vdCBGb3VuZCciLCJ0cmFjZWJh
+        Y2siOiIgIEZpbGUgXCIvdXNyL2xvY2FsL2xpYi9wdWxwL2xpYjY0L3B5dGhv
+        bjMuNi9zaXRlLXBhY2thZ2VzL3JxL3dvcmtlci5weVwiLCBsaW5lIDgxMiwg
+        aW4gcGVyZm9ybV9qb2JcbiAgICBydiA9IGpvYi5wZXJmb3JtKClcbiAgRmls
+        ZSBcIi91c3IvbG9jYWwvbGliL3B1bHAvbGliNjQvcHl0aG9uMy42L3NpdGUt
+        cGFja2FnZXMvcnEvam9iLnB5XCIsIGxpbmUgNTg4LCBpbiBwZXJmb3JtXG4g
+        ICAgc2VsZi5fcmVzdWx0ID0gc2VsZi5fZXhlY3V0ZSgpXG4gIEZpbGUgXCIv
+        dXNyL2xvY2FsL2xpYi9wdWxwL2xpYjY0L3B5dGhvbjMuNi9zaXRlLXBhY2th
+        Z2VzL3JxL2pvYi5weVwiLCBsaW5lIDU5NCwgaW4gX2V4ZWN1dGVcbiAgICBy
+        ZXR1cm4gc2VsZi5mdW5jKCpzZWxmLmFyZ3MsICoqc2VsZi5rd2FyZ3MpXG4g
+        IEZpbGUgXCIvdXNyL2xvY2FsL2xpYi9wdWxwL3NyYy9wdWxwLWRvY2tlci9w
+        dWxwX2RvY2tlci9hcHAvdGFza3Mvc3luY2hyb25pemUucHlcIiwgbGluZSA0
+        NywgaW4gc3luY2hyb25pemVcbiAgICBkdi5jcmVhdGUoKVxuICBGaWxlIFwi
+        L3Vzci9sb2NhbC9saWIvcHVscC9zcmMvcHVscGNvcmUtcGx1Z2luL3B1bHBj
+        b3JlL3BsdWdpbi9zdGFnZXMvZGVjbGFyYXRpdmVfdmVyc2lvbi5weVwiLCBs
+        aW5lIDE2OSwgaW4gY3JlYXRlXG4gICAgbG9vcC5ydW5fdW50aWxfY29tcGxl
+        dGUocGlwZWxpbmUpXG4gIEZpbGUgXCIvdXNyL2xpYjY0L3B5dGhvbjMuNi9h
+        c3luY2lvL2Jhc2VfZXZlbnRzLnB5XCIsIGxpbmUgNDg0LCBpbiBydW5fdW50
+        aWxfY29tcGxldGVcbiAgICByZXR1cm4gZnV0dXJlLnJlc3VsdCgpXG4gIEZp
+        bGUgXCIvdXNyL2xvY2FsL2xpYi9wdWxwL3NyYy9wdWxwY29yZS1wbHVnaW4v
+        cHVscGNvcmUvcGx1Z2luL3N0YWdlcy9hcGkucHlcIiwgbGluZSAyMDksIGlu
+        IGNyZWF0ZV9waXBlbGluZVxuICAgIGF3YWl0IGFzeW5jaW8uZ2F0aGVyKCpm
+        dXR1cmVzKVxuICBGaWxlIFwiL3Vzci9sb2NhbC9saWIvcHVscC9zcmMvcHVs
+        cGNvcmUtcGx1Z2luL3B1bHBjb3JlL3BsdWdpbi9zdGFnZXMvYXBpLnB5XCIs
+        IGxpbmUgNDMsIGluIF9fY2FsbF9fXG4gICAgYXdhaXQgc2VsZi5ydW4oKVxu
+        ICBGaWxlIFwiL3Vzci9sb2NhbC9saWIvcHVscC9zcmMvcHVscC1kb2NrZXIv
+        cHVscF9kb2NrZXIvYXBwL3Rhc2tzL3N5bmNfc3RhZ2VzLnB5XCIsIGxpbmUg
+        NTUsIGluIHJ1blxuICAgIGF3YWl0IGxpc3RfZG93bmxvYWRlci5ydW4oZXh0
+        cmFfZGF0YT17J3JlcG9fbmFtZSc6IHJlcG9fbmFtZX0pXG4gIEZpbGUgXCIv
+        dXNyL2xvY2FsL2xpYi9wdWxwL3NyYy9wdWxwY29yZS1wbHVnaW4vcHVscGNv
+        cmUvcGx1Z2luL2Rvd25sb2FkL2Jhc2UucHlcIiwgbGluZSAyMTIsIGluIHJ1
+        blxuICAgIHJldHVybiBhd2FpdCBzZWxmLl9ydW4oZXh0cmFfZGF0YT1leHRy
+        YV9kYXRhKVxuICBGaWxlIFwiL3Vzci9sb2NhbC9saWIvcHVscC9saWI2NC9w
+        eXRob24zLjYvc2l0ZS1wYWNrYWdlcy9iYWNrb2ZmL19hc3luYy5weVwiLCBs
+        aW5lIDEzMSwgaW4gcmV0cnlcbiAgICByZXQgPSBhd2FpdCB0YXJnZXQoKmFy
+        Z3MsICoqa3dhcmdzKVxuICBGaWxlIFwiL3Vzci9sb2NhbC9saWIvcHVscC9z
+        cmMvcHVscC1kb2NrZXIvcHVscF9kb2NrZXIvYXBwL2Rvd25sb2FkZXJzLnB5
+        XCIsIGxpbmUgNjIsIGluIF9ydW5cbiAgICByZXNwb25zZS5yYWlzZV9mb3Jf
+        c3RhdHVzKClcbiAgRmlsZSBcIi91c3IvbG9jYWwvbGliL3B1bHAvbGliNjQv
+        cHl0aG9uMy42L3NpdGUtcGFja2FnZXMvYWlvaHR0cC9jbGllbnRfcmVxcmVw
+        LnB5XCIsIGxpbmUgOTQyLCBpbiByYWlzZV9mb3Jfc3RhdHVzXG4gICAgaGVh
+        ZGVycz1zZWxmLmhlYWRlcnMpXG4ifSwid29ya2VyIjoiL3B1bHAvYXBpL3Yz
+        L3dvcmtlcnMvMzU1NWRkNTYtNzZlNy00NTY0LThlOGMtZDhkYzM5N2IyMDE2
+        LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInByb2dyZXNz
+        X3JlcG9ydHMiOlt7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMi
+        LCJzdGF0ZSI6ImNhbmNlbGVkIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1
+        ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIs
+        InN0YXRlIjoiY2FuY2VsZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3Vm
+        Zml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyB0YWcgbGlzdCIs
+        InN0YXRlIjoiZmFpbGVkIiwidG90YWwiOjEsImRvbmUiOjAsInN1ZmZpeCI6
+        bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:48 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/remotes/docker/docker/519a9cac-87e2-4bc7-a6df-bc8206420dac/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563368915/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:49 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQzZTJiYjJhLWYwZWMtNGM3
+        ZS1iMjRmLWY3NjBjZGY2NzIxNi8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:49 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/43e2bb2a-f0ec-4c7e-b24f-f760cdf67216/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:49 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy80M2UyYmIyYS1mMGVjLTRj
+        N2UtYjI0Zi1mNzYwY2RmNjcyMTYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjA2OjQ5LjE1NDU3MloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTE3VDIxOjA2OjQ5LjI0NzQ5M1oiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMTdUMjE6MDY6NDkuMjY4OTMwWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMTYwMjFmZDEtOTQ2ZS00MzEyLTgzNDUtNjIwMTFl
+        ZmUwYjA1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:49 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/docker/docker/?base_path=ACME_Corporation/library/busybox
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563368915/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:49 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '503'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9jcmVhdGVkIjoiMjAxOS0wNy0xN1QyMTowNjo0Ny4zMTM0Mjda
+        IiwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIv
+        ZG9ja2VyLzE2MDNkOWYxLWQzNzAtNDliNy1hYWM4LWMxZjRiY2IxNDVmZi8i
+        LCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2JjZmU1YjYxLWIzYTUtNGZkZC1iODNmLTdhYzUzODIyYjMzOC92ZXJz
+        aW9ucy8xLyIsInJlcG9zaXRvcnkiOm51bGwsImNvbnRlbnRfZ3VhcmQiOm51
+        bGwsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1UZXN0LWJ1c3lib3gt
+        bGlicmFyeSIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vbGlicmFy
+        eS9idXN5Ym94IiwicmVnaXN0cnlfcGF0aCI6InB1bHAzLWRldmVsLTIuY2Fu
+        bm9sby5leGFtcGxlLmNvbS9BQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvYnVz
+        eWJveCJ9XX0=
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:49 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/docker/docker/1603d9f1-d370-49b7-aac8-c1f4bcb145ff/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563368915/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:49 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U0NDFlYzY5LTQwY2UtNDQ5
+        ZS05ZTM2LWU3NGE5YTQ5NzVhYi8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:49 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/repositories/bcfe5b61-b3a5-4fdd-b83f-7ac53822b338/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:49 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk2YjQ5MjE4LThiYzAtNDgy
+        Ni1hZTkzLWQ0NzExMTdkNjY5Yy8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:49 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/96b49218-8bc0-4826-ae93-d471117d669c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:06:49 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '445'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85NmI0OTIxOC04YmMwLTQ4
+        MjYtYWU5My1kNDcxMTE3ZDY2OWMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjA2OjQ5LjY4MjU3NVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5kZWxldGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0xN1QyMTowNjo0OS43NTQ1MThaIiwiZmluaXNo
+        ZWRfYXQiOiIyMDE5LTA3LTE3VDIxOjA2OjQ5Ljc3NjE3N1oiLCJub25fZmF0
+        YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2Fw
+        aS92My93b3JrZXJzLzM1NTVkZDU2LTc2ZTctNDU2NC04ZThjLWQ4ZGMzOTdi
+        MjAxNi8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9n
+        cmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:06:49 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/repositories/68e80edc-ac5e-4709-9e4c-2b0e31d3d656/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:09 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q1YjY4M2ZmLTI0ODMtNGUy
+        YS04ODExLWIxNjliZDU3MTgzMC8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:09 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/d5b683ff-2483-4e2a-8811-b169bd571830/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:09 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '502'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kNWI2ODNmZi0yNDgzLTRl
+        MmEtODgxMS1iMTY5YmQ1NzE4MzAvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjI2OjA5LjU0Mjk5NVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLnJlcG9zaXRvcnkuYWRkX2FuZF9yZW1vdmUi
+        LCJzdGFydGVkX2F0IjoiMjAxOS0wNy0xN1QyMToyNjowOS42NDg4NzNaIiwi
+        ZmluaXNoZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJv
+        ciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMTYwMjFm
+        ZDEtOTQ2ZS00MzEyLTgzNDUtNjIwMTFlZmUwYjA1LyIsInBhcmVudCI6bnVs
+        bCwic3Bhd25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJj
+        cmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        LzY4ZTgwZWRjLWFjNWUtNDcwOS05ZTRjLTJiMGUzMWQzZDY1Ni92ZXJzaW9u
+        cy8xLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:09 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/d5b683ff-2483-4e2a-8811-b169bd571830/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:09 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kNWI2ODNmZi0yNDgzLTRl
+        MmEtODgxMS1iMTY5YmQ1NzE4MzAvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjI2OjA5LjU0Mjk5NVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTE3VDIxOjI2OjA5LjY0ODg3M1oi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMTdUMjE6MjY6MDkuNjgwMzA3WiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvMTYwMjFmZDEtOTQ2ZS00MzEyLTgzNDUt
+        NjIwMTFlZmUwYjA1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzY4ZTgwZWRjLWFjNWUtNDcw
+        OS05ZTRjLTJiMGUzMWQzZDY1Ni92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:09 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/repositories/68e80edc-ac5e-4709-9e4c-2b0e31d3d656/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:09 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNjhlODBlZGMt
+        YWM1ZS00NzA5LTllNGMtMmIwZTMxZDNkNjU2L3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTE3VDIxOjI2OjA5LjY2NDA3NFoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:09 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNh
+        YmluZXQtcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzY4ZTgwZWRjLWFjNWUtNDcwOS05
+        ZTRjLTJiMGUzMWQzZDY1Ni92ZXJzaW9ucy8xLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563368915/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:10 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U5YjI5ZmY2LWI1OTctNGVi
+        MC05ZmU3LWRlNWZiMTQxODEyMy8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:10 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/e9b29ff6-b597-4eb0-9fe7-de5fb1418123/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:10 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lOWIyOWZmNi1iNTk3LTRl
+        YjAtOWZlNy1kZTVmYjE0MTgxMjMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjI2OjEwLjE0MzE3M1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0xN1QyMToyNjoxMC4yNjcwMjdaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMTYwMjFmZDEtOTQ2
+        ZS00MzEyLTgzNDUtNjIwMTFlZmUwYjA1LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:10 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/e9b29ff6-b597-4eb0-9fe7-de5fb1418123/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:10 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lOWIyOWZmNi1iNTk3LTRl
+        YjAtOWZlNy1kZTVmYjE0MTgxMjMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjI2OjEwLjE0MzE3M1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0xN1QyMToyNjoxMC4yNjcwMjdaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMTYwMjFmZDEtOTQ2
+        ZS00MzEyLTgzNDUtNjIwMTFlZmUwYjA1LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:10 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/e9b29ff6-b597-4eb0-9fe7-de5fb1418123/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:10 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '527'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lOWIyOWZmNi1iNTk3LTRl
+        YjAtOWZlNy1kZTVmYjE0MTgxMjMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjI2OjEwLjE0MzE3M1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTE3VDIxOjI2OjEwLjI2NzAyN1oiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMTdUMjE6MjY6MTAuNDMyMjc1WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMTYwMjFmZDEtOTQ2ZS00MzEyLTgzNDUtNjIwMTFl
+        ZmUwYjA1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyL2NmYjE1MTc3
+        LTQyYTMtNDk2Yi04ZDE0LTMwZThhNzEwZTFmYi8iXX0=
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:10 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/docker/docker/cfb15177-42a3-496b-8d14-30e8a710e1fb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563368915/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:10 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '475'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfY3JlYXRlZCI6IjIwMTktMDctMTdUMjE6MjY6MTAuNDIzMjc5WiIsIl9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZG9ja2VyL2RvY2tl
+        ci9jZmIxNTE3Ny00MmEzLTQ5NmItOGQxNC0zMGU4YTcxMGUxZmIvIiwicmVw
+        b3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy82
+        OGU4MGVkYy1hYzVlLTQ3MDktOWU0Yy0yYjBlMzFkM2Q2NTYvdmVyc2lvbnMv
+        MS8iLCJyZXBvc2l0b3J5IjpudWxsLCJjb250ZW50X2d1YXJkIjpudWxsLCJu
+        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2Nr
+        ZXJfMSIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJh
+        cnkvcHVscDNfRG9ja2VyXzEiLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tL0RlZmF1bHRfT3JnYW5pemF0aW9u
+        L2xpYnJhcnkvcHVscDNfRG9ja2VyXzEifQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:10 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/remotes/docker/docker/ed952706-bb06-4344-ac52-6daacef5737c/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy82OGU4
+        MGVkYy1hYzVlLTQ3MDktOWU0Yy0yYjBlMzFkM2Q2NTYvIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563368915/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:11 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U3NGNjZDUyLTg3NzMtNDhm
+        Yi1iNDNmLWNhODQxNTI4NWY4My8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:11 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/e74ccd52-8773-48fb-b43f-ca8415285f83/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:11 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lNzRjY2Q1Mi04NzczLTQ4
+        ZmItYjQzZi1jYTg0MTUyODVmODMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjI2OjExLjAyNTU5NloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMTdUMjE6MjY6MTEuMTE5NzAwWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzE2MDIx
+        ZmQxLTk0NmUtNDMxMi04MzQ1LTYyMDExZWZlMGIwNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:11 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/e74ccd52-8773-48fb-b43f-ca8415285f83/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:11 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lNzRjY2Q1Mi04NzczLTQ4
+        ZmItYjQzZi1jYTg0MTUyODVmODMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjI2OjExLjAyNTU5NloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMTdUMjE6MjY6MTEuMTE5NzAwWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzE2MDIx
+        ZmQxLTk0NmUtNDMxMi04MzQ1LTYyMDExZWZlMGIwNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:11 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/e74ccd52-8773-48fb-b43f-ca8415285f83/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:11 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lNzRjY2Q1Mi04NzczLTQ4
+        ZmItYjQzZi1jYTg0MTUyODVmODMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjI2OjExLjAyNTU5NloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMTdUMjE6MjY6MTEuMTE5NzAwWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzE2MDIx
+        ZmQxLTk0NmUtNDMxMi04MzQ1LTYyMDExZWZlMGIwNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:11 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/e74ccd52-8773-48fb-b43f-ca8415285f83/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:11 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lNzRjY2Q1Mi04NzczLTQ4
+        ZmItYjQzZi1jYTg0MTUyODVmODMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjI2OjExLjAyNTU5NloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMTdUMjE6MjY6MTEuMTE5NzAwWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzE2MDIx
+        ZmQxLTk0NmUtNDMxMi04MzQ1LTYyMDExZWZlMGIwNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:11 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/e74ccd52-8773-48fb-b43f-ca8415285f83/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:11 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '879'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lNzRjY2Q1Mi04NzczLTQ4
+        ZmItYjQzZi1jYTg0MTUyODVmODMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjI2OjExLjAyNTU5NloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0xN1QyMToyNjoxMS4xMTk3MDBa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTE3VDIxOjI2OjExLjY3OTE1Mloi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzE2MDIxZmQxLTk0NmUtNDMxMi04MzQ1
+        LTYyMDExZWZlMGIwNS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Npbmcg
+        VGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvNjhlODBlZGMtYWM1ZS00NzA5LTllNGMtMmIw
+        ZTMxZDNkNjU2L3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:11 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/repositories/68e80edc-ac5e-4709-9e4c-2b0e31d3d656/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:11 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '1281'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNjhlODBlZGMt
+        YWM1ZS00NzA5LTllNGMtMmIwZTMxZDNkNjU2L3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTE3VDIxOjI2OjExLjE0MTQ4NloiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy82
+        OGU4MGVkYy1hYzVlLTQ3MDktOWU0Yy0yYjBlMzFkM2Q2NTYvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0LXRhZyI6eyJjb3VudCI6MSwiaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdC10YWdzLz9y
+        ZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRv
+        cmllcy82OGU4MGVkYy1hYzVlLTQ3MDktOWU0Yy0yYjBlMzFkM2Q2NTYvdmVy
+        c2lvbnMvMi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvNjhlODBlZGMtYWM1ZS00NzA5LTllNGMtMmIwZTMxZDNkNjU2L3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvNjhlODBlZGMtYWM1ZS00NzA5LTllNGMt
+        MmIwZTMxZDNkNjU2L3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdC10
+        YWciOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvbWFuaWZlc3QtdGFncy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvNjhlODBlZGMtYWM1ZS00NzA5LTllNGMt
+        MmIwZTMxZDNkNjU2L3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzY4ZTgwZWRjLWFjNWUtNDcwOS05ZTRjLTJiMGUzMWQz
+        ZDY1Ni92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:11 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/docker/docker/cfb15177-42a3-496b-8d14-30e8a710e1fb/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzY4ZTgwZWRjLWFjNWUtNDcwOS05ZTRjLTJiMGUzMWQzZDY1Ni92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563368915/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEzMDg5MmIxLTA2NmUtNDc3
+        NC05Mzg4LWI5MGRmZDAxNTk1Ny8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:12 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/130892b1-066e-4774-9388-b90dfd015957/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8xMzA4OTJiMS0wNjZlLTQ3
+        NzQtOTM4OC1iOTBkZmQwMTU5NTcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjI2OjEyLjA5MTIwMFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0xN1QyMToyNjoxMi4yMTc4NDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMTYwMjFmZDEtOTQ2
+        ZS00MzEyLTgzNDUtNjIwMTFlZmUwYjA1LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:12 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/130892b1-066e-4774-9388-b90dfd015957/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8xMzA4OTJiMS0wNjZlLTQ3
+        NzQtOTM4OC1iOTBkZmQwMTU5NTcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjI2OjEyLjA5MTIwMFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTE3VDIxOjI2OjEyLjIxNzg0M1oiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMTdUMjE6MjY6MTIuMjk4NjI4WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMTYwMjFmZDEtOTQ2ZS00MzEyLTgzNDUtNjIwMTFl
+        ZmUwYjA1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:12 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/remotes/docker/docker/ed952706-bb06-4344-ac52-6daacef5737c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563368915/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFlZGIzMzI2LTdmMDItNDU0
+        My05ODBhLTRhMDg0OWU4YTJkZS8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:12 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/1edb3326-7f02-4543-980a-4a0849e8a2de/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8xZWRiMzMyNi03ZjAyLTQ1
+        NDMtOTgwYS00YTA4NDllOGEyZGUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjI2OjEyLjcwNjgyMFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTE3VDIxOjI2OjEyLjgwODkwMloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMTdUMjE6MjY6MTIuODMzNzY2WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMTYwMjFmZDEtOTQ2ZS00MzEyLTgzNDUtNjIwMTFl
+        ZmUwYjA1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:12 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/distributions/docker/docker/cfb15177-42a3-496b-8d14-30e8a710e1fb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563368915/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:13 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzliMjNiMjZkLWI2ZWEtNDQz
+        Mi04YTA2LTllODllOWNkZDE3MS8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:13 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/repositories/68e80edc-ac5e-4709-9e4c-2b0e31d3d656/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:13 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U3YmRkNDA2LTI0N2QtNDNl
+        Ni05OWYyLWQ3NTdiYzJlMGI5ZC8ifQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:13 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-2.cannolo.example.com/pulp/api/v3/tasks/e7bdd406-247d-43e6-99f2-d757bc2e0b9d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563124894/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 17 Jul 2019 21:26:13 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '445'
+      Via:
+      - 1.1 pulp3-devel-2.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lN2JkZDQwNi0yNDdkLTQz
+        ZTYtOTlmMi1kNzU3YmMyZTBiOWQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE3
+        VDIxOjI2OjEzLjIzMzcwMloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5kZWxldGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0xN1QyMToyNjoxMy4zMDQ3NzVaIiwiZmluaXNo
+        ZWRfYXQiOiIyMDE5LTA3LTE3VDIxOjI2OjEzLjMzMDE5M1oiLCJub25fZmF0
+        YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2Fw
+        aS92My93b3JrZXJzLzE2MDIxZmQxLTk0NmUtNDMxMi04MzQ1LTYyMDExZWZl
+        MGIwNS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9n
+        cmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 17 Jul 2019 21:26:13 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/c9fa232e-68cc-4d9a-889b-d616e0752725/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:20 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgxYWZhY2ZjLWJkNzEtNDE0
+        Ni1hZjk0LTY4ODcxMTg0MmZhMS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:20 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '350'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlbW90ZXMvZG9ja2VyL2Rv
+        Y2tlci9mYzFmMDAwYi0wZWFjLTRhYWYtODYyMC1jNDQ2ZTBhMDk1NjkvIiwi
+        X2NyZWF0ZWQiOiIyMDE5LTA3LTI0VDE2OjM5OjM4LjkyMDU5OVoiLCJfdHlw
+        ZSI6ImRvY2tlci5kb2NrZXIiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        b24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInVybCI6Imh0dHBzOi8vcmVn
+        aXN0cnktMS5kb2NrZXIuaW8vIiwic3NsX2NhX2NlcnRpZmljYXRlIjpudWxs
+        LCJzc2xfY2xpZW50X2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2tl
+        eSI6bnVsbCwic3NsX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVs
+        bCwiX2xhc3RfdXBkYXRlZCI6IjIwMTktMDctMjRUMTY6Mzk6MzguOTIwNjI0
+        WiIsImRvd25sb2FkX2NvbmN1cnJlbmN5IjoyMCwicG9saWN5IjoiaW1tZWRp
+        YXRlIiwidXBzdHJlYW1fbmFtZSI6ImZlZG9yYS9zc2giLCJ3aGl0ZWxpc3Rf
+        dGFncyI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:21 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/fc1f000b-0eac-4aaf-8620-c446e0a09569/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I2MWNhMTcwLTE0ZGEtNDUy
+        OC1iMjQxLWMwMGE0MDg0MWNhMC8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:21 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '279'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJh
+        cnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5IjpudWxsLCJfY3JlYXRl
+        ZCI6IjIwMTktMDctMjRUMTY6Mzk6NDAuMDc3Mzc1WiIsIm5hbWUiOiJEZWZh
+        dWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0RvY2tlcl8xIiwicmVw
+        b3NpdG9yeV92ZXJzaW9uIjpudWxsLCJjb250ZW50X2d1YXJkIjpudWxsLCJf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2RvY2tlci9kb2Nr
+        ZXIvZWRiMWVjZjctYWU1My00YmIwLTg5ZTYtYzU5NGM1OWQzMDI0LyIsInJl
+        Z2lzdHJ5X3BhdGgiOiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29t
+        L0RlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRG9ja2VyXzEi
+        fV19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:21 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/edb1ecf7-ae53-4bb0-89e6-c594c59d3024/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ4OTZlOGI1LThmZTMtNGEw
+        Yi05MTI1LTU1ZjQ5NzgyZDlmNS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:21 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:21 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/86b503ad-df0d-4e25-b239-3ae202321261/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM4YjY0NmU5LTE1ODQtNGZl
+        Yi1iYzhiLTVhYTliNzgzZDU5Yi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:22 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/38b646e9-1584-4feb-bc8b-5aa9b783d59b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zOGI2NDZlOS0xNTg0LTRm
+        ZWItYmM4Yi01YWE5Yjc4M2Q1OWIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjQwOjIyLjQyODI5NFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjQwOjIyLjUwNjY5NVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjRUMTY6NDA6MjIuNTM3OTYwWiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2UwYy00NDlhLTkzNzgt
+        NDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzg2YjUwM2FkLWRmMGQtNGUy
+        NS1iMjM5LTNhZTIwMjMyMTI2MS92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:22 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/86b503ad-df0d-4e25-b239-3ae202321261/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvODZiNTAzYWQt
+        ZGYwZC00ZTI1LWIyMzktM2FlMjAyMzIxMjYxL3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI0VDE2OjQwOjIyLjUyMTIzOFoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:22 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19E
+        b2NrZXJfMSIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzg2YjUwM2FkLWRmMGQtNGUyNS1i
+        MjM5LTNhZTIwMjMyMTI2MS92ZXJzaW9ucy8xLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QzMjZmZjRkLWJkNTktNDAy
+        YS1hYzczLTJlZmEwZTY4MzViYy8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:22 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d326ff4d-bd59-402a-ac73-2efa0e6835bc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kMzI2ZmY0ZC1iZDU5LTQw
+        MmEtYWM3My0yZWZhMGU2ODM1YmMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjQwOjIyLjg2MTM1MVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yNFQxNjo0MDoyMi45ODYwNTZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2Uw
+        Yy00NDlhLTkzNzgtNDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:22 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d326ff4d-bd59-402a-ac73-2efa0e6835bc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kMzI2ZmY0ZC1iZDU5LTQw
+        MmEtYWM3My0yZWZhMGU2ODM1YmMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjQwOjIyLjg2MTM1MVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yNFQxNjo0MDoyMi45ODYwNTZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2Uw
+        Yy00NDlhLTkzNzgtNDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:23 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d326ff4d-bd59-402a-ac73-2efa0e6835bc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '527'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kMzI2ZmY0ZC1iZDU5LTQw
+        MmEtYWM3My0yZWZhMGU2ODM1YmMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjQwOjIyLjg2MTM1MVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjQwOjIyLjk4NjA1NloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjRUMTY6NDA6MjMuMTQwOTQ2WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2UwYy00NDlhLTkzNzgtNDg3YWZl
+        ZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzhlZGU3Yzdj
+        LTA2NjQtNDg0OC1iMDc0LTc5M2U2ZjExMGI4OC8iXX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:23 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/8ede7c7c-0664-4848-b074-793e6f110b88/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '289'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTI0VDE2OjQwOjIzLjEzMzQ5MFoiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvODZiNTAz
+        YWQtZGYwZC00ZTI1LWIyMzktM2FlMjAyMzIxMjYxL3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzhlZGU3YzdjLTA2NjQtNDg0OC1i
+        MDc0LTc5M2U2ZjExMGI4OC8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:23 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/bb2d7ab8-6bd8-4c96-976c-5f9bacb541a0/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy84NmI1
+        MDNhZC1kZjBkLTRlMjUtYjIzOS0zYWUyMDIzMjEyNjEvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UzZmI2NDUzLWRjOTktNGQ3
+        My05MDlhLThlZTcwYjdkNTJhYS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:23 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/e3fb6453-dc99-4d73-909a-8ee70b7d52aa/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lM2ZiNjQ1My1kYzk5LTRk
+        NzMtOTA5YS04ZWU3MGI3ZDUyYWEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjQwOjIzLjcxMzExOFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6NDA6MjMuNzgzMjgxWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:23 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/e3fb6453-dc99-4d73-909a-8ee70b7d52aa/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lM2ZiNjQ1My1kYzk5LTRk
+        NzMtOTA5YS04ZWU3MGI3ZDUyYWEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjQwOjIzLjcxMzExOFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6NDA6MjMuNzgzMjgxWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:23 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/e3fb6453-dc99-4d73-909a-8ee70b7d52aa/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lM2ZiNjQ1My1kYzk5LTRk
+        NzMtOTA5YS04ZWU3MGI3ZDUyYWEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjQwOjIzLjcxMzExOFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6NDA6MjMuNzgzMjgxWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:24 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/e3fb6453-dc99-4d73-909a-8ee70b7d52aa/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lM2ZiNjQ1My1kYzk5LTRk
+        NzMtOTA5YS04ZWU3MGI3ZDUyYWEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjQwOjIzLjcxMzExOFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6NDA6MjMuNzgzMjgxWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:24 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/e3fb6453-dc99-4d73-909a-8ee70b7d52aa/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lM2ZiNjQ1My1kYzk5LTRk
+        NzMtOTA5YS04ZWU3MGI3ZDUyYWEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjQwOjIzLjcxMzExOFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6NDA6MjMuNzgzMjgxWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:24 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/e3fb6453-dc99-4d73-909a-8ee70b7d52aa/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '879'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lM2ZiNjQ1My1kYzk5LTRk
+        NzMtOTA5YS04ZWU3MGI3ZDUyYWEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjQwOjIzLjcxMzExOFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yNFQxNjo0MDoyMy43ODMyODFa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjQwOjI0LjQ3OTU4OVoi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3MmFiLTNlMGMtNDQ5YS05Mzc4
+        LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Npbmcg
+        VGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvODZiNTAzYWQtZGYwZC00ZTI1LWIyMzktM2Fl
+        MjAyMzIxMjYxL3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:24 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/86b503ad-df0d-4e25-b239-3ae202321261/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '1281'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvODZiNTAzYWQt
+        ZGYwZC00ZTI1LWIyMzktM2FlMjAyMzIxMjYxL3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI0VDE2OjQwOjIzLjgwMzA1NFoiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy84
+        NmI1MDNhZC1kZjBkLTRlMjUtYjIzOS0zYWUyMDIzMjEyNjEvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvODZi
+        NTAzYWQtZGYwZC00ZTI1LWIyMzktM2FlMjAyMzIxMjYxL3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvODZiNTAzYWQtZGYwZC00ZTI1LWIyMzktM2FlMjAyMzIxMjYxL3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvODZiNTAzYWQtZGYwZC00ZTI1LWIyMzkt
+        M2FlMjAyMzIxMjYxL3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzg2YjUwM2FkLWRmMGQtNGUyNS1iMjM5LTNhZTIwMjMy
+        MTI2MS92ZXJzaW9ucy8yLyJ9LCJkb2NrZXIubWFuaWZlc3QtdGFnIjp7ImNv
+        dW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzg2YjUwM2FkLWRmMGQtNGUyNS1iMjM5LTNhZTIwMjMy
+        MTI2MS92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:24 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/8ede7c7c-0664-4848-b074-793e6f110b88/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzg2YjUwM2FkLWRmMGQtNGUyNS1iMjM5LTNhZTIwMjMyMTI2MS92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhjYjk2NDBkLTc0NWQtNGQ1
+        Ni1iYzBhLWQxYjgxY2I3YTc3Ni8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:24 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/8cb9640d-745d-4d56-bc0a-d1b81cb7a776/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84Y2I5NjQwZC03NDVkLTRk
+        NTYtYmMwYS1kMWI4MWNiN2E3NzYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjQwOjI0LjgxODA2NVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yNFQxNjo0MDoyNC45NDA1MDlaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2
+        YS00MjE2LTgwMjUtZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:24 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/8cb9640d-745d-4d56-bc0a-d1b81cb7a776/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84Y2I5NjQwZC03NDVkLTRk
+        NTYtYmMwYS1kMWI4MWNiN2E3NzYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjQwOjI0LjgxODA2NVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjQwOjI0Ljk0MDUwOVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjRUMTY6NDA6MjUuMDAwMDgyWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUtZjRlZmYy
+        NDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:25 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/bb2d7ab8-6bd8-4c96-976c-5f9bacb541a0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YxZWRmMTMzLWRkOWYtNDU0
+        NC04ZTAyLTk1NWZhYjM5NmRmNi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:25 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/f1edf133-dd9f-4544-8e02-955fab396df6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9mMWVkZjEzMy1kZDlmLTQ1
+        NDQtOGUwMi05NTVmYWIzOTZkZjYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjQwOjI1LjQxNDg1NVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjQwOjI1LjUwOTAxOVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjRUMTY6NDA6MjUuNTM2MjQ0WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2UwYy00NDlhLTkzNzgtNDg3YWZl
+        ZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:25 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '318'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJh
+        cnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5IjpudWxsLCJfY3JlYXRl
+        ZCI6IjIwMTktMDctMjRUMTY6NDA6MjMuMTMzNDkwWiIsIm5hbWUiOiJEZWZh
+        dWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0RvY2tlcl8xIiwicmVw
+        b3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy84
+        NmI1MDNhZC1kZjBkLTRlMjUtYjIzOS0zYWUyMDIzMjEyNjEvdmVyc2lvbnMv
+        Mi8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9kaXN0cmlidXRpb25zL2RvY2tlci9kb2NrZXIvOGVkZTdjN2MtMDY2NC00
+        ODQ4LWIwNzQtNzkzZTZmMTEwYjg4LyIsInJlZ2lzdHJ5X3BhdGgiOiJwdWxw
+        My1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29tL0RlZmF1bHRfT3JnYW5pemF0
+        aW9uL2xpYnJhcnkvcHVscDNfRG9ja2VyXzEifV19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:25 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/8ede7c7c-0664-4848-b074-793e6f110b88/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY0YTM2MzJmLTdmOTQtNGQx
+        Yy04OWJiLTIxMDE0MmEzYTI5My8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:25 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/86b503ad-df0d-4e25-b239-3ae202321261/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:26 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NiYzBhYWU2LWQ3MDktNGQy
+        NC05YmU2LTBmMjU5NTUwNDNlNi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:26 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/cbc0aae6-d709-4d24-9be6-0f25955043e6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:40:26 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '445'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jYmMwYWFlNi1kNzA5LTRk
+        MjQtOWJlNi0wZjI1OTU1MDQzZTYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjQwOjI2LjAwMjIwOFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5kZWxldGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yNFQxNjo0MDoyNi4wNjczOTRaIiwiZmluaXNo
+        ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjQwOjI2LjA5MTkzMloiLCJub25fZmF0
+        YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2Fw
+        aS92My93b3JrZXJzLzA2YmQ3MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUx
+        OWVhNS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9n
+        cmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:40:26 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:12 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:12 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:12 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/?base_path=Default_Organization/library/pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:12 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19E
+        b2NrZXJfMSJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:13 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/e9204612-ef56-47dc-a36d-b69e014dcf06/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '308'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZTkyMDQ2MTIt
+        ZWY1Ni00N2RjLWEzNmQtYjY5ZTAxNGRjZjA2LyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wNy0yOVQxMzoyNToxMy4xMzAzMTVaIiwiX3ZlcnNpb25zX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2U5MjA0NjEyLWVmNTYtNDdkYy1h
+        MzZkLWI2OWUwMTRkY2YwNi92ZXJzaW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25f
+        aHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfRG9ja2VyXzEiLCJkZXNjcmlwdGlvbiI6bnVsbH0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:13 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19E
+        b2NrZXJfMSIsInVybCI6Imh0dHBzOi8vcmVnaXN0cnktMS5kb2NrZXIuaW8v
+        Iiwic3NsX3ZhbGlkYXRpb24iOnRydWUsInBvbGljeSI6ImltbWVkaWF0ZSIs
+        InVwc3RyZWFtX25hbWUiOiJmZWRvcmEvc3NoIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:13 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/docker/docker/da71f6bc-cce9-4275-92d3-9726ba1ead3f/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '501'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2RvY2tlci9kb2NrZXIv
+        ZGE3MWY2YmMtY2NlOS00Mjc1LTkyZDMtOTcyNmJhMWVhZDNmLyIsIl9jcmVh
+        dGVkIjoiMjAxOS0wNy0yOVQxMzoyNToxMy4yODc2NjRaIiwiX3R5cGUiOiJk
+        b2NrZXIuZG9ja2VyIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNh
+        YmluZXQtcHVscDNfRG9ja2VyXzEiLCJ1cmwiOiJodHRwczovL3JlZ2lzdHJ5
+        LTEuZG9ja2VyLmlvLyIsInNzbF9jYV9jZXJ0aWZpY2F0ZSI6bnVsbCwic3Ns
+        X2NsaWVudF9jZXJ0aWZpY2F0ZSI6bnVsbCwic3NsX2NsaWVudF9rZXkiOm51
+        bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsIl9s
+        YXN0X3VwZGF0ZWQiOiIyMDE5LTA3LTI5VDEzOjI1OjEzLjI4NzY3OFoiLCJk
+        b3dubG9hZF9jb25jdXJyZW5jeSI6MjAsInBvbGljeSI6ImltbWVkaWF0ZSIs
+        InVwc3RyZWFtX25hbWUiOiJmZWRvcmEvc3NoIiwid2hpdGVsaXN0X3RhZ3Mi
+        Om51bGx9
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:13 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/e9204612-ef56-47dc-a36d-b69e014dcf06/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:13 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IwMWUwMDk0LTJlMzAtNDVm
+        ZC05ZDUyLWRmMmYwMWVjNjIzYy8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:13 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/b01e0094-2e30-45fd-9d52-df2f01ec623c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:13 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '326'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9iMDFlMDA5NC0yZTMwLTQ1
+        ZmQtOWQ1Mi1kZjJmMDFlYzYyM2MvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI1OjEzLjY0OTYwMFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLnJlcG9zaXRvcnkuYWRkX2FuZF9yZW1vdmUi
+        LCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yOVQxMzoyNToxMy43NTYwNDRaIiwi
+        ZmluaXNoZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJv
+        ciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNl
+        ODYtODQxZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVs
+        bCwic3Bhd25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJj
+        cmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L2U5MjA0NjEyLWVmNTYtNDdkYy1hMzZkLWI2OWUwMTRkY2YwNi92ZXJzaW9u
+        cy8xLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:13 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/b01e0094-2e30-45fd-9d52-df2f01ec623c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:13 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '334'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9iMDFlMDA5NC0yZTMwLTQ1
+        ZmQtOWQ1Mi1kZjJmMDFlYzYyM2MvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI1OjEzLjY0OTYwMFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTI5VDEzOjI1OjEzLjc1NjA0NFoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjlUMTM6MjU6MTMuNzk2OTU5WiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUt
+        Y2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2U5MjA0NjEyLWVmNTYtNDdk
+        Yy1hMzZkLWI2OWUwMTRkY2YwNi92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:13 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/e9204612-ef56-47dc-a36d-b69e014dcf06/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:14 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '185'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZTkyMDQ2MTIt
+        ZWY1Ni00N2RjLWEzNmQtYjY5ZTAxNGRjZjA2L3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI5VDEzOjI1OjEzLjc3NzUyNloiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:14 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19E
+        b2NrZXJfMSIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2U5MjA0NjEyLWVmNTYtNDdkYy1h
+        MzZkLWI2OWUwMTRkY2YwNi92ZXJzaW9ucy8xLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:14 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EzZjM1MzA3LTU5ZjMtNGU2
+        Ni1hNjUxLTk2ZWIyNDFlN2NiZC8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:14 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/a3f35307-59f3-4e66-a651-96eb241e7cbd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:14 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '277'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hM2YzNTMwNy01OWYzLTRl
+        NjYtYTY1MS05NmViMjQxZTdjYmQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI1OjE0LjI4Mzg1OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yOVQxMzoyNToxNC40MTI0OTZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQx
+        ZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:14 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/a3f35307-59f3-4e66-a651-96eb241e7cbd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:14 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '330'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hM2YzNTMwNy01OWYzLTRl
+        NjYtYTY1MS05NmViMjQxZTdjYmQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI1OjE0LjI4Mzg1OVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI5VDEzOjI1OjE0LjQxMjQ5NloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjlUMTM6MjU6MTQuNTU5Njk1WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUtY2MxMjUx
+        OGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzQ3N2M2OGZl
+        LTZlMjItNDBiZC1hN2NlLThjZTE0OTFjNTI3Yi8iXX0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:14 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/477c68fe-6e22-40bd-a7ce-8ce1491c527b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:14 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '473'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTI5VDEzOjI1OjE0LjU1MTkwOFoiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZTkyMDQ2
+        MTItZWY1Ni00N2RjLWEzNmQtYjY5ZTAxNGRjZjA2L3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzQ3N2M2OGZlLTZlMjItNDBiZC1h
+        N2NlLThjZTE0OTFjNTI3Yi8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:14 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/da71f6bc-cce9-4275-92d3-9726ba1ead3f/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9lOTIw
+        NDYxMi1lZjU2LTQ3ZGMtYTM2ZC1iNjllMDE0ZGNmMDYvIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIzNjMzZjcxLTQ1YjMtNDMz
+        ZC1hZTAxLTNjZDU3YzAzNjU5NC8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:15 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/23633f71-45b3-433d-ae01-3cd57c036594/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '285'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yMzYzM2Y3MS00NWIzLTQz
+        M2QtYWUwMS0zY2Q1N2MwMzY1OTQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI1OjE1LjA4NDAxNloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjlUMTM6MjU6MTUuMTk2NDY3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwi
+        Y3JlYXRlZF9yZXNvdXJjZXMiOltudWxsXX0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:15 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/23633f71-45b3-433d-ae01-3cd57c036594/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '369'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yMzYzM2Y3MS00NWIzLTQz
+        M2QtYWUwMS0zY2Q1N2MwMzY1OTQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI1OjE1LjA4NDAxNloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjlUMTM6MjU6MTUuMTk2NDY3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:15 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/23633f71-45b3-433d-ae01-3cd57c036594/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '369'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yMzYzM2Y3MS00NWIzLTQz
+        M2QtYWUwMS0zY2Q1N2MwMzY1OTQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI1OjE1LjA4NDAxNloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjlUMTM6MjU6MTUuMTk2NDY3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:15 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/23633f71-45b3-433d-ae01-3cd57c036594/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '377'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yMzYzM2Y3MS00NWIzLTQz
+        M2QtYWUwMS0zY2Q1N2MwMzY1OTQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI1OjE1LjA4NDAxNloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjlUMTM6MjU6MTUuMTk2NDY3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:15 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/23633f71-45b3-433d-ae01-3cd57c036594/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '443'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yMzYzM2Y3MS00NWIzLTQz
+        M2QtYWUwMS0zY2Q1N2MwMzY1OTQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI1OjE1LjA4NDAxNloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yOVQxMzoyNToxNS4xOTY0Njda
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTI5VDEzOjI1OjE1LjgzNTQxMloi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkzZTg2LTg0MWUtNGUxMC1iMmI1
+        LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Npbmcg
+        VGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvZTkyMDQ2MTItZWY1Ni00N2RjLWEzNmQtYjY5
+        ZTAxNGRjZjA2L3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:15 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/e9204612-ef56-47dc-a36d-b69e014dcf06/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:16 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '280'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZTkyMDQ2MTIt
+        ZWY1Ni00N2RjLWEzNmQtYjY5ZTAxNGRjZjA2L3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI5VDEzOjI1OjE1LjIyMzc5MVoiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9l
+        OTIwNDYxMi1lZjU2LTQ3ZGMtYTM2ZC1iNjllMDE0ZGNmMDYvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZTky
+        MDQ2MTItZWY1Ni00N2RjLWEzNmQtYjY5ZTAxNGRjZjA2L3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvZTkyMDQ2MTItZWY1Ni00N2RjLWEzNmQtYjY5ZTAxNGRjZjA2L3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZTkyMDQ2MTItZWY1Ni00N2RjLWEzNmQt
+        YjY5ZTAxNGRjZjA2L3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2U5MjA0NjEyLWVmNTYtNDdkYy1hMzZkLWI2OWUwMTRk
+        Y2YwNi92ZXJzaW9ucy8yLyJ9LCJkb2NrZXIubWFuaWZlc3QtdGFnIjp7ImNv
+        dW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2U5MjA0NjEyLWVmNTYtNDdkYy1hMzZkLWI2OWUwMTRk
+        Y2YwNi92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:16 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/477c68fe-6e22-40bd-a7ce-8ce1491c527b/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2U5MjA0NjEyLWVmNTYtNDdkYy1hMzZkLWI2OWUwMTRkY2YwNi92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:16 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MxNjEwZGE3LTI1MDMtNDBm
+        MS1iMmVlLWUzZmJjMWFjODcyMi8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:16 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/c1610da7-2503-40f1-b2ee-e3fbc1ac8722/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:16 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '280'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jMTYxMGRhNy0yNTAzLTQw
+        ZjEtYjJlZS1lM2ZiYzFhYzg3MjIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI1OjE2LjIxNjA4OFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yOVQxMzoyNToxNi4zMTU4ODRaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQx
+        ZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:16 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/c1610da7-2503-40f1-b2ee-e3fbc1ac8722/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:16 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '287'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jMTYxMGRhNy0yNTAzLTQw
+        ZjEtYjJlZS1lM2ZiYzFhYzg3MjIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI1OjE2LjIxNjA4OFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI5VDEzOjI1OjE2LjMxNTg4NFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjlUMTM6MjU6MTYuMzk1MjYwWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUtY2MxMjUx
+        OGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:16 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/da71f6bc-cce9-4275-92d3-9726ba1ead3f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:16 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNjNGY0YjkxLWYzY2YtNDRj
+        Yi04YWU5LTgzZmEyNWI4YmQ2OC8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:16 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3c4f4b91-f3cf-44cb-8ae9-83fa25b8bd68/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:16 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '287'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zYzRmNGI5MS1mM2NmLTQ0
+        Y2ItOGFlOS04M2ZhMjViOGJkNjgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI1OjE2Ljc0ODU5OFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI5VDEzOjI1OjE2Ljg0MzIzNVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjlUMTM6MjU6MTYuODY5NTg4WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUtY2MxMjUx
+        OGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:16 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/?base_path=Default_Organization/library/pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '525'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJh
+        cnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5IjpudWxsLCJfY3JlYXRl
+        ZCI6IjIwMTktMDctMjlUMTM6MjU6MTQuNTUxOTA4WiIsIm5hbWUiOiJEZWZh
+        dWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0RvY2tlcl8xIiwicmVw
+        b3NpdG9yeV92ZXJzaW9uIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9l
+        OTIwNDYxMi1lZjU2LTQ3ZGMtYTM2ZC1iNjllMDE0ZGNmMDYvdmVyc2lvbnMv
+        Mi8iLCJjb250ZW50X2d1YXJkIjpudWxsLCJfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9kaXN0cmlidXRpb25zL2RvY2tlci9kb2NrZXIvNDc3YzY4ZmUtNmUyMi00
+        MGJkLWE3Y2UtOGNlMTQ5MWM1MjdiLyIsInJlZ2lzdHJ5X3BhdGgiOiJwdWxw
+        My1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29tL0RlZmF1bHRfT3JnYW5pemF0
+        aW9uL2xpYnJhcnkvcHVscDNfRG9ja2VyXzEifV19
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:17 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/477c68fe-6e22-40bd-a7ce-8ce1491c527b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA5NGZmYmNhLTA1MWQtNDdk
+        Ny05NDU0LWY3MjFlMjEzMjI0Yy8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:17 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/e9204612-ef56-47dc-a36d-b69e014dcf06/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc3M2U0Mjk5LWEwM2YtNGVi
+        OS05MDBhLTJiNWM1Yzc5YjA2NC8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:17 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/773e4299-a03f-4eb9-900a-2b5c5c79b064/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:25:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '286'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy83NzNlNDI5OS1hMDNmLTRl
+        YjktOTAwYS0yYjVjNWM3OWIwNjQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI1OjE3LjI5ODg0MVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5kZWxldGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yOVQxMzoyNToxNy4zNzYxMzFaIiwiZmluaXNo
+        ZWRfYXQiOiIyMDE5LTA3LTI5VDEzOjI1OjE3LjQwMjQxMVoiLCJub25fZmF0
+        YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2Fw
+        aS92My93b3JrZXJzLzBmOTllOGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1
+        YWQ2Ni8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9n
+        cmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:25:17 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/docker_tag/index_model.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/docker_tag/index_model.yml
@@ -1,0 +1,17650 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/93686ca8-d9b2-44fa-b1e6-bdee5a90667f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:59 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y4YTY0ZTYwLWZjYzgtNDAx
+        OC1hOTMzLWYzNDZkMzJiMTA2OS8ifQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:59 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/e4e58367-03a1-4953-88cd-e763887e02ee/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:59 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JiM2JjZjk1LTdjMjItNGY0
+        ZC04NTAzLTA0MWMyMTVjMTMwNC8ifQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:59 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/2dfaff53-f987-4872-8209-91f8305fbc82/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:59 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RjMWNhMjhhLTJmZDktNGU0
+        YS04MDlmLTk5NzlkZjJmZjE5Yy8ifQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:59 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/2dfaff53-f987-4872-8209-91f8305fbc82/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:59 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '23'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:59 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/97929fe2-8cf2-4db4-9f31-77ee03617304/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:47:01 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZiZWI4M2Q2LTI1MTItNDYx
+        Yy1hYmRkLTAwNGFmYzYwZTlhNC8ifQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:47:01 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/6beb83d6-2512-461c-abdd-004afc60e9a4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:47:01 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '502'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy82YmViODNkNi0yNTEyLTQ2
+        MWMtYWJkZC0wMDRhZmM2MGU5YTQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDIwOjQ3OjAxLjA3NDM2N1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLnJlcG9zaXRvcnkuYWRkX2FuZF9yZW1vdmUi
+        LCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yMlQyMDo0NzowMS4xODg0MjlaIiwi
+        ZmluaXNoZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJv
+        ciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcy
+        YWItM2UwYy00NDlhLTkzNzgtNDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVs
+        bCwic3Bhd25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJj
+        cmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        Lzk3OTI5ZmUyLThjZjItNGRiNC05ZjMxLTc3ZWUwMzYxNzMwNC92ZXJzaW9u
+        cy8xLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:47:01 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/6beb83d6-2512-461c-abdd-004afc60e9a4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:47:01 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy82YmViODNkNi0yNTEyLTQ2
+        MWMtYWJkZC0wMDRhZmM2MGU5YTQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDIwOjQ3OjAxLjA3NDM2N1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTIyVDIwOjQ3OjAxLjE4ODQyOVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjJUMjA6NDc6MDEuMjI5ODAxWiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2UwYy00NDlhLTkzNzgt
+        NDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzk3OTI5ZmUyLThjZjItNGRi
+        NC05ZjMxLTc3ZWUwMzYxNzMwNC92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:47:01 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/97929fe2-8cf2-4db4-9f31-77ee03617304/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:47:01 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOTc5MjlmZTIt
+        OGNmMi00ZGI0LTlmMzEtNzdlZTAzNjE3MzA0L3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIyVDIwOjQ3OjAxLjIxMTA2MFoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:47:01 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzk3OTI5ZmUyLThjZjItNGRiNC05ZjMxLTc3ZWUwMzYxNzMwNC92ZXJz
+        aW9ucy8xLyIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6
+        YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:47:01 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M2YjgxNDk2LTg0MjctNDZj
+        Yy1iN2U0LTczN2EyMDQ0ZDhkYy8ifQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:47:01 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/c6b81496-8427-46cc-b7e4-737a2044d8dc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:47:01 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jNmI4MTQ5Ni04NDI3LTQ2
+        Y2MtYjdlNC03MzdhMjA0NGQ4ZGMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDIwOjQ3OjAxLjY0MjczNVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yMlQyMDo0NzowMS43NzA3MzBaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQx
+        ZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:47:01 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/c6b81496-8427-46cc-b7e4-737a2044d8dc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:47:01 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '527'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jNmI4MTQ5Ni04NDI3LTQ2
+        Y2MtYjdlNC03MzdhMjA0NGQ4ZGMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDIwOjQ3OjAxLjY0MjczNVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTIyVDIwOjQ3OjAxLjc3MDczMFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjJUMjA6NDc6MDEuOTE1ODI3WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUtY2MxMjUx
+        OGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzJkY2JkNmQ2
+        LTJjYmEtNGFmMC1hZDk2LTIyZWYxMWU4MjFhMi8iXX0=
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:47:01 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/2dcbd6d6-2cba-4af0-ad96-22ef11e821a2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:47:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '473'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTIyVDIwOjQ3OjAxLjkwODI1OFoiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOTc5Mjlm
+        ZTItOGNmMi00ZGI0LTlmMzEtNzdlZTAzNjE3MzA0L3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzJkY2JkNmQ2LTJjYmEtNGFmMC1h
+        ZDk2LTIyZWYxMWU4MjFhMi8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:47:02 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/c02115d8-7eb8-450c-bbe7-a81c51ea2aff/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85Nzky
+        OWZlMi04Y2YyLTRkYjQtOWYzMS03N2VlMDM2MTczMDQvIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:47:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNmNzVjNjU2LWYzOGEtNGZj
+        Yi04NTBmLTczYTg3OGRmNDcxMy8ifQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:47:02 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3f75c656-f38a-4fcb-850f-73a878df4713/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:47:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '427'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zZjc1YzY1Ni1mMzhhLTRm
+        Y2ItODUwZi03M2E4NzhkZjQ3MTMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDIwOjQ3OjAyLjQxMzg4MloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjJUMjA6NDc6MDIuNTI3MDE2WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwi
+        Y3JlYXRlZF9yZXNvdXJjZXMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:47:02 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3f75c656-f38a-4fcb-850f-73a878df4713/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:47:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zZjc1YzY1Ni1mMzhhLTRm
+        Y2ItODUwZi03M2E4NzhkZjQ3MTMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDIwOjQ3OjAyLjQxMzg4MloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjJUMjA6NDc6MDIuNTI3MDE2WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:47:02 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3f75c656-f38a-4fcb-850f-73a878df4713/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:47:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zZjc1YzY1Ni1mMzhhLTRm
+        Y2ItODUwZi03M2E4NzhkZjQ3MTMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDIwOjQ3OjAyLjQxMzg4MloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjJUMjA6NDc6MDIuNTI3MDE2WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:47:02 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3f75c656-f38a-4fcb-850f-73a878df4713/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:47:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '852'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zZjc1YzY1Ni1mMzhhLTRm
+        Y2ItODUwZi03M2E4NzhkZjQ3MTMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDIwOjQ3OjAyLjQxMzg4MloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjJUMjA6NDc6MDIuNTI3MDE2WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBs
+        ZXRlZCIsInRvdGFsIjoxLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IlByb2Nlc3NpbmcgVGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoi
+        RG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
+        b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
+        b3RhbCI6NiwiZG9uZSI6Niwic3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVz
+        b3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOTc5MjlmZTIt
+        OGNmMi00ZGI0LTlmMzEtNzdlZTAzNjE3MzA0L3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:47:03 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3f75c656-f38a-4fcb-850f-73a878df4713/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:47:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '879'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zZjc1YzY1Ni1mMzhhLTRm
+        Y2ItODUwZi03M2E4NzhkZjQ3MTMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDIwOjQ3OjAyLjQxMzg4MloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yMlQyMDo0NzowMi41MjcwMTZa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTIyVDIwOjQ3OjAzLjAxNjU2MVoi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3MmFiLTNlMGMtNDQ5YS05Mzc4
+        LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Npbmcg
+        VGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvOTc5MjlmZTItOGNmMi00ZGI0LTlmMzEtNzdl
+        ZTAzNjE3MzA0L3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:47:03 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/97929fe2-8cf2-4db4-9f31-77ee03617304/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:47:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '1281'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOTc5MjlmZTIt
+        OGNmMi00ZGI0LTlmMzEtNzdlZTAzNjE3MzA0L3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIyVDIwOjQ3OjAyLjU1MDk5NloiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85
+        NzkyOWZlMi04Y2YyLTRkYjQtOWYzMS03N2VlMDM2MTczMDQvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOTc5
+        MjlmZTItOGNmMi00ZGI0LTlmMzEtNzdlZTAzNjE3MzA0L3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvOTc5MjlmZTItOGNmMi00ZGI0LTlmMzEtNzdlZTAzNjE3MzA0L3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvOTc5MjlmZTItOGNmMi00ZGI0LTlmMzEt
+        NzdlZTAzNjE3MzA0L3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdC10
+        YWciOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvbWFuaWZlc3QtdGFncy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvOTc5MjlmZTItOGNmMi00ZGI0LTlmMzEt
+        NzdlZTAzNjE3MzA0L3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzk3OTI5ZmUyLThjZjItNGRiNC05ZjMxLTc3ZWUwMzYx
+        NzMwNC92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:47:03 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/2dcbd6d6-2cba-4af0-ad96-22ef11e821a2/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzk3OTI5ZmUyLThjZjItNGRiNC05ZjMxLTc3ZWUwMzYxNzMwNC92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:47:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q1MWNkOTNhLWUzZmEtNGMx
+        Zi04Y2E5LTBkOGExMzgwNTFlMC8ifQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:47:03 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d51cd93a-e3fa-4c1f-8ca9-0d8a138051e0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:47:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '395'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kNTFjZDkzYS1lM2ZhLTRj
+        MWYtOGNhOS0wZDhhMTM4MDUxZTAvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDIwOjQ3OjAzLjQ2OTU5OVoiLCJzdGF0ZSI6IndhaXRpbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjpudWxsLCJmaW5pc2hlZF9hdCI6bnVsbCwibm9uX2ZhdGFsX2Vy
+        cm9ycyI6W10sImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
+        d29ya2Vycy8wZjk5ZThmYy1jMzZhLTQyMTYtODAyNS1mNGVmZjI0NWFkNjYv
+        IiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jlc3Nf
+        cmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpbXX0=
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:47:03 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d51cd93a-e3fa-4c1f-8ca9-0d8a138051e0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:47:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kNTFjZDkzYS1lM2ZhLTRj
+        MWYtOGNhOS0wZDhhMTM4MDUxZTAvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDIwOjQ3OjAzLjQ2OTU5OVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTIyVDIwOjQ3OjAzLjU5ODcyN1oiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjJUMjA6NDc6MDMuNjU3Njg0WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUtZjRlZmYy
+        NDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:47:03 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/97929fe2-8cf2-4db4-9f31-77ee03617304/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:47:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:47:03 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/97929fe2-8cf2-4db4-9f31-77ee03617304/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:47:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '793'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy9kMmMzMmUwNS05NzkwLTRmMzUtOWUwZS1kZTI0NzI3YWVkODgv
+        IiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjM5OjM4LjI3NTI5NVoiLCJf
+        dHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2Fw
+        aS92My9hcnRpZmFjdHMvMDk4ZWQ3YzEtNmRhYi00YTM3LTgwZmQtYWUyMzdh
+        MDhlYjc2LyIsImRpZ2VzdCI6InNoYTI1NjphNmVjYmIxNTUzMzUzYTA4OTM2
+        ZjUwYzI3NWIwMTAzODhlZDFiZDZkOWQ4NDc0M2M3ZThlNzQ2OGUyYWNkODJl
+        Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlv
+        bi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwi
+        bGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzcyOGIyN2U4LTk5YzEtNGFjNi1h
+        MTY0LWFiNDdlMTNlZWE4NS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvYmxvYnMvYTgyZTMwNGItYzVjYy00MDQ5LTg0YzgtODA5
+        ZjMwNzE1ZjY3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9i
+        cy81MzZiNTc2MC04YzZiLTQ0YTctYTc5Mi0xYWExMjFhYWQxZDkvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzNkZGFmNDg0LWRkZWMt
+        NGIwMC1hZjEyLWI2Y2ZkNzU1NmE4ZC8iXX1dfQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:47:04 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/97929fe2-8cf2-4db4-9f31-77ee03617304/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:47:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:47:04 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifest-tags/?page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/97929fe2-8cf2-4db4-9f31-77ee03617304/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:47:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '401'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvZTU0NmM4MGItMTk0OS00OWJjLTg5MWYtNDg3MTQ2ZGI4
+        ZDdhLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzozOTozOC4yNzg0MTNa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QtdGFnIiwiX2FydGlmYWN0Ijoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wOThlZDdjMS02ZGFiLTRhMzctODBm
+        ZC1hZTIzN2EwOGViNzYvIiwibmFtZSI6ImxhdGVzdCIsInRhZ2dlZF9tYW5p
+        ZmVzdCI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMv
+        ZDJjMzJlMDUtOTc5MC00ZjM1LTllMGUtZGUyNDcyN2FlZDg4LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:47:04 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/97929fe2-8cf2-4db4-9f31-77ee03617304/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:54:58 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFhY2I4YjRmLWY5MDEtNDFm
+        NC04YjQ2LTExMDg0YjQ5M2UyMS8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:54:58 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/c02115d8-7eb8-450c-bbe7-a81c51ea2aff/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:54:59 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcwYmFkOTU1LWEyMjktNDM0
+        NS05YzY4LTRlNGViODg2NTYwNy8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:54:59 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/2dcbd6d6-2cba-4af0-ad96-22ef11e821a2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:54:59 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ViODg3M2VlLTIzNGYtNDI2
+        Ny1hYmQzLTBjZDlmMzIzOWI2NC8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:54:59 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/2dcbd6d6-2cba-4af0-ad96-22ef11e821a2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:54:59 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '23'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:54:59 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/5fc530d3-3a1e-49d6-a295-977a7bdbd246/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:00 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJmNTQ4NTc2LTU3YTAtNDQz
+        Zi04Njc3LWJhNDkzMjcxNTdhMy8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:00 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/2f548576-57a0-443f-8677-ba49327157a3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:01 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yZjU0ODU3Ni01N2EwLTQ0
+        M2YtODY3Ny1iYTQ5MzI3MTU3YTMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEyOjU1OjAwLjkzNzY1OFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEyOjU1OjAxLjAzNTc3NVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjNUMTI6NTU6MDEuMDg0NDExWiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUt
+        ZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzVmYzUzMGQzLTNhMWUtNDlk
+        Ni1hMjk1LTk3N2E3YmRiZDI0Ni92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:01 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/5fc530d3-3a1e-49d6-a295-977a7bdbd246/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:01 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNWZjNTMwZDMt
+        M2ExZS00OWQ2LWEyOTUtOTc3YTdiZGJkMjQ2L3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIzVDEyOjU1OjAxLjA1MjU5OVoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:01 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzVmYzUzMGQzLTNhMWUtNDlkNi1hMjk1LTk3N2E3YmRiZDI0Ni92ZXJz
+        aW9ucy8xLyIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6
+        YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:01 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEwMzNjYmFhLTlhNDUtNGM4
+        Ni1hNTg1LWJkZWEyZTI5NDY2OC8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:01 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/1033cbaa-9a45-4c86-a585-bdea2e294668/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:01 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8xMDMzY2JhYS05YTQ1LTRj
+        ODYtYTU4NS1iZGVhMmUyOTQ2NjgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEyOjU1OjAxLjQwMTc5MVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yM1QxMjo1NTowMS41MTM5MzNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQx
+        ZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:01 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/1033cbaa-9a45-4c86-a585-bdea2e294668/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:01 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8xMDMzY2JhYS05YTQ1LTRj
+        ODYtYTU4NS1iZGVhMmUyOTQ2NjgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEyOjU1OjAxLjQwMTc5MVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yM1QxMjo1NTowMS41MTM5MzNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQx
+        ZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:01 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/1033cbaa-9a45-4c86-a585-bdea2e294668/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:01 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '527'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8xMDMzY2JhYS05YTQ1LTRj
+        ODYtYTU4NS1iZGVhMmUyOTQ2NjgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEyOjU1OjAxLjQwMTc5MVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEyOjU1OjAxLjUxMzkzM1oiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjNUMTI6NTU6MDEuNzAxNTAxWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUtY2MxMjUx
+        OGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzgxNTg1N2Fh
+        LTNhNTctNGQ4MC04NDY3LTg1OGQ4N2Q0YjRkOC8iXX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:01 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/815857aa-3a57-4d80-8467-858d87d4b4d8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:01 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '473'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTIzVDEyOjU1OjAxLjY5MzY0NloiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNWZjNTMw
+        ZDMtM2ExZS00OWQ2LWEyOTUtOTc3YTdiZGJkMjQ2L3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzgxNTg1N2FhLTNhNTctNGQ4MC04
+        NDY3LTg1OGQ4N2Q0YjRkOC8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:01 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/50d53c4a-8db9-442c-b32e-b5aaaf0a67b6/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy81ZmM1
+        MzBkMy0zYTFlLTQ5ZDYtYTI5NS05NzdhN2JkYmQyNDYvIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QzMjRjYjU5LWU1NTgtNDZh
+        NC04NzQwLWE3MmZmOGJjMmEzNC8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:02 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d324cb59-e558-46a4-8740-a72ff8bc2a34/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '516'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kMzI0Y2I1OS1lNTU4LTQ2
+        YTQtODc0MC1hNzJmZjhiYzJhMzQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEyOjU1OjAyLjM4MjE3OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTI6NTU6MDIuNDk1MjQwWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:02 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d324cb59-e558-46a4-8740-a72ff8bc2a34/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kMzI0Y2I1OS1lNTU4LTQ2
+        YTQtODc0MC1hNzJmZjhiYzJhMzQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEyOjU1OjAyLjM4MjE3OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTI6NTU6MDIuNDk1MjQwWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:02 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d324cb59-e558-46a4-8740-a72ff8bc2a34/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kMzI0Y2I1OS1lNTU4LTQ2
+        YTQtODc0MC1hNzJmZjhiYzJhMzQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEyOjU1OjAyLjM4MjE3OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTI6NTU6MDIuNDk1MjQwWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:02 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d324cb59-e558-46a4-8740-a72ff8bc2a34/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kMzI0Y2I1OS1lNTU4LTQ2
+        YTQtODc0MC1hNzJmZjhiYzJhMzQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEyOjU1OjAyLjM4MjE3OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTI6NTU6MDIuNDk1MjQwWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:02 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d324cb59-e558-46a4-8740-a72ff8bc2a34/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kMzI0Y2I1OS1lNTU4LTQ2
+        YTQtODc0MC1hNzJmZjhiYzJhMzQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEyOjU1OjAyLjM4MjE3OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTI6NTU6MDIuNDk1MjQwWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:03 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d324cb59-e558-46a4-8740-a72ff8bc2a34/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kMzI0Y2I1OS1lNTU4LTQ2
+        YTQtODc0MC1hNzJmZjhiYzJhMzQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEyOjU1OjAyLjM4MjE3OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTI6NTU6MDIuNDk1MjQwWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:03 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d324cb59-e558-46a4-8740-a72ff8bc2a34/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '879'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kMzI0Y2I1OS1lNTU4LTQ2
+        YTQtODc0MC1hNzJmZjhiYzJhMzQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEyOjU1OjAyLjM4MjE3OVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yM1QxMjo1NTowMi40OTUyNDBa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTIzVDEyOjU1OjAzLjMyNzA0N1oi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTllOGZjLWMzNmEtNDIxNi04MDI1
+        LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Npbmcg
+        VGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvNWZjNTMwZDMtM2ExZS00OWQ2LWEyOTUtOTc3
+        YTdiZGJkMjQ2L3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:03 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/5fc530d3-3a1e-49d6-a295-977a7bdbd246/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '1281'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNWZjNTMwZDMt
+        M2ExZS00OWQ2LWEyOTUtOTc3YTdiZGJkMjQ2L3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIzVDEyOjU1OjAyLjUxNTQzMFoiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy81
+        ZmM1MzBkMy0zYTFlLTQ5ZDYtYTI5NS05NzdhN2JkYmQyNDYvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNWZj
+        NTMwZDMtM2ExZS00OWQ2LWEyOTUtOTc3YTdiZGJkMjQ2L3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvNWZjNTMwZDMtM2ExZS00OWQ2LWEyOTUtOTc3YTdiZGJkMjQ2L3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvNWZjNTMwZDMtM2ExZS00OWQ2LWEyOTUt
+        OTc3YTdiZGJkMjQ2L3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzVmYzUzMGQzLTNhMWUtNDlkNi1hMjk1LTk3N2E3YmRi
+        ZDI0Ni92ZXJzaW9ucy8yLyJ9LCJkb2NrZXIubWFuaWZlc3QtdGFnIjp7ImNv
+        dW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzVmYzUzMGQzLTNhMWUtNDlkNi1hMjk1LTk3N2E3YmRi
+        ZDI0Ni92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:03 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/815857aa-3a57-4d80-8467-858d87d4b4d8/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzVmYzUzMGQzLTNhMWUtNDlkNi1hMjk1LTk3N2E3YmRiZDI0Ni92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FlMmU4YjI5LWUzYjgtNDk1
+        YS04ZTcyLTM5NmIzMmViOTZiYi8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:03 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/ae2e8b29-e3b8-495a-8e72-396b32eb96bb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hZTJlOGIyOS1lM2I4LTQ5
+        NWEtOGU3Mi0zOTZiMzJlYjk2YmIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEyOjU1OjAzLjcyNTQzMVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yM1QxMjo1NTowMy44NTI4MDVaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQx
+        ZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:03 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/ae2e8b29-e3b8-495a-8e72-396b32eb96bb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hZTJlOGIyOS1lM2I4LTQ5
+        NWEtOGU3Mi0zOTZiMzJlYjk2YmIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEyOjU1OjAzLjcyNTQzMVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEyOjU1OjAzLjg1MjgwNVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjNUMTI6NTU6MDMuOTE0OTMxWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUtY2MxMjUx
+        OGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:03 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/5fc530d3-3a1e-49d6-a295-977a7bdbd246/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:04 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/5fc530d3-3a1e-49d6-a295-977a7bdbd246/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '793'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy9kMmMzMmUwNS05NzkwLTRmMzUtOWUwZS1kZTI0NzI3YWVkODgv
+        IiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjM5OjM4LjI3NTI5NVoiLCJf
+        dHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2Fw
+        aS92My9hcnRpZmFjdHMvMDk4ZWQ3YzEtNmRhYi00YTM3LTgwZmQtYWUyMzdh
+        MDhlYjc2LyIsImRpZ2VzdCI6InNoYTI1NjphNmVjYmIxNTUzMzUzYTA4OTM2
+        ZjUwYzI3NWIwMTAzODhlZDFiZDZkOWQ4NDc0M2M3ZThlNzQ2OGUyYWNkODJl
+        Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlv
+        bi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwi
+        bGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzcyOGIyN2U4LTk5YzEtNGFjNi1h
+        MTY0LWFiNDdlMTNlZWE4NS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvYmxvYnMvYTgyZTMwNGItYzVjYy00MDQ5LTg0YzgtODA5
+        ZjMwNzE1ZjY3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9i
+        cy81MzZiNTc2MC04YzZiLTQ0YTctYTc5Mi0xYWExMjFhYWQxZDkvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzNkZGFmNDg0LWRkZWMt
+        NGIwMC1hZjEyLWI2Y2ZkNzU1NmE4ZC8iXX1dfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:04 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/5fc530d3-3a1e-49d6-a295-977a7bdbd246/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:04 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifest-tags/?page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/5fc530d3-3a1e-49d6-a295-977a7bdbd246/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 12:55:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '401'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvZTU0NmM4MGItMTk0OS00OWJjLTg5MWYtNDg3MTQ2ZGI4
+        ZDdhLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzozOTozOC4yNzg0MTNa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QtdGFnIiwiX2FydGlmYWN0Ijoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wOThlZDdjMS02ZGFiLTRhMzctODBm
+        ZC1hZTIzN2EwOGViNzYvIiwibmFtZSI6ImxhdGVzdCIsInRhZ2dlZF9tYW5p
+        ZmVzdCI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMv
+        ZDJjMzJlMDUtOTc5MC00ZjM1LTllMGUtZGUyNDcyN2FlZDg4LyJ9XX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 12:55:04 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/905e38f9-49a3-4350-b4f5-98da1223273c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRlZmUwMTU3LTA3ZmYtNDBm
+        OC04MWE1LWJmMjk4NmExNmQ1Ny8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:23 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/e084b5b2-927b-4ff6-b00c-6684dd581a5b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NhNTM0NzYwLWIzNzYtNDRi
+        YS1iM2JhLTQ0MmZlNWY0NmZjNS8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:23 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/517e3cd1-d3ac-4a1e-81c3-6ed6b61cb414/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhmMmI1OWY4LWUxZDUtNGI0
+        Ny04NmNmLTZkYmRiZDg2ZDNiNi8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:23 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/517e3cd1-d3ac-4a1e-81c3-6ed6b61cb414/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '23'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:23 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/c7fdd121-79fd-4bee-a665-1ea677c46d05/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMxYTEwZDY0LTI4NTYtNGNi
+        YS05OTUyLWNmZmUxNDBjMDY0Ny8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:25 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/31a10d64-2856-4cba-9952-cffe140c0647/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '502'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zMWExMGQ2NC0yODU2LTRj
+        YmEtOTk1Mi1jZmZlMTQwYzA2NDcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjI1LjI1MTE1OFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLnJlcG9zaXRvcnkuYWRkX2FuZF9yZW1vdmUi
+        LCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowMjoyNS4zNDc3NTJaIiwi
+        ZmluaXNoZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJv
+        ciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNl
+        ODYtODQxZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVs
+        bCwic3Bhd25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJj
+        cmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L2M3ZmRkMTIxLTc5ZmQtNGJlZS1hNjY1LTFlYTY3N2M0NmQwNS92ZXJzaW9u
+        cy8xLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:25 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/31a10d64-2856-4cba-9952-cffe140c0647/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zMWExMGQ2NC0yODU2LTRj
+        YmEtOTk1Mi1jZmZlMTQwYzA2NDcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjI1LjI1MTE1OFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjAyOjI1LjM0Nzc1Mloi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjNUMTM6MDI6MjUuMzk3NDc5WiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUt
+        Y2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2M3ZmRkMTIxLTc5ZmQtNGJl
+        ZS1hNjY1LTFlYTY3N2M0NmQwNS92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:25 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/c7fdd121-79fd-4bee-a665-1ea677c46d05/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYzdmZGQxMjEt
+        NzlmZC00YmVlLWE2NjUtMWVhNjc3YzQ2ZDA1L3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIzVDEzOjAyOjI1LjM3NTY1MFoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:25 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2M3ZmRkMTIxLTc5ZmQtNGJlZS1hNjY1LTFlYTY3N2M0NmQwNS92ZXJz
+        aW9ucy8xLyIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6
+        YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VmZDk3ZWYxLWE5ZmEtNDFm
+        Mi1hNzdlLWQxYzc0Y2EwNGFiOC8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:25 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/efd97ef1-a9fa-41f2-a77e-d1c74ca04ab8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:26 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '395'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lZmQ5N2VmMS1hOWZhLTQx
+        ZjItYTc3ZS1kMWM3NGNhMDRhYjgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjI1Ljg2NjAwOVoiLCJzdGF0ZSI6IndhaXRpbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjpudWxsLCJmaW5pc2hlZF9hdCI6bnVsbCwibm9uX2ZhdGFsX2Vy
+        cm9ycyI6W10sImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
+        d29ya2Vycy8wZjk5ZThmYy1jMzZhLTQyMTYtODAyNS1mNGVmZjI0NWFkNjYv
+        IiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jlc3Nf
+        cmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpbXX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:26 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/efd97ef1-a9fa-41f2-a77e-d1c74ca04ab8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:26 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lZmQ5N2VmMS1hOWZhLTQx
+        ZjItYTc3ZS1kMWM3NGNhMDRhYjgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjI1Ljg2NjAwOVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowMjoyNi4wMDgyMDNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2
+        YS00MjE2LTgwMjUtZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:26 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/efd97ef1-a9fa-41f2-a77e-d1c74ca04ab8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:26 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '527'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lZmQ5N2VmMS1hOWZhLTQx
+        ZjItYTc3ZS1kMWM3NGNhMDRhYjgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjI1Ljg2NjAwOVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjAyOjI2LjAwODIwM1oiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjNUMTM6MDI6MjYuMTg1NjgxWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUtZjRlZmYy
+        NDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyL2IzMDEyM2M0
+        LTkxYTItNGUxOC1iOGFjLTI1NTViNjNmN2VjNi8iXX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:26 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/b30123c4-91a2-4e18-b8ac-2555b63f7ec6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:26 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '473'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTIzVDEzOjAyOjI2LjE3Nzk2MVoiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYzdmZGQx
+        MjEtNzlmZC00YmVlLWE2NjUtMWVhNjc3YzQ2ZDA1L3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyL2IzMDEyM2M0LTkxYTItNGUxOC1i
+        OGFjLTI1NTViNjNmN2VjNi8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:26 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/5b48769e-c4fc-475c-92e9-777b6044fa52/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9jN2Zk
+        ZDEyMS03OWZkLTRiZWUtYTY2NS0xZWE2NzdjNDZkMDUvIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:26 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FhZmJmYzVmLWE1NDgtNDI3
+        OC1iZGIyLWI3Mzk4NGYwZWVjZS8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:26 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/aafbfc5f-a548-4278-bdb2-b73984f0eece/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:26 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '427'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hYWZiZmM1Zi1hNTQ4LTQy
+        NzgtYmRiMi1iNzM5ODRmMGVlY2UvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjI2Ljg1MTQxOFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDI6MjYuOTYyOTk2WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwi
+        Y3JlYXRlZF9yZXNvdXJjZXMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:26 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/aafbfc5f-a548-4278-bdb2-b73984f0eece/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:27 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hYWZiZmM1Zi1hNTQ4LTQy
+        NzgtYmRiMi1iNzM5ODRmMGVlY2UvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjI2Ljg1MTQxOFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDI6MjYuOTYyOTk2WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:27 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/aafbfc5f-a548-4278-bdb2-b73984f0eece/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:27 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hYWZiZmM1Zi1hNTQ4LTQy
+        NzgtYmRiMi1iNzM5ODRmMGVlY2UvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjI2Ljg1MTQxOFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDI6MjYuOTYyOTk2WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:27 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/aafbfc5f-a548-4278-bdb2-b73984f0eece/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:27 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hYWZiZmM1Zi1hNTQ4LTQy
+        NzgtYmRiMi1iNzM5ODRmMGVlY2UvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjI2Ljg1MTQxOFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDI6MjYuOTYyOTk2WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:27 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/aafbfc5f-a548-4278-bdb2-b73984f0eece/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:27 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hYWZiZmM1Zi1hNTQ4LTQy
+        NzgtYmRiMi1iNzM5ODRmMGVlY2UvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjI2Ljg1MTQxOFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDI6MjYuOTYyOTk2WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:27 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/aafbfc5f-a548-4278-bdb2-b73984f0eece/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:27 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '852'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hYWZiZmM1Zi1hNTQ4LTQy
+        NzgtYmRiMi1iNzM5ODRmMGVlY2UvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjI2Ljg1MTQxOFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDI6MjYuOTYyOTk2WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBs
+        ZXRlZCIsInRvdGFsIjoxLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IlByb2Nlc3NpbmcgVGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoi
+        RG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
+        b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
+        b3RhbCI6NiwiZG9uZSI6Niwic3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVz
+        b3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYzdmZGQxMjEt
+        NzlmZC00YmVlLWE2NjUtMWVhNjc3YzQ2ZDA1L3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:27 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/aafbfc5f-a548-4278-bdb2-b73984f0eece/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:27 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '879'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hYWZiZmM1Zi1hNTQ4LTQy
+        NzgtYmRiMi1iNzM5ODRmMGVlY2UvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjI2Ljg1MTQxOFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowMjoyNi45NjI5OTZa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjAyOjI3LjY5MDYwN1oi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTllOGZjLWMzNmEtNDIxNi04MDI1
+        LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Npbmcg
+        VGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvYzdmZGQxMjEtNzlmZC00YmVlLWE2NjUtMWVh
+        Njc3YzQ2ZDA1L3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:27 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/c7fdd121-79fd-4bee-a665-1ea677c46d05/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '1281'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYzdmZGQxMjEt
+        NzlmZC00YmVlLWE2NjUtMWVhNjc3YzQ2ZDA1L3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIzVDEzOjAyOjI2Ljk5MDE2M1oiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9j
+        N2ZkZDEyMS03OWZkLTRiZWUtYTY2NS0xZWE2NzdjNDZkMDUvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYzdm
+        ZGQxMjEtNzlmZC00YmVlLWE2NjUtMWVhNjc3YzQ2ZDA1L3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvYzdmZGQxMjEtNzlmZC00YmVlLWE2NjUtMWVhNjc3YzQ2ZDA1L3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvYzdmZGQxMjEtNzlmZC00YmVlLWE2NjUt
+        MWVhNjc3YzQ2ZDA1L3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdC10
+        YWciOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvbWFuaWZlc3QtdGFncy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvYzdmZGQxMjEtNzlmZC00YmVlLWE2NjUt
+        MWVhNjc3YzQ2ZDA1L3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2M3ZmRkMTIxLTc5ZmQtNGJlZS1hNjY1LTFlYTY3N2M0
+        NmQwNS92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:28 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/b30123c4-91a2-4e18-b8ac-2555b63f7ec6/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2M3ZmRkMTIxLTc5ZmQtNGJlZS1hNjY1LTFlYTY3N2M0NmQwNS92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxNmZkMmIwLTIxMzEtNDQ3
+        NC05ZjVmLTc0NGZmNjE0MDY2Zi8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:28 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/016fd2b0-2131-4474-9f5f-744ff614066f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8wMTZmZDJiMC0yMTMxLTQ0
+        NzQtOWY1Zi03NDRmZjYxNDA2NmYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjI4LjE0MjgzMVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowMjoyOC4yNjUzMTRaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2Uw
+        Yy00NDlhLTkzNzgtNDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:28 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/016fd2b0-2131-4474-9f5f-744ff614066f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8wMTZmZDJiMC0yMTMxLTQ0
+        NzQtOWY1Zi03NDRmZjYxNDA2NmYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjI4LjE0MjgzMVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjAyOjI4LjI2NTMxNFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjNUMTM6MDI6MjguMzM2NDAxWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2UwYy00NDlhLTkzNzgtNDg3YWZl
+        ZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:28 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/c7fdd121-79fd-4bee-a665-1ea677c46d05/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:28 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/c7fdd121-79fd-4bee-a665-1ea677c46d05/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '793'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy9kMmMzMmUwNS05NzkwLTRmMzUtOWUwZS1kZTI0NzI3YWVkODgv
+        IiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjM5OjM4LjI3NTI5NVoiLCJf
+        dHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2Fw
+        aS92My9hcnRpZmFjdHMvMDk4ZWQ3YzEtNmRhYi00YTM3LTgwZmQtYWUyMzdh
+        MDhlYjc2LyIsImRpZ2VzdCI6InNoYTI1NjphNmVjYmIxNTUzMzUzYTA4OTM2
+        ZjUwYzI3NWIwMTAzODhlZDFiZDZkOWQ4NDc0M2M3ZThlNzQ2OGUyYWNkODJl
+        Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlv
+        bi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwi
+        bGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzcyOGIyN2U4LTk5YzEtNGFjNi1h
+        MTY0LWFiNDdlMTNlZWE4NS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvYmxvYnMvYTgyZTMwNGItYzVjYy00MDQ5LTg0YzgtODA5
+        ZjMwNzE1ZjY3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9i
+        cy81MzZiNTc2MC04YzZiLTQ0YTctYTc5Mi0xYWExMjFhYWQxZDkvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzNkZGFmNDg0LWRkZWMt
+        NGIwMC1hZjEyLWI2Y2ZkNzU1NmE4ZC8iXX1dfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:28 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/c7fdd121-79fd-4bee-a665-1ea677c46d05/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:28 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifest-tags/?page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/c7fdd121-79fd-4bee-a665-1ea677c46d05/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '401'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvZTU0NmM4MGItMTk0OS00OWJjLTg5MWYtNDg3MTQ2ZGI4
+        ZDdhLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzozOTozOC4yNzg0MTNa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QtdGFnIiwiX2FydGlmYWN0Ijoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wOThlZDdjMS02ZGFiLTRhMzctODBm
+        ZC1hZTIzN2EwOGViNzYvIiwibmFtZSI6ImxhdGVzdCIsInRhZ2dlZF9tYW5p
+        ZmVzdCI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMv
+        ZDJjMzJlMDUtOTc5MC00ZjM1LTllMGUtZGUyNDcyN2FlZDg4LyJ9XX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:29 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/5bc969bc-f351-4889-9b1e-3ff75d302399/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlhNDc0YTY1LTAzYzUtNGEx
+        YS04YTU1LTI2NmI2NDY5YWMyYi8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:53 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/5c950445-20b8-4884-8cc4-f6ed31408535/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE5NTNjOTAzLTdkMDItNDQ2
+        Yi05NzllLTA0NzAwNTE2ZWU3NC8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:53 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/6de417b0-1084-4930-8f66-fa48d9a22765/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQzNGJjZTMwLTkwMTgtNDc4
+        Zi04YTAwLTdjZGU5NWI4NzY3MC8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:53 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/6de417b0-1084-4930-8f66-fa48d9a22765/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '23'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:53 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/4d841803-2e97-49b8-96a4-9d3ecc28b10e/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UyNjFkNGNiLWJjMDQtNDUw
+        OC1iYzQ4LTczMTllNzgwY2Q1Yi8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:55 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/e261d4cb-bc04-4508-bc48-7319e780cd5b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lMjYxZDRjYi1iYzA0LTQ1
+        MDgtYmM0OC03MzE5ZTc4MGNkNWIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAzOjU1LjE0OTUxNFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjAzOjU1LjIzNzQ3Nloi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjNUMTM6MDM6NTUuMjY5NTU3WiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUt
+        ZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzRkODQxODAzLTJlOTctNDli
+        OC05NmE0LTlkM2VjYzI4YjEwZS92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:55 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/4d841803-2e97-49b8-96a4-9d3ecc28b10e/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNGQ4NDE4MDMt
+        MmU5Ny00OWI4LTk2YTQtOWQzZWNjMjhiMTBlL3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIzVDEzOjAzOjU1LjI1Mjk5MloiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:55 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzRkODQxODAzLTJlOTctNDliOC05NmE0LTlkM2VjYzI4YjEwZS92ZXJz
+        aW9ucy8xLyIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6
+        YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NjMGRlOWQ5LWY5NjUtNGNl
+        MS1hZjUyLTk4Nzc2YjY4OThhZS8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:55 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/cc0de9d9-f965-4ce1-af52-98776b6898ae/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jYzBkZTlkOS1mOTY1LTRj
+        ZTEtYWY1Mi05ODc3NmI2ODk4YWUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAzOjU1LjU4NzEzMloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowMzo1NS42Nzc2NDZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2Uw
+        Yy00NDlhLTkzNzgtNDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:55 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/cc0de9d9-f965-4ce1-af52-98776b6898ae/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '527'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jYzBkZTlkOS1mOTY1LTRj
+        ZTEtYWY1Mi05ODc3NmI2ODk4YWUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAzOjU1LjU4NzEzMloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjAzOjU1LjY3NzY0NloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjNUMTM6MDM6NTUuODQ0NTA5WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2UwYy00NDlhLTkzNzgtNDg3YWZl
+        ZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyL2Y4MDk3ZTFh
+        LWJhY2EtNDM3Zi1iMDRiLTdjMTVlOWU0YmNiYS8iXX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:55 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/f8097e1a-baca-437f-b04b-7c15e9e4bcba/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '473'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTIzVDEzOjAzOjU1LjgzNTIzNloiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNGQ4NDE4
+        MDMtMmU5Ny00OWI4LTk2YTQtOWQzZWNjMjhiMTBlL3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyL2Y4MDk3ZTFhLWJhY2EtNDM3Zi1i
+        MDRiLTdjMTVlOWU0YmNiYS8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:55 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/a3a57716-d12b-4584-9c17-3484a2af328d/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy80ZDg0
+        MTgwMy0yZTk3LTQ5YjgtOTZhNC05ZDNlY2MyOGIxMGUvIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMzZDc3YTA0LTViNjktNDM3
+        MS05MTIzLTIyZWY3NWUzMDRiMS8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:56 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/33d77a04-5b69-4371-9123-22ef75e304b1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '516'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zM2Q3N2EwNC01YjY5LTQz
+        NzEtOTEyMy0yMmVmNzVlMzA0YjEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAzOjU2LjI5NTE5NVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDM6NTYuNDA4NTQzWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:56 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/33d77a04-5b69-4371-9123-22ef75e304b1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zM2Q3N2EwNC01YjY5LTQz
+        NzEtOTEyMy0yMmVmNzVlMzA0YjEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAzOjU2LjI5NTE5NVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDM6NTYuNDA4NTQzWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:56 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/33d77a04-5b69-4371-9123-22ef75e304b1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zM2Q3N2EwNC01YjY5LTQz
+        NzEtOTEyMy0yMmVmNzVlMzA0YjEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAzOjU2LjI5NTE5NVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDM6NTYuNDA4NTQzWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:56 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/33d77a04-5b69-4371-9123-22ef75e304b1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zM2Q3N2EwNC01YjY5LTQz
+        NzEtOTEyMy0yMmVmNzVlMzA0YjEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAzOjU2LjI5NTE5NVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDM6NTYuNDA4NTQzWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:56 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/33d77a04-5b69-4371-9123-22ef75e304b1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zM2Q3N2EwNC01YjY5LTQz
+        NzEtOTEyMy0yMmVmNzVlMzA0YjEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAzOjU2LjI5NTE5NVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDM6NTYuNDA4NTQzWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:56 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/33d77a04-5b69-4371-9123-22ef75e304b1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:57 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zM2Q3N2EwNC01YjY5LTQz
+        NzEtOTEyMy0yMmVmNzVlMzA0YjEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAzOjU2LjI5NTE5NVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDM6NTYuNDA4NTQzWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:57 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/33d77a04-5b69-4371-9123-22ef75e304b1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:57 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '781'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zM2Q3N2EwNC01YjY5LTQz
+        NzEtOTEyMy0yMmVmNzVlMzA0YjEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAzOjU2LjI5NTE5NVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDM6NTYuNDA4NTQzWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJQcm9jZXNzaW5nIFRhZ3MiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjoxLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
+        d25sb2FkaW5nIEFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jl
+        c291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:57 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/33d77a04-5b69-4371-9123-22ef75e304b1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:57 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '879'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zM2Q3N2EwNC01YjY5LTQz
+        NzEtOTEyMy0yMmVmNzVlMzA0YjEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAzOjU2LjI5NTE5NVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowMzo1Ni40MDg1NDNa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjAzOjU3LjIyMzI3OVoi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkzZTg2LTg0MWUtNGUxMC1iMmI1
+        LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Npbmcg
+        VGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvNGQ4NDE4MDMtMmU5Ny00OWI4LTk2YTQtOWQz
+        ZWNjMjhiMTBlL3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:57 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/4d841803-2e97-49b8-96a4-9d3ecc28b10e/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:57 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '1281'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNGQ4NDE4MDMt
+        MmU5Ny00OWI4LTk2YTQtOWQzZWNjMjhiMTBlL3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIzVDEzOjAzOjU2LjQyMzM1MFoiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy80
+        ZDg0MTgwMy0yZTk3LTQ5YjgtOTZhNC05ZDNlY2MyOGIxMGUvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNGQ4
+        NDE4MDMtMmU5Ny00OWI4LTk2YTQtOWQzZWNjMjhiMTBlL3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvNGQ4NDE4MDMtMmU5Ny00OWI4LTk2YTQtOWQzZWNjMjhiMTBlL3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvNGQ4NDE4MDMtMmU5Ny00OWI4LTk2YTQt
+        OWQzZWNjMjhiMTBlL3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzRkODQxODAzLTJlOTctNDliOC05NmE0LTlkM2VjYzI4
+        YjEwZS92ZXJzaW9ucy8yLyJ9LCJkb2NrZXIubWFuaWZlc3QtdGFnIjp7ImNv
+        dW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzRkODQxODAzLTJlOTctNDliOC05NmE0LTlkM2VjYzI4
+        YjEwZS92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:57 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/f8097e1a-baca-437f-b04b-7c15e9e4bcba/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzRkODQxODAzLTJlOTctNDliOC05NmE0LTlkM2VjYzI4YjEwZS92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:57 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZlYmM5Mzk4LWU4OWItNDdk
+        OC05MzIxLTQ4MjY5OTQxOGQxMC8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:57 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/6ebc9398-e89b-47d8-9321-482699418d10/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:57 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy82ZWJjOTM5OC1lODliLTQ3
+        ZDgtOTMyMS00ODI2OTk0MThkMTAvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAzOjU3LjY2MDAxOFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowMzo1Ny43OTAwMjZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2
+        YS00MjE2LTgwMjUtZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:57 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/6ebc9398-e89b-47d8-9321-482699418d10/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:57 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy82ZWJjOTM5OC1lODliLTQ3
+        ZDgtOTMyMS00ODI2OTk0MThkMTAvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAzOjU3LjY2MDAxOFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjAzOjU3Ljc5MDAyNloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjNUMTM6MDM6NTcuODczNTM2WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUtZjRlZmYy
+        NDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:57 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/4d841803-2e97-49b8-96a4-9d3ecc28b10e/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:58 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:58 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/4d841803-2e97-49b8-96a4-9d3ecc28b10e/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:58 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '793'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy9kMmMzMmUwNS05NzkwLTRmMzUtOWUwZS1kZTI0NzI3YWVkODgv
+        IiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjM5OjM4LjI3NTI5NVoiLCJf
+        dHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2Fw
+        aS92My9hcnRpZmFjdHMvMDk4ZWQ3YzEtNmRhYi00YTM3LTgwZmQtYWUyMzdh
+        MDhlYjc2LyIsImRpZ2VzdCI6InNoYTI1NjphNmVjYmIxNTUzMzUzYTA4OTM2
+        ZjUwYzI3NWIwMTAzODhlZDFiZDZkOWQ4NDc0M2M3ZThlNzQ2OGUyYWNkODJl
+        Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlv
+        bi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwi
+        bGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzcyOGIyN2U4LTk5YzEtNGFjNi1h
+        MTY0LWFiNDdlMTNlZWE4NS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvYmxvYnMvYTgyZTMwNGItYzVjYy00MDQ5LTg0YzgtODA5
+        ZjMwNzE1ZjY3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9i
+        cy81MzZiNTc2MC04YzZiLTQ0YTctYTc5Mi0xYWExMjFhYWQxZDkvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzNkZGFmNDg0LWRkZWMt
+        NGIwMC1hZjEyLWI2Y2ZkNzU1NmE4ZC8iXX1dfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:58 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/4d841803-2e97-49b8-96a4-9d3ecc28b10e/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:58 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:58 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifest-tags/?page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/4d841803-2e97-49b8-96a4-9d3ecc28b10e/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:58 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '401'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvZTU0NmM4MGItMTk0OS00OWJjLTg5MWYtNDg3MTQ2ZGI4
+        ZDdhLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzozOTozOC4yNzg0MTNa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QtdGFnIiwiX2FydGlmYWN0Ijoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wOThlZDdjMS02ZGFiLTRhMzctODBm
+        ZC1hZTIzN2EwOGViNzYvIiwibmFtZSI6ImxhdGVzdCIsInRhZ2dlZF9tYW5p
+        ZmVzdCI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMv
+        ZDJjMzJlMDUtOTc5MC00ZjM1LTllMGUtZGUyNDcyN2FlZDg4LyJ9XX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:58 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/a7096407-d8df-4748-a1c7-66d176f328a6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:20 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U3YmM2MDE3LWY4N2ItNDdh
+        NS05OGZjLThiZWZlMjExMGQyMS8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:20 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/99baa627-903d-427c-87ef-9ed8f437a60e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:20 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QxOTNiYjBlLTdkNjktNDM3
+        YS1hMjBhLTcwOTFhOWFlNWQ0Yy8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:20 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/b57d954b-6fcd-49a2-90ff-f4acac5f1a67/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:20 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NhZmU2YmM0LTM5Y2ItNGYw
+        ZC1iZDkxLTViMDkzZGMwOGJjZi8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:20 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/b57d954b-6fcd-49a2-90ff-f4acac5f1a67/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:20 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '23'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:20 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/7600dcb6-9f6b-4b38-957d-9bdb20ef941f/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzljODFiNGU0LWNiYzUtNDU3
+        MC04YTBiLTZlYzJlMzFiMmU2ZS8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:21 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/9c81b4e4-cbc5-4570-8a0b-6ec2e31b2e6e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '426'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85YzgxYjRlNC1jYmM1LTQ1
+        NzAtOGEwYi02ZWMyZTMxYjJlNmUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjIxLjgxMDQ0OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLnJlcG9zaXRvcnkuYWRkX2FuZF9yZW1vdmUi
+        LCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowNToyMS45Mjg1MTFaIiwi
+        ZmluaXNoZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJv
+        ciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4
+        ZmMtYzM2YS00MjE2LTgwMjUtZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVs
+        bCwic3Bhd25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJj
+        cmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:21 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/9c81b4e4-cbc5-4570-8a0b-6ec2e31b2e6e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85YzgxYjRlNC1jYmM1LTQ1
+        NzAtOGEwYi02ZWMyZTMxYjJlNmUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjIxLjgxMDQ0OVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjA1OjIxLjkyODUxMVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjNUMTM6MDU6MjEuOTcwODIxWiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUt
+        ZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzc2MDBkY2I2LTlmNmItNGIz
+        OC05NTdkLTliZGIyMGVmOTQxZi92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:22 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/7600dcb6-9f6b-4b38-957d-9bdb20ef941f/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNzYwMGRjYjYt
+        OWY2Yi00YjM4LTk1N2QtOWJkYjIwZWY5NDFmL3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIzVDEzOjA1OjIxLjk1MDgwM1oiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:22 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzc2MDBkY2I2LTlmNmItNGIzOC05NTdkLTliZGIyMGVmOTQxZi92ZXJz
+        aW9ucy8xLyIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6
+        YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MxNTc3MGYwLTllYWMtNGU2
+        Yy1iYzIwLTMwMjQ2NTk4MGZiZi8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:22 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/c15770f0-9eac-4e6c-bc20-302465980fbf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jMTU3NzBmMC05ZWFjLTRl
+        NmMtYmMyMC0zMDI0NjU5ODBmYmYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjIyLjM3NzIwN1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowNToyMi40OTgyMDFaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2
+        YS00MjE2LTgwMjUtZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:22 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/c15770f0-9eac-4e6c-bc20-302465980fbf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '500'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jMTU3NzBmMC05ZWFjLTRl
+        NmMtYmMyMC0zMDI0NjU5ODBmYmYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjIyLjM3NzIwN1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowNToyMi40OTgyMDFaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2
+        YS00MjE2LTgwMjUtZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2Nr
+        ZXIvZG9ja2VyLzE5Yjk2NGQyLTk5ZjQtNGQ4MS05NWIzLTViYjZlZDczNzVj
+        NS8iXX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:22 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/c15770f0-9eac-4e6c-bc20-302465980fbf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '527'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jMTU3NzBmMC05ZWFjLTRl
+        NmMtYmMyMC0zMDI0NjU5ODBmYmYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjIyLjM3NzIwN1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjA1OjIyLjQ5ODIwMVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjNUMTM6MDU6MjIuNjU1Mzk0WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUtZjRlZmYy
+        NDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzE5Yjk2NGQy
+        LTk5ZjQtNGQ4MS05NWIzLTViYjZlZDczNzVjNS8iXX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:22 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/19b964d2-99f4-4d81-95b3-5bb6ed7375c5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '473'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTIzVDEzOjA1OjIyLjY0NzY4M1oiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNzYwMGRj
+        YjYtOWY2Yi00YjM4LTk1N2QtOWJkYjIwZWY5NDFmL3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzE5Yjk2NGQyLTk5ZjQtNGQ4MS05
+        NWIzLTViYjZlZDczNzVjNS8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:22 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/44989003-41c8-41e9-9f09-49b78b32a36b/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy83NjAw
+        ZGNiNi05ZjZiLTRiMzgtOTU3ZC05YmRiMjBlZjk0MWYvIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NkOGRiY2U1LTE5ZTEtNDUx
+        NS1hMzU0LTJmNmZhZjA4NDM3MS8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:23 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/cd8dbce5-19e1-4515-a354-2f6faf084371/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '427'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jZDhkYmNlNS0xOWUxLTQ1
+        MTUtYTM1NC0yZjZmYWYwODQzNzEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjIzLjI1NjMxNVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDU6MjMuMzcxNTk3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwi
+        Y3JlYXRlZF9yZXNvdXJjZXMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:23 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/cd8dbce5-19e1-4515-a354-2f6faf084371/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jZDhkYmNlNS0xOWUxLTQ1
+        MTUtYTM1NC0yZjZmYWYwODQzNzEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjIzLjI1NjMxNVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDU6MjMuMzcxNTk3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJydW5uaW5n
+        IiwidG90YWwiOjEsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:23 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/cd8dbce5-19e1-4515-a354-2f6faf084371/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jZDhkYmNlNS0xOWUxLTQ1
+        MTUtYTM1NC0yZjZmYWYwODQzNzEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjIzLjI1NjMxNVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDU6MjMuMzcxNTk3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJydW5uaW5n
+        IiwidG90YWwiOjEsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:23 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/cd8dbce5-19e1-4515-a354-2f6faf084371/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jZDhkYmNlNS0xOWUxLTQ1
+        MTUtYTM1NC0yZjZmYWYwODQzNzEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjIzLjI1NjMxNVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDU6MjMuMzcxNTk3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:23 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/cd8dbce5-19e1-4515-a354-2f6faf084371/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '852'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jZDhkYmNlNS0xOWUxLTQ1
+        MTUtYTM1NC0yZjZmYWYwODQzNzEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjIzLjI1NjMxNVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDU6MjMuMzcxNTk3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBs
+        ZXRlZCIsInRvdGFsIjoxLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IlByb2Nlc3NpbmcgVGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoi
+        RG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
+        b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
+        b3RhbCI6NiwiZG9uZSI6Niwic3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVz
+        b3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNzYwMGRjYjYt
+        OWY2Yi00YjM4LTk1N2QtOWJkYjIwZWY5NDFmL3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:23 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/cd8dbce5-19e1-4515-a354-2f6faf084371/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '879'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jZDhkYmNlNS0xOWUxLTQ1
+        MTUtYTM1NC0yZjZmYWYwODQzNzEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjIzLjI1NjMxNVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowNToyMy4zNzE1OTda
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjA1OjIzLjk1ODA4NFoi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkzZTg2LTg0MWUtNGUxMC1iMmI1
+        LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Npbmcg
+        VGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvNzYwMGRjYjYtOWY2Yi00YjM4LTk1N2QtOWJk
+        YjIwZWY5NDFmL3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:24 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/7600dcb6-9f6b-4b38-957d-9bdb20ef941f/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '1281'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNzYwMGRjYjYt
+        OWY2Yi00YjM4LTk1N2QtOWJkYjIwZWY5NDFmL3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIzVDEzOjA1OjIzLjM5NDA1NVoiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy83
+        NjAwZGNiNi05ZjZiLTRiMzgtOTU3ZC05YmRiMjBlZjk0MWYvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNzYw
+        MGRjYjYtOWY2Yi00YjM4LTk1N2QtOWJkYjIwZWY5NDFmL3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvNzYwMGRjYjYtOWY2Yi00YjM4LTk1N2QtOWJkYjIwZWY5NDFmL3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvNzYwMGRjYjYtOWY2Yi00YjM4LTk1N2Qt
+        OWJkYjIwZWY5NDFmL3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzc2MDBkY2I2LTlmNmItNGIzOC05NTdkLTliZGIyMGVm
+        OTQxZi92ZXJzaW9ucy8yLyJ9LCJkb2NrZXIubWFuaWZlc3QtdGFnIjp7ImNv
+        dW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzc2MDBkY2I2LTlmNmItNGIzOC05NTdkLTliZGIyMGVm
+        OTQxZi92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:24 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/19b964d2-99f4-4d81-95b3-5bb6ed7375c5/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzc2MDBkY2I2LTlmNmItNGIzOC05NTdkLTliZGIyMGVmOTQxZi92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ0NDhhYTJkLTYwMTItNDJl
+        MC1hN2I3LTZlYWNiMTYzNmE0NC8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:24 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/4448aa2d-6012-42e0-a7b7-6eacb1636a44/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy80NDQ4YWEyZC02MDEyLTQy
+        ZTAtYTdiNy02ZWFjYjE2MzZhNDQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjI0LjQxNzMzMVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowNToyNC41NDcyODVaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2Uw
+        Yy00NDlhLTkzNzgtNDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:24 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/4448aa2d-6012-42e0-a7b7-6eacb1636a44/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy80NDQ4YWEyZC02MDEyLTQy
+        ZTAtYTdiNy02ZWFjYjE2MzZhNDQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjI0LjQxNzMzMVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjA1OjI0LjU0NzI4NVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjNUMTM6MDU6MjQuNjE0NDYyWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2UwYy00NDlhLTkzNzgtNDg3YWZl
+        ZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:24 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/7600dcb6-9f6b-4b38-957d-9bdb20ef941f/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:24 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/7600dcb6-9f6b-4b38-957d-9bdb20ef941f/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '793'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy9kMmMzMmUwNS05NzkwLTRmMzUtOWUwZS1kZTI0NzI3YWVkODgv
+        IiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjM5OjM4LjI3NTI5NVoiLCJf
+        dHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2Fw
+        aS92My9hcnRpZmFjdHMvMDk4ZWQ3YzEtNmRhYi00YTM3LTgwZmQtYWUyMzdh
+        MDhlYjc2LyIsImRpZ2VzdCI6InNoYTI1NjphNmVjYmIxNTUzMzUzYTA4OTM2
+        ZjUwYzI3NWIwMTAzODhlZDFiZDZkOWQ4NDc0M2M3ZThlNzQ2OGUyYWNkODJl
+        Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlv
+        bi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwi
+        bGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzcyOGIyN2U4LTk5YzEtNGFjNi1h
+        MTY0LWFiNDdlMTNlZWE4NS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvYmxvYnMvYTgyZTMwNGItYzVjYy00MDQ5LTg0YzgtODA5
+        ZjMwNzE1ZjY3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9i
+        cy81MzZiNTc2MC04YzZiLTQ0YTctYTc5Mi0xYWExMjFhYWQxZDkvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzNkZGFmNDg0LWRkZWMt
+        NGIwMC1hZjEyLWI2Y2ZkNzU1NmE4ZC8iXX1dfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:25 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/7600dcb6-9f6b-4b38-957d-9bdb20ef941f/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:25 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifest-tags/?page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/7600dcb6-9f6b-4b38-957d-9bdb20ef941f/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '401'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvZTU0NmM4MGItMTk0OS00OWJjLTg5MWYtNDg3MTQ2ZGI4
+        ZDdhLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzozOTozOC4yNzg0MTNa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QtdGFnIiwiX2FydGlmYWN0Ijoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wOThlZDdjMS02ZGFiLTRhMzctODBm
+        ZC1hZTIzN2EwOGViNzYvIiwibmFtZSI6ImxhdGVzdCIsInRhZ2dlZF9tYW5p
+        ZmVzdCI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMv
+        ZDJjMzJlMDUtOTc5MC00ZjM1LTllMGUtZGUyNDcyN2FlZDg4LyJ9XX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:25 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/956e4dad-d688-4fc8-bc5a-529b8a6ddebd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:32:07 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBlN2I2NGQ0LTQ5YmEtNDM5
+        Yy1iNTc5LTYyMjRhOTBmMWEwYi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:32:07 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/59cc42b2-3a98-44f3-9abc-c6c832069bb8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:32:07 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU1OTdlODExLTA3ZDQtNDcw
+        My1iYWUwLTU5MjhhMjljMzJkNi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:32:07 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/757d01f4-c182-46aa-b08c-fd7fccc1e54d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:32:08 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkwNGI1ZmVlLTRkZjctNDdk
+        Yi1hMmQ5LTA5OWU3OTViMWI5Mi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:32:08 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/757d01f4-c182-46aa-b08c-fd7fccc1e54d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:32:08 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '23'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:32:08 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/a6aa5f4d-57a6-40d9-80a1-5257a17ee100/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:32:08 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EwOTcxZTJjLTA2ZGUtNDc4
+        My04M2RhLWJlNWYwZjQzMjg1ZC8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:32:08 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/87926e69-1b3d-4cda-bc11-2561c33f6b70/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:32:09 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q5YmExMDBiLWNiMTgtNDlj
+        Mi04MjczLTg0YTYwZmExYzAwNy8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:32:09 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/87926e69-1b3d-4cda-bc11-2561c33f6b70/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:32:09 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '23'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:32:09 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/8808bcdb-613e-4e3f-9356-59f16ed74cca/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:42 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ3MzAxY2I1LWJiMDQtNDI3
+        Ny05ZTA5LTMxNjA2N2JkNTlmMy8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:42 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/2095d9e9-1a9b-4163-97b5-5f9bf5d5cbfa/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:43 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFiNmNkMDZhLTMzOGItNGJm
+        Yi1hZTg4LTliNGI5NmM0YzY2NS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:43 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/cd2b6afa-17a4-4093-81af-847e03727fd6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:43 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NlM2RjMTM0LTBmNzQtNGU4
+        NC1iYjY4LWUyOTM1NDBmY2E0Ny8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:43 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/19b964d2-99f4-4d81-95b3-5bb6ed7375c5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:43 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IyOTk1OWNjLTM2ODEtNDVk
+        MS04MmQ5LTgzYmIyMmMwNjVlOS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:43 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/44989003-41c8-41e9-9f09-49b78b32a36b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:44 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdjNWRlMTA4LWUzMGItNDNl
+        Zi04NDk4LTA0OWIxZDJiMWJjZS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:44 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/399e0dce-24ed-47d2-8ca8-f67d4ac3e3ff/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg2ODgwY2IzLTdiNDktNDA3
+        My1hNjNjLTBiYmEyMWEzODUxNS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:45 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/86880cb3-7b49-4073-a63c-0bba21a38515/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84Njg4MGNiMy03YjQ5LTQw
+        NzMtYTYzYy0wYmJhMjFhMzg1MTUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjQ1LjAxMzQzM1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM0OjQ1LjEwMDA2M1oi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjRUMTY6MzQ6NDUuMTMyNDM2WiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUt
+        ZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzM5OWUwZGNlLTI0ZWQtNDdk
+        Mi04Y2E4LWY2N2Q0YWMzZTNmZi92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:45 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/399e0dce-24ed-47d2-8ca8-f67d4ac3e3ff/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvMzk5ZTBkY2Ut
+        MjRlZC00N2QyLThjYTgtZjY3ZDRhYzNlM2ZmL3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI0VDE2OjM0OjQ1LjExNTk3NFoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:45 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19E
+        b2NrZXJfMSIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzM5OWUwZGNlLTI0ZWQtNDdkMi04
+        Y2E4LWY2N2Q0YWMzZTNmZi92ZXJzaW9ucy8xLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U5OWNhNWMxLTFjODYtNDU2
+        NS04ZWUzLWQ5YmVjNjgyNzU4OS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:45 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/e99ca5c1-1c86-4565-8ee3-d9bec6827589/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lOTljYTVjMS0xYzg2LTQ1
+        NjUtOGVlMy1kOWJlYzY4Mjc1ODkvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjQ1LjQ2MjMxNFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozNDo0NS41NTg4NTVaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQx
+        ZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:45 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/e99ca5c1-1c86-4565-8ee3-d9bec6827589/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '527'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lOTljYTVjMS0xYzg2LTQ1
+        NjUtOGVlMy1kOWJlYzY4Mjc1ODkvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjQ1LjQ2MjMxNFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM0OjQ1LjU1ODg1NVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjRUMTY6MzQ6NDUuNzAyOTA1WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUtY2MxMjUx
+        OGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyL2FkMGUzNjFl
+        LTMyMGUtNGFlMC1iNWExLTRiNDA0NDhmYjkwYS8iXX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:45 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/ad0e361e-320e-4ae0-b5a1-4b40448fb90a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '288'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTI0VDE2OjM0OjQ1LjY5NTE0OFoiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvMzk5ZTBk
+        Y2UtMjRlZC00N2QyLThjYTgtZjY3ZDRhYzNlM2ZmL3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyL2FkMGUzNjFlLTMyMGUtNGFlMC1i
+        NWExLTRiNDA0NDhmYjkwYS8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:45 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/5124aa76-557f-4f13-bc22-0341769d1c18/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy8zOTll
+        MGRjZS0yNGVkLTQ3ZDItOGNhOC1mNjdkNGFjM2UzZmYvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJiMzZjZmJhLWYzOTgtNGMx
+        YS04OGZmLTcyOWFjMWNkYjIwMi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:46 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/2b36cfba-f398-4c1a-88ff-729ac1cdb202/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '427'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yYjM2Y2ZiYS1mMzk4LTRj
+        MWEtODhmZi03MjlhYzFjZGIyMDIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjQ2LjE2NTk1OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6MzQ6NDYuMjY0ODc2WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwi
+        Y3JlYXRlZF9yZXNvdXJjZXMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:46 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/2b36cfba-f398-4c1a-88ff-729ac1cdb202/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yYjM2Y2ZiYS1mMzk4LTRj
+        MWEtODhmZi03MjlhYzFjZGIyMDIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjQ2LjE2NTk1OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6MzQ6NDYuMjY0ODc2WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:46 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/2b36cfba-f398-4c1a-88ff-729ac1cdb202/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yYjM2Y2ZiYS1mMzk4LTRj
+        MWEtODhmZi03MjlhYzFjZGIyMDIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjQ2LjE2NTk1OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6MzQ6NDYuMjY0ODc2WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:46 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/2b36cfba-f398-4c1a-88ff-729ac1cdb202/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yYjM2Y2ZiYS1mMzk4LTRj
+        MWEtODhmZi03MjlhYzFjZGIyMDIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjQ2LjE2NTk1OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6MzQ6NDYuMjY0ODc2WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:46 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/2b36cfba-f398-4c1a-88ff-729ac1cdb202/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yYjM2Y2ZiYS1mMzk4LTRj
+        MWEtODhmZi03MjlhYzFjZGIyMDIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjQ2LjE2NTk1OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6MzQ6NDYuMjY0ODc2WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:46 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/2b36cfba-f398-4c1a-88ff-729ac1cdb202/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '879'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yYjM2Y2ZiYS1mMzk4LTRj
+        MWEtODhmZi03MjlhYzFjZGIyMDIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjQ2LjE2NTk1OVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozNDo0Ni4yNjQ4NzZa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM0OjQ2Ljk2Mzc4Nloi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3MmFiLTNlMGMtNDQ5YS05Mzc4
+        LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Npbmcg
+        VGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvMzk5ZTBkY2UtMjRlZC00N2QyLThjYTgtZjY3
+        ZDRhYzNlM2ZmL3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:47 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/399e0dce-24ed-47d2-8ca8-f67d4ac3e3ff/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '1281'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvMzk5ZTBkY2Ut
+        MjRlZC00N2QyLThjYTgtZjY3ZDRhYzNlM2ZmL3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI0VDE2OjM0OjQ2LjI4NTE2N1oiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy8z
+        OTllMGRjZS0yNGVkLTQ3ZDItOGNhOC1mNjdkNGFjM2UzZmYvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvMzk5
+        ZTBkY2UtMjRlZC00N2QyLThjYTgtZjY3ZDRhYzNlM2ZmL3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvMzk5ZTBkY2UtMjRlZC00N2QyLThjYTgtZjY3ZDRhYzNlM2ZmL3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvMzk5ZTBkY2UtMjRlZC00N2QyLThjYTgt
+        ZjY3ZDRhYzNlM2ZmL3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzM5OWUwZGNlLTI0ZWQtNDdkMi04Y2E4LWY2N2Q0YWMz
+        ZTNmZi92ZXJzaW9ucy8yLyJ9LCJkb2NrZXIubWFuaWZlc3QtdGFnIjp7ImNv
+        dW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzM5OWUwZGNlLTI0ZWQtNDdkMi04Y2E4LWY2N2Q0YWMz
+        ZTNmZi92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:47 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/ad0e361e-320e-4ae0-b5a1-4b40448fb90a/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzM5OWUwZGNlLTI0ZWQtNDdkMi04Y2E4LWY2N2Q0YWMzZTNmZi92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNkZjE5MGIwLTgzMGQtNDZj
+        Ny05ZjZmLTlkNzQ4ZDI1ZWY2Yy8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:47 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3df190b0-830d-46c7-9f6f-9d748d25ef6c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zZGYxOTBiMC04MzBkLTQ2
+        YzctOWY2Zi05ZDc0OGQyNWVmNmMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjQ3LjM0MjA2OFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozNDo0Ny40NjcxNjVaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2
+        YS00MjE2LTgwMjUtZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:47 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3df190b0-830d-46c7-9f6f-9d748d25ef6c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zZGYxOTBiMC04MzBkLTQ2
+        YzctOWY2Zi05ZDc0OGQyNWVmNmMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjQ3LjM0MjA2OFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM0OjQ3LjQ2NzE2NVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjRUMTY6MzQ6NDcuNTMxMzYwWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUtZjRlZmYy
+        NDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:47 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/cdd6fe15-988f-411d-a0b4-8d85952d47ad/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:18 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFlMzE1NTg1LWM3N2EtNGVj
+        MS05Y2QzLTU0OWNiY2I4ZWNhMi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:18 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/9f0876de-48e9-47fa-8cda-8cd06db1bb61/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:18 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI4NWUxN2U3LTIxODQtNDNk
+        Zi05ZGY4LTEzZDA5NGI0NzVjNC8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:18 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/3005b083-9f9e-4c28-89f0-82093307cc66/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:18 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkxMTRlMjQ5LTc1MzktNDg3
+        MS1iNzQ2LTkxMDcyMDk4NmU0Zi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:18 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/52ba30df-33df-46f0-93bd-4a1cca6a5b61/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:20 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkyMGYxNTMxLTcxNTctNGYx
+        MS04M2Y2LTM2MDIzMDEzYmY4ZC8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:20 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/920f1531-7157-4f11-83f6-36023013bf8d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:20 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '502'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85MjBmMTUzMS03MTU3LTRm
+        MTEtODNmNi0zNjAyMzAxM2JmOGQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjIwLjQ1NDA0MFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLnJlcG9zaXRvcnkuYWRkX2FuZF9yZW1vdmUi
+        LCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozNjoyMC41NTM5MjRaIiwi
+        ZmluaXNoZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJv
+        ciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNl
+        ODYtODQxZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVs
+        bCwic3Bhd25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJj
+        cmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        LzUyYmEzMGRmLTMzZGYtNDZmMC05M2JkLTRhMWNjYTZhNWI2MS92ZXJzaW9u
+        cy8xLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:20 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/920f1531-7157-4f11-83f6-36023013bf8d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:20 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85MjBmMTUzMS03MTU3LTRm
+        MTEtODNmNi0zNjAyMzAxM2JmOGQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjIwLjQ1NDA0MFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM2OjIwLjU1MzkyNFoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjRUMTY6MzY6MjAuNTkxNDQ0WiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUt
+        Y2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzUyYmEzMGRmLTMzZGYtNDZm
+        MC05M2JkLTRhMWNjYTZhNWI2MS92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:20 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/52ba30df-33df-46f0-93bd-4a1cca6a5b61/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:20 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNTJiYTMwZGYt
+        MzNkZi00NmYwLTkzYmQtNGExY2NhNmE1YjYxL3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI0VDE2OjM2OjIwLjU3MzA3NVoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:20 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19E
+        b2NrZXJfMSIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzUyYmEzMGRmLTMzZGYtNDZmMC05
+        M2JkLTRhMWNjYTZhNWI2MS92ZXJzaW9ucy8xLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY5YTQyYWFkLWMyMjYtNDdj
+        ZC05M2RkLWZjM2M1ZTNjZjg3MS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:21 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/69a42aad-c226-47cd-93dd-fc3c5e3cf871/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy82OWE0MmFhZC1jMjI2LTQ3
+        Y2QtOTNkZC1mYzNjNWUzY2Y4NzEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjIxLjA1OTY5M1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozNjoyMS4xNzc0MDJaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2
+        YS00MjE2LTgwMjUtZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:21 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/69a42aad-c226-47cd-93dd-fc3c5e3cf871/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '527'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy82OWE0MmFhZC1jMjI2LTQ3
+        Y2QtOTNkZC1mYzNjNWUzY2Y4NzEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjIxLjA1OTY5M1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM2OjIxLjE3NzQwMloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjRUMTY6MzY6MjEuMzI3MjA3WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUtZjRlZmYy
+        NDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzY0ZDVmYzQ2
+        LWYyZDktNGM3MC05MDNiLTg1MjVkMDAyY2IyNC8iXX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:21 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/64d5fc46-f2d9-4c70-903b-8525d002cb24/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '289'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTI0VDE2OjM2OjIxLjMxOTU1NloiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNTJiYTMw
+        ZGYtMzNkZi00NmYwLTkzYmQtNGExY2NhNmE1YjYxL3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzY0ZDVmYzQ2LWYyZDktNGM3MC05
+        MDNiLTg1MjVkMDAyY2IyNC8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:21 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/7b1a39c2-d252-45ca-97cb-7624e8092d70/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy81MmJh
+        MzBkZi0zM2RmLTQ2ZjAtOTNiZC00YTFjY2E2YTViNjEvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RiZjE5NjA1LTAyMDgtNGU5
+        Ni04YjMwLTgzZWRkNTQyYTRhMS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:21 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/dbf19605-0208-4e96-8b30-83edd542a4a1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kYmYxOTYwNS0wMjA4LTRl
+        OTYtOGIzMC04M2VkZDU0MmE0YTEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjIxLjk3Nzk4OFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6MzY6MjIuMDc0NDY5WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:22 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/dbf19605-0208-4e96-8b30-83edd542a4a1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kYmYxOTYwNS0wMjA4LTRl
+        OTYtOGIzMC04M2VkZDU0MmE0YTEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjIxLjk3Nzk4OFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6MzY6MjIuMDc0NDY5WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:22 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/dbf19605-0208-4e96-8b30-83edd542a4a1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kYmYxOTYwNS0wMjA4LTRl
+        OTYtOGIzMC04M2VkZDU0MmE0YTEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjIxLjk3Nzk4OFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6MzY6MjIuMDc0NDY5WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:22 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/dbf19605-0208-4e96-8b30-83edd542a4a1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kYmYxOTYwNS0wMjA4LTRl
+        OTYtOGIzMC04M2VkZDU0MmE0YTEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjIxLjk3Nzk4OFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6MzY6MjIuMDc0NDY5WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:22 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/dbf19605-0208-4e96-8b30-83edd542a4a1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kYmYxOTYwNS0wMjA4LTRl
+        OTYtOGIzMC04M2VkZDU0MmE0YTEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjIxLjk3Nzk4OFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6MzY6MjIuMDc0NDY5WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:22 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/dbf19605-0208-4e96-8b30-83edd542a4a1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '879'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kYmYxOTYwNS0wMjA4LTRl
+        OTYtOGIzMC04M2VkZDU0MmE0YTEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjIxLjk3Nzk4OFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozNjoyMi4wNzQ0Njla
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM2OjIyLjc5MTk5MVoi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkzZTg2LTg0MWUtNGUxMC1iMmI1
+        LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVs
+        bCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lh
+        dGluZyBDb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6Niwi
+        ZG9uZSI6Niwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGlu
+        ZyB0YWcgbGlzdCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRv
+        bmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUHJvY2Vzc2luZyBU
+        YWdzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvNTJiYTMwZGYtMzNkZi00NmYwLTkzYmQtNGEx
+        Y2NhNmE1YjYxL3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:22 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/52ba30df-33df-46f0-93bd-4a1cca6a5b61/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '1281'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNTJiYTMwZGYt
+        MzNkZi00NmYwLTkzYmQtNGExY2NhNmE1YjYxL3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI0VDE2OjM2OjIyLjA5MDQ0OVoiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy81
+        MmJhMzBkZi0zM2RmLTQ2ZjAtOTNiZC00YTFjY2E2YTViNjEvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNTJi
+        YTMwZGYtMzNkZi00NmYwLTkzYmQtNGExY2NhNmE1YjYxL3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvNTJiYTMwZGYtMzNkZi00NmYwLTkzYmQtNGExY2NhNmE1YjYxL3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvNTJiYTMwZGYtMzNkZi00NmYwLTkzYmQt
+        NGExY2NhNmE1YjYxL3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzUyYmEzMGRmLTMzZGYtNDZmMC05M2JkLTRhMWNjYTZh
+        NWI2MS92ZXJzaW9ucy8yLyJ9LCJkb2NrZXIubWFuaWZlc3QtdGFnIjp7ImNv
+        dW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzUyYmEzMGRmLTMzZGYtNDZmMC05M2JkLTRhMWNjYTZh
+        NWI2MS92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:23 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/64d5fc46-f2d9-4c70-903b-8525d002cb24/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzUyYmEzMGRmLTMzZGYtNDZmMC05M2JkLTRhMWNjYTZhNWI2MS92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlmYzk1ZmY0LWIwYWUtNDNi
+        ZC1hZTExLWRiYTQxOTE2YzNmYy8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:23 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/9fc95ff4-b0ae-43bd-ae11-dba41916c3fc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85ZmM5NWZmNC1iMGFlLTQz
+        YmQtYWUxMS1kYmE0MTkxNmMzZmMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjIzLjE5MTAzNloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozNjoyMy4zMjUwNTFaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQx
+        ZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:23 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/9fc95ff4-b0ae-43bd-ae11-dba41916c3fc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85ZmM5NWZmNC1iMGFlLTQz
+        YmQtYWUxMS1kYmE0MTkxNmMzZmMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjIzLjE5MTAzNloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM2OjIzLjMyNTA1MVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjRUMTY6MzY6MjMuMzk2OTg2WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUtY2MxMjUx
+        OGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:23 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/fb874738-ef41-4f54-932a-e8952b78c3ad/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:09 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y0YjRlMWVmLWYyODYtNDU0
+        Mi1iZjBhLWU4MmUxMTdjNTZlYS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:09 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/5fd57129-3c75-4e1d-b8a9-6a23f90a31d6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:09 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y3N2RjZGNlLWVhMmEtNGEx
+        Yi1iZDM5LWI5MjFlZTJhZWU2ZC8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:09 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/e9fae216-63a6-4253-b8c7-6188c81f0e2a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:10 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ExYjY5YWJiLWFhYWEtNGZm
+        NC04ZTNiLTBmZGY4OTA0MzQ1ZC8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:10 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/7e75dcbf-5ba9-42a0-aa8f-002942468a11/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:11 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NlYTBjMGVhLTQ1MDEtNDgw
+        Zi1hZGUxLWY3NTlhYzY0NWY2MS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:11 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/cea0c0ea-4501-480f-ade1-f759ac645f61/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:11 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '502'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jZWEwYzBlYS00NTAxLTQ4
+        MGYtYWRlMS1mNzU5YWM2NDVmNjEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjExLjY3NjUxNFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLnJlcG9zaXRvcnkuYWRkX2FuZF9yZW1vdmUi
+        LCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozNzoxMS43ODMxMjFaIiwi
+        ZmluaXNoZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJv
+        ciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcy
+        YWItM2UwYy00NDlhLTkzNzgtNDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVs
+        bCwic3Bhd25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJj
+        cmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        LzdlNzVkY2JmLTViYTktNDJhMC1hYThmLTAwMjk0MjQ2OGExMS92ZXJzaW9u
+        cy8xLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:11 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/cea0c0ea-4501-480f-ade1-f759ac645f61/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:11 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jZWEwYzBlYS00NTAxLTQ4
+        MGYtYWRlMS1mNzU5YWM2NDVmNjEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjExLjY3NjUxNFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM3OjExLjc4MzEyMVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzc6MTEuODIyOTgzWiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2UwYy00NDlhLTkzNzgt
+        NDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzdlNzVkY2JmLTViYTktNDJh
+        MC1hYThmLTAwMjk0MjQ2OGExMS92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:11 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/7e75dcbf-5ba9-42a0-aa8f-002942468a11/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvN2U3NWRjYmYt
+        NWJhOS00MmEwLWFhOGYtMDAyOTQyNDY4YTExL3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI0VDE2OjM3OjExLjgwNDEwNVoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:12 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19E
+        b2NrZXJfMSIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzdlNzVkY2JmLTViYTktNDJhMC1h
+        YThmLTAwMjk0MjQ2OGExMS92ZXJzaW9ucy8xLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIxYjA3N2ZlLTNlYzgtNDQ2
+        ZC04MGZlLTVhMjg1YTJhNGZiMy8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:12 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/21b077fe-3ec8-446d-80fe-5a285a2a4fb3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '395'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yMWIwNzdmZS0zZWM4LTQ0
+        NmQtODBmZS01YTI4NWEyYTRmYjMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjEyLjI5ODc4MVoiLCJzdGF0ZSI6IndhaXRpbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjpudWxsLCJmaW5pc2hlZF9hdCI6bnVsbCwibm9uX2ZhdGFsX2Vy
+        cm9ycyI6W10sImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
+        d29ya2Vycy8wZjk5ZThmYy1jMzZhLTQyMTYtODAyNS1mNGVmZjI0NWFkNjYv
+        IiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jlc3Nf
+        cmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpbXX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:12 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/21b077fe-3ec8-446d-80fe-5a285a2a4fb3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yMWIwNzdmZS0zZWM4LTQ0
+        NmQtODBmZS01YTI4NWEyYTRmYjMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjEyLjI5ODc4MVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozNzoxMi40MzYyMjRaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2
+        YS00MjE2LTgwMjUtZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:12 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/21b077fe-3ec8-446d-80fe-5a285a2a4fb3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '527'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yMWIwNzdmZS0zZWM4LTQ0
+        NmQtODBmZS01YTI4NWEyYTRmYjMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjEyLjI5ODc4MVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM3OjEyLjQzNjIyNFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzc6MTIuNTg3NjI3WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUtZjRlZmYy
+        NDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzI2ZmExODll
+        LTcwNDQtNDU3ZC05YTBkLTc4ZTc1MTM4MGIyZC8iXX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:12 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/26fa189e-7044-457d-9a0d-78e751380b2d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '290'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTI0VDE2OjM3OjEyLjU4MDExM1oiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvN2U3NWRj
+        YmYtNWJhOS00MmEwLWFhOGYtMDAyOTQyNDY4YTExL3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzI2ZmExODllLTcwNDQtNDU3ZC05
+        YTBkLTc4ZTc1MTM4MGIyZC8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:12 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/61189ffb-ad18-48b9-997e-0944e58502a3/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy83ZTc1
+        ZGNiZi01YmE5LTQyYTAtYWE4Zi0wMDI5NDI0NjhhMTEvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:13 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U4M2NjMTA2LWE0ZDEtNGJm
+        Mi04YjIxLWIwZjY1NjA5MmY4MS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:13 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/e83cc106-a4d1-4bf2-8b21-b0f656092f81/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:13 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '516'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lODNjYzEwNi1hNGQxLTRi
+        ZjItOGIyMS1iMGY2NTYwOTJmODEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjEzLjI0MDk1NVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzc6MTMuMzM5OTE5WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:13 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/e83cc106-a4d1-4bf2-8b21-b0f656092f81/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:13 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lODNjYzEwNi1hNGQxLTRi
+        ZjItOGIyMS1iMGY2NTYwOTJmODEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjEzLjI0MDk1NVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzc6MTMuMzM5OTE5WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:13 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/e83cc106-a4d1-4bf2-8b21-b0f656092f81/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:13 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lODNjYzEwNi1hNGQxLTRi
+        ZjItOGIyMS1iMGY2NTYwOTJmODEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjEzLjI0MDk1NVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzc6MTMuMzM5OTE5WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:13 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/e83cc106-a4d1-4bf2-8b21-b0f656092f81/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:13 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lODNjYzEwNi1hNGQxLTRi
+        ZjItOGIyMS1iMGY2NTYwOTJmODEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjEzLjI0MDk1NVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzc6MTMuMzM5OTE5WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:13 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/e83cc106-a4d1-4bf2-8b21-b0f656092f81/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:14 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '879'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lODNjYzEwNi1hNGQxLTRi
+        ZjItOGIyMS1iMGY2NTYwOTJmODEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjEzLjI0MDk1NVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozNzoxMy4zMzk5MTla
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM3OjEzLjk4NzI3MVoi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTllOGZjLWMzNmEtNDIxNi04MDI1
+        LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiUHJvY2Vzc2lu
+        ZyBUYWdzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6
+        MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyB0YWcg
+        bGlzdCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvN2U3NWRjYmYtNWJhOS00MmEwLWFhOGYtMDAy
+        OTQyNDY4YTExL3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:14 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/7e75dcbf-5ba9-42a0-aa8f-002942468a11/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:14 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '1281'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvN2U3NWRjYmYt
+        NWJhOS00MmEwLWFhOGYtMDAyOTQyNDY4YTExL3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI0VDE2OjM3OjEzLjM2MzM4OVoiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy83
+        ZTc1ZGNiZi01YmE5LTQyYTAtYWE4Zi0wMDI5NDI0NjhhMTEvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvN2U3
+        NWRjYmYtNWJhOS00MmEwLWFhOGYtMDAyOTQyNDY4YTExL3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvN2U3NWRjYmYtNWJhOS00MmEwLWFhOGYtMDAyOTQyNDY4YTExL3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvN2U3NWRjYmYtNWJhOS00MmEwLWFhOGYt
+        MDAyOTQyNDY4YTExL3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzdlNzVkY2JmLTViYTktNDJhMC1hYThmLTAwMjk0MjQ2
+        OGExMS92ZXJzaW9ucy8yLyJ9LCJkb2NrZXIubWFuaWZlc3QtdGFnIjp7ImNv
+        dW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzdlNzVkY2JmLTViYTktNDJhMC1hYThmLTAwMjk0MjQ2
+        OGExMS92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:14 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/26fa189e-7044-457d-9a0d-78e751380b2d/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzdlNzVkY2JmLTViYTktNDJhMC1hYThmLTAwMjk0MjQ2OGExMS92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:14 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UxODM1YTNlLWUyMjQtNGYw
+        My04N2VmLTdhYTZhNTYxYTNkMS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:14 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/e1835a3e-e224-4f03-87ef-7aa6a561a3d1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:14 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lMTgzNWEzZS1lMjI0LTRm
+        MDMtODdlZi03YWE2YTU2MWEzZDEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjE0LjMyNTYwNVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozNzoxNC40NDUyMDZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2Uw
+        Yy00NDlhLTkzNzgtNDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:14 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/e1835a3e-e224-4f03-87ef-7aa6a561a3d1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:14 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lMTgzNWEzZS1lMjI0LTRm
+        MDMtODdlZi03YWE2YTU2MWEzZDEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjE0LjMyNTYwNVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM3OjE0LjQ0NTIwNloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzc6MTQuNTI1MzE5WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2UwYy00NDlhLTkzNzgtNDg3YWZl
+        ZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:14 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/77f0dab4-6871-4a09-a791-9bef077d2bde/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQyN2I4NDYwLTkxNDctNDVm
+        Yi04MWQ0LTk5NDhjNGNjYWViNS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:29 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '350'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlbW90ZXMvZG9ja2VyL2Rv
+        Y2tlci81OWNkNzk4ZC1kZTBhLTQ2NGYtODNjOC01MTJmNGI4NWI5OGMvIiwi
+        X2NyZWF0ZWQiOiIyMDE5LTA3LTI0VDE2OjM3OjE4Ljk4MTI1NFoiLCJfdHlw
+        ZSI6ImRvY2tlci5kb2NrZXIiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        b24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInVybCI6Imh0dHBzOi8vcmVn
+        aXN0cnktMS5kb2NrZXIuaW8vIiwic3NsX2NhX2NlcnRpZmljYXRlIjpudWxs
+        LCJzc2xfY2xpZW50X2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2tl
+        eSI6bnVsbCwic3NsX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVs
+        bCwiX2xhc3RfdXBkYXRlZCI6IjIwMTktMDctMjRUMTY6Mzc6MTguOTgxMjY4
+        WiIsImRvd25sb2FkX2NvbmN1cnJlbmN5IjoyMCwicG9saWN5IjoiaW1tZWRp
+        YXRlIiwidXBzdHJlYW1fbmFtZSI6ImZlZG9yYS9zc2giLCJ3aGl0ZWxpc3Rf
+        dGFncyI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:29 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/59cd798d-de0a-464f-83c8-512f4b85b98c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk2YzVjNTY5LWJhYzEtNDY3
+        ZC05NDY3LWMyZWY3MjYwMzE1MC8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:29 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '278'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJh
+        cnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5IjpudWxsLCJfY3JlYXRl
+        ZCI6IjIwMTktMDctMjRUMTY6Mzc6MjAuMTI1NzE0WiIsIm5hbWUiOiJEZWZh
+        dWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0RvY2tlcl8xIiwicmVw
+        b3NpdG9yeV92ZXJzaW9uIjpudWxsLCJjb250ZW50X2d1YXJkIjpudWxsLCJf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2RvY2tlci9kb2Nr
+        ZXIvYWExMWM1MzYtYjIyMi00M2MwLTkxZjAtOTUwOWVlMWVhYTRkLyIsInJl
+        Z2lzdHJ5X3BhdGgiOiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29t
+        L0RlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRG9ja2VyXzEi
+        fV19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:29 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/aa11c536-b222-43c0-91f0-9509ee1eaa4d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhlZGE2NTBiLTcwNjktNDAz
+        My1iYjA3LTg2ZjJjYmUxZTJlNi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:29 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:30 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '278'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJh
+        cnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5IjpudWxsLCJfY3JlYXRl
+        ZCI6IjIwMTktMDctMjRUMTY6Mzc6MjAuMTI1NzE0WiIsIm5hbWUiOiJEZWZh
+        dWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0RvY2tlcl8xIiwicmVw
+        b3NpdG9yeV92ZXJzaW9uIjpudWxsLCJjb250ZW50X2d1YXJkIjpudWxsLCJf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2RvY2tlci9kb2Nr
+        ZXIvYWExMWM1MzYtYjIyMi00M2MwLTkxZjAtOTUwOWVlMWVhYTRkLyIsInJl
+        Z2lzdHJ5X3BhdGgiOiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29t
+        L0RlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRG9ja2VyXzEi
+        fV19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:30 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/aa11c536-b222-43c0-91f0-9509ee1eaa4d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:30 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '23'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:30 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:30 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:30 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:30 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:30 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:30 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:30 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/a4be8757-25a9-409e-b6e6-59f1a92c741c/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:31 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM3OWE5YTY2LTMzMjQtNDYz
+        Yy1iMGU3LTg0OGM2Y2M5NGMyYy8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:31 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/379a9a66-3324-463c-b0e7-848c6cc94c2c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:31 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '502'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zNzlhOWE2Ni0zMzI0LTQ2
+        M2MtYjBlNy04NDhjNmNjOTRjMmMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjMxLjQyNjUxNFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLnJlcG9zaXRvcnkuYWRkX2FuZF9yZW1vdmUi
+        LCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozOTozMS41MzM1NTRaIiwi
+        ZmluaXNoZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJv
+        ciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNl
+        ODYtODQxZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVs
+        bCwic3Bhd25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJj
+        cmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L2E0YmU4NzU3LTI1YTktNDA5ZS1iNmU2LTU5ZjFhOTJjNzQxYy92ZXJzaW9u
+        cy8xLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:31 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/379a9a66-3324-463c-b0e7-848c6cc94c2c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:31 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zNzlhOWE2Ni0zMzI0LTQ2
+        M2MtYjBlNy04NDhjNmNjOTRjMmMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjMxLjQyNjUxNFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM5OjMxLjUzMzU1NFoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzk6MzEuNTY1MjkyWiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUt
+        Y2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2E0YmU4NzU3LTI1YTktNDA5
+        ZS1iNmU2LTU5ZjFhOTJjNzQxYy92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:31 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/a4be8757-25a9-409e-b6e6-59f1a92c741c/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:31 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYTRiZTg3NTct
+        MjVhOS00MDllLWI2ZTYtNTlmMWE5MmM3NDFjL3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI0VDE2OjM5OjMxLjU0NzczM1oiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:31 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19E
+        b2NrZXJfMSIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2E0YmU4NzU3LTI1YTktNDA5ZS1i
+        NmU2LTU5ZjFhOTJjNzQxYy92ZXJzaW9ucy8xLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:32 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJkYTA5YmY5LTJkZTMtNDli
+        Yi04YjJhLTQ2MDYzYjBkMzlhNi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:32 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/2da09bf9-2de3-49bb-8b2a-46063b0d39a6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:32 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yZGEwOWJmOS0yZGUzLTQ5
+        YmItOGIyYS00NjA2M2IwZDM5YTYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjMxLjk5NzE1NVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozOTozMi4xMTE1ODJaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2Uw
+        Yy00NDlhLTkzNzgtNDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:32 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/2da09bf9-2de3-49bb-8b2a-46063b0d39a6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:32 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '527'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yZGEwOWJmOS0yZGUzLTQ5
+        YmItOGIyYS00NjA2M2IwZDM5YTYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjMxLjk5NzE1NVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM5OjMyLjExMTU4MloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzk6MzIuMjU1NDc5WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2UwYy00NDlhLTkzNzgtNDg3YWZl
+        ZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyL2I0ZDA4MzEz
+        LTQwMTgtNGYwYi04ZmE2LTE4YTEyYmQ4ZWQ1ZS8iXX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:32 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/b4d08313-4018-4f0b-8fa6-18a12bd8ed5e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:32 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '289'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTI0VDE2OjM5OjMyLjI0Nzg0N1oiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYTRiZTg3
+        NTctMjVhOS00MDllLWI2ZTYtNTlmMWE5MmM3NDFjL3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyL2I0ZDA4MzEzLTQwMTgtNGYwYi04
+        ZmE2LTE4YTEyYmQ4ZWQ1ZS8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:32 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/a83099c4-63b8-44f9-8a35-a4d1122b6d27/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9hNGJl
+        ODc1Ny0yNWE5LTQwOWUtYjZlNi01OWYxYTkyYzc0MWMvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:32 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEwYTJhZmMyLTI5YWUtNDg3
+        Ny04MWYwLWEwODBmZmM5OTczNS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:32 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/10a2afc2-29ae-4877-81f0-a080ffc99735/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:32 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '427'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8xMGEyYWZjMi0yOWFlLTQ4
+        NzctODFmMC1hMDgwZmZjOTk3MzUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjMyLjgzMDI3N1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzk6MzIuOTQ1Mjc3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwi
+        Y3JlYXRlZF9yZXNvdXJjZXMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:32 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/10a2afc2-29ae-4877-81f0-a080ffc99735/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:33 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8xMGEyYWZjMi0yOWFlLTQ4
+        NzctODFmMC1hMDgwZmZjOTk3MzUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjMyLjgzMDI3N1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzk6MzIuOTQ1Mjc3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:33 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/10a2afc2-29ae-4877-81f0-a080ffc99735/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:33 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8xMGEyYWZjMi0yOWFlLTQ4
+        NzctODFmMC1hMDgwZmZjOTk3MzUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjMyLjgzMDI3N1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzk6MzIuOTQ1Mjc3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:33 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/10a2afc2-29ae-4877-81f0-a080ffc99735/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:33 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8xMGEyYWZjMi0yOWFlLTQ4
+        NzctODFmMC1hMDgwZmZjOTk3MzUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjMyLjgzMDI3N1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzk6MzIuOTQ1Mjc3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:33 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/10a2afc2-29ae-4877-81f0-a080ffc99735/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:33 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8xMGEyYWZjMi0yOWFlLTQ4
+        NzctODFmMC1hMDgwZmZjOTk3MzUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjMyLjgzMDI3N1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzk6MzIuOTQ1Mjc3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:33 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/10a2afc2-29ae-4877-81f0-a080ffc99735/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:33 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '879'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8xMGEyYWZjMi0yOWFlLTQ4
+        NzctODFmMC1hMDgwZmZjOTk3MzUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjMyLjgzMDI3N1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozOTozMi45NDUyNzda
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM5OjMzLjY1OTcyNFoi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkzZTg2LTg0MWUtNGUxMC1iMmI1
+        LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Npbmcg
+        VGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvYTRiZTg3NTctMjVhOS00MDllLWI2ZTYtNTlm
+        MWE5MmM3NDFjL3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:33 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/a4be8757-25a9-409e-b6e6-59f1a92c741c/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:33 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '1281'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYTRiZTg3NTct
+        MjVhOS00MDllLWI2ZTYtNTlmMWE5MmM3NDFjL3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI0VDE2OjM5OjMyLjk2Njg3NloiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9h
+        NGJlODc1Ny0yNWE5LTQwOWUtYjZlNi01OWYxYTkyYzc0MWMvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYTRi
+        ZTg3NTctMjVhOS00MDllLWI2ZTYtNTlmMWE5MmM3NDFjL3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvYTRiZTg3NTctMjVhOS00MDllLWI2ZTYtNTlmMWE5MmM3NDFjL3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvYTRiZTg3NTctMjVhOS00MDllLWI2ZTYt
+        NTlmMWE5MmM3NDFjL3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdC10
+        YWciOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvbWFuaWZlc3QtdGFncy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvYTRiZTg3NTctMjVhOS00MDllLWI2ZTYt
+        NTlmMWE5MmM3NDFjL3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2E0YmU4NzU3LTI1YTktNDA5ZS1iNmU2LTU5ZjFhOTJj
+        NzQxYy92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:33 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/b4d08313-4018-4f0b-8fa6-18a12bd8ed5e/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2E0YmU4NzU3LTI1YTktNDA5ZS1iNmU2LTU5ZjFhOTJjNzQxYy92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:34 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA5Zjg1YTFjLTBlNTUtNDc3
+        Yy05OTQ4LTlmMmY5MDU4NGE5Yy8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:34 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/09f85a1c-0e55-477c-9948-9f2f90584a9c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:34 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '395'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8wOWY4NWExYy0wZTU1LTQ3
+        N2MtOTk0OC05ZjJmOTA1ODRhOWMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjM0LjA2MjU2M1oiLCJzdGF0ZSI6IndhaXRpbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjpudWxsLCJmaW5pc2hlZF9hdCI6bnVsbCwibm9uX2ZhdGFsX2Vy
+        cm9ycyI6W10sImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
+        d29ya2Vycy8wZjk5ZThmYy1jMzZhLTQyMTYtODAyNS1mNGVmZjI0NWFkNjYv
+        IiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jlc3Nf
+        cmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpbXX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:34 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/09f85a1c-0e55-477c-9948-9f2f90584a9c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:34 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8wOWY4NWExYy0wZTU1LTQ3
+        N2MtOTk0OC05ZjJmOTA1ODRhOWMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjM0LjA2MjU2M1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM5OjM0LjE5NzU4NVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzk6MzQuMjU3MzQ4WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUtZjRlZmYy
+        NDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:34 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:34 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '5132'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MzQsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9t
+        YW5pZmVzdHMvOTViZTA1NWYtZmJhNS00NTc0LTg2YWEtOTg2YmNmZTRlZmM0
+        LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xN1QxOToxNzowNS43NzI3MzZaIiwi
+        X3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9h
+        cGkvdjMvYXJ0aWZhY3RzLzhjNzAwMTNjLWRjZDMtNDM3Yy1iNDRmLWJiYTkw
+        N2IwN2E5Ny8iLCJkaWdlc3QiOiJzaGEyNTY6ZGMyYWU2MzYxNjkxNWNlOTUy
+        N2ViOWJiMzg2NDZjYjM3MDBkMWE3OTAyNTI2NmQ2MDcwOWUyMTRiNDI0OGU1
+        NCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRp
+        b24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitq
+        c29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvbWFuaWZlc3RzLzRlMjYxMjJlLTQ1OGItNGI5My04ODQ1LWU1
+        NzUwNjIyY2Q5NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFu
+        aWZlc3RzLzAzY2ZlNzQ3LTFhNDQtNDRmNC1iZjFjLTY0NjI5ZGUxOThiZC8i
+        XSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpbXX0seyJfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvNGUyNjEyMmUt
+        NDU4Yi00YjkzLTg4NDUtZTU3NTA2MjJjZDk1LyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wNy0xN1QxOToxNzowNS43NjkzODhaIiwiX3R5cGUiOiJkb2NrZXIubWFu
+        aWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzAy
+        ZjkyNzcyLWMwOTItNDczYS04MWRmLTg2OTIzNzk3ZmY2OS8iLCJkaWdlc3Qi
+        OiJzaGEyNTY6YjM1MjAwYmU2NzhkNDc1M2ZlNzc5ZWU1NDA2YzFmYzllZWM5
+        ZTllZTU2ZjAyYjc5ZTQ2YzY1ZDVmMGNlNzYyNyIsInNjaGVtYV92ZXJzaW9u
+        IjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0
+        cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMi
+        OltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9ibG9icy8xYmQ0ODBkYy1hNTI5LTQxNjYtYWM0ZC1mNTVlMDFkNWY5ZmIv
+        IiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2Jz
+        LzJjYWQ0Y2Y4LTc0MDctNDhmZS05ZTg5LTBjMDc2MWQ1M2NlZi8iXX0seyJf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMv
+        MDNjZmU3NDctMWE0NC00NGY0LWJmMWMtNjQ2MjlkZTE5OGJkLyIsIl9jcmVh
+        dGVkIjoiMjAxOS0wNy0xN1QxOToxNzowNS43NjMzMjhaIiwiX3R5cGUiOiJk
+        b2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0
+        aWZhY3RzL2E0YTM2YjIyLWJkYzMtNDk3Ni05ZDE3LTZmMmEyNDE5MzI3YS8i
+        LCJkaWdlc3QiOiJzaGEyNTY6OWI4NzRjY2RiNzNlMWFhZjI5ZTFjMGZkM2E1
+        NTBkZGZhNDg2ZDczNTI1ZjJkNzdiNDUyZTMwYTA5ZDNjYjQxNyIsInNjaGVt
+        YV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRv
+        Y2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9t
+        YW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L2RvY2tlci9ibG9icy9mYTBmZDhkMy1hZWI3LTQ5MjgtYjg3Ni05YzM0
+        YWJhOTViYjEvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL2Jsb2JzLzg1YjRjNDk1LWY3NzYtNGViZi04YWRjLWM3ZDFjMmI1NDFk
+        My8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9t
+        YW5pZmVzdHMvZDM1MmUzODctOTUyYi00MmIzLThjZTEtMzEzZTVmNTEwZmI3
+        LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC40OTgyNDRaIiwi
+        X3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9h
+        cGkvdjMvYXJ0aWZhY3RzLzFjMTVmYTYwLTcxOWMtNDBmYS1iMTQzLTE5ZWQ2
+        NjhiNzI0Mi8iLCJkaWdlc3QiOiJzaGEyNTY6ZDgyODNjODUwYWMyZjFhOTBj
+        NWRkOTRiOWE3YWM5N2NjYWJjYjllMjA4MmUzMTI3YjQzMmIyOTdkMmFiYjZj
+        OCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRp
+        b24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitq
+        c29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvbWFuaWZlc3RzL2RkMDFmY2YxLTZjNTMtNGM0Ny1hNzIzLTMy
+        ZTk5NTNiNTE5ZS8iXSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpbXX0s
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVz
+        dHMvMTNiMGI1YzctYzFjOS00YzY1LThlNDgtYmY2ZmI2OTk1NjVlLyIsIl9j
+        cmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41MDIzOTFaIiwiX3R5cGUi
+        OiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
+        YXJ0aWZhY3RzLzM5Yjg1ODhmLWRkZjAtNGY5YS04NTEyLTIxMjVmODMxZGU2
+        NC8iLCJkaWdlc3QiOiJzaGEyNTY6MzFhYjk5YjU1YTMyYWI2ZGQwZGVhODA0
+        NGRjMjZmODllM2M4NTRiZjA3ZTQ3ZTAyMWJkYjY5ZjVjOGE5MThiMyIsInNj
+        aGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5k
+        LmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitqc29uIiwi
+        bGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvbWFuaWZlc3RzLzk1ZDk0NGYxLWU3MWQtNDExYy1hMmEzLTYyODY2ODk1
+        ZmUwNC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3Rz
+        LzdhMTI4N2NlLTRkMzUtNGQyZC04ZTUzLTNlYzI1NzllOTk3Yy8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzQyMmY2NWRjLTRm
+        YmQtNDI1OC04NGE5LTU2ZGQ2YjZjNGY4ZC8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvbWFuaWZlc3RzLzZjZDU1ZTliLWJiODktNDI3My1hZmVk
+        LTk0MzRkNjVmMjQ5Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIv
+        bWFuaWZlc3RzL2EzNDUzYjc4LTc1OWMtNDEyYi1hYTgxLTVhZTA5NWVlMDRk
+        NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzhk
+        ODQzZGZjLTk3OWQtNDBmMS05YjFkLWIwNWMxOGQ5YTViMi8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzliNjY0NTA0LTQwZGEt
+        NGEzMC05ZTlhLTYwOGZiMmFiNjA1YS8iXSwiY29uZmlnX2Jsb2IiOm51bGws
+        ImJsb2JzIjpbXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Rv
+        Y2tlci9tYW5pZmVzdHMvZDZlZWVjODYtZDkwNi00OGRlLTk4ZGMtZjBlZDhk
+        MDIxZTY4LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41MDYw
+        ODNaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIv
+        cHVscC9hcGkvdjMvYXJ0aWZhY3RzL2M3M2NjOTI5LWFjMGItNDdjZC05N2Y2
+        LWZiOTkwZWI3MTNiMS8iLCJkaWdlc3QiOiJzaGEyNTY6NjU0MGZjMDhlZTZl
+        NmI3YjYzNDY4ZGMzMzE3ZTMzMDNhYWUxNzhjYjhhNDVlZDMxMjMxODAzMjhi
+        Y2MxZDIwZiIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBw
+        bGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlz
+        dC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMv
+        Y29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzk1ZDk0NGYxLWU3MWQtNDExYy1h
+        MmEzLTYyODY2ODk1ZmUwNC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvbWFuaWZlc3RzLzdhMTI4N2NlLTRkMzUtNGQyZC04ZTUzLTNlYzI1Nzll
+        OTk3Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3Rz
+        LzBlOTVlNzI1LThhNzktNGU3ZC05NDgzLTllMDlkODQ0ZDU5NS8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzQyMmY2NWRjLTRm
+        YmQtNDI1OC04NGE5LTU2ZGQ2YjZjNGY4ZC8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvbWFuaWZlc3RzL2RkMDFmY2YxLTZjNTMtNGM0Ny1hNzIz
+        LTMyZTk5NTNiNTE5ZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIv
+        bWFuaWZlc3RzL2EzNDUzYjc4LTc1OWMtNDEyYi1hYTgxLTVhZTA5NWVlMDRk
+        NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzhk
+        ODQzZGZjLTk3OWQtNDBmMS05YjFkLWIwNWMxOGQ5YTViMi8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzliNjY0NTA0LTQwZGEt
+        NGEzMC05ZTlhLTYwOGZiMmFiNjA1YS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvbWFuaWZlc3RzLzM4ZWNkOGNhLWU2YjQtNDI3NC1iYTY5LTc5
+        Nzc1NTExOWFkZi8iXSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpbXX0s
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVz
+        dHMvMThhOTVhZGQtM2Q3My00NDMyLWIwM2EtY2I5MjgwODM1MWJlLyIsIl9j
+        cmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41MDg5ODdaIiwiX3R5cGUi
+        OiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
+        YXJ0aWZhY3RzLzFmNmEyMGQ5LTNhZTktNDVjYS1iNTlkLTc3NWMyMzQwNDc5
+        Mi8iLCJkaWdlc3QiOiJzaGEyNTY6OWQ2NmRiMGM2YTNkZThhMjgwODE5Nzdh
+        NzVjNmYyYTk2NTgyZGIzZWUwZDgzM2E1MWQxODQzODU0MTJkYmQyMCIsInNj
+        aGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5k
+        LmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitqc29uIiwi
+        bGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvbWFuaWZlc3RzLzBlOTVlNzI1LThhNzktNGU3ZC05NDgzLTllMDlkODQ0
+        ZDU5NS8iXSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpbXX0seyJfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvZDlh
+        NTNiOTgtNDI2MS00YmNiLThkZDYtZmQzZGFhMzA3YjA2LyIsIl9jcmVhdGVk
+        IjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41MTE3NDdaIiwiX3R5cGUiOiJkb2Nr
+        ZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
+        Y3RzLzllNjkxM2MyLTE4NzEtNDYxOS05OWZmLTA3ZjQyN2Q3N2I4Mi8iLCJk
+        aWdlc3QiOiJzaGEyNTY6MWQyOTg2YWJkOTMzYzBjOTc3OTliMzRlNmNlMTZm
+        M2ExMWY3NDI5YTkzODM4YzcwMzNjY2IyZjdmMDE5OTc5MCIsInNjaGVtYV92
+        ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tl
+        ci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitqc29uIiwibGlzdGVk
+        X21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFu
+        aWZlc3RzLzAzZDI1YmZjLWY4ZTMtNDZiMy05NmY5LThiNTljZTE3NzhiMS8i
+        XSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpbXX0seyJfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvOGUwMmFmYTYt
+        MTk0NS00Nzk3LWFjMWMtYTE4NGUwMWMzYjYwLyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wNy0xOFQxNzo0MjoyMC41MTQ1MDRaIiwiX3R5cGUiOiJkb2NrZXIubWFu
+        aWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzJk
+        MjczYjE5LTI1NjYtNDk2Ni04MTg5LWNmY2ZkMWYyNzQzMS8iLCJkaWdlc3Qi
+        OiJzaGEyNTY6ZTI2ZmE4ZGIyY2M0NjgzNTA5NGE4NGY1OWE1NTE1YzNlNzI3
+        ZjFlNWQ3NTc4YjIzYTExNzBhYjhmNjFmYmZhZSIsInNjaGVtYV92ZXJzaW9u
+        IjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0
+        cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitqc29uIiwibGlzdGVkX21hbmlm
+        ZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3Rz
+        LzBlOTVlNzI1LThhNzktNGU3ZC05NDgzLTllMDlkODQ0ZDU5NS8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzL2RkMDFmY2YxLTZj
+        NTMtNGM0Ny1hNzIzLTMyZTk5NTNiNTE5ZS8iXSwiY29uZmlnX2Jsb2IiOm51
+        bGwsImJsb2JzIjpbXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L2RvY2tlci9tYW5pZmVzdHMvMTRiYTM3NGEtN2IwZS00MTYxLWJhN2YtOGM0
+        MjQwMzQ1MjU4LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41
+        MTcyMTVaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3Qi
+        OiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2MyMTBjZDU1LTc1YjUtNDMwMS1h
+        YTc1LTJiMTNhODhmNjJiZS8iLCJkaWdlc3QiOiJzaGEyNTY6ODc4ZmQ5MTMw
+        MTBkMjY2MTMzMTllYzdjYzgzYjQwMGNiOTIxMTNjMzE0ZGEzMjQ2ODFkOWZl
+        Y2ZiNTA4MmVkYyIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoi
+        YXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3Qu
+        bGlzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkv
+        djMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzcxMDAxOTk3LTRiNDctNDY4
+        Mi04OTdlLTJkZTMwZDc1OTc5OS8iXSwiY29uZmlnX2Jsb2IiOm51bGwsImJs
+        b2JzIjpbXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvNTNkODhiZGQtNjdjNy00M2M4LTg0NTItYzA2Yzk3ODgy
+        NzE3LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41MTk2NjVa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVs
+        cC9hcGkvdjMvYXJ0aWZhY3RzL2I4MDVkMmIwLTRiYWUtNDIzZC1iZWE2LWJm
+        Y2VmNDYyMWFkNy8iLCJkaWdlc3QiOiJzaGEyNTY6ZDNjNmEzYmVlNmZkNzZm
+        NWZlMmIwNTk2OGJmM2E3MGVjNzVhMGQyNmZiZjk4ZDI0MjlkODI0YjViMDE5
+        MmY4MyIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGlj
+        YXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52
+        Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvbWFuaWZlc3RzL2E0YTE2Yzk4LTBkN2QtNDZlOC1iYzdh
+        LTkxM2U0ODhkOGQzZi8iXSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpb
+        XX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5p
+        ZmVzdHMvOGQ4NDNkZmMtOTc5ZC00MGYxLTliMWQtYjA1YzE4ZDlhNWIyLyIs
+        Il9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC43NTUyMjVaIiwiX3R5
+        cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkv
+        djMvYXJ0aWZhY3RzLzkzMzM5YWZlLTYwNmYtNGUyZC05YWNjLTk2NDQzNzNj
+        YWY4NS8iLCJkaWdlc3QiOiJzaGEyNTY6NTc3YWQ0MzMxZDRmYWM5MTgwNzMw
+        OGRhOTllY2MxMDdkY2M2YjIyNTRiYzRjNzE2NjMyNWZkMDExMTNiZWEyYSIs
+        InNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24v
+        dm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxp
+        c3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L2RvY2tlci9ibG9icy9jOGRmNjRjMC1iNTYwLTQyOTYtYjJi
+        My05MDA0MDdkMjhmMGIvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL2Jsb2JzL2ExNWQ3NmI1LTQ3NjgtNGVhMC04NGQxLWM0Y2Ni
+        ZTkyMDFmNC8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Rv
+        Y2tlci9tYW5pZmVzdHMvOWI2NjQ1MDQtNDBkYS00YTMwLTllOWEtNjA4ZmIy
+        YWI2MDVhLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC42ODU5
+        OTBaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIv
+        cHVscC9hcGkvdjMvYXJ0aWZhY3RzLzE2NWFjMWE3LWJiYzgtNGExMS05Mjll
+        LTJkZjk3MDMyZjU4OC8iLCJkaWdlc3QiOiJzaGEyNTY6ZDBkNGM1Mzg5YjUz
+        ODc1YjBmMjM2NGY5NGM0NjZmNzdjZjZmMDI4MTFmYjAyZjA0NzdiOTdkNjA5
+        ZmI1MDU2OCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBw
+        bGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIr
+        anNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy9lYTFmOGYyYy1jNzMz
+        LTRlZTgtOWJmZC03NjZkMTA4NjgyYjYvIiwiYmxvYnMiOlsiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzL2I2MjhhZDY3LTc3MTEtNDMwOS05
+        OGFkLWEzOTIwMWI3Y2FiYi8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9tYW5pZmVzdHMvOTVkOTQ0ZjEtZTcxZC00MTFjLWEy
+        YTMtNjI4NjY4OTVmZTA0LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0
+        MjoyMC41Njc2OTdaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0
+        aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzI4ZTZkOWIzLTI0ZmUt
+        NGZiZi05Y2ViLWY2MTNlNjE3ZDJiZC8iLCJkaWdlc3QiOiJzaGEyNTY6OTJj
+        N2Y5YzkyODQ0YmJiYjVkMGExMDFiMjJmN2MyYTc5NDllNDBmOGVhOTBjOGIz
+        YmMzOTY4NzlkOTVlODk5YSIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90
+        eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFu
+        aWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdf
+        YmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy9hMmRj
+        NDZlOS0zYmYxLTRhNDktYTE2Ni1kNzVlMmY3MzgxNDIvIiwiYmxvYnMiOlsi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzL2E1YjFmNDEzLTcz
+        ZWEtNDJlZi1hZmJiLTk4NTNmZDI2N2I2ZC8iXX0seyJfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvMzhlY2Q4Y2EtZTZi
+        NC00Mjc0LWJhNjktNzk3NzU1MTE5YWRmLyIsIl9jcmVhdGVkIjoiMjAxOS0w
+        Ny0xOFQxNzo0MjoyMC43NTkxNzhaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZl
+        c3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2U4NjNm
+        NTIyLWI1ZTItNDg4MC04NTBiLTllYzBlMmY0YzY0MC8iLCJkaWdlc3QiOiJz
+        aGEyNTY6NWE0YmRhZGQ5YWNkODc3OWVkNmZjZjAwN2E0ZTdlZDdmOTE5MDU2
+        YTkyYzNjNjc4MjRiNGZkZWQwNmVmMGE2ZSIsInNjaGVtYV92ZXJzaW9uIjoy
+        LCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmli
+        dXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltd
+        LCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9i
+        bG9icy9jY2EwZTU0OC0xNzJmLTRiOWYtYWE5Ny04Y2ZjNWY0ZDJmYTMvIiwi
+        YmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzA2
+        ZDgwNGJmLTJiOWYtNDZiZi05NzMwLThiOWEzYjczNmE0Mi8iXX0seyJfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvMGU5
+        NWU3MjUtOGE3OS00ZTdkLTk0ODMtOWUwOWQ4NDRkNTk1LyIsIl9jcmVhdGVk
+        IjoiMjAxOS0wNy0xOFQxNzo0MjoyMC42ODc0MDNaIiwiX3R5cGUiOiJkb2Nr
+        ZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
+        Y3RzLzFlYWVhNzdlLWQ3Y2YtNGJhNC04ZGE4LTUyMTlmNjQzMzc1Ni8iLCJk
+        aWdlc3QiOiJzaGEyNTY6MDg1YmEyOWU5YWU4N2YxMzdkZDg2ODZiOWJmZmVl
+        NzljMjM4MDBiNjM1N2EwMDU1OGJhNjQzNjdjODA4NGZjMyIsInNjaGVtYV92
+        ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tl
+        ci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5p
+        ZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L2RvY2tlci9ibG9icy8zNDI0ZDEwZi03NjBlLTQ3ZjItYmVmOS04YmNjNmEy
+        MDExODYvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2Vy
+        L2Jsb2JzLzczZmE0Yjg4LWY1ZTgtNGM1Yy1hMTQ4LTljYzJiOTQ4NjEwOC8i
+        LCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvYmVjNDEzYTQt
+        NjNiNy00ZThiLWFiY2EtOTE3YWZmNjg5NjE5LyJdfSx7Il9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy83YTEyODdjZS00
+        ZDM1LTRkMmQtOGU1My0zZWMyNTc5ZTk5N2MvIiwiX2NyZWF0ZWQiOiIyMDE5
+        LTA3LTE4VDE3OjQyOjIwLjUyMjEzMloiLCJfdHlwZSI6ImRvY2tlci5tYW5p
+        ZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMjgx
+        Y2U0ZjktZTMzYy00MTNkLWE1YTMtMDBmOTdhNDdmN2U1LyIsImRpZ2VzdCI6
+        InNoYTI1NjoxMmNmOWVmOTA4MzU0NjUzMTZjYjBiMzcyOWMzNmJmZDg2NTRk
+        N2YyZjY5N2UyMzQzMmZkZGZhYTdkN2UzMWI1Iiwic2NoZW1hX3ZlcnNpb24i
+        OjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3Ry
+        aWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6
+        W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2Vy
+        L2Jsb2JzL2MzMjQ0NzU1LWU1ZTYtNGUxMy04YzdjLTJjZmI3OGExZGMyNi8i
+        LCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMv
+        YWY3YmYwYzEtMzY1OC00ZmY4LTkwZDAtYmI3ODBmNDFhYjdlLyJdfSx7Il9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy83
+        MTAwMTk5Ny00YjQ3LTQ2ODItODk3ZS0yZGUzMGQ3NTk3OTkvIiwiX2NyZWF0
+        ZWQiOiIyMDE5LTA3LTE4VDE3OjQyOjIxLjAzMTgzMFoiLCJfdHlwZSI6ImRv
+        Y2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
+        ZmFjdHMvMWE2NmEzNTUtMTFmZS00YTVlLWFjMzktOWMwMGRmZGVlMjE2LyIs
+        ImRpZ2VzdCI6InNoYTI1NjpjMWJlNmUxNDY4NDg1NzU3Njk4YWY1MjhmZmY3
+        NzRkNDc0ZTY5ZjQ0OGVlZjQzYzM2OGZhMmYyYmUxMjg4YjRkIiwic2NoZW1h
+        X3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9j
+        a2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21h
+        bmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL2Jsb2JzLzIxNDA0M2IwLWY0YmItNDI1Mi04YTg4LTMxNDg3
+        YzY0NGYwMC8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvYmxvYnMvYjY0YmY0MzctMWQzYy00ZGE1LTg3MTQtYzY4N2I1MWFiNmY4
+        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy8xMjcwYTA2
+        My0wYzIxLTQ2YjEtYjgzMS05M2QyOTU1MGI5MjQvIl19LHsiX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzQyMmY2NWRj
+        LTRmYmQtNDI1OC04NGE5LTU2ZGQ2YjZjNGY4ZC8iLCJfY3JlYXRlZCI6IjIw
+        MTktMDctMThUMTc6NDI6MjAuNzMxNzgwWiIsIl90eXBlIjoiZG9ja2VyLm1h
+        bmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8x
+        NzMyZWYwZi0xOGU1LTQ4NTMtYmYzZS04OTNkOWM5ODlkNTAvIiwiZGlnZXN0
+        Ijoic2hhMjU2OjFlNDRkOGJjYTZmYjA0NjQ3OTQ1NTVlNWNjZDNhMzJlMmE0
+        ZjZlNDRhMjA2MDVlNGU4MjYwNTE4OTkwNGY0NGQiLCJzY2hlbWFfdmVyc2lv
+        biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
+        dHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3Rz
+        IjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvYmxvYnMvYzgxOWJkMmItZWUxZS00YzQzLTgyMmQtMTQwM2RiODQwODE2
+        LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9i
+        cy82MjkxYjZlMi1lNTQwLTRhZjYtYjdiMi1lNjg0ZjdmMTc2YWEvIl19LHsi
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3Rz
+        L2RkMDFmY2YxLTZjNTMtNGM0Ny1hNzIzLTMyZTk5NTNiNTE5ZS8iLCJfY3Jl
+        YXRlZCI6IjIwMTktMDctMThUMTc6NDI6MjAuNjg0NDI2WiIsIl90eXBlIjoi
+        ZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2Fy
+        dGlmYWN0cy84MDc2Yjg5Ny0xMzQyLTRlODktOTViMi1jNmQ1NTE2ZjJmNTYv
+        IiwiZGlnZXN0Ijoic2hhMjU2OmFmMzdiNjZkMDE3YWUyMmQyZGUxYTEyOGNl
+        MDQ5ZGE2NjFlYjc1YTBmNTIwMDdjNTdjMmY2MTY4MWQ5OTllNTAiLCJzY2hl
+        bWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5k
+        b2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRf
+        bWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvYmxvYnMvMTNlYzUxMDgtMmIyZC00ZWRmLWJjOWYtZTNl
+        MWQ1Mjg2ZDgyLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2Rv
+        Y2tlci9ibG9icy8yNzcxMmMxZC0zZGJiLTQ3YmQtYWZmNi1lMGY0YmRmMjky
+        NGYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzL2Y3ZTk1
+        YmJhLWUyZTktNGI3Ny1hNGUwLWZmOTQyMmUyZGM1Yy8iXX0seyJfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvNmNkNTVl
+        OWItYmI4OS00MjczLWFmZWQtOTQzNGQ2NWYyNDljLyIsIl9jcmVhdGVkIjoi
+        MjAxOS0wNy0xOFQxNzo0MjoyMC43Mjg4OTNaIiwiX3R5cGUiOiJkb2NrZXIu
+        bWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3Rz
+        LzlhNjE2NWIzLTg3YjEtNGE1Ni05NzU4LTM1M2E0NzRlZGIzZS8iLCJkaWdl
+        c3QiOiJzaGEyNTY6ODVkYzVmYmUxNjIxNDM2Njc0OGViZTlkN2NjNzNiYzQy
+        ZDYxZDE5ZDYxZmUwNWYwMWUzMTdkMjc4YzIyODdlZCIsInNjaGVtYV92ZXJz
+        aW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5k
+        aXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVz
+        dHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Rv
+        Y2tlci9ibG9icy9iNDQ4MTU4Ny1hODIwLTQwOWEtOTEzZC1lMzVlZGEwY2Vm
+        ZmMvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Js
+        b2JzLzI1YmJlYmJiLWFiZWItNDI2Ni1iZmE1LTFjYjMxY2QyZjE2My8iXX0s
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVz
+        dHMvYTM0NTNiNzgtNzU5Yy00MTJiLWFhODEtNWFlMDk1ZWUwNGQ0LyIsIl9j
+        cmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC43Mjc3NjJaIiwiX3R5cGUi
+        OiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
+        YXJ0aWZhY3RzL2MxMWU4ODNhLWZjYjUtNGZiZi1iZmVjLTc1MmNhY2JlOGVl
+        MS8iLCJkaWdlc3QiOiJzaGEyNTY6ZDFmZDJlMjA0YWYwYTJiY2EzYWIwMzNi
+        NDE3YjI5Yzc2ZDc5NTBlZDI5YTQ0ZTQyN2QxYzRkMDdkMTRmMDRmOSIsInNj
+        aGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5k
+        LmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3Rl
+        ZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy9jYzRjYzNkMC1iM2VlLTQwOTQtOWM1NS0y
+        ZDlkZmRlZjllMWEvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        ZG9ja2VyL2Jsb2JzLzJjNzg3NWZhLWRlNmItNDFkNy04MmFhLWRjNDgxNDBj
+        YzQ3ZS8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvYTRhMTZjOTgtMGQ3ZC00NmU4LWJjN2EtOTEzZTQ4OGQ4
+        ZDNmLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC45ODk1MDFa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVs
+        cC9hcGkvdjMvYXJ0aWZhY3RzLzg0ZTcwYmZhLWJiMjItNDJiNy04NzAxLWNk
+        M2U5MWI4MDU0Yi8iLCJkaWdlc3QiOiJzaGEyNTY6Nzg2YTI5OTc0OTA4NTUx
+        MzM1ZjM3OWI3NDQ0MzhmMjVkZTBhNTdlOTA3MzU4ZDQzMGU4Y2Y4NWJlNWZj
+        MTQ2NCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGlj
+        YXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNv
+        biIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy8xNzk5ODYyMy0zOTRmLTQ3
+        YjAtOWU0Ny0xYWU0MzJhNzA0YjUvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzM1MjIyMzExLTYyODYtNDA0MS1hOWE1
+        LWQ1YmU1ZmUwM2UwYi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIv
+        YmxvYnMvOGEyNzYxZGYtMGMzMy00ZDMwLTk2ZTAtMThmZDY3NGU4MDdiLyJd
+        fSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlm
+        ZXN0cy8wM2QyNWJmYy1mOGUzLTQ2YjMtOTZmOS04YjU5Y2UxNzc4YjEvIiwi
+        X2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjQyOjIwLjc1ODEyN1oiLCJfdHlw
+        ZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92
+        My9hcnRpZmFjdHMvMTYzNDI2ZmMtZGQ0OC00ZGI3LWFlMmUtNzk0OTRjZTY1
+        MDE3LyIsImRpZ2VzdCI6InNoYTI1NjowOGNhNGYyYzQ1MzE2Y2IwYjc5ZmFm
+        OGYwNzYyNTA0NmRiYmMxNmY2ZjE0MGIwYzU5ZGEwM2YxMzIzYWRhOGE0Iiwi
+        c2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92
+        bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlz
+        dGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvZG9ja2VyL2Jsb2JzL2E4NjI5YTljLTVlMGMtNDI0OS05ZDUz
+        LTZlOTcwNzFmMDIzZC8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvYmxvYnMvNGI0NWVjM2EtN2Q4Yy00YjBmLWExMDctYTFlNmVj
+        Y2QyZWQ3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy8z
+        MTJhZGZiZi1iZTQwLTQ5ZTUtOTFhYy00YjBhY2M0MmY4NTMvIl19LHsiX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzYz
+        NGY2MWI2LWNkZDYtNGYwZi04YzhlLTFjZTE5Y2ZjN2U2OC8iLCJfY3JlYXRl
+        ZCI6IjIwMTktMDctMjJUMTk6NDA6MDEuOTA0NTQyWiIsIl90eXBlIjoiZG9j
+        a2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
+        YWN0cy83MTc2NTRkMC0zZWVkLTQzNjktOTQ2YS00YjU3ZmYzNzRiZmUvIiwi
+        ZGlnZXN0Ijoic2hhMjU2OjlmMTAwM2M0ODA2OTliZTU2ODE1ZGIwZjgxNDZh
+        ZDJlMjJlZmVhODUxMjliNWI1OTgzZDBlMGZiNTJkOWFiNzAiLCJzY2hlbWFf
+        dmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2Nr
+        ZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3Rl
+        ZF9tYW5pZmVzdHMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy81ODI5ZmUwYy00YmRhLTQ3YWYtYTQ5ZS03MmYyY2Q5OTFhNWUv
+        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8zYmFi
+        NDZhOC0yNmE5LTRkZWQtOGMyNS05N2UxNTA2YzJkZTYvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy9mZjk4NTUxYy1jMGYwLTRm
+        ODItYWJlYy0xNDA4NWYyOWVjZmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        ZG9ja2VyL21hbmlmZXN0cy82ZjA1NjJhZC1kZTU3LTRmYTItOWIwOC04YTcw
+        OTE5MjI1ZTcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlm
+        ZXN0cy81MzM0YjNmMS1kNTc4LTRlZGQtYmYzMy1mYzAyODBmM2I2MDgvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8wNDE0MmUx
+        Yy1mYjgyLTRhMTAtOWJkYS01ZmZlM2Y0OTA3MzkvIiwiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy80NDIwOTQ4OS0wZGY0LTRlNTEt
+        YWNmZS00NWU0Y2MxMmEyNjYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL21hbmlmZXN0cy9jNWMzZDM0ZC03MDdhLTRiYjQtYjEwZC0xYzFhZmJl
+        MGY3ZjMvIl0sImNvbmZpZ19ibG9iIjpudWxsLCJibG9icyI6W119LHsiX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzQ0
+        MjA5NDg5LTBkZjQtNGU1MS1hY2ZlLTQ1ZTRjYzEyYTI2Ni8iLCJfY3JlYXRl
+        ZCI6IjIwMTktMDctMjJUMTk6NDA6MDEuOTgzNTYwWiIsIl90eXBlIjoiZG9j
+        a2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
+        YWN0cy8yM2NlZTY3Ny1iNmFkLTRiNTMtOThhMC00NWU3NzliNmI4ZGIvIiwi
+        ZGlnZXN0Ijoic2hhMjU2OmUxOGNlNTFiNThiYjExZWVkMjIxNmNhM2U1ZTk0
+        ZGM5MDZiYjA0YjM1OTM3Njg4NGJlMTEwZjUwMjZiMWY5YzEiLCJzY2hlbWFf
+        dmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2Nr
+        ZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFu
+        aWZlc3RzIjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvYmxvYnMvMzNmZDQwY2MtZjBjYS00OTM4LWJkN2MtZjliMDNm
+        MGJmYTQ0LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9ibG9icy84YWM0YmVlOC02MzBhLTRiODYtOGJhOS1jNzU4NjUwNDA4MjIv
+        Il19LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFu
+        aWZlc3RzL2ZmOTg1NTFjLWMwZjAtNGY4Mi1hYmVjLTE0MDg1ZjI5ZWNmYi8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDctMjJUMTk6NDA6MDIuMDcxODgwWiIsIl90
+        eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBp
+        L3YzL2FydGlmYWN0cy9hNjhhNzUzNi1lMDhlLTRiYmYtOWY4My1iYTc3Zjhj
+        MmRiNDMvIiwiZGlnZXN0Ijoic2hhMjU2OmZkODZhY2Q1YTlmOGIyYmQzNGQz
+        OWNkMGFlZmE5YzUwM2RjOGZlNjE1MGZlMTVjZTNjZjkwZjI4OGViMTU1ZDMi
+        LCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9u
+        L3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJs
+        aXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9kb2NrZXIvYmxvYnMvNjllM2IwN2YtMzc0NC00NTRjLWI4
+        NTMtMzk5Yzk1OTNiYTQ4LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250
+        ZW50L2RvY2tlci9ibG9icy9kMTViMjEwMy1kZWU2LTQ5M2ItOTc2MS1kZTE0
+        MGZmMmQxYmMvIl19LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvbWFuaWZlc3RzL2QyYzMyZTA1LTk3OTAtNGYzNS05ZTBlLWRlMjQ3
+        MjdhZWQ4OC8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6Mzk6MzguMjc1
+        Mjk1WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0Ijoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wOThlZDdjMS02ZGFiLTRhMzctODBm
+        ZC1hZTIzN2EwOGViNzYvIiwiZGlnZXN0Ijoic2hhMjU2OmE2ZWNiYjE1NTMz
+        NTNhMDg5MzZmNTBjMjc1YjAxMDM4OGVkMWJkNmQ5ZDg0NzQzYzdlOGU3NDY4
+        ZTJhY2Q4MmUiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFw
+        cGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYy
+        K2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2IiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvNzI4YjI3ZTgtOTlj
+        MS00YWM2LWExNjQtYWI0N2UxM2VlYTg1LyIsImJsb2JzIjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L2RvY2tlci9ibG9icy9hODJlMzA0Yi1jNWNjLTQwNDkt
+        ODRjOC04MDlmMzA3MTVmNjcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL2Jsb2JzLzUzNmI1NzYwLThjNmItNDRhNy1hNzkyLTFhYTEyMWFhZDFk
+        OS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvM2RkYWY0
+        ODQtZGRlYy00YjAwLWFmMTItYjZjZmQ3NTU2YThkLyJdfSx7Il9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8wNDE0MmUx
+        Yy1mYjgyLTRhMTAtOWJkYS01ZmZlM2Y0OTA3MzkvIiwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTIyVDE5OjQwOjAyLjA4Mjk4NVoiLCJfdHlwZSI6ImRvY2tlci5t
+        YW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
+        OWVjNjhhNmUtMDdmYi00Y2MzLTk5YmQtZGVlNWJlYWNiZGY0LyIsImRpZ2Vz
+        dCI6InNoYTI1NjpmM2RlZTk4OGJhOTAxYmQyZjI4MjI2MjUyMzAyOTliYTVl
+        ZTJkZGZiZTJiOGI0NTU4NTZmMmIwNzMzYmFmOGQwIiwic2NoZW1hX3ZlcnNp
+        b24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRp
+        c3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0
+        cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL2Jsb2JzL2EzNmRmNGM0LTJkZmEtNDMzZi1iZDQ4LTE5NjFjZGM5YWJl
+        NC8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxv
+        YnMvM2M4ZDk5OWQtZjFhZi00YjMxLWE1ZGItNzVjYjE3MmUyZjMzLyJdfSx7
+        Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0
+        cy9jNWMzZDM0ZC03MDdhLTRiYjQtYjEwZC0xYzFhZmJlMGY3ZjMvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAxLjk4NDk1NFoiLCJfdHlwZSI6
+        ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9h
+        cnRpZmFjdHMvODZkYjI2N2QtMzNjYy00NTI5LWEyNDctNmZlYWY3OGIwN2Ji
+        LyIsImRpZ2VzdCI6InNoYTI1NjpmYjgyZWY3YjdhZTA5MWY2NzVmNmUwMzRm
+        MzEzNGUyZjEyOWY0ZjdiZWMyYjIwNWU0NTg5NDNhOGYzZWRiNzNiIiwic2No
+        ZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQu
+        ZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVk
+        X21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZG9ja2VyL2Jsb2JzL2VmZGFmYzY3LThhMjUtNGVkNi1hYWQyLTEz
+        ZjhiMDk3ZTg0YS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvYmxvYnMvZjQ4ZDc2OTktZWIwNC00OTEwLTg2YzMtZjExMzAxMjRh
+        ZDZmLyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2Vy
+        L21hbmlmZXN0cy82ZjA1NjJhZC1kZTU3LTRmYTItOWIwOC04YTcwOTE5MjI1
+        ZTcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAxLjk2NTY5Mloi
+        LCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxw
+        L2FwaS92My9hcnRpZmFjdHMvMjY4NTY2NWYtZDZjOC00MGZmLWJlOWUtMDVm
+        ZjBlOTUwMzc0LyIsImRpZ2VzdCI6InNoYTI1Njo4OTVhYjYyMmU5MmUxOGQ2
+        YjQ2MWQ2NzEwODE3NTdhZjdkYmFhM2IwMGUzZTI4ZTEyNTA1YWY3ODE3Zjcz
+        NjQ5Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNh
+        dGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29u
+        IiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzkxMzZiNThkLTRlODktNDhj
+        YS1hYmVkLTE1NTBlOWYzZjg3OS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMv
+        Y29udGVudC9kb2NrZXIvYmxvYnMvZGY4ZmIwN2MtYThjMi00NjRmLWIxNzMt
+        YTYwMzBmNTY2ODA4LyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL21hbmlmZXN0cy8zYmFiNDZhOC0yNmE5LTRkZWQtOGMyNS05
+        N2UxNTA2YzJkZTYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAx
+        Ljk5NTI2NVoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFj
+        dCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZWQyZGE2N2ItYzMzNC00OTVh
+        LWFiNDEtNjE4ZmJkY2UwMTZlLyIsImRpZ2VzdCI6InNoYTI1NjowZDc2MDQ1
+        NThmOTVkY2UwYzE3Y2VlMGNkZjQ1YThjNjhmMzVkN2ZjNzEwYTYwYTU5OGNk
+        NDNmNjUyOTc2ODc4Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUi
+        OiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVz
+        dC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9i
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzc2ZmFmOTMw
+        LTE2NmEtNGM2OS1iYmYwLTc4Y2U2ZjFlMTQ5OS8iLCJibG9icyI6WyIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvYTFhODAzMjItMDhlNi00
+        NGQzLWFkM2YtODU5ODk2ZmY0ZTA1LyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy81ODI5ZmUwYy00YmRhLTQ3
+        YWYtYTQ5ZS03MmYyY2Q5OTFhNWUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDE5OjQwOjAxLjkxMDczNVoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIs
+        Il9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvOGZjZjc3ZDAt
+        ZDgwNy00YTEwLThiNjgtMmQ3NTdmNjNjNDdmLyIsImRpZ2VzdCI6InNoYTI1
+        NjphZGZhYzBjMmJlNGJiODYwMDQ1OTViOGY5OTVkZjg4YmQ5OWIyODkxOTMx
+        NjE3ZGYwNTAxNThiYWE3MDljMzMxIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
+        ZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlv
+        bi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNv
+        bmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2Jz
+        LzA2NmM1YzQ5LTFjY2UtNGE3Yy1hYWQyLTY1Y2RiNDkyYjNjMi8iLCJibG9i
+        cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvNWQ4ZDc2
+        MjAtMDgzMy00MDc2LWE2NTYtOGM5NjgxMTkxYTJlLyJdfSx7Il9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy81MzM0YjNm
+        MS1kNTc4LTRlZGQtYmYzMy1mYzAyODBmM2I2MDgvIiwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTIyVDE5OjQwOjAxLjk4MjE0MVoiLCJfdHlwZSI6ImRvY2tlci5t
+        YW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
+        ZGJhNjA2YWItZjc2Yy00MGY5LWJhM2EtMGRkYTY2M2QzNmRhLyIsImRpZ2Vz
+        dCI6InNoYTI1Njo3OTI4OWMzMTQ2YTc3Y2U1YzdmZTBmYzhmYjA5NGMwYzE3
+        ZjhlZmVlMjkyNjIzZjkwYzUxNjMwZjk0YmI2NTE5Iiwic2NoZW1hX3ZlcnNp
+        b24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRp
+        c3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0
+        cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL2Jsb2JzLzE3MjhjMjAyLWFmMWMtNGU4My04ZmZkLWJjOGNjZTdhMGY3
+        MS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxv
+        YnMvZTAwNTQ0ZjYtMTMzMC00YTNiLWIyNmEtNmY4MzAwNWZiYTQwLyJdfV19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:34 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:34 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '5132'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MzQsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9t
+        YW5pZmVzdHMvOTViZTA1NWYtZmJhNS00NTc0LTg2YWEtOTg2YmNmZTRlZmM0
+        LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xN1QxOToxNzowNS43NzI3MzZaIiwi
+        X3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9h
+        cGkvdjMvYXJ0aWZhY3RzLzhjNzAwMTNjLWRjZDMtNDM3Yy1iNDRmLWJiYTkw
+        N2IwN2E5Ny8iLCJkaWdlc3QiOiJzaGEyNTY6ZGMyYWU2MzYxNjkxNWNlOTUy
+        N2ViOWJiMzg2NDZjYjM3MDBkMWE3OTAyNTI2NmQ2MDcwOWUyMTRiNDI0OGU1
+        NCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRp
+        b24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitq
+        c29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvbWFuaWZlc3RzLzRlMjYxMjJlLTQ1OGItNGI5My04ODQ1LWU1
+        NzUwNjIyY2Q5NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFu
+        aWZlc3RzLzAzY2ZlNzQ3LTFhNDQtNDRmNC1iZjFjLTY0NjI5ZGUxOThiZC8i
+        XSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpbXX0seyJfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvNGUyNjEyMmUt
+        NDU4Yi00YjkzLTg4NDUtZTU3NTA2MjJjZDk1LyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wNy0xN1QxOToxNzowNS43NjkzODhaIiwiX3R5cGUiOiJkb2NrZXIubWFu
+        aWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzAy
+        ZjkyNzcyLWMwOTItNDczYS04MWRmLTg2OTIzNzk3ZmY2OS8iLCJkaWdlc3Qi
+        OiJzaGEyNTY6YjM1MjAwYmU2NzhkNDc1M2ZlNzc5ZWU1NDA2YzFmYzllZWM5
+        ZTllZTU2ZjAyYjc5ZTQ2YzY1ZDVmMGNlNzYyNyIsInNjaGVtYV92ZXJzaW9u
+        IjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0
+        cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMi
+        OltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9ibG9icy8xYmQ0ODBkYy1hNTI5LTQxNjYtYWM0ZC1mNTVlMDFkNWY5ZmIv
+        IiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2Jz
+        LzJjYWQ0Y2Y4LTc0MDctNDhmZS05ZTg5LTBjMDc2MWQ1M2NlZi8iXX0seyJf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMv
+        MDNjZmU3NDctMWE0NC00NGY0LWJmMWMtNjQ2MjlkZTE5OGJkLyIsIl9jcmVh
+        dGVkIjoiMjAxOS0wNy0xN1QxOToxNzowNS43NjMzMjhaIiwiX3R5cGUiOiJk
+        b2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0
+        aWZhY3RzL2E0YTM2YjIyLWJkYzMtNDk3Ni05ZDE3LTZmMmEyNDE5MzI3YS8i
+        LCJkaWdlc3QiOiJzaGEyNTY6OWI4NzRjY2RiNzNlMWFhZjI5ZTFjMGZkM2E1
+        NTBkZGZhNDg2ZDczNTI1ZjJkNzdiNDUyZTMwYTA5ZDNjYjQxNyIsInNjaGVt
+        YV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRv
+        Y2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9t
+        YW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L2RvY2tlci9ibG9icy9mYTBmZDhkMy1hZWI3LTQ5MjgtYjg3Ni05YzM0
+        YWJhOTViYjEvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL2Jsb2JzLzg1YjRjNDk1LWY3NzYtNGViZi04YWRjLWM3ZDFjMmI1NDFk
+        My8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9t
+        YW5pZmVzdHMvZDM1MmUzODctOTUyYi00MmIzLThjZTEtMzEzZTVmNTEwZmI3
+        LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC40OTgyNDRaIiwi
+        X3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9h
+        cGkvdjMvYXJ0aWZhY3RzLzFjMTVmYTYwLTcxOWMtNDBmYS1iMTQzLTE5ZWQ2
+        NjhiNzI0Mi8iLCJkaWdlc3QiOiJzaGEyNTY6ZDgyODNjODUwYWMyZjFhOTBj
+        NWRkOTRiOWE3YWM5N2NjYWJjYjllMjA4MmUzMTI3YjQzMmIyOTdkMmFiYjZj
+        OCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRp
+        b24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitq
+        c29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvbWFuaWZlc3RzL2RkMDFmY2YxLTZjNTMtNGM0Ny1hNzIzLTMy
+        ZTk5NTNiNTE5ZS8iXSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpbXX0s
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVz
+        dHMvMTNiMGI1YzctYzFjOS00YzY1LThlNDgtYmY2ZmI2OTk1NjVlLyIsIl9j
+        cmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41MDIzOTFaIiwiX3R5cGUi
+        OiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
+        YXJ0aWZhY3RzLzM5Yjg1ODhmLWRkZjAtNGY5YS04NTEyLTIxMjVmODMxZGU2
+        NC8iLCJkaWdlc3QiOiJzaGEyNTY6MzFhYjk5YjU1YTMyYWI2ZGQwZGVhODA0
+        NGRjMjZmODllM2M4NTRiZjA3ZTQ3ZTAyMWJkYjY5ZjVjOGE5MThiMyIsInNj
+        aGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5k
+        LmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitqc29uIiwi
+        bGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvbWFuaWZlc3RzLzk1ZDk0NGYxLWU3MWQtNDExYy1hMmEzLTYyODY2ODk1
+        ZmUwNC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3Rz
+        LzdhMTI4N2NlLTRkMzUtNGQyZC04ZTUzLTNlYzI1NzllOTk3Yy8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzQyMmY2NWRjLTRm
+        YmQtNDI1OC04NGE5LTU2ZGQ2YjZjNGY4ZC8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvbWFuaWZlc3RzLzZjZDU1ZTliLWJiODktNDI3My1hZmVk
+        LTk0MzRkNjVmMjQ5Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIv
+        bWFuaWZlc3RzL2EzNDUzYjc4LTc1OWMtNDEyYi1hYTgxLTVhZTA5NWVlMDRk
+        NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzhk
+        ODQzZGZjLTk3OWQtNDBmMS05YjFkLWIwNWMxOGQ5YTViMi8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzliNjY0NTA0LTQwZGEt
+        NGEzMC05ZTlhLTYwOGZiMmFiNjA1YS8iXSwiY29uZmlnX2Jsb2IiOm51bGws
+        ImJsb2JzIjpbXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Rv
+        Y2tlci9tYW5pZmVzdHMvZDZlZWVjODYtZDkwNi00OGRlLTk4ZGMtZjBlZDhk
+        MDIxZTY4LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41MDYw
+        ODNaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIv
+        cHVscC9hcGkvdjMvYXJ0aWZhY3RzL2M3M2NjOTI5LWFjMGItNDdjZC05N2Y2
+        LWZiOTkwZWI3MTNiMS8iLCJkaWdlc3QiOiJzaGEyNTY6NjU0MGZjMDhlZTZl
+        NmI3YjYzNDY4ZGMzMzE3ZTMzMDNhYWUxNzhjYjhhNDVlZDMxMjMxODAzMjhi
+        Y2MxZDIwZiIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBw
+        bGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlz
+        dC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMv
+        Y29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzk1ZDk0NGYxLWU3MWQtNDExYy1h
+        MmEzLTYyODY2ODk1ZmUwNC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvbWFuaWZlc3RzLzdhMTI4N2NlLTRkMzUtNGQyZC04ZTUzLTNlYzI1Nzll
+        OTk3Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3Rz
+        LzBlOTVlNzI1LThhNzktNGU3ZC05NDgzLTllMDlkODQ0ZDU5NS8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzQyMmY2NWRjLTRm
+        YmQtNDI1OC04NGE5LTU2ZGQ2YjZjNGY4ZC8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvbWFuaWZlc3RzL2RkMDFmY2YxLTZjNTMtNGM0Ny1hNzIz
+        LTMyZTk5NTNiNTE5ZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIv
+        bWFuaWZlc3RzL2EzNDUzYjc4LTc1OWMtNDEyYi1hYTgxLTVhZTA5NWVlMDRk
+        NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzhk
+        ODQzZGZjLTk3OWQtNDBmMS05YjFkLWIwNWMxOGQ5YTViMi8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzliNjY0NTA0LTQwZGEt
+        NGEzMC05ZTlhLTYwOGZiMmFiNjA1YS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvbWFuaWZlc3RzLzM4ZWNkOGNhLWU2YjQtNDI3NC1iYTY5LTc5
+        Nzc1NTExOWFkZi8iXSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpbXX0s
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVz
+        dHMvMThhOTVhZGQtM2Q3My00NDMyLWIwM2EtY2I5MjgwODM1MWJlLyIsIl9j
+        cmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41MDg5ODdaIiwiX3R5cGUi
+        OiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
+        YXJ0aWZhY3RzLzFmNmEyMGQ5LTNhZTktNDVjYS1iNTlkLTc3NWMyMzQwNDc5
+        Mi8iLCJkaWdlc3QiOiJzaGEyNTY6OWQ2NmRiMGM2YTNkZThhMjgwODE5Nzdh
+        NzVjNmYyYTk2NTgyZGIzZWUwZDgzM2E1MWQxODQzODU0MTJkYmQyMCIsInNj
+        aGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5k
+        LmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitqc29uIiwi
+        bGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvbWFuaWZlc3RzLzBlOTVlNzI1LThhNzktNGU3ZC05NDgzLTllMDlkODQ0
+        ZDU5NS8iXSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpbXX0seyJfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvZDlh
+        NTNiOTgtNDI2MS00YmNiLThkZDYtZmQzZGFhMzA3YjA2LyIsIl9jcmVhdGVk
+        IjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41MTE3NDdaIiwiX3R5cGUiOiJkb2Nr
+        ZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
+        Y3RzLzllNjkxM2MyLTE4NzEtNDYxOS05OWZmLTA3ZjQyN2Q3N2I4Mi8iLCJk
+        aWdlc3QiOiJzaGEyNTY6MWQyOTg2YWJkOTMzYzBjOTc3OTliMzRlNmNlMTZm
+        M2ExMWY3NDI5YTkzODM4YzcwMzNjY2IyZjdmMDE5OTc5MCIsInNjaGVtYV92
+        ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tl
+        ci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitqc29uIiwibGlzdGVk
+        X21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFu
+        aWZlc3RzLzAzZDI1YmZjLWY4ZTMtNDZiMy05NmY5LThiNTljZTE3NzhiMS8i
+        XSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpbXX0seyJfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvOGUwMmFmYTYt
+        MTk0NS00Nzk3LWFjMWMtYTE4NGUwMWMzYjYwLyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wNy0xOFQxNzo0MjoyMC41MTQ1MDRaIiwiX3R5cGUiOiJkb2NrZXIubWFu
+        aWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzJk
+        MjczYjE5LTI1NjYtNDk2Ni04MTg5LWNmY2ZkMWYyNzQzMS8iLCJkaWdlc3Qi
+        OiJzaGEyNTY6ZTI2ZmE4ZGIyY2M0NjgzNTA5NGE4NGY1OWE1NTE1YzNlNzI3
+        ZjFlNWQ3NTc4YjIzYTExNzBhYjhmNjFmYmZhZSIsInNjaGVtYV92ZXJzaW9u
+        IjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0
+        cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitqc29uIiwibGlzdGVkX21hbmlm
+        ZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3Rz
+        LzBlOTVlNzI1LThhNzktNGU3ZC05NDgzLTllMDlkODQ0ZDU5NS8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzL2RkMDFmY2YxLTZj
+        NTMtNGM0Ny1hNzIzLTMyZTk5NTNiNTE5ZS8iXSwiY29uZmlnX2Jsb2IiOm51
+        bGwsImJsb2JzIjpbXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L2RvY2tlci9tYW5pZmVzdHMvMTRiYTM3NGEtN2IwZS00MTYxLWJhN2YtOGM0
+        MjQwMzQ1MjU4LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41
+        MTcyMTVaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3Qi
+        OiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2MyMTBjZDU1LTc1YjUtNDMwMS1h
+        YTc1LTJiMTNhODhmNjJiZS8iLCJkaWdlc3QiOiJzaGEyNTY6ODc4ZmQ5MTMw
+        MTBkMjY2MTMzMTllYzdjYzgzYjQwMGNiOTIxMTNjMzE0ZGEzMjQ2ODFkOWZl
+        Y2ZiNTA4MmVkYyIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoi
+        YXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3Qu
+        bGlzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkv
+        djMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzcxMDAxOTk3LTRiNDctNDY4
+        Mi04OTdlLTJkZTMwZDc1OTc5OS8iXSwiY29uZmlnX2Jsb2IiOm51bGwsImJs
+        b2JzIjpbXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvNTNkODhiZGQtNjdjNy00M2M4LTg0NTItYzA2Yzk3ODgy
+        NzE3LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41MTk2NjVa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVs
+        cC9hcGkvdjMvYXJ0aWZhY3RzL2I4MDVkMmIwLTRiYWUtNDIzZC1iZWE2LWJm
+        Y2VmNDYyMWFkNy8iLCJkaWdlc3QiOiJzaGEyNTY6ZDNjNmEzYmVlNmZkNzZm
+        NWZlMmIwNTk2OGJmM2E3MGVjNzVhMGQyNmZiZjk4ZDI0MjlkODI0YjViMDE5
+        MmY4MyIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGlj
+        YXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52
+        Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvbWFuaWZlc3RzL2E0YTE2Yzk4LTBkN2QtNDZlOC1iYzdh
+        LTkxM2U0ODhkOGQzZi8iXSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpb
+        XX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5p
+        ZmVzdHMvOGQ4NDNkZmMtOTc5ZC00MGYxLTliMWQtYjA1YzE4ZDlhNWIyLyIs
+        Il9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC43NTUyMjVaIiwiX3R5
+        cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkv
+        djMvYXJ0aWZhY3RzLzkzMzM5YWZlLTYwNmYtNGUyZC05YWNjLTk2NDQzNzNj
+        YWY4NS8iLCJkaWdlc3QiOiJzaGEyNTY6NTc3YWQ0MzMxZDRmYWM5MTgwNzMw
+        OGRhOTllY2MxMDdkY2M2YjIyNTRiYzRjNzE2NjMyNWZkMDExMTNiZWEyYSIs
+        InNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24v
+        dm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxp
+        c3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L2RvY2tlci9ibG9icy9jOGRmNjRjMC1iNTYwLTQyOTYtYjJi
+        My05MDA0MDdkMjhmMGIvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL2Jsb2JzL2ExNWQ3NmI1LTQ3NjgtNGVhMC04NGQxLWM0Y2Ni
+        ZTkyMDFmNC8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Rv
+        Y2tlci9tYW5pZmVzdHMvOWI2NjQ1MDQtNDBkYS00YTMwLTllOWEtNjA4ZmIy
+        YWI2MDVhLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC42ODU5
+        OTBaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIv
+        cHVscC9hcGkvdjMvYXJ0aWZhY3RzLzE2NWFjMWE3LWJiYzgtNGExMS05Mjll
+        LTJkZjk3MDMyZjU4OC8iLCJkaWdlc3QiOiJzaGEyNTY6ZDBkNGM1Mzg5YjUz
+        ODc1YjBmMjM2NGY5NGM0NjZmNzdjZjZmMDI4MTFmYjAyZjA0NzdiOTdkNjA5
+        ZmI1MDU2OCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBw
+        bGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIr
+        anNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy9lYTFmOGYyYy1jNzMz
+        LTRlZTgtOWJmZC03NjZkMTA4NjgyYjYvIiwiYmxvYnMiOlsiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzL2I2MjhhZDY3LTc3MTEtNDMwOS05
+        OGFkLWEzOTIwMWI3Y2FiYi8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9tYW5pZmVzdHMvOTVkOTQ0ZjEtZTcxZC00MTFjLWEy
+        YTMtNjI4NjY4OTVmZTA0LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0
+        MjoyMC41Njc2OTdaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0
+        aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzI4ZTZkOWIzLTI0ZmUt
+        NGZiZi05Y2ViLWY2MTNlNjE3ZDJiZC8iLCJkaWdlc3QiOiJzaGEyNTY6OTJj
+        N2Y5YzkyODQ0YmJiYjVkMGExMDFiMjJmN2MyYTc5NDllNDBmOGVhOTBjOGIz
+        YmMzOTY4NzlkOTVlODk5YSIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90
+        eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFu
+        aWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdf
+        YmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy9hMmRj
+        NDZlOS0zYmYxLTRhNDktYTE2Ni1kNzVlMmY3MzgxNDIvIiwiYmxvYnMiOlsi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzL2E1YjFmNDEzLTcz
+        ZWEtNDJlZi1hZmJiLTk4NTNmZDI2N2I2ZC8iXX0seyJfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvMzhlY2Q4Y2EtZTZi
+        NC00Mjc0LWJhNjktNzk3NzU1MTE5YWRmLyIsIl9jcmVhdGVkIjoiMjAxOS0w
+        Ny0xOFQxNzo0MjoyMC43NTkxNzhaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZl
+        c3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2U4NjNm
+        NTIyLWI1ZTItNDg4MC04NTBiLTllYzBlMmY0YzY0MC8iLCJkaWdlc3QiOiJz
+        aGEyNTY6NWE0YmRhZGQ5YWNkODc3OWVkNmZjZjAwN2E0ZTdlZDdmOTE5MDU2
+        YTkyYzNjNjc4MjRiNGZkZWQwNmVmMGE2ZSIsInNjaGVtYV92ZXJzaW9uIjoy
+        LCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmli
+        dXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltd
+        LCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9i
+        bG9icy9jY2EwZTU0OC0xNzJmLTRiOWYtYWE5Ny04Y2ZjNWY0ZDJmYTMvIiwi
+        YmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzA2
+        ZDgwNGJmLTJiOWYtNDZiZi05NzMwLThiOWEzYjczNmE0Mi8iXX0seyJfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvMGU5
+        NWU3MjUtOGE3OS00ZTdkLTk0ODMtOWUwOWQ4NDRkNTk1LyIsIl9jcmVhdGVk
+        IjoiMjAxOS0wNy0xOFQxNzo0MjoyMC42ODc0MDNaIiwiX3R5cGUiOiJkb2Nr
+        ZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
+        Y3RzLzFlYWVhNzdlLWQ3Y2YtNGJhNC04ZGE4LTUyMTlmNjQzMzc1Ni8iLCJk
+        aWdlc3QiOiJzaGEyNTY6MDg1YmEyOWU5YWU4N2YxMzdkZDg2ODZiOWJmZmVl
+        NzljMjM4MDBiNjM1N2EwMDU1OGJhNjQzNjdjODA4NGZjMyIsInNjaGVtYV92
+        ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tl
+        ci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5p
+        ZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L2RvY2tlci9ibG9icy8zNDI0ZDEwZi03NjBlLTQ3ZjItYmVmOS04YmNjNmEy
+        MDExODYvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2Vy
+        L2Jsb2JzLzczZmE0Yjg4LWY1ZTgtNGM1Yy1hMTQ4LTljYzJiOTQ4NjEwOC8i
+        LCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvYmVjNDEzYTQt
+        NjNiNy00ZThiLWFiY2EtOTE3YWZmNjg5NjE5LyJdfSx7Il9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy83YTEyODdjZS00
+        ZDM1LTRkMmQtOGU1My0zZWMyNTc5ZTk5N2MvIiwiX2NyZWF0ZWQiOiIyMDE5
+        LTA3LTE4VDE3OjQyOjIwLjUyMjEzMloiLCJfdHlwZSI6ImRvY2tlci5tYW5p
+        ZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMjgx
+        Y2U0ZjktZTMzYy00MTNkLWE1YTMtMDBmOTdhNDdmN2U1LyIsImRpZ2VzdCI6
+        InNoYTI1NjoxMmNmOWVmOTA4MzU0NjUzMTZjYjBiMzcyOWMzNmJmZDg2NTRk
+        N2YyZjY5N2UyMzQzMmZkZGZhYTdkN2UzMWI1Iiwic2NoZW1hX3ZlcnNpb24i
+        OjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3Ry
+        aWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6
+        W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2Vy
+        L2Jsb2JzL2MzMjQ0NzU1LWU1ZTYtNGUxMy04YzdjLTJjZmI3OGExZGMyNi8i
+        LCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMv
+        YWY3YmYwYzEtMzY1OC00ZmY4LTkwZDAtYmI3ODBmNDFhYjdlLyJdfSx7Il9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy83
+        MTAwMTk5Ny00YjQ3LTQ2ODItODk3ZS0yZGUzMGQ3NTk3OTkvIiwiX2NyZWF0
+        ZWQiOiIyMDE5LTA3LTE4VDE3OjQyOjIxLjAzMTgzMFoiLCJfdHlwZSI6ImRv
+        Y2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
+        ZmFjdHMvMWE2NmEzNTUtMTFmZS00YTVlLWFjMzktOWMwMGRmZGVlMjE2LyIs
+        ImRpZ2VzdCI6InNoYTI1NjpjMWJlNmUxNDY4NDg1NzU3Njk4YWY1MjhmZmY3
+        NzRkNDc0ZTY5ZjQ0OGVlZjQzYzM2OGZhMmYyYmUxMjg4YjRkIiwic2NoZW1h
+        X3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9j
+        a2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21h
+        bmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL2Jsb2JzLzIxNDA0M2IwLWY0YmItNDI1Mi04YTg4LTMxNDg3
+        YzY0NGYwMC8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvYmxvYnMvYjY0YmY0MzctMWQzYy00ZGE1LTg3MTQtYzY4N2I1MWFiNmY4
+        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy8xMjcwYTA2
+        My0wYzIxLTQ2YjEtYjgzMS05M2QyOTU1MGI5MjQvIl19LHsiX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzQyMmY2NWRj
+        LTRmYmQtNDI1OC04NGE5LTU2ZGQ2YjZjNGY4ZC8iLCJfY3JlYXRlZCI6IjIw
+        MTktMDctMThUMTc6NDI6MjAuNzMxNzgwWiIsIl90eXBlIjoiZG9ja2VyLm1h
+        bmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8x
+        NzMyZWYwZi0xOGU1LTQ4NTMtYmYzZS04OTNkOWM5ODlkNTAvIiwiZGlnZXN0
+        Ijoic2hhMjU2OjFlNDRkOGJjYTZmYjA0NjQ3OTQ1NTVlNWNjZDNhMzJlMmE0
+        ZjZlNDRhMjA2MDVlNGU4MjYwNTE4OTkwNGY0NGQiLCJzY2hlbWFfdmVyc2lv
+        biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
+        dHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3Rz
+        IjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvYmxvYnMvYzgxOWJkMmItZWUxZS00YzQzLTgyMmQtMTQwM2RiODQwODE2
+        LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9i
+        cy82MjkxYjZlMi1lNTQwLTRhZjYtYjdiMi1lNjg0ZjdmMTc2YWEvIl19LHsi
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3Rz
+        L2RkMDFmY2YxLTZjNTMtNGM0Ny1hNzIzLTMyZTk5NTNiNTE5ZS8iLCJfY3Jl
+        YXRlZCI6IjIwMTktMDctMThUMTc6NDI6MjAuNjg0NDI2WiIsIl90eXBlIjoi
+        ZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2Fy
+        dGlmYWN0cy84MDc2Yjg5Ny0xMzQyLTRlODktOTViMi1jNmQ1NTE2ZjJmNTYv
+        IiwiZGlnZXN0Ijoic2hhMjU2OmFmMzdiNjZkMDE3YWUyMmQyZGUxYTEyOGNl
+        MDQ5ZGE2NjFlYjc1YTBmNTIwMDdjNTdjMmY2MTY4MWQ5OTllNTAiLCJzY2hl
+        bWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5k
+        b2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRf
+        bWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvYmxvYnMvMTNlYzUxMDgtMmIyZC00ZWRmLWJjOWYtZTNl
+        MWQ1Mjg2ZDgyLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2Rv
+        Y2tlci9ibG9icy8yNzcxMmMxZC0zZGJiLTQ3YmQtYWZmNi1lMGY0YmRmMjky
+        NGYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzL2Y3ZTk1
+        YmJhLWUyZTktNGI3Ny1hNGUwLWZmOTQyMmUyZGM1Yy8iXX0seyJfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvNmNkNTVl
+        OWItYmI4OS00MjczLWFmZWQtOTQzNGQ2NWYyNDljLyIsIl9jcmVhdGVkIjoi
+        MjAxOS0wNy0xOFQxNzo0MjoyMC43Mjg4OTNaIiwiX3R5cGUiOiJkb2NrZXIu
+        bWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3Rz
+        LzlhNjE2NWIzLTg3YjEtNGE1Ni05NzU4LTM1M2E0NzRlZGIzZS8iLCJkaWdl
+        c3QiOiJzaGEyNTY6ODVkYzVmYmUxNjIxNDM2Njc0OGViZTlkN2NjNzNiYzQy
+        ZDYxZDE5ZDYxZmUwNWYwMWUzMTdkMjc4YzIyODdlZCIsInNjaGVtYV92ZXJz
+        aW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5k
+        aXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVz
+        dHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Rv
+        Y2tlci9ibG9icy9iNDQ4MTU4Ny1hODIwLTQwOWEtOTEzZC1lMzVlZGEwY2Vm
+        ZmMvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Js
+        b2JzLzI1YmJlYmJiLWFiZWItNDI2Ni1iZmE1LTFjYjMxY2QyZjE2My8iXX0s
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVz
+        dHMvYTM0NTNiNzgtNzU5Yy00MTJiLWFhODEtNWFlMDk1ZWUwNGQ0LyIsIl9j
+        cmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC43Mjc3NjJaIiwiX3R5cGUi
+        OiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
+        YXJ0aWZhY3RzL2MxMWU4ODNhLWZjYjUtNGZiZi1iZmVjLTc1MmNhY2JlOGVl
+        MS8iLCJkaWdlc3QiOiJzaGEyNTY6ZDFmZDJlMjA0YWYwYTJiY2EzYWIwMzNi
+        NDE3YjI5Yzc2ZDc5NTBlZDI5YTQ0ZTQyN2QxYzRkMDdkMTRmMDRmOSIsInNj
+        aGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5k
+        LmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3Rl
+        ZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy9jYzRjYzNkMC1iM2VlLTQwOTQtOWM1NS0y
+        ZDlkZmRlZjllMWEvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        ZG9ja2VyL2Jsb2JzLzJjNzg3NWZhLWRlNmItNDFkNy04MmFhLWRjNDgxNDBj
+        YzQ3ZS8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvYTRhMTZjOTgtMGQ3ZC00NmU4LWJjN2EtOTEzZTQ4OGQ4
+        ZDNmLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC45ODk1MDFa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVs
+        cC9hcGkvdjMvYXJ0aWZhY3RzLzg0ZTcwYmZhLWJiMjItNDJiNy04NzAxLWNk
+        M2U5MWI4MDU0Yi8iLCJkaWdlc3QiOiJzaGEyNTY6Nzg2YTI5OTc0OTA4NTUx
+        MzM1ZjM3OWI3NDQ0MzhmMjVkZTBhNTdlOTA3MzU4ZDQzMGU4Y2Y4NWJlNWZj
+        MTQ2NCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGlj
+        YXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNv
+        biIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy8xNzk5ODYyMy0zOTRmLTQ3
+        YjAtOWU0Ny0xYWU0MzJhNzA0YjUvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzM1MjIyMzExLTYyODYtNDA0MS1hOWE1
+        LWQ1YmU1ZmUwM2UwYi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIv
+        YmxvYnMvOGEyNzYxZGYtMGMzMy00ZDMwLTk2ZTAtMThmZDY3NGU4MDdiLyJd
+        fSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlm
+        ZXN0cy8wM2QyNWJmYy1mOGUzLTQ2YjMtOTZmOS04YjU5Y2UxNzc4YjEvIiwi
+        X2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjQyOjIwLjc1ODEyN1oiLCJfdHlw
+        ZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92
+        My9hcnRpZmFjdHMvMTYzNDI2ZmMtZGQ0OC00ZGI3LWFlMmUtNzk0OTRjZTY1
+        MDE3LyIsImRpZ2VzdCI6InNoYTI1NjowOGNhNGYyYzQ1MzE2Y2IwYjc5ZmFm
+        OGYwNzYyNTA0NmRiYmMxNmY2ZjE0MGIwYzU5ZGEwM2YxMzIzYWRhOGE0Iiwi
+        c2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92
+        bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlz
+        dGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvZG9ja2VyL2Jsb2JzL2E4NjI5YTljLTVlMGMtNDI0OS05ZDUz
+        LTZlOTcwNzFmMDIzZC8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvYmxvYnMvNGI0NWVjM2EtN2Q4Yy00YjBmLWExMDctYTFlNmVj
+        Y2QyZWQ3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy8z
+        MTJhZGZiZi1iZTQwLTQ5ZTUtOTFhYy00YjBhY2M0MmY4NTMvIl19LHsiX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzYz
+        NGY2MWI2LWNkZDYtNGYwZi04YzhlLTFjZTE5Y2ZjN2U2OC8iLCJfY3JlYXRl
+        ZCI6IjIwMTktMDctMjJUMTk6NDA6MDEuOTA0NTQyWiIsIl90eXBlIjoiZG9j
+        a2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
+        YWN0cy83MTc2NTRkMC0zZWVkLTQzNjktOTQ2YS00YjU3ZmYzNzRiZmUvIiwi
+        ZGlnZXN0Ijoic2hhMjU2OjlmMTAwM2M0ODA2OTliZTU2ODE1ZGIwZjgxNDZh
+        ZDJlMjJlZmVhODUxMjliNWI1OTgzZDBlMGZiNTJkOWFiNzAiLCJzY2hlbWFf
+        dmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2Nr
+        ZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3Rl
+        ZF9tYW5pZmVzdHMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy81ODI5ZmUwYy00YmRhLTQ3YWYtYTQ5ZS03MmYyY2Q5OTFhNWUv
+        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8zYmFi
+        NDZhOC0yNmE5LTRkZWQtOGMyNS05N2UxNTA2YzJkZTYvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy9mZjk4NTUxYy1jMGYwLTRm
+        ODItYWJlYy0xNDA4NWYyOWVjZmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        ZG9ja2VyL21hbmlmZXN0cy82ZjA1NjJhZC1kZTU3LTRmYTItOWIwOC04YTcw
+        OTE5MjI1ZTcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlm
+        ZXN0cy81MzM0YjNmMS1kNTc4LTRlZGQtYmYzMy1mYzAyODBmM2I2MDgvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8wNDE0MmUx
+        Yy1mYjgyLTRhMTAtOWJkYS01ZmZlM2Y0OTA3MzkvIiwiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy80NDIwOTQ4OS0wZGY0LTRlNTEt
+        YWNmZS00NWU0Y2MxMmEyNjYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL21hbmlmZXN0cy9jNWMzZDM0ZC03MDdhLTRiYjQtYjEwZC0xYzFhZmJl
+        MGY3ZjMvIl0sImNvbmZpZ19ibG9iIjpudWxsLCJibG9icyI6W119LHsiX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzQ0
+        MjA5NDg5LTBkZjQtNGU1MS1hY2ZlLTQ1ZTRjYzEyYTI2Ni8iLCJfY3JlYXRl
+        ZCI6IjIwMTktMDctMjJUMTk6NDA6MDEuOTgzNTYwWiIsIl90eXBlIjoiZG9j
+        a2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
+        YWN0cy8yM2NlZTY3Ny1iNmFkLTRiNTMtOThhMC00NWU3NzliNmI4ZGIvIiwi
+        ZGlnZXN0Ijoic2hhMjU2OmUxOGNlNTFiNThiYjExZWVkMjIxNmNhM2U1ZTk0
+        ZGM5MDZiYjA0YjM1OTM3Njg4NGJlMTEwZjUwMjZiMWY5YzEiLCJzY2hlbWFf
+        dmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2Nr
+        ZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFu
+        aWZlc3RzIjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvYmxvYnMvMzNmZDQwY2MtZjBjYS00OTM4LWJkN2MtZjliMDNm
+        MGJmYTQ0LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9ibG9icy84YWM0YmVlOC02MzBhLTRiODYtOGJhOS1jNzU4NjUwNDA4MjIv
+        Il19LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFu
+        aWZlc3RzL2ZmOTg1NTFjLWMwZjAtNGY4Mi1hYmVjLTE0MDg1ZjI5ZWNmYi8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDctMjJUMTk6NDA6MDIuMDcxODgwWiIsIl90
+        eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBp
+        L3YzL2FydGlmYWN0cy9hNjhhNzUzNi1lMDhlLTRiYmYtOWY4My1iYTc3Zjhj
+        MmRiNDMvIiwiZGlnZXN0Ijoic2hhMjU2OmZkODZhY2Q1YTlmOGIyYmQzNGQz
+        OWNkMGFlZmE5YzUwM2RjOGZlNjE1MGZlMTVjZTNjZjkwZjI4OGViMTU1ZDMi
+        LCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9u
+        L3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJs
+        aXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9kb2NrZXIvYmxvYnMvNjllM2IwN2YtMzc0NC00NTRjLWI4
+        NTMtMzk5Yzk1OTNiYTQ4LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250
+        ZW50L2RvY2tlci9ibG9icy9kMTViMjEwMy1kZWU2LTQ5M2ItOTc2MS1kZTE0
+        MGZmMmQxYmMvIl19LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvbWFuaWZlc3RzL2QyYzMyZTA1LTk3OTAtNGYzNS05ZTBlLWRlMjQ3
+        MjdhZWQ4OC8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6Mzk6MzguMjc1
+        Mjk1WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0Ijoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wOThlZDdjMS02ZGFiLTRhMzctODBm
+        ZC1hZTIzN2EwOGViNzYvIiwiZGlnZXN0Ijoic2hhMjU2OmE2ZWNiYjE1NTMz
+        NTNhMDg5MzZmNTBjMjc1YjAxMDM4OGVkMWJkNmQ5ZDg0NzQzYzdlOGU3NDY4
+        ZTJhY2Q4MmUiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFw
+        cGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYy
+        K2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2IiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvNzI4YjI3ZTgtOTlj
+        MS00YWM2LWExNjQtYWI0N2UxM2VlYTg1LyIsImJsb2JzIjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L2RvY2tlci9ibG9icy9hODJlMzA0Yi1jNWNjLTQwNDkt
+        ODRjOC04MDlmMzA3MTVmNjcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL2Jsb2JzLzUzNmI1NzYwLThjNmItNDRhNy1hNzkyLTFhYTEyMWFhZDFk
+        OS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvM2RkYWY0
+        ODQtZGRlYy00YjAwLWFmMTItYjZjZmQ3NTU2YThkLyJdfSx7Il9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8wNDE0MmUx
+        Yy1mYjgyLTRhMTAtOWJkYS01ZmZlM2Y0OTA3MzkvIiwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTIyVDE5OjQwOjAyLjA4Mjk4NVoiLCJfdHlwZSI6ImRvY2tlci5t
+        YW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
+        OWVjNjhhNmUtMDdmYi00Y2MzLTk5YmQtZGVlNWJlYWNiZGY0LyIsImRpZ2Vz
+        dCI6InNoYTI1NjpmM2RlZTk4OGJhOTAxYmQyZjI4MjI2MjUyMzAyOTliYTVl
+        ZTJkZGZiZTJiOGI0NTU4NTZmMmIwNzMzYmFmOGQwIiwic2NoZW1hX3ZlcnNp
+        b24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRp
+        c3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0
+        cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL2Jsb2JzL2EzNmRmNGM0LTJkZmEtNDMzZi1iZDQ4LTE5NjFjZGM5YWJl
+        NC8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxv
+        YnMvM2M4ZDk5OWQtZjFhZi00YjMxLWE1ZGItNzVjYjE3MmUyZjMzLyJdfSx7
+        Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0
+        cy9jNWMzZDM0ZC03MDdhLTRiYjQtYjEwZC0xYzFhZmJlMGY3ZjMvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAxLjk4NDk1NFoiLCJfdHlwZSI6
+        ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9h
+        cnRpZmFjdHMvODZkYjI2N2QtMzNjYy00NTI5LWEyNDctNmZlYWY3OGIwN2Ji
+        LyIsImRpZ2VzdCI6InNoYTI1NjpmYjgyZWY3YjdhZTA5MWY2NzVmNmUwMzRm
+        MzEzNGUyZjEyOWY0ZjdiZWMyYjIwNWU0NTg5NDNhOGYzZWRiNzNiIiwic2No
+        ZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQu
+        ZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVk
+        X21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZG9ja2VyL2Jsb2JzL2VmZGFmYzY3LThhMjUtNGVkNi1hYWQyLTEz
+        ZjhiMDk3ZTg0YS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvYmxvYnMvZjQ4ZDc2OTktZWIwNC00OTEwLTg2YzMtZjExMzAxMjRh
+        ZDZmLyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2Vy
+        L21hbmlmZXN0cy82ZjA1NjJhZC1kZTU3LTRmYTItOWIwOC04YTcwOTE5MjI1
+        ZTcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAxLjk2NTY5Mloi
+        LCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxw
+        L2FwaS92My9hcnRpZmFjdHMvMjY4NTY2NWYtZDZjOC00MGZmLWJlOWUtMDVm
+        ZjBlOTUwMzc0LyIsImRpZ2VzdCI6InNoYTI1Njo4OTVhYjYyMmU5MmUxOGQ2
+        YjQ2MWQ2NzEwODE3NTdhZjdkYmFhM2IwMGUzZTI4ZTEyNTA1YWY3ODE3Zjcz
+        NjQ5Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNh
+        dGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29u
+        IiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzkxMzZiNThkLTRlODktNDhj
+        YS1hYmVkLTE1NTBlOWYzZjg3OS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMv
+        Y29udGVudC9kb2NrZXIvYmxvYnMvZGY4ZmIwN2MtYThjMi00NjRmLWIxNzMt
+        YTYwMzBmNTY2ODA4LyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL21hbmlmZXN0cy8zYmFiNDZhOC0yNmE5LTRkZWQtOGMyNS05
+        N2UxNTA2YzJkZTYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAx
+        Ljk5NTI2NVoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFj
+        dCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZWQyZGE2N2ItYzMzNC00OTVh
+        LWFiNDEtNjE4ZmJkY2UwMTZlLyIsImRpZ2VzdCI6InNoYTI1NjowZDc2MDQ1
+        NThmOTVkY2UwYzE3Y2VlMGNkZjQ1YThjNjhmMzVkN2ZjNzEwYTYwYTU5OGNk
+        NDNmNjUyOTc2ODc4Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUi
+        OiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVz
+        dC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9i
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzc2ZmFmOTMw
+        LTE2NmEtNGM2OS1iYmYwLTc4Y2U2ZjFlMTQ5OS8iLCJibG9icyI6WyIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvYTFhODAzMjItMDhlNi00
+        NGQzLWFkM2YtODU5ODk2ZmY0ZTA1LyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy81ODI5ZmUwYy00YmRhLTQ3
+        YWYtYTQ5ZS03MmYyY2Q5OTFhNWUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDE5OjQwOjAxLjkxMDczNVoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIs
+        Il9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvOGZjZjc3ZDAt
+        ZDgwNy00YTEwLThiNjgtMmQ3NTdmNjNjNDdmLyIsImRpZ2VzdCI6InNoYTI1
+        NjphZGZhYzBjMmJlNGJiODYwMDQ1OTViOGY5OTVkZjg4YmQ5OWIyODkxOTMx
+        NjE3ZGYwNTAxNThiYWE3MDljMzMxIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
+        ZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlv
+        bi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNv
+        bmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2Jz
+        LzA2NmM1YzQ5LTFjY2UtNGE3Yy1hYWQyLTY1Y2RiNDkyYjNjMi8iLCJibG9i
+        cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvNWQ4ZDc2
+        MjAtMDgzMy00MDc2LWE2NTYtOGM5NjgxMTkxYTJlLyJdfSx7Il9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy81MzM0YjNm
+        MS1kNTc4LTRlZGQtYmYzMy1mYzAyODBmM2I2MDgvIiwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTIyVDE5OjQwOjAxLjk4MjE0MVoiLCJfdHlwZSI6ImRvY2tlci5t
+        YW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
+        ZGJhNjA2YWItZjc2Yy00MGY5LWJhM2EtMGRkYTY2M2QzNmRhLyIsImRpZ2Vz
+        dCI6InNoYTI1Njo3OTI4OWMzMTQ2YTc3Y2U1YzdmZTBmYzhmYjA5NGMwYzE3
+        ZjhlZmVlMjkyNjIzZjkwYzUxNjMwZjk0YmI2NTE5Iiwic2NoZW1hX3ZlcnNp
+        b24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRp
+        c3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0
+        cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL2Jsb2JzLzE3MjhjMjAyLWFmMWMtNGU4My04ZmZkLWJjOGNjZTdhMGY3
+        MS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxv
+        YnMvZTAwNTQ0ZjYtMTMzMC00YTNiLWIyNmEtNmY4MzAwNWZiYTQwLyJdfV19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:34 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:35 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '5132'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MzQsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9t
+        YW5pZmVzdHMvOTViZTA1NWYtZmJhNS00NTc0LTg2YWEtOTg2YmNmZTRlZmM0
+        LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xN1QxOToxNzowNS43NzI3MzZaIiwi
+        X3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9h
+        cGkvdjMvYXJ0aWZhY3RzLzhjNzAwMTNjLWRjZDMtNDM3Yy1iNDRmLWJiYTkw
+        N2IwN2E5Ny8iLCJkaWdlc3QiOiJzaGEyNTY6ZGMyYWU2MzYxNjkxNWNlOTUy
+        N2ViOWJiMzg2NDZjYjM3MDBkMWE3OTAyNTI2NmQ2MDcwOWUyMTRiNDI0OGU1
+        NCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRp
+        b24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitq
+        c29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvbWFuaWZlc3RzLzRlMjYxMjJlLTQ1OGItNGI5My04ODQ1LWU1
+        NzUwNjIyY2Q5NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFu
+        aWZlc3RzLzAzY2ZlNzQ3LTFhNDQtNDRmNC1iZjFjLTY0NjI5ZGUxOThiZC8i
+        XSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpbXX0seyJfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvNGUyNjEyMmUt
+        NDU4Yi00YjkzLTg4NDUtZTU3NTA2MjJjZDk1LyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wNy0xN1QxOToxNzowNS43NjkzODhaIiwiX3R5cGUiOiJkb2NrZXIubWFu
+        aWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzAy
+        ZjkyNzcyLWMwOTItNDczYS04MWRmLTg2OTIzNzk3ZmY2OS8iLCJkaWdlc3Qi
+        OiJzaGEyNTY6YjM1MjAwYmU2NzhkNDc1M2ZlNzc5ZWU1NDA2YzFmYzllZWM5
+        ZTllZTU2ZjAyYjc5ZTQ2YzY1ZDVmMGNlNzYyNyIsInNjaGVtYV92ZXJzaW9u
+        IjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0
+        cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMi
+        OltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9ibG9icy8xYmQ0ODBkYy1hNTI5LTQxNjYtYWM0ZC1mNTVlMDFkNWY5ZmIv
+        IiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2Jz
+        LzJjYWQ0Y2Y4LTc0MDctNDhmZS05ZTg5LTBjMDc2MWQ1M2NlZi8iXX0seyJf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMv
+        MDNjZmU3NDctMWE0NC00NGY0LWJmMWMtNjQ2MjlkZTE5OGJkLyIsIl9jcmVh
+        dGVkIjoiMjAxOS0wNy0xN1QxOToxNzowNS43NjMzMjhaIiwiX3R5cGUiOiJk
+        b2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0
+        aWZhY3RzL2E0YTM2YjIyLWJkYzMtNDk3Ni05ZDE3LTZmMmEyNDE5MzI3YS8i
+        LCJkaWdlc3QiOiJzaGEyNTY6OWI4NzRjY2RiNzNlMWFhZjI5ZTFjMGZkM2E1
+        NTBkZGZhNDg2ZDczNTI1ZjJkNzdiNDUyZTMwYTA5ZDNjYjQxNyIsInNjaGVt
+        YV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRv
+        Y2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9t
+        YW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L2RvY2tlci9ibG9icy9mYTBmZDhkMy1hZWI3LTQ5MjgtYjg3Ni05YzM0
+        YWJhOTViYjEvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL2Jsb2JzLzg1YjRjNDk1LWY3NzYtNGViZi04YWRjLWM3ZDFjMmI1NDFk
+        My8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9t
+        YW5pZmVzdHMvZDM1MmUzODctOTUyYi00MmIzLThjZTEtMzEzZTVmNTEwZmI3
+        LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC40OTgyNDRaIiwi
+        X3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9h
+        cGkvdjMvYXJ0aWZhY3RzLzFjMTVmYTYwLTcxOWMtNDBmYS1iMTQzLTE5ZWQ2
+        NjhiNzI0Mi8iLCJkaWdlc3QiOiJzaGEyNTY6ZDgyODNjODUwYWMyZjFhOTBj
+        NWRkOTRiOWE3YWM5N2NjYWJjYjllMjA4MmUzMTI3YjQzMmIyOTdkMmFiYjZj
+        OCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRp
+        b24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitq
+        c29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvbWFuaWZlc3RzL2RkMDFmY2YxLTZjNTMtNGM0Ny1hNzIzLTMy
+        ZTk5NTNiNTE5ZS8iXSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpbXX0s
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVz
+        dHMvMTNiMGI1YzctYzFjOS00YzY1LThlNDgtYmY2ZmI2OTk1NjVlLyIsIl9j
+        cmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41MDIzOTFaIiwiX3R5cGUi
+        OiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
+        YXJ0aWZhY3RzLzM5Yjg1ODhmLWRkZjAtNGY5YS04NTEyLTIxMjVmODMxZGU2
+        NC8iLCJkaWdlc3QiOiJzaGEyNTY6MzFhYjk5YjU1YTMyYWI2ZGQwZGVhODA0
+        NGRjMjZmODllM2M4NTRiZjA3ZTQ3ZTAyMWJkYjY5ZjVjOGE5MThiMyIsInNj
+        aGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5k
+        LmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitqc29uIiwi
+        bGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvbWFuaWZlc3RzLzk1ZDk0NGYxLWU3MWQtNDExYy1hMmEzLTYyODY2ODk1
+        ZmUwNC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3Rz
+        LzdhMTI4N2NlLTRkMzUtNGQyZC04ZTUzLTNlYzI1NzllOTk3Yy8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzQyMmY2NWRjLTRm
+        YmQtNDI1OC04NGE5LTU2ZGQ2YjZjNGY4ZC8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvbWFuaWZlc3RzLzZjZDU1ZTliLWJiODktNDI3My1hZmVk
+        LTk0MzRkNjVmMjQ5Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIv
+        bWFuaWZlc3RzL2EzNDUzYjc4LTc1OWMtNDEyYi1hYTgxLTVhZTA5NWVlMDRk
+        NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzhk
+        ODQzZGZjLTk3OWQtNDBmMS05YjFkLWIwNWMxOGQ5YTViMi8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzliNjY0NTA0LTQwZGEt
+        NGEzMC05ZTlhLTYwOGZiMmFiNjA1YS8iXSwiY29uZmlnX2Jsb2IiOm51bGws
+        ImJsb2JzIjpbXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Rv
+        Y2tlci9tYW5pZmVzdHMvZDZlZWVjODYtZDkwNi00OGRlLTk4ZGMtZjBlZDhk
+        MDIxZTY4LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41MDYw
+        ODNaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIv
+        cHVscC9hcGkvdjMvYXJ0aWZhY3RzL2M3M2NjOTI5LWFjMGItNDdjZC05N2Y2
+        LWZiOTkwZWI3MTNiMS8iLCJkaWdlc3QiOiJzaGEyNTY6NjU0MGZjMDhlZTZl
+        NmI3YjYzNDY4ZGMzMzE3ZTMzMDNhYWUxNzhjYjhhNDVlZDMxMjMxODAzMjhi
+        Y2MxZDIwZiIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBw
+        bGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlz
+        dC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMv
+        Y29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzk1ZDk0NGYxLWU3MWQtNDExYy1h
+        MmEzLTYyODY2ODk1ZmUwNC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvbWFuaWZlc3RzLzdhMTI4N2NlLTRkMzUtNGQyZC04ZTUzLTNlYzI1Nzll
+        OTk3Yy8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3Rz
+        LzBlOTVlNzI1LThhNzktNGU3ZC05NDgzLTllMDlkODQ0ZDU5NS8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzQyMmY2NWRjLTRm
+        YmQtNDI1OC04NGE5LTU2ZGQ2YjZjNGY4ZC8iLCIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvbWFuaWZlc3RzL2RkMDFmY2YxLTZjNTMtNGM0Ny1hNzIz
+        LTMyZTk5NTNiNTE5ZS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIv
+        bWFuaWZlc3RzL2EzNDUzYjc4LTc1OWMtNDEyYi1hYTgxLTVhZTA5NWVlMDRk
+        NC8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzhk
+        ODQzZGZjLTk3OWQtNDBmMS05YjFkLWIwNWMxOGQ5YTViMi8iLCIvcHVscC9h
+        cGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzliNjY0NTA0LTQwZGEt
+        NGEzMC05ZTlhLTYwOGZiMmFiNjA1YS8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvbWFuaWZlc3RzLzM4ZWNkOGNhLWU2YjQtNDI3NC1iYTY5LTc5
+        Nzc1NTExOWFkZi8iXSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpbXX0s
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVz
+        dHMvMThhOTVhZGQtM2Q3My00NDMyLWIwM2EtY2I5MjgwODM1MWJlLyIsIl9j
+        cmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41MDg5ODdaIiwiX3R5cGUi
+        OiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
+        YXJ0aWZhY3RzLzFmNmEyMGQ5LTNhZTktNDVjYS1iNTlkLTc3NWMyMzQwNDc5
+        Mi8iLCJkaWdlc3QiOiJzaGEyNTY6OWQ2NmRiMGM2YTNkZThhMjgwODE5Nzdh
+        NzVjNmYyYTk2NTgyZGIzZWUwZDgzM2E1MWQxODQzODU0MTJkYmQyMCIsInNj
+        aGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5k
+        LmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitqc29uIiwi
+        bGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvbWFuaWZlc3RzLzBlOTVlNzI1LThhNzktNGU3ZC05NDgzLTllMDlkODQ0
+        ZDU5NS8iXSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpbXX0seyJfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvZDlh
+        NTNiOTgtNDI2MS00YmNiLThkZDYtZmQzZGFhMzA3YjA2LyIsIl9jcmVhdGVk
+        IjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41MTE3NDdaIiwiX3R5cGUiOiJkb2Nr
+        ZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
+        Y3RzLzllNjkxM2MyLTE4NzEtNDYxOS05OWZmLTA3ZjQyN2Q3N2I4Mi8iLCJk
+        aWdlc3QiOiJzaGEyNTY6MWQyOTg2YWJkOTMzYzBjOTc3OTliMzRlNmNlMTZm
+        M2ExMWY3NDI5YTkzODM4YzcwMzNjY2IyZjdmMDE5OTc5MCIsInNjaGVtYV92
+        ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tl
+        ci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitqc29uIiwibGlzdGVk
+        X21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFu
+        aWZlc3RzLzAzZDI1YmZjLWY4ZTMtNDZiMy05NmY5LThiNTljZTE3NzhiMS8i
+        XSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpbXX0seyJfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvOGUwMmFmYTYt
+        MTk0NS00Nzk3LWFjMWMtYTE4NGUwMWMzYjYwLyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wNy0xOFQxNzo0MjoyMC41MTQ1MDRaIiwiX3R5cGUiOiJkb2NrZXIubWFu
+        aWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzJk
+        MjczYjE5LTI1NjYtNDk2Ni04MTg5LWNmY2ZkMWYyNzQzMS8iLCJkaWdlc3Qi
+        OiJzaGEyNTY6ZTI2ZmE4ZGIyY2M0NjgzNTA5NGE4NGY1OWE1NTE1YzNlNzI3
+        ZjFlNWQ3NTc4YjIzYTExNzBhYjhmNjFmYmZhZSIsInNjaGVtYV92ZXJzaW9u
+        IjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0
+        cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitqc29uIiwibGlzdGVkX21hbmlm
+        ZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3Rz
+        LzBlOTVlNzI1LThhNzktNGU3ZC05NDgzLTllMDlkODQ0ZDU5NS8iLCIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzL2RkMDFmY2YxLTZj
+        NTMtNGM0Ny1hNzIzLTMyZTk5NTNiNTE5ZS8iXSwiY29uZmlnX2Jsb2IiOm51
+        bGwsImJsb2JzIjpbXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L2RvY2tlci9tYW5pZmVzdHMvMTRiYTM3NGEtN2IwZS00MTYxLWJhN2YtOGM0
+        MjQwMzQ1MjU4LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41
+        MTcyMTVaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3Qi
+        OiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2MyMTBjZDU1LTc1YjUtNDMwMS1h
+        YTc1LTJiMTNhODhmNjJiZS8iLCJkaWdlc3QiOiJzaGEyNTY6ODc4ZmQ5MTMw
+        MTBkMjY2MTMzMTllYzdjYzgzYjQwMGNiOTIxMTNjMzE0ZGEzMjQ2ODFkOWZl
+        Y2ZiNTA4MmVkYyIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoi
+        YXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3Qu
+        bGlzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkv
+        djMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzcxMDAxOTk3LTRiNDctNDY4
+        Mi04OTdlLTJkZTMwZDc1OTc5OS8iXSwiY29uZmlnX2Jsb2IiOm51bGwsImJs
+        b2JzIjpbXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvNTNkODhiZGQtNjdjNy00M2M4LTg0NTItYzA2Yzk3ODgy
+        NzE3LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41MTk2NjVa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVs
+        cC9hcGkvdjMvYXJ0aWZhY3RzL2I4MDVkMmIwLTRiYWUtNDIzZC1iZWE2LWJm
+        Y2VmNDYyMWFkNy8iLCJkaWdlc3QiOiJzaGEyNTY6ZDNjNmEzYmVlNmZkNzZm
+        NWZlMmIwNTk2OGJmM2E3MGVjNzVhMGQyNmZiZjk4ZDI0MjlkODI0YjViMDE5
+        MmY4MyIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGlj
+        YXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52
+        Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvbWFuaWZlc3RzL2E0YTE2Yzk4LTBkN2QtNDZlOC1iYzdh
+        LTkxM2U0ODhkOGQzZi8iXSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpb
+        XX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5p
+        ZmVzdHMvOGQ4NDNkZmMtOTc5ZC00MGYxLTliMWQtYjA1YzE4ZDlhNWIyLyIs
+        Il9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC43NTUyMjVaIiwiX3R5
+        cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkv
+        djMvYXJ0aWZhY3RzLzkzMzM5YWZlLTYwNmYtNGUyZC05YWNjLTk2NDQzNzNj
+        YWY4NS8iLCJkaWdlc3QiOiJzaGEyNTY6NTc3YWQ0MzMxZDRmYWM5MTgwNzMw
+        OGRhOTllY2MxMDdkY2M2YjIyNTRiYzRjNzE2NjMyNWZkMDExMTNiZWEyYSIs
+        InNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24v
+        dm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxp
+        c3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L2RvY2tlci9ibG9icy9jOGRmNjRjMC1iNTYwLTQyOTYtYjJi
+        My05MDA0MDdkMjhmMGIvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL2Jsb2JzL2ExNWQ3NmI1LTQ3NjgtNGVhMC04NGQxLWM0Y2Ni
+        ZTkyMDFmNC8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Rv
+        Y2tlci9tYW5pZmVzdHMvOWI2NjQ1MDQtNDBkYS00YTMwLTllOWEtNjA4ZmIy
+        YWI2MDVhLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC42ODU5
+        OTBaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIv
+        cHVscC9hcGkvdjMvYXJ0aWZhY3RzLzE2NWFjMWE3LWJiYzgtNGExMS05Mjll
+        LTJkZjk3MDMyZjU4OC8iLCJkaWdlc3QiOiJzaGEyNTY6ZDBkNGM1Mzg5YjUz
+        ODc1YjBmMjM2NGY5NGM0NjZmNzdjZjZmMDI4MTFmYjAyZjA0NzdiOTdkNjA5
+        ZmI1MDU2OCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBw
+        bGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIr
+        anNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy9lYTFmOGYyYy1jNzMz
+        LTRlZTgtOWJmZC03NjZkMTA4NjgyYjYvIiwiYmxvYnMiOlsiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzL2I2MjhhZDY3LTc3MTEtNDMwOS05
+        OGFkLWEzOTIwMWI3Y2FiYi8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9tYW5pZmVzdHMvOTVkOTQ0ZjEtZTcxZC00MTFjLWEy
+        YTMtNjI4NjY4OTVmZTA0LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0
+        MjoyMC41Njc2OTdaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0
+        aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzI4ZTZkOWIzLTI0ZmUt
+        NGZiZi05Y2ViLWY2MTNlNjE3ZDJiZC8iLCJkaWdlc3QiOiJzaGEyNTY6OTJj
+        N2Y5YzkyODQ0YmJiYjVkMGExMDFiMjJmN2MyYTc5NDllNDBmOGVhOTBjOGIz
+        YmMzOTY4NzlkOTVlODk5YSIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90
+        eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFu
+        aWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdf
+        YmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy9hMmRj
+        NDZlOS0zYmYxLTRhNDktYTE2Ni1kNzVlMmY3MzgxNDIvIiwiYmxvYnMiOlsi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzL2E1YjFmNDEzLTcz
+        ZWEtNDJlZi1hZmJiLTk4NTNmZDI2N2I2ZC8iXX0seyJfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvMzhlY2Q4Y2EtZTZi
+        NC00Mjc0LWJhNjktNzk3NzU1MTE5YWRmLyIsIl9jcmVhdGVkIjoiMjAxOS0w
+        Ny0xOFQxNzo0MjoyMC43NTkxNzhaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZl
+        c3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzL2U4NjNm
+        NTIyLWI1ZTItNDg4MC04NTBiLTllYzBlMmY0YzY0MC8iLCJkaWdlc3QiOiJz
+        aGEyNTY6NWE0YmRhZGQ5YWNkODc3OWVkNmZjZjAwN2E0ZTdlZDdmOTE5MDU2
+        YTkyYzNjNjc4MjRiNGZkZWQwNmVmMGE2ZSIsInNjaGVtYV92ZXJzaW9uIjoy
+        LCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmli
+        dXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltd
+        LCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9i
+        bG9icy9jY2EwZTU0OC0xNzJmLTRiOWYtYWE5Ny04Y2ZjNWY0ZDJmYTMvIiwi
+        YmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzA2
+        ZDgwNGJmLTJiOWYtNDZiZi05NzMwLThiOWEzYjczNmE0Mi8iXX0seyJfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvMGU5
+        NWU3MjUtOGE3OS00ZTdkLTk0ODMtOWUwOWQ4NDRkNTk1LyIsIl9jcmVhdGVk
+        IjoiMjAxOS0wNy0xOFQxNzo0MjoyMC42ODc0MDNaIiwiX3R5cGUiOiJkb2Nr
+        ZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
+        Y3RzLzFlYWVhNzdlLWQ3Y2YtNGJhNC04ZGE4LTUyMTlmNjQzMzc1Ni8iLCJk
+        aWdlc3QiOiJzaGEyNTY6MDg1YmEyOWU5YWU4N2YxMzdkZDg2ODZiOWJmZmVl
+        NzljMjM4MDBiNjM1N2EwMDU1OGJhNjQzNjdjODA4NGZjMyIsInNjaGVtYV92
+        ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tl
+        ci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5p
+        ZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L2RvY2tlci9ibG9icy8zNDI0ZDEwZi03NjBlLTQ3ZjItYmVmOS04YmNjNmEy
+        MDExODYvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2Vy
+        L2Jsb2JzLzczZmE0Yjg4LWY1ZTgtNGM1Yy1hMTQ4LTljYzJiOTQ4NjEwOC8i
+        LCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvYmVjNDEzYTQt
+        NjNiNy00ZThiLWFiY2EtOTE3YWZmNjg5NjE5LyJdfSx7Il9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy83YTEyODdjZS00
+        ZDM1LTRkMmQtOGU1My0zZWMyNTc5ZTk5N2MvIiwiX2NyZWF0ZWQiOiIyMDE5
+        LTA3LTE4VDE3OjQyOjIwLjUyMjEzMloiLCJfdHlwZSI6ImRvY2tlci5tYW5p
+        ZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMjgx
+        Y2U0ZjktZTMzYy00MTNkLWE1YTMtMDBmOTdhNDdmN2U1LyIsImRpZ2VzdCI6
+        InNoYTI1NjoxMmNmOWVmOTA4MzU0NjUzMTZjYjBiMzcyOWMzNmJmZDg2NTRk
+        N2YyZjY5N2UyMzQzMmZkZGZhYTdkN2UzMWI1Iiwic2NoZW1hX3ZlcnNpb24i
+        OjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3Ry
+        aWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6
+        W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2Vy
+        L2Jsb2JzL2MzMjQ0NzU1LWU1ZTYtNGUxMy04YzdjLTJjZmI3OGExZGMyNi8i
+        LCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMv
+        YWY3YmYwYzEtMzY1OC00ZmY4LTkwZDAtYmI3ODBmNDFhYjdlLyJdfSx7Il9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy83
+        MTAwMTk5Ny00YjQ3LTQ2ODItODk3ZS0yZGUzMGQ3NTk3OTkvIiwiX2NyZWF0
+        ZWQiOiIyMDE5LTA3LTE4VDE3OjQyOjIxLjAzMTgzMFoiLCJfdHlwZSI6ImRv
+        Y2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
+        ZmFjdHMvMWE2NmEzNTUtMTFmZS00YTVlLWFjMzktOWMwMGRmZGVlMjE2LyIs
+        ImRpZ2VzdCI6InNoYTI1NjpjMWJlNmUxNDY4NDg1NzU3Njk4YWY1MjhmZmY3
+        NzRkNDc0ZTY5ZjQ0OGVlZjQzYzM2OGZhMmYyYmUxMjg4YjRkIiwic2NoZW1h
+        X3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9j
+        a2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21h
+        bmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL2Jsb2JzLzIxNDA0M2IwLWY0YmItNDI1Mi04YTg4LTMxNDg3
+        YzY0NGYwMC8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvYmxvYnMvYjY0YmY0MzctMWQzYy00ZGE1LTg3MTQtYzY4N2I1MWFiNmY4
+        LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy8xMjcwYTA2
+        My0wYzIxLTQ2YjEtYjgzMS05M2QyOTU1MGI5MjQvIl19LHsiX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzQyMmY2NWRj
+        LTRmYmQtNDI1OC04NGE5LTU2ZGQ2YjZjNGY4ZC8iLCJfY3JlYXRlZCI6IjIw
+        MTktMDctMThUMTc6NDI6MjAuNzMxNzgwWiIsIl90eXBlIjoiZG9ja2VyLm1h
+        bmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8x
+        NzMyZWYwZi0xOGU1LTQ4NTMtYmYzZS04OTNkOWM5ODlkNTAvIiwiZGlnZXN0
+        Ijoic2hhMjU2OjFlNDRkOGJjYTZmYjA0NjQ3OTQ1NTVlNWNjZDNhMzJlMmE0
+        ZjZlNDRhMjA2MDVlNGU4MjYwNTE4OTkwNGY0NGQiLCJzY2hlbWFfdmVyc2lv
+        biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
+        dHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3Rz
+        IjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvYmxvYnMvYzgxOWJkMmItZWUxZS00YzQzLTgyMmQtMTQwM2RiODQwODE2
+        LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9i
+        cy82MjkxYjZlMi1lNTQwLTRhZjYtYjdiMi1lNjg0ZjdmMTc2YWEvIl19LHsi
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3Rz
+        L2RkMDFmY2YxLTZjNTMtNGM0Ny1hNzIzLTMyZTk5NTNiNTE5ZS8iLCJfY3Jl
+        YXRlZCI6IjIwMTktMDctMThUMTc6NDI6MjAuNjg0NDI2WiIsIl90eXBlIjoi
+        ZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2Fy
+        dGlmYWN0cy84MDc2Yjg5Ny0xMzQyLTRlODktOTViMi1jNmQ1NTE2ZjJmNTYv
+        IiwiZGlnZXN0Ijoic2hhMjU2OmFmMzdiNjZkMDE3YWUyMmQyZGUxYTEyOGNl
+        MDQ5ZGE2NjFlYjc1YTBmNTIwMDdjNTdjMmY2MTY4MWQ5OTllNTAiLCJzY2hl
+        bWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5k
+        b2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRf
+        bWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvYmxvYnMvMTNlYzUxMDgtMmIyZC00ZWRmLWJjOWYtZTNl
+        MWQ1Mjg2ZDgyLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2Rv
+        Y2tlci9ibG9icy8yNzcxMmMxZC0zZGJiLTQ3YmQtYWZmNi1lMGY0YmRmMjky
+        NGYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzL2Y3ZTk1
+        YmJhLWUyZTktNGI3Ny1hNGUwLWZmOTQyMmUyZGM1Yy8iXX0seyJfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvNmNkNTVl
+        OWItYmI4OS00MjczLWFmZWQtOTQzNGQ2NWYyNDljLyIsIl9jcmVhdGVkIjoi
+        MjAxOS0wNy0xOFQxNzo0MjoyMC43Mjg4OTNaIiwiX3R5cGUiOiJkb2NrZXIu
+        bWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3Rz
+        LzlhNjE2NWIzLTg3YjEtNGE1Ni05NzU4LTM1M2E0NzRlZGIzZS8iLCJkaWdl
+        c3QiOiJzaGEyNTY6ODVkYzVmYmUxNjIxNDM2Njc0OGViZTlkN2NjNzNiYzQy
+        ZDYxZDE5ZDYxZmUwNWYwMWUzMTdkMjc4YzIyODdlZCIsInNjaGVtYV92ZXJz
+        aW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5k
+        aXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVz
+        dHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Rv
+        Y2tlci9ibG9icy9iNDQ4MTU4Ny1hODIwLTQwOWEtOTEzZC1lMzVlZGEwY2Vm
+        ZmMvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Js
+        b2JzLzI1YmJlYmJiLWFiZWItNDI2Ni1iZmE1LTFjYjMxY2QyZjE2My8iXX0s
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVz
+        dHMvYTM0NTNiNzgtNzU5Yy00MTJiLWFhODEtNWFlMDk1ZWUwNGQ0LyIsIl9j
+        cmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC43Mjc3NjJaIiwiX3R5cGUi
+        OiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMv
+        YXJ0aWZhY3RzL2MxMWU4ODNhLWZjYjUtNGZiZi1iZmVjLTc1MmNhY2JlOGVl
+        MS8iLCJkaWdlc3QiOiJzaGEyNTY6ZDFmZDJlMjA0YWYwYTJiY2EzYWIwMzNi
+        NDE3YjI5Yzc2ZDc5NTBlZDI5YTQ0ZTQyN2QxYzRkMDdkMTRmMDRmOSIsInNj
+        aGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5k
+        LmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3Rl
+        ZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy9jYzRjYzNkMC1iM2VlLTQwOTQtOWM1NS0y
+        ZDlkZmRlZjllMWEvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        ZG9ja2VyL2Jsb2JzLzJjNzg3NWZhLWRlNmItNDFkNy04MmFhLWRjNDgxNDBj
+        YzQ3ZS8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvYTRhMTZjOTgtMGQ3ZC00NmU4LWJjN2EtOTEzZTQ4OGQ4
+        ZDNmLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC45ODk1MDFa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVs
+        cC9hcGkvdjMvYXJ0aWZhY3RzLzg0ZTcwYmZhLWJiMjItNDJiNy04NzAxLWNk
+        M2U5MWI4MDU0Yi8iLCJkaWdlc3QiOiJzaGEyNTY6Nzg2YTI5OTc0OTA4NTUx
+        MzM1ZjM3OWI3NDQ0MzhmMjVkZTBhNTdlOTA3MzU4ZDQzMGU4Y2Y4NWJlNWZj
+        MTQ2NCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGlj
+        YXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNv
+        biIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy8xNzk5ODYyMy0zOTRmLTQ3
+        YjAtOWU0Ny0xYWU0MzJhNzA0YjUvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzM1MjIyMzExLTYyODYtNDA0MS1hOWE1
+        LWQ1YmU1ZmUwM2UwYi8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIv
+        YmxvYnMvOGEyNzYxZGYtMGMzMy00ZDMwLTk2ZTAtMThmZDY3NGU4MDdiLyJd
+        fSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlm
+        ZXN0cy8wM2QyNWJmYy1mOGUzLTQ2YjMtOTZmOS04YjU5Y2UxNzc4YjEvIiwi
+        X2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjQyOjIwLjc1ODEyN1oiLCJfdHlw
+        ZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92
+        My9hcnRpZmFjdHMvMTYzNDI2ZmMtZGQ0OC00ZGI3LWFlMmUtNzk0OTRjZTY1
+        MDE3LyIsImRpZ2VzdCI6InNoYTI1NjowOGNhNGYyYzQ1MzE2Y2IwYjc5ZmFm
+        OGYwNzYyNTA0NmRiYmMxNmY2ZjE0MGIwYzU5ZGEwM2YxMzIzYWRhOGE0Iiwi
+        c2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92
+        bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlz
+        dGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvZG9ja2VyL2Jsb2JzL2E4NjI5YTljLTVlMGMtNDI0OS05ZDUz
+        LTZlOTcwNzFmMDIzZC8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvYmxvYnMvNGI0NWVjM2EtN2Q4Yy00YjBmLWExMDctYTFlNmVj
+        Y2QyZWQ3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy8z
+        MTJhZGZiZi1iZTQwLTQ5ZTUtOTFhYy00YjBhY2M0MmY4NTMvIl19LHsiX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzYz
+        NGY2MWI2LWNkZDYtNGYwZi04YzhlLTFjZTE5Y2ZjN2U2OC8iLCJfY3JlYXRl
+        ZCI6IjIwMTktMDctMjJUMTk6NDA6MDEuOTA0NTQyWiIsIl90eXBlIjoiZG9j
+        a2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
+        YWN0cy83MTc2NTRkMC0zZWVkLTQzNjktOTQ2YS00YjU3ZmYzNzRiZmUvIiwi
+        ZGlnZXN0Ijoic2hhMjU2OjlmMTAwM2M0ODA2OTliZTU2ODE1ZGIwZjgxNDZh
+        ZDJlMjJlZmVhODUxMjliNWI1OTgzZDBlMGZiNTJkOWFiNzAiLCJzY2hlbWFf
+        dmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2Nr
+        ZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3Rl
+        ZF9tYW5pZmVzdHMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy81ODI5ZmUwYy00YmRhLTQ3YWYtYTQ5ZS03MmYyY2Q5OTFhNWUv
+        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8zYmFi
+        NDZhOC0yNmE5LTRkZWQtOGMyNS05N2UxNTA2YzJkZTYvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy9mZjk4NTUxYy1jMGYwLTRm
+        ODItYWJlYy0xNDA4NWYyOWVjZmIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        ZG9ja2VyL21hbmlmZXN0cy82ZjA1NjJhZC1kZTU3LTRmYTItOWIwOC04YTcw
+        OTE5MjI1ZTcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlm
+        ZXN0cy81MzM0YjNmMS1kNTc4LTRlZGQtYmYzMy1mYzAyODBmM2I2MDgvIiwi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8wNDE0MmUx
+        Yy1mYjgyLTRhMTAtOWJkYS01ZmZlM2Y0OTA3MzkvIiwiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy80NDIwOTQ4OS0wZGY0LTRlNTEt
+        YWNmZS00NWU0Y2MxMmEyNjYvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL21hbmlmZXN0cy9jNWMzZDM0ZC03MDdhLTRiYjQtYjEwZC0xYzFhZmJl
+        MGY3ZjMvIl0sImNvbmZpZ19ibG9iIjpudWxsLCJibG9icyI6W119LHsiX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzQ0
+        MjA5NDg5LTBkZjQtNGU1MS1hY2ZlLTQ1ZTRjYzEyYTI2Ni8iLCJfY3JlYXRl
+        ZCI6IjIwMTktMDctMjJUMTk6NDA6MDEuOTgzNTYwWiIsIl90eXBlIjoiZG9j
+        a2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
+        YWN0cy8yM2NlZTY3Ny1iNmFkLTRiNTMtOThhMC00NWU3NzliNmI4ZGIvIiwi
+        ZGlnZXN0Ijoic2hhMjU2OmUxOGNlNTFiNThiYjExZWVkMjIxNmNhM2U1ZTk0
+        ZGM5MDZiYjA0YjM1OTM3Njg4NGJlMTEwZjUwMjZiMWY5YzEiLCJzY2hlbWFf
+        dmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2Nr
+        ZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFu
+        aWZlc3RzIjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvYmxvYnMvMzNmZDQwY2MtZjBjYS00OTM4LWJkN2MtZjliMDNm
+        MGJmYTQ0LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9ibG9icy84YWM0YmVlOC02MzBhLTRiODYtOGJhOS1jNzU4NjUwNDA4MjIv
+        Il19LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFu
+        aWZlc3RzL2ZmOTg1NTFjLWMwZjAtNGY4Mi1hYmVjLTE0MDg1ZjI5ZWNmYi8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDctMjJUMTk6NDA6MDIuMDcxODgwWiIsIl90
+        eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBp
+        L3YzL2FydGlmYWN0cy9hNjhhNzUzNi1lMDhlLTRiYmYtOWY4My1iYTc3Zjhj
+        MmRiNDMvIiwiZGlnZXN0Ijoic2hhMjU2OmZkODZhY2Q1YTlmOGIyYmQzNGQz
+        OWNkMGFlZmE5YzUwM2RjOGZlNjE1MGZlMTVjZTNjZjkwZjI4OGViMTU1ZDMi
+        LCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9u
+        L3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJs
+        aXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9kb2NrZXIvYmxvYnMvNjllM2IwN2YtMzc0NC00NTRjLWI4
+        NTMtMzk5Yzk1OTNiYTQ4LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250
+        ZW50L2RvY2tlci9ibG9icy9kMTViMjEwMy1kZWU2LTQ5M2ItOTc2MS1kZTE0
+        MGZmMmQxYmMvIl19LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvbWFuaWZlc3RzL2QyYzMyZTA1LTk3OTAtNGYzNS05ZTBlLWRlMjQ3
+        MjdhZWQ4OC8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6Mzk6MzguMjc1
+        Mjk1WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0Ijoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wOThlZDdjMS02ZGFiLTRhMzctODBm
+        ZC1hZTIzN2EwOGViNzYvIiwiZGlnZXN0Ijoic2hhMjU2OmE2ZWNiYjE1NTMz
+        NTNhMDg5MzZmNTBjMjc1YjAxMDM4OGVkMWJkNmQ5ZDg0NzQzYzdlOGU3NDY4
+        ZTJhY2Q4MmUiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFw
+        cGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYy
+        K2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2IiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvNzI4YjI3ZTgtOTlj
+        MS00YWM2LWExNjQtYWI0N2UxM2VlYTg1LyIsImJsb2JzIjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L2RvY2tlci9ibG9icy9hODJlMzA0Yi1jNWNjLTQwNDkt
+        ODRjOC04MDlmMzA3MTVmNjcvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL2Jsb2JzLzUzNmI1NzYwLThjNmItNDRhNy1hNzkyLTFhYTEyMWFhZDFk
+        OS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvM2RkYWY0
+        ODQtZGRlYy00YjAwLWFmMTItYjZjZmQ3NTU2YThkLyJdfSx7Il9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8wNDE0MmUx
+        Yy1mYjgyLTRhMTAtOWJkYS01ZmZlM2Y0OTA3MzkvIiwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTIyVDE5OjQwOjAyLjA4Mjk4NVoiLCJfdHlwZSI6ImRvY2tlci5t
+        YW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
+        OWVjNjhhNmUtMDdmYi00Y2MzLTk5YmQtZGVlNWJlYWNiZGY0LyIsImRpZ2Vz
+        dCI6InNoYTI1NjpmM2RlZTk4OGJhOTAxYmQyZjI4MjI2MjUyMzAyOTliYTVl
+        ZTJkZGZiZTJiOGI0NTU4NTZmMmIwNzMzYmFmOGQwIiwic2NoZW1hX3ZlcnNp
+        b24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRp
+        c3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0
+        cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL2Jsb2JzL2EzNmRmNGM0LTJkZmEtNDMzZi1iZDQ4LTE5NjFjZGM5YWJl
+        NC8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxv
+        YnMvM2M4ZDk5OWQtZjFhZi00YjMxLWE1ZGItNzVjYjE3MmUyZjMzLyJdfSx7
+        Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0
+        cy9jNWMzZDM0ZC03MDdhLTRiYjQtYjEwZC0xYzFhZmJlMGY3ZjMvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAxLjk4NDk1NFoiLCJfdHlwZSI6
+        ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9h
+        cnRpZmFjdHMvODZkYjI2N2QtMzNjYy00NTI5LWEyNDctNmZlYWY3OGIwN2Ji
+        LyIsImRpZ2VzdCI6InNoYTI1NjpmYjgyZWY3YjdhZTA5MWY2NzVmNmUwMzRm
+        MzEzNGUyZjEyOWY0ZjdiZWMyYjIwNWU0NTg5NDNhOGYzZWRiNzNiIiwic2No
+        ZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQu
+        ZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVk
+        X21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZG9ja2VyL2Jsb2JzL2VmZGFmYzY3LThhMjUtNGVkNi1hYWQyLTEz
+        ZjhiMDk3ZTg0YS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvYmxvYnMvZjQ4ZDc2OTktZWIwNC00OTEwLTg2YzMtZjExMzAxMjRh
+        ZDZmLyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2Vy
+        L21hbmlmZXN0cy82ZjA1NjJhZC1kZTU3LTRmYTItOWIwOC04YTcwOTE5MjI1
+        ZTcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAxLjk2NTY5Mloi
+        LCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxw
+        L2FwaS92My9hcnRpZmFjdHMvMjY4NTY2NWYtZDZjOC00MGZmLWJlOWUtMDVm
+        ZjBlOTUwMzc0LyIsImRpZ2VzdCI6InNoYTI1Njo4OTVhYjYyMmU5MmUxOGQ2
+        YjQ2MWQ2NzEwODE3NTdhZjdkYmFhM2IwMGUzZTI4ZTEyNTA1YWY3ODE3Zjcz
+        NjQ5Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNh
+        dGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29u
+        IiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzkxMzZiNThkLTRlODktNDhj
+        YS1hYmVkLTE1NTBlOWYzZjg3OS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMv
+        Y29udGVudC9kb2NrZXIvYmxvYnMvZGY4ZmIwN2MtYThjMi00NjRmLWIxNzMt
+        YTYwMzBmNTY2ODA4LyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL21hbmlmZXN0cy8zYmFiNDZhOC0yNmE5LTRkZWQtOGMyNS05
+        N2UxNTA2YzJkZTYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAx
+        Ljk5NTI2NVoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFj
+        dCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZWQyZGE2N2ItYzMzNC00OTVh
+        LWFiNDEtNjE4ZmJkY2UwMTZlLyIsImRpZ2VzdCI6InNoYTI1NjowZDc2MDQ1
+        NThmOTVkY2UwYzE3Y2VlMGNkZjQ1YThjNjhmMzVkN2ZjNzEwYTYwYTU5OGNk
+        NDNmNjUyOTc2ODc4Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUi
+        OiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVz
+        dC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9i
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzc2ZmFmOTMw
+        LTE2NmEtNGM2OS1iYmYwLTc4Y2U2ZjFlMTQ5OS8iLCJibG9icyI6WyIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvYTFhODAzMjItMDhlNi00
+        NGQzLWFkM2YtODU5ODk2ZmY0ZTA1LyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy81ODI5ZmUwYy00YmRhLTQ3
+        YWYtYTQ5ZS03MmYyY2Q5OTFhNWUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDE5OjQwOjAxLjkxMDczNVoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIs
+        Il9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvOGZjZjc3ZDAt
+        ZDgwNy00YTEwLThiNjgtMmQ3NTdmNjNjNDdmLyIsImRpZ2VzdCI6InNoYTI1
+        NjphZGZhYzBjMmJlNGJiODYwMDQ1OTViOGY5OTVkZjg4YmQ5OWIyODkxOTMx
+        NjE3ZGYwNTAxNThiYWE3MDljMzMxIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
+        ZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlv
+        bi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNv
+        bmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2Jz
+        LzA2NmM1YzQ5LTFjY2UtNGE3Yy1hYWQyLTY1Y2RiNDkyYjNjMi8iLCJibG9i
+        cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvNWQ4ZDc2
+        MjAtMDgzMy00MDc2LWE2NTYtOGM5NjgxMTkxYTJlLyJdfSx7Il9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy81MzM0YjNm
+        MS1kNTc4LTRlZGQtYmYzMy1mYzAyODBmM2I2MDgvIiwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTIyVDE5OjQwOjAxLjk4MjE0MVoiLCJfdHlwZSI6ImRvY2tlci5t
+        YW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
+        ZGJhNjA2YWItZjc2Yy00MGY5LWJhM2EtMGRkYTY2M2QzNmRhLyIsImRpZ2Vz
+        dCI6InNoYTI1Njo3OTI4OWMzMTQ2YTc3Y2U1YzdmZTBmYzhmYjA5NGMwYzE3
+        ZjhlZmVlMjkyNjIzZjkwYzUxNjMwZjk0YmI2NTE5Iiwic2NoZW1hX3ZlcnNp
+        b24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRp
+        c3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0
+        cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL2Jsb2JzLzE3MjhjMjAyLWFmMWMtNGU4My04ZmZkLWJjOGNjZTdhMGY3
+        MS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxv
+        YnMvZTAwNTQ0ZjYtMTMzMC00YTNiLWIyNmEtNmY4MzAwNWZiYTQwLyJdfV19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:35 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifest-tags/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:35 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '1321'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MTQsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9t
+        YW5pZmVzdC10YWdzLzMyNjE4NWJiLThiOTAtNDE3NC1iZDY3LTMzMjkyY2Ix
+        ZDMxYy8iLCJfY3JlYXRlZCI6IjIwMTktMDctMTdUMTk6MTc6MDUuNzY3MDE1
+        WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0LXRhZyIsIl9hcnRpZmFjdCI6
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYTRhMzZiMjItYmRjMy00OTc2LTlk
+        MTctNmYyYTI0MTkzMjdhLyIsIm5hbWUiOiJsaW51eCIsInRhZ2dlZF9tYW5p
+        ZmVzdCI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMv
+        MDNjZmU3NDctMWE0NC00NGY0LWJmMWMtNjQ2MjlkZTE5OGJkLyJ9LHsiX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFn
+        cy9jZTJiNDAzMS1iZDRiLTRhYzUtOGE4NS1iYjU2YjE2MjRjMWEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTE3VDE5OjE3OjA1Ljc3MTA5M1oiLCJfdHlwZSI6
+        ImRvY2tlci5tYW5pZmVzdC10YWciLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkv
+        djMvYXJ0aWZhY3RzLzAyZjkyNzcyLWMwOTItNDczYS04MWRmLTg2OTIzNzk3
+        ZmY2OS8iLCJuYW1lIjoid2luZG93cyIsInRhZ2dlZF9tYW5pZmVzdCI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvNGUyNjEyMmUt
+        NDU4Yi00YjkzLTg4NDUtZTU3NTA2MjJjZDk1LyJ9LHsiX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy85ZDY3Y2Fi
+        YS00NjZhLTQwZDYtOWM0Ny02ZjM0YWNlNjZjOGYvIiwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTE3VDE5OjE3OjA1Ljc3NDI5M1oiLCJfdHlwZSI6ImRvY2tlci5t
+        YW5pZmVzdC10YWciLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
+        Y3RzLzhjNzAwMTNjLWRjZDMtNDM3Yy1iNDRmLWJiYTkwN2IwN2E5Ny8iLCJu
+        YW1lIjoibGF0ZXN0IiwidGFnZ2VkX21hbmlmZXN0IjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy85NWJlMDU1Zi1mYmE1LTQ1NzQt
+        ODZhYS05ODZiY2ZlNGVmYzQvIn0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9tYW5pZmVzdC10YWdzL2U1NDZjODBiLTE5NDktNDli
+        Yy04OTFmLTQ4NzE0NmRiOGQ3YS8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThU
+        MTc6Mzk6MzguMjc4NDEzWiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0LXRh
+        ZyIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDk4ZWQ3
+        YzEtNmRhYi00YTM3LTgwZmQtYWUyMzdhMDhlYjc2LyIsIm5hbWUiOiJsYXRl
+        c3QiLCJ0YWdnZWRfbWFuaWZlc3QiOiIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvbWFuaWZlc3RzL2QyYzMyZTA1LTk3OTAtNGYzNS05ZTBlLWRlMjQ3
+        MjdhZWQ4OC8ifSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL21hbmlmZXN0LXRhZ3MvM2I5MzdlMjMtNDBkNi00NDY0LTk5M2ItYzUx
+        Y2UzYWYyNGZiLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41
+        MDA0NDJaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QtdGFnIiwiX2FydGlm
+        YWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8xYzE1ZmE2MC03MTljLTQw
+        ZmEtYjE0My0xOWVkNjY4YjcyNDIvIiwibmFtZSI6Im5hbm9zZXJ2ZXItMTgw
+        MyIsInRhZ2dlZF9tYW5pZmVzdCI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Rv
+        Y2tlci9tYW5pZmVzdHMvZDM1MmUzODctOTUyYi00MmIzLThjZTEtMzEzZTVm
+        NTEwZmI3LyJ9LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvbWFuaWZlc3QtdGFncy8xMmQzOTdmOS0wNmJmLTQ4YjEtYmJkYS0xODg0
+        OTU5NGY3MzYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjQyOjIwLjUw
+        NDI2NFoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdC10YWciLCJfYXJ0aWZh
+        Y3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzM5Yjg1ODhmLWRkZjAtNGY5
+        YS04NTEyLTIxMjVmODMxZGU2NC8iLCJuYW1lIjoibGludXgiLCJ0YWdnZWRf
+        bWFuaWZlc3QiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZl
+        c3RzLzEzYjBiNWM3LWMxYzktNGM2NS04ZTQ4LWJmNmZiNjk5NTY1ZS8ifSx7
+        Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0
+        LXRhZ3MvNDIzNTZiMTQtZmZiZC00MTg1LWJiNWMtNDQ3ODRlYzdlNDk5LyIs
+        Il9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41MDc1ODNaIiwiX3R5
+        cGUiOiJkb2NrZXIubWFuaWZlc3QtdGFnIiwiX2FydGlmYWN0IjoiL3B1bHAv
+        YXBpL3YzL2FydGlmYWN0cy9jNzNjYzkyOS1hYzBiLTQ3Y2QtOTdmNi1mYjk5
+        MGViNzEzYjEvIiwibmFtZSI6ImxhdGVzdCIsInRhZ2dlZF9tYW5pZmVzdCI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvZDZlZWVj
+        ODYtZDkwNi00OGRlLTk4ZGMtZjBlZDhkMDIxZTY4LyJ9LHsiX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy9mMWQy
+        YTA4Mi1iODZmLTRjNTItODAzYS02ZmY1ZWIyZWU1ZDUvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA3LTE4VDE3OjQyOjIwLjUxMDM2M1oiLCJfdHlwZSI6ImRvY2tl
+        ci5tYW5pZmVzdC10YWciLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0
+        aWZhY3RzLzFmNmEyMGQ5LTNhZTktNDVjYS1iNTlkLTc3NWMyMzQwNDc5Mi8i
+        LCJuYW1lIjoibmFub3NlcnZlci0xODA5IiwidGFnZ2VkX21hbmlmZXN0Ijoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8xOGE5NWFk
+        ZC0zZDczLTQ0MzItYjAzYS1jYjkyODA4MzUxYmUvIn0seyJfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdC10YWdzLzYxZjcx
+        YzIyLWI4ZGQtNDI1Mi05NTM3LTdlMGJlOWRhMTQ3Ni8iLCJfY3JlYXRlZCI6
+        IjIwMTktMDctMThUMTc6NDI6MjAuNTEzMTQxWiIsIl90eXBlIjoiZG9ja2Vy
+        Lm1hbmlmZXN0LXRhZyIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
+        ZmFjdHMvOWU2OTEzYzItMTg3MS00NjE5LTk5ZmYtMDdmNDI3ZDc3YjgyLyIs
+        Im5hbWUiOiJuYW5vc2VydmVyLTE3MDkiLCJ0YWdnZWRfbWFuaWZlc3QiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzL2Q5YTUzYjk4
+        LTQyNjEtNGJjYi04ZGQ2LWZkM2RhYTMwN2IwNi8ifSx7Il9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0LXRhZ3MvZGY0OWE1
+        MWMtNzlkMS00ZGM3LTk1MWEtYTljY2JjNmU1Y2MwLyIsIl9jcmVhdGVkIjoi
+        MjAxOS0wNy0xOFQxNzo0MjoyMC41MTU5NTdaIiwiX3R5cGUiOiJkb2NrZXIu
+        bWFuaWZlc3QtdGFnIiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
+        YWN0cy8yZDI3M2IxOS0yNTY2LTQ5NjYtODE4OS1jZmNmZDFmMjc0MzEvIiwi
+        bmFtZSI6Im5hbm9zZXJ2ZXIiLCJ0YWdnZWRfbWFuaWZlc3QiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzhlMDJhZmE2LTE5NDUt
+        NDc5Ny1hYzFjLWExODRlMDFjM2I2MC8ifSx7Il9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0LXRhZ3MvZDE2OTE3YjktNGJh
+        Ny00OWU1LTk2YjEtOWNiYzg1NjYwNDE2LyIsIl9jcmVhdGVkIjoiMjAxOS0w
+        Ny0xOFQxNzo0MjoyMC41MTg0NDJaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZl
+        c3QtdGFnIiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9j
+        MjEwY2Q1NS03NWI1LTQzMDEtYWE3NS0yYjEzYTg4ZjYyYmUvIiwibmFtZSI6
+        Im5hbm9zZXJ2ZXItc2FjMjAxNiIsInRhZ2dlZF9tYW5pZmVzdCI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvMTRiYTM3NGEtN2Iw
+        ZS00MTYxLWJhN2YtOGM0MjQwMzQ1MjU4LyJ9LHsiX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy9lMWY1N2RhMy02
+        YjgxLTRiODktOGJlNy0xODVlMGNhNzUxY2UvIiwiX2NyZWF0ZWQiOiIyMDE5
+        LTA3LTE4VDE3OjQyOjIwLjUyMDkxMVoiLCJfdHlwZSI6ImRvY2tlci5tYW5p
+        ZmVzdC10YWciLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3Rz
+        L2I4MDVkMmIwLTRiYWUtNDIzZC1iZWE2LWJmY2VmNDYyMWFkNy8iLCJuYW1l
+        IjoibmFub3NlcnZlcjE3MDkiLCJ0YWdnZWRfbWFuaWZlc3QiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzUzZDg4YmRkLTY3Yzct
+        NDNjOC04NDUyLWMwNmM5Nzg4MjcxNy8ifSx7Il9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0LXRhZ3MvYzA4NDQyMDQtODVj
+        MC00NWYzLWFmYmMtYmVmMTU4ODE1OWU4LyIsIl9jcmVhdGVkIjoiMjAxOS0w
+        Ny0yMlQxOTo0MDowMS45MDc5NTVaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZl
+        c3QtdGFnIiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy83
+        MTc2NTRkMC0zZWVkLTQzNjktOTQ2YS00YjU3ZmYzNzRiZmUvIiwibmFtZSI6
+        ImxhdGVzdCIsInRhZ2dlZF9tYW5pZmVzdCI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L2RvY2tlci9tYW5pZmVzdHMvNjM0ZjYxYjYtY2RkNi00ZjBmLThjOGUt
+        MWNlMTljZmM3ZTY4LyJ9LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvbWFuaWZlc3QtdGFncy82ODVmZjg0ZC0yYTQ4LTQzYTUtYmEx
+        NC05NTA2Yjc5YTkwOTAvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjU2
+        OjEzLjQ5NzU2MFoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdC10YWciLCJf
+        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzcxNzY1NGQwLTNl
+        ZWQtNDM2OS05NDZhLTRiNTdmZjM3NGJmZS8iLCJuYW1lIjoibGF0ZXN0Iiwi
+        dGFnZ2VkX21hbmlmZXN0IjpudWxsfV19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:35 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/d66f3ff1-a28a-432f-b84e-e5b62ef50959/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:42 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EzZjdhNDc5LWRjOWUtNDNh
+        NC1hY2QzLWY3YTJiNmFiMTgxMi8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:42 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/d8403b61-b02d-4cf8-a756-7ae5a33e3fd1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:42 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhkYWU4M2MyLTYwZDgtNDY1
+        YS1iYjg3LWE4NzM4ODMyZWZlYS8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:42 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/dc03b29e-0cc2-4369-a9f3-1e7eecc54c1e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:43 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxNzdjMjg2LTJiNGEtNDc3
+        Ny1iYjNkLWYwOTVmNTVjZTBmOS8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:43 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/dc03b29e-0cc2-4369-a9f3-1e7eecc54c1e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:43 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '23'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:43 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/8516e8b9-69e6-486e-8149-b69c8e11ad74/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:44 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcyOWYyOTg0LWFiZWYtNDIw
+        ZS04YWYxLTllMTEzZTkzMzNlMS8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:44 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/729f2984-abef-420e-8af1-9e113e9333e1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:44 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '327'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy83MjlmMjk4NC1hYmVmLTQy
+        MGUtOGFmMS05ZTExM2U5MzMzZTEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI3OjQ0LjY1MjE2MFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLnJlcG9zaXRvcnkuYWRkX2FuZF9yZW1vdmUi
+        LCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yOVQxMzoyNzo0NC43NjgzODVaIiwi
+        ZmluaXNoZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJv
+        ciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcy
+        YWItM2UwYy00NDlhLTkzNzgtNDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVs
+        bCwic3Bhd25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJj
+        cmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        Lzg1MTZlOGI5LTY5ZTYtNDg2ZS04MTQ5LWI2OWM4ZTExYWQ3NC92ZXJzaW9u
+        cy8xLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:44 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/729f2984-abef-420e-8af1-9e113e9333e1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:44 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '333'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy83MjlmMjk4NC1hYmVmLTQy
+        MGUtOGFmMS05ZTExM2U5MzMzZTEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI3OjQ0LjY1MjE2MFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTI5VDEzOjI3OjQ0Ljc2ODM4NVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjlUMTM6Mjc6NDQuODE1MjYwWiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2UwYy00NDlhLTkzNzgt
+        NDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzg1MTZlOGI5LTY5ZTYtNDg2
+        ZS04MTQ5LWI2OWM4ZTExYWQ3NC92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:44 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/8516e8b9-69e6-486e-8149-b69c8e11ad74/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '186'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvODUxNmU4Yjkt
+        NjllNi00ODZlLTgxNDktYjY5YzhlMTFhZDc0L3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI5VDEzOjI3OjQ0Ljc4NzIxMloiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:45 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19E
+        b2NrZXJfMSIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzg1MTZlOGI5LTY5ZTYtNDg2ZS04
+        MTQ5LWI2OWM4ZTExYWQ3NC92ZXJzaW9ucy8xLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQxYWQ1ODNlLTcwYjktNDVl
+        NC1iMWViLWZmNDkyNzE1MzMwMy8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:45 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/41ad583e-70b9-45e4-b1eb-ff4927153303/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '277'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy80MWFkNTgzZS03MGI5LTQ1
+        ZTQtYjFlYi1mZjQ5MjcxNTMzMDMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI3OjQ1LjIyMDExMloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yOVQxMzoyNzo0NS4zNTY2NzdaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2
+        YS00MjE2LTgwMjUtZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:45 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/41ad583e-70b9-45e4-b1eb-ff4927153303/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '330'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy80MWFkNTgzZS03MGI5LTQ1
+        ZTQtYjFlYi1mZjQ5MjcxNTMzMDMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI3OjQ1LjIyMDExMloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI5VDEzOjI3OjQ1LjM1NjY3N1oiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjlUMTM6Mjc6NDUuNTA2OTQyWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUtZjRlZmYy
+        NDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzE0MzBhMzMw
+        LWZlYjQtNDEzZi05MDU4LWZhODk3MzQwMzZiNi8iXX0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:45 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/1430a330-feb4-413f-9058-fa89734036b6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '473'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTI5VDEzOjI3OjQ1LjQ5OTMzNloiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvODUxNmU4
+        YjktNjllNi00ODZlLTgxNDktYjY5YzhlMTFhZDc0L3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzE0MzBhMzMwLWZlYjQtNDEzZi05
+        MDU4LWZhODk3MzQwMzZiNi8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:45 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/33e803cd-103f-4e4e-8a1a-96dfd7cf81d3/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy84NTE2
+        ZThiOS02OWU2LTQ4NmUtODE0OS1iNjljOGUxMWFkNzQvIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYzNTZlYjg5LWUyZGQtNGU2
+        OS04MzdhLWU2YTViNmQ3ODE0OC8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:45 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/6356eb89-e2dd-4e69-837a-e6a5b6d78148/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '372'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy82MzU2ZWI4OS1lMmRkLTRl
+        NjktODM3YS1lNmE1YjZkNzgxNDgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI3OjQ1LjkzODg1N1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjlUMTM6Mjc6NDYuMDQyNzQ4WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:46 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/6356eb89-e2dd-4e69-837a-e6a5b6d78148/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '372'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy82MzU2ZWI4OS1lMmRkLTRl
+        NjktODM3YS1lNmE1YjZkNzgxNDgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI3OjQ1LjkzODg1N1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjlUMTM6Mjc6NDYuMDQyNzQ4WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:46 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/6356eb89-e2dd-4e69-837a-e6a5b6d78148/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '377'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy82MzU2ZWI4OS1lMmRkLTRl
+        NjktODM3YS1lNmE1YjZkNzgxNDgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI3OjQ1LjkzODg1N1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjlUMTM6Mjc6NDYuMDQyNzQ4WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:46 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/6356eb89-e2dd-4e69-837a-e6a5b6d78148/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '443'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy82MzU2ZWI4OS1lMmRkLTRl
+        NjktODM3YS1lNmE1YjZkNzgxNDgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI3OjQ1LjkzODg1N1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yOVQxMzoyNzo0Ni4wNDI3NDha
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTI5VDEzOjI3OjQ2LjQ5ODg4MVoi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3MmFiLTNlMGMtNDQ5YS05Mzc4
+        LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Npbmcg
+        VGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvODUxNmU4YjktNjllNi00ODZlLTgxNDktYjY5
+        YzhlMTFhZDc0L3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:46 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/8516e8b9-69e6-486e-8149-b69c8e11ad74/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '287'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvODUxNmU4Yjkt
+        NjllNi00ODZlLTgxNDktYjY5YzhlMTFhZDc0L3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI5VDEzOjI3OjQ2LjA2MjczM1oiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy84
+        NTE2ZThiOS02OWU2LTQ4NmUtODE0OS1iNjljOGUxMWFkNzQvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvODUx
+        NmU4YjktNjllNi00ODZlLTgxNDktYjY5YzhlMTFhZDc0L3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvODUxNmU4YjktNjllNi00ODZlLTgxNDktYjY5YzhlMTFhZDc0L3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvbWFuaWZlc3RzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAv
+        YXBpL3YzL3JlcG9zaXRvcmllcy84NTE2ZThiOS02OWU2LTQ4NmUtODE0OS1i
+        NjljOGUxMWFkNzQvdmVyc2lvbnMvMi8ifSwiZG9ja2VyLm1hbmlmZXN0LWJs
+        b2IiOnsiY291bnQiOjQsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvYmxvYnMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzg1MTZlOGI5LTY5ZTYtNDg2ZS04MTQ5LWI2OWM4ZTEx
+        YWQ3NC92ZXJzaW9ucy8yLyJ9LCJkb2NrZXIubWFuaWZlc3QtdGFnIjp7ImNv
+        dW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzg1MTZlOGI5LTY5ZTYtNDg2ZS04MTQ5LWI2OWM4ZTEx
+        YWQ3NC92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:46 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/1430a330-feb4-413f-9058-fa89734036b6/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzg1MTZlOGI5LTY5ZTYtNDg2ZS04MTQ5LWI2OWM4ZTExYWQ3NC92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QxNGZmZjA0LWY2NTMtNDlm
+        OC04ZDRiLTBmMjhkOTlhZWNiNy8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:46 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d14fff04-f653-49f8-8d4b-0f28d99aecb7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '280'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kMTRmZmYwNC1mNjUzLTQ5
+        ZjgtOGQ0Yi0wZjI4ZDk5YWVjYjcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI3OjQ2Ljg5ODM1MVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yOVQxMzoyNzo0Ny4wMTk0ODZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQx
+        ZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:47 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d14fff04-f653-49f8-8d4b-0f28d99aecb7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '288'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kMTRmZmYwNC1mNjUzLTQ5
+        ZjgtOGQ0Yi0wZjI4ZDk5YWVjYjcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI3OjQ2Ljg5ODM1MVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI5VDEzOjI3OjQ3LjAxOTQ4NloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjlUMTM6Mjc6NDcuMDgyOTI2WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUtY2MxMjUx
+        OGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:47 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/8516e8b9-69e6-486e-8149-b69c8e11ad74/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:47 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/8516e8b9-69e6-486e-8149-b69c8e11ad74/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '793'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy9kMmMzMmUwNS05NzkwLTRmMzUtOWUwZS1kZTI0NzI3YWVkODgv
+        IiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjM5OjM4LjI3NTI5NVoiLCJf
+        dHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2Fw
+        aS92My9hcnRpZmFjdHMvMDk4ZWQ3YzEtNmRhYi00YTM3LTgwZmQtYWUyMzdh
+        MDhlYjc2LyIsImRpZ2VzdCI6InNoYTI1NjphNmVjYmIxNTUzMzUzYTA4OTM2
+        ZjUwYzI3NWIwMTAzODhlZDFiZDZkOWQ4NDc0M2M3ZThlNzQ2OGUyYWNkODJl
+        Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlv
+        bi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwi
+        bGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzcyOGIyN2U4LTk5YzEtNGFjNi1h
+        MTY0LWFiNDdlMTNlZWE4NS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvYmxvYnMvYTgyZTMwNGItYzVjYy00MDQ5LTg0YzgtODA5
+        ZjMwNzE1ZjY3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9i
+        cy81MzZiNTc2MC04YzZiLTQ0YTctYTc5Mi0xYWExMjFhYWQxZDkvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzNkZGFmNDg0LWRkZWMt
+        NGIwMC1hZjEyLWI2Y2ZkNzU1NmE4ZC8iXX1dfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:47 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/8516e8b9-69e6-486e-8149-b69c8e11ad74/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:47 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifest-tags/?page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/8516e8b9-69e6-486e-8149-b69c8e11ad74/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '401'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvZTU0NmM4MGItMTk0OS00OWJjLTg5MWYtNDg3MTQ2ZGI4
+        ZDdhLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzozOTozOC4yNzg0MTNa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QtdGFnIiwiX2FydGlmYWN0Ijoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wOThlZDdjMS02ZGFiLTRhMzctODBm
+        ZC1hZTIzN2EwOGViNzYvIiwibmFtZSI6ImxhdGVzdCIsInRhZ2dlZF9tYW5p
+        ZmVzdCI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMv
+        ZDJjMzJlMDUtOTc5MC00ZjM1LTllMGUtZGUyNDcyN2FlZDg4LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:47 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '235'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy84NTE2
+        ZThiOS02OWU2LTQ4NmUtODE0OS1iNjljOGUxMWFkNzQvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA3LTI5VDEzOjI3OjQ0LjE0MjcwMFoiLCJfdmVyc2lvbnNfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvODUxNmU4YjktNjllNi00
+        ODZlLTgxNDktYjY5YzhlMTFhZDc0L3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVy
+        c2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy84NTE2ZThi
+        OS02OWU2LTQ4NmUtODE0OS1iNjljOGUxMWFkNzQvdmVyc2lvbnMvMi8iLCJu
+        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2Nr
+        ZXJfMSIsImRlc2NyaXB0aW9uIjpudWxsfV19
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:55 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/8516e8b9-69e6-486e-8149-b69c8e11ad74/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc0ZmEzNTkzLWYxZGYtNDM1
+        MS05OWFiLTY2Y2FjM2QzZGIxZS8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:56 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '553'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlbW90ZXMvZG9ja2VyL2Rv
+        Y2tlci8zM2U4MDNjZC0xMDNmLTRlNGUtOGExYS05NmRmZDdjZjgxZDMvIiwi
+        X2NyZWF0ZWQiOiIyMDE5LTA3LTI5VDEzOjI3OjQ0LjMwMTU2MVoiLCJfdHlw
+        ZSI6ImRvY2tlci5kb2NrZXIiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        b24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInVybCI6Imh0dHBzOi8vcmVn
+        aXN0cnktMS5kb2NrZXIuaW8vIiwic3NsX2NhX2NlcnRpZmljYXRlIjpudWxs
+        LCJzc2xfY2xpZW50X2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2tl
+        eSI6bnVsbCwic3NsX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVs
+        bCwiX2xhc3RfdXBkYXRlZCI6IjIwMTktMDctMjlUMTM6Mjc6NDQuMzAxNTc3
+        WiIsImRvd25sb2FkX2NvbmN1cnJlbmN5IjoyMCwicG9saWN5IjoiaW1tZWRp
+        YXRlIiwidXBzdHJlYW1fbmFtZSI6ImZlZG9yYS9zc2giLCJ3aGl0ZWxpc3Rf
+        dGFncyI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:56 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/33e803cd-103f-4e4e-8a1a-96dfd7cf81d3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMwMTIxMjBhLWIzMTEtNGEy
+        Mi1hOGE3LTQ0NDE4ZWFhOGIwMC8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:56 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '453'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJh
+        cnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5IjpudWxsLCJfY3JlYXRl
+        ZCI6IjIwMTktMDctMjlUMTM6Mjc6NDUuNDk5MzM2WiIsIm5hbWUiOiJEZWZh
+        dWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0RvY2tlcl8xIiwicmVw
+        b3NpdG9yeV92ZXJzaW9uIjpudWxsLCJjb250ZW50X2d1YXJkIjpudWxsLCJf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2RvY2tlci9kb2Nr
+        ZXIvMTQzMGEzMzAtZmViNC00MTNmLTkwNTgtZmE4OTczNDAzNmI2LyIsInJl
+        Z2lzdHJ5X3BhdGgiOiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29t
+        L0RlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRG9ja2VyXzEi
+        fV19
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:56 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/1430a330-feb4-413f-9058-fa89734036b6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYzNTNjOTI1LTM2ZjktNDNl
+        MC1iMzhjLWYzMWUzZGJjMDk2Yi8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:56 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/?base_path=Default_Organization/library/pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:56 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:56 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:57 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:57 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:57 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:57 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/?base_path=Default_Organization/library/pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:57 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:57 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19E
+        b2NrZXJfMSJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:57 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/31a063eb-3aa0-4c6e-a9b7-4883e08cbe09/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '308'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvMzFhMDYzZWIt
+        M2FhMC00YzZlLWE5YjctNDg4M2UwOGNiZTA5LyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wNy0yOVQxMzoyOTo1Ny40ODM2ODJaIiwiX3ZlcnNpb25zX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzMxYTA2M2ViLTNhYTAtNGM2ZS1h
+        OWI3LTQ4ODNlMDhjYmUwOS92ZXJzaW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25f
+        aHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfRG9ja2VyXzEiLCJkZXNjcmlwdGlvbiI6bnVsbH0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:57 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19E
+        b2NrZXJfMSIsInVybCI6Imh0dHBzOi8vcmVnaXN0cnktMS5kb2NrZXIuaW8v
+        Iiwic3NsX3ZhbGlkYXRpb24iOnRydWUsInBvbGljeSI6ImltbWVkaWF0ZSIs
+        InVwc3RyZWFtX25hbWUiOiJmZWRvcmEvc3NoIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:57 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/docker/docker/2f4a4348-62f6-4269-b6ca-e0172f3046a4/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '501'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2RvY2tlci9kb2NrZXIv
+        MmY0YTQzNDgtNjJmNi00MjY5LWI2Y2EtZTAxNzJmMzA0NmE0LyIsIl9jcmVh
+        dGVkIjoiMjAxOS0wNy0yOVQxMzoyOTo1Ny42MTk0NjNaIiwiX3R5cGUiOiJk
+        b2NrZXIuZG9ja2VyIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNh
+        YmluZXQtcHVscDNfRG9ja2VyXzEiLCJ1cmwiOiJodHRwczovL3JlZ2lzdHJ5
+        LTEuZG9ja2VyLmlvLyIsInNzbF9jYV9jZXJ0aWZpY2F0ZSI6bnVsbCwic3Ns
+        X2NsaWVudF9jZXJ0aWZpY2F0ZSI6bnVsbCwic3NsX2NsaWVudF9rZXkiOm51
+        bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsIl9s
+        YXN0X3VwZGF0ZWQiOiIyMDE5LTA3LTI5VDEzOjI5OjU3LjYxOTQ3N1oiLCJk
+        b3dubG9hZF9jb25jdXJyZW5jeSI6MjAsInBvbGljeSI6ImltbWVkaWF0ZSIs
+        InVwc3RyZWFtX25hbWUiOiJmZWRvcmEvc3NoIiwid2hpdGVsaXN0X3RhZ3Mi
+        Om51bGx9
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:57 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/31a063eb-3aa0-4c6e-a9b7-4883e08cbe09/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:58 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JjYjRlNjhiLTY3YjItNDQ2
+        Yy1hNGQ1LWQ2NDE3ZDI0YjQzOC8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:58 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/bcb4e68b-67b2-446c-a4d5-d6417d24b438/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:58 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '337'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9iY2I0ZTY4Yi02N2IyLTQ0
+        NmMtYTRkNS1kNjQxN2QyNGI0MzgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI5OjU3Ljk5NzQ2NFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTI5VDEzOjI5OjU4LjEwMDM3MVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjlUMTM6Mjk6NTguMTMxOTIyWiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUt
+        Y2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzMxYTA2M2ViLTNhYTAtNGM2
+        ZS1hOWI3LTQ4ODNlMDhjYmUwOS92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:58 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/31a063eb-3aa0-4c6e-a9b7-4883e08cbe09/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:58 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '185'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvMzFhMDYzZWIt
+        M2FhMC00YzZlLWE5YjctNDg4M2UwOGNiZTA5L3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI5VDEzOjI5OjU4LjExNDg2MFoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:58 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19E
+        b2NrZXJfMSIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzMxYTA2M2ViLTNhYTAtNGM2ZS1h
+        OWI3LTQ4ODNlMDhjYmUwOS92ZXJzaW9ucy8xLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:58 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdkZDRkZWQ5LWNjY2UtNDkw
+        OS04YWJiLTU3NzY5MWI4MGVlMS8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:58 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/7dd4ded9-ccce-4909-8abb-577691b80ee1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:58 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '277'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy83ZGQ0ZGVkOS1jY2NlLTQ5
+        MDktOGFiYi01Nzc2OTFiODBlZTEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI5OjU4LjQyNzg4N1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yOVQxMzoyOTo1OC41NDE5NzlaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2Uw
+        Yy00NDlhLTkzNzgtNDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:58 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/7dd4ded9-ccce-4909-8abb-577691b80ee1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:58 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '277'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy83ZGQ0ZGVkOS1jY2NlLTQ5
+        MDktOGFiYi01Nzc2OTFiODBlZTEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI5OjU4LjQyNzg4N1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yOVQxMzoyOTo1OC41NDE5NzlaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2Uw
+        Yy00NDlhLTkzNzgtNDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:58 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/7dd4ded9-ccce-4909-8abb-577691b80ee1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:58 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '330'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy83ZGQ0ZGVkOS1jY2NlLTQ5
+        MDktOGFiYi01Nzc2OTFiODBlZTEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI5OjU4LjQyNzg4N1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI5VDEzOjI5OjU4LjU0MTk3OVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjlUMTM6Mjk6NTguNzI5MDgwWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2UwYy00NDlhLTkzNzgtNDg3YWZl
+        ZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzJiYzQ3MzA1
+        LTQ2MTAtNDk0MC1hYjc2LWNlOTZkZjI5YmZiMC8iXX0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:58 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/2bc47305-4610-4940-ab76-ce96df29bfb0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:58 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '473'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTI5VDEzOjI5OjU4LjcyMTYzNloiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvMzFhMDYz
+        ZWItM2FhMC00YzZlLWE5YjctNDg4M2UwOGNiZTA5L3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzJiYzQ3MzA1LTQ2MTAtNDk0MC1h
+        Yjc2LWNlOTZkZjI5YmZiMC8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:58 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/2f4a4348-62f6-4269-b6ca-e0172f3046a4/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy8zMWEw
+        NjNlYi0zYWEwLTRjNmUtYTliNy00ODgzZTA4Y2JlMDkvIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:59 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlmM2Q5MThmLTBkMjEtNDgx
+        OC1hNjg2LTBhMWVmMWQ2NTcwMi8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:59 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/9f3d918f-0d21-4818-a686-0a1ef1d65702/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:59 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '281'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85ZjNkOTE4Zi0wZDIxLTQ4
+        MTgtYTY4Ni0wYTFlZjFkNjU3MDIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI5OjU5LjMwOTI4NFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjlUMTM6Mjk6NTkuNDI0MDA3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwi
+        Y3JlYXRlZF9yZXNvdXJjZXMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:59 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/9f3d918f-0d21-4818-a686-0a1ef1d65702/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:59 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '370'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85ZjNkOTE4Zi0wZDIxLTQ4
+        MTgtYTY4Ni0wYTFlZjFkNjU3MDIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI5OjU5LjMwOTI4NFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjlUMTM6Mjk6NTkuNDI0MDA3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:59 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/9f3d918f-0d21-4818-a686-0a1ef1d65702/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:59 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '370'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85ZjNkOTE4Zi0wZDIxLTQ4
+        MTgtYTY4Ni0wYTFlZjFkNjU3MDIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI5OjU5LjMwOTI4NFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjlUMTM6Mjk6NTkuNDI0MDA3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:59 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/9f3d918f-0d21-4818-a686-0a1ef1d65702/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:29:59 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '376'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85ZjNkOTE4Zi0wZDIxLTQ4
+        MTgtYTY4Ni0wYTFlZjFkNjU3MDIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI5OjU5LjMwOTI4NFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjlUMTM6Mjk6NTkuNDI0MDA3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:29:59 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/9f3d918f-0d21-4818-a686-0a1ef1d65702/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:00 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '442'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85ZjNkOTE4Zi0wZDIxLTQ4
+        MTgtYTY4Ni0wYTFlZjFkNjU3MDIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI5OjU5LjMwOTI4NFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yOVQxMzoyOTo1OS40MjQwMDda
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTI5VDEzOjI5OjU5Ljk5OTc4M1oi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTllOGZjLWMzNmEtNDIxNi04MDI1
+        LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Npbmcg
+        VGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvMzFhMDYzZWItM2FhMC00YzZlLWE5YjctNDg4
+        M2UwOGNiZTA5L3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:00 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/31a063eb-3aa0-4c6e-a9b7-4883e08cbe09/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:00 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '281'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvMzFhMDYzZWIt
+        M2FhMC00YzZlLWE5YjctNDg4M2UwOGNiZTA5L3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI5VDEzOjI5OjU5LjQ0NzIyNFoiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy8z
+        MWEwNjNlYi0zYWEwLTRjNmUtYTliNy00ODgzZTA4Y2JlMDkvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvMzFh
+        MDYzZWItM2FhMC00YzZlLWE5YjctNDg4M2UwOGNiZTA5L3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvMzFhMDYzZWItM2FhMC00YzZlLWE5YjctNDg4M2UwOGNiZTA5L3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvMzFhMDYzZWItM2FhMC00YzZlLWE5Yjct
+        NDg4M2UwOGNiZTA5L3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzMxYTA2M2ViLTNhYTAtNGM2ZS1hOWI3LTQ4ODNlMDhj
+        YmUwOS92ZXJzaW9ucy8yLyJ9LCJkb2NrZXIubWFuaWZlc3QtdGFnIjp7ImNv
+        dW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzMxYTA2M2ViLTNhYTAtNGM2ZS1hOWI3LTQ4ODNlMDhj
+        YmUwOS92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:00 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/2bc47305-4610-4940-ab76-ce96df29bfb0/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzMxYTA2M2ViLTNhYTAtNGM2ZS1hOWI3LTQ4ODNlMDhjYmUwOS92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:00 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkyNDExMmEwLTgyZjktNDBh
+        MS1iM2Q2LTVmMzcyMzgxNTkyMS8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:00 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/924112a0-82f9-40a1-b3d6-5f3723815921/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:00 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '279'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85MjQxMTJhMC04MmY5LTQw
+        YTEtYjNkNi01ZjM3MjM4MTU5MjEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjMwOjAwLjM5NzI0MVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yOVQxMzozMDowMC41MTc4MTFaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2
+        YS00MjE2LTgwMjUtZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:00 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/924112a0-82f9-40a1-b3d6-5f3723815921/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:00 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '287'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85MjQxMTJhMC04MmY5LTQw
+        YTEtYjNkNi01ZjM3MjM4MTU5MjEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjMwOjAwLjM5NzI0MVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI5VDEzOjMwOjAwLjUxNzgxMVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjlUMTM6MzA6MDAuNTkwMzA0WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUtZjRlZmYy
+        NDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:00 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/31a063eb-3aa0-4c6e-a9b7-4883e08cbe09/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:00 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:00 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/31a063eb-3aa0-4c6e-a9b7-4883e08cbe09/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:01 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '793'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy9kMmMzMmUwNS05NzkwLTRmMzUtOWUwZS1kZTI0NzI3YWVkODgv
+        IiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjM5OjM4LjI3NTI5NVoiLCJf
+        dHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2Fw
+        aS92My9hcnRpZmFjdHMvMDk4ZWQ3YzEtNmRhYi00YTM3LTgwZmQtYWUyMzdh
+        MDhlYjc2LyIsImRpZ2VzdCI6InNoYTI1NjphNmVjYmIxNTUzMzUzYTA4OTM2
+        ZjUwYzI3NWIwMTAzODhlZDFiZDZkOWQ4NDc0M2M3ZThlNzQ2OGUyYWNkODJl
+        Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlv
+        bi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwi
+        bGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzcyOGIyN2U4LTk5YzEtNGFjNi1h
+        MTY0LWFiNDdlMTNlZWE4NS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvYmxvYnMvYTgyZTMwNGItYzVjYy00MDQ5LTg0YzgtODA5
+        ZjMwNzE1ZjY3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9i
+        cy81MzZiNTc2MC04YzZiLTQ0YTctYTc5Mi0xYWExMjFhYWQxZDkvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzNkZGFmNDg0LWRkZWMt
+        NGIwMC1hZjEyLWI2Y2ZkNzU1NmE4ZC8iXX1dfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:01 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/31a063eb-3aa0-4c6e-a9b7-4883e08cbe09/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:01 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:01 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifest-tags/?page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/31a063eb-3aa0-4c6e-a9b7-4883e08cbe09/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:01 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '401'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvZTU0NmM4MGItMTk0OS00OWJjLTg5MWYtNDg3MTQ2ZGI4
+        ZDdhLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzozOTozOC4yNzg0MTNa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QtdGFnIiwiX2FydGlmYWN0Ijoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wOThlZDdjMS02ZGFiLTRhMzctODBm
+        ZC1hZTIzN2EwOGViNzYvIiwibmFtZSI6ImxhdGVzdCIsInRhZ2dlZF9tYW5p
+        ZmVzdCI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMv
+        ZDJjMzJlMDUtOTc5MC00ZjM1LTllMGUtZGUyNDcyN2FlZDg4LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:01 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/docker_tag/index_on_sync.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/docker_tag/index_on_sync.yml
@@ -1,0 +1,17194 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/ad1b7d7d-8318-4be3-8eac-51dbe083789c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRjODQwMWYyLTM2ZDUtNDcz
+        Ny05NzY0LWY2ZWIwYjIzZDk2ZS8ifQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:52 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/92188fac-e992-45f6-a7fa-09641f857cb1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBjZjJmNWU3LTQ0YzMtNDA5
+        ZC1hZDQzLTgzODE3OTU1YmJlYi8ifQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:52 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/735eb717-f9e3-415b-ab55-4117c70209e1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EzMGJiZDQ5LTY0ODYtNDZm
+        Ni05MTk0LTBmOGE0MmZkZTQ5Ny8ifQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:52 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/735eb717-f9e3-415b-ab55-4117c70209e1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '23'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:52 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/93686ca8-d9b2-44fa-b1e6-bdee5a90667f/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:54 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJhYjE5NzM3LTA1ZGItNGVl
+        My05MjY3LWI5OTlhMTQ0MjUxZS8ifQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:54 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/2ab19737-05db-4ee3-9267-b999a144251e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:54 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '430'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yYWIxOTczNy0wNWRiLTRl
+        ZTMtOTI2Ny1iOTk5YTE0NDI1MWUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDIwOjQ2OjU0LjQwNjAyOVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLnJlcG9zaXRvcnkuYWRkX2FuZF9yZW1vdmUi
+        LCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yMlQyMDo0Njo1NC41MjE4OTVaIiwi
+        ZmluaXNoZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJv
+        ciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNl
+        ODYtODQxZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVs
+        bCwic3Bhd25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJj
+        cmVhdGVkX3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:54 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/2ab19737-05db-4ee3-9267-b999a144251e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:54 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yYWIxOTczNy0wNWRiLTRl
+        ZTMtOTI2Ny1iOTk5YTE0NDI1MWUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDIwOjQ2OjU0LjQwNjAyOVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTIyVDIwOjQ2OjU0LjUyMTg5NVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjJUMjA6NDY6NTQuNTYxNzczWiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUt
+        Y2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzkzNjg2Y2E4LWQ5YjItNDRm
+        YS1iMWU2LWJkZWU1YTkwNjY3Zi92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:54 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/93686ca8-d9b2-44fa-b1e6-bdee5a90667f/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:54 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOTM2ODZjYTgt
+        ZDliMi00NGZhLWIxZTYtYmRlZTVhOTA2NjdmL3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIyVDIwOjQ2OjU0LjU0MTc2MloiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:54 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzkzNjg2Y2E4LWQ5YjItNDRmYS1iMWU2LWJkZWU1YTkwNjY3Zi92ZXJz
+        aW9ucy8xLyIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6
+        YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:54 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdkNDlmYTJlLWE3NjUtNGJh
+        Ny04ZDE3LTNmNWQzYzhlMzdjNS8ifQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:55 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/7d49fa2e-a765-4ba7-8d17-3f5d3c8e37c5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy83ZDQ5ZmEyZS1hNzY1LTRi
+        YTctOGQxNy0zZjVkM2M4ZTM3YzUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDIwOjQ2OjU0Ljk5NjIwNFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yMlQyMDo0Njo1NS4xMTgwMTVaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2
+        YS00MjE2LTgwMjUtZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:55 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/7d49fa2e-a765-4ba7-8d17-3f5d3c8e37c5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '527'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy83ZDQ5ZmEyZS1hNzY1LTRi
+        YTctOGQxNy0zZjVkM2M4ZTM3YzUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDIwOjQ2OjU0Ljk5NjIwNFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTIyVDIwOjQ2OjU1LjExODAxNVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjJUMjA6NDY6NTUuMjcyMzcwWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUtZjRlZmYy
+        NDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzJkZmFmZjUz
+        LWY5ODctNDg3Mi04MjA5LTkxZjgzMDVmYmM4Mi8iXX0=
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:55 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/2dfaff53-f987-4872-8209-91f8305fbc82/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '473'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTIyVDIwOjQ2OjU1LjI2NDYzN1oiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOTM2ODZj
+        YTgtZDliMi00NGZhLWIxZTYtYmRlZTVhOTA2NjdmL3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzJkZmFmZjUzLWY5ODctNDg3Mi04
+        MjA5LTkxZjgzMDVmYmM4Mi8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:55 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/e4e58367-03a1-4953-88cd-e763887e02ee/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85MzY4
+        NmNhOC1kOWIyLTQ0ZmEtYjFlNi1iZGVlNWE5MDY2N2YvIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRmZGEyMjYyLWJiYjMtNGJi
+        OS1hMDM2LTNlMjBkYmQ1MzFiZi8ifQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:55 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/4fda2262-bbb3-4bb9-a036-3e20dbd531bf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '516'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy80ZmRhMjI2Mi1iYmIzLTRi
+        YjktYTAzNi0zZTIwZGJkNTMxYmYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDIwOjQ2OjU1Ljg1MjkyMloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjJUMjA6NDY6NTUuOTU3MTU3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:56 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/4fda2262-bbb3-4bb9-a036-3e20dbd531bf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy80ZmRhMjI2Mi1iYmIzLTRi
+        YjktYTAzNi0zZTIwZGJkNTMxYmYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDIwOjQ2OjU1Ljg1MjkyMloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjJUMjA6NDY6NTUuOTU3MTU3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:56 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/4fda2262-bbb3-4bb9-a036-3e20dbd531bf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy80ZmRhMjI2Mi1iYmIzLTRi
+        YjktYTAzNi0zZTIwZGJkNTMxYmYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDIwOjQ2OjU1Ljg1MjkyMloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjJUMjA6NDY6NTUuOTU3MTU3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:56 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/4fda2262-bbb3-4bb9-a036-3e20dbd531bf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy80ZmRhMjI2Mi1iYmIzLTRi
+        YjktYTAzNi0zZTIwZGJkNTMxYmYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDIwOjQ2OjU1Ljg1MjkyMloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjJUMjA6NDY6NTUuOTU3MTU3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBs
+        ZXRlZCIsInRvdGFsIjoxLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIEFydGlmYWN0cyIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkFzc29jaWF0aW5nIENvbnRlbnQiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:56 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/4fda2262-bbb3-4bb9-a036-3e20dbd531bf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '879'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy80ZmRhMjI2Mi1iYmIzLTRi
+        YjktYTAzNi0zZTIwZGJkNTMxYmYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDIwOjQ2OjU1Ljg1MjkyMloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yMlQyMDo0Njo1NS45NTcxNTda
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTIyVDIwOjQ2OjU2LjU0MTAzNFoi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkzZTg2LTg0MWUtNGUxMC1iMmI1
+        LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Npbmcg
+        VGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvOTM2ODZjYTgtZDliMi00NGZhLWIxZTYtYmRl
+        ZTVhOTA2NjdmL3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:56 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/93686ca8-d9b2-44fa-b1e6-bdee5a90667f/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '1281'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOTM2ODZjYTgt
+        ZDliMi00NGZhLWIxZTYtYmRlZTVhOTA2NjdmL3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIyVDIwOjQ2OjU1Ljk3OTg3NloiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85
+        MzY4NmNhOC1kOWIyLTQ0ZmEtYjFlNi1iZGVlNWE5MDY2N2YvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOTM2
+        ODZjYTgtZDliMi00NGZhLWIxZTYtYmRlZTVhOTA2NjdmL3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvOTM2ODZjYTgtZDliMi00NGZhLWIxZTYtYmRlZTVhOTA2NjdmL3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvOTM2ODZjYTgtZDliMi00NGZhLWIxZTYt
+        YmRlZTVhOTA2NjdmL3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdC10
+        YWciOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvbWFuaWZlc3QtdGFncy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvOTM2ODZjYTgtZDliMi00NGZhLWIxZTYt
+        YmRlZTVhOTA2NjdmL3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzkzNjg2Y2E4LWQ5YjItNDRmYS1iMWU2LWJkZWU1YTkw
+        NjY3Zi92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:56 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/2dfaff53-f987-4872-8209-91f8305fbc82/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzkzNjg2Y2E4LWQ5YjItNDRmYS1iMWU2LWJkZWU1YTkwNjY3Zi92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJkM2E5M2M5LTk1MzUtNDMw
+        NC1hZjVjLTU4ZjJmZjI5NWM5Zi8ifQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:56 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/2d3a93c9-9535-4304-af5c-58f2ff295c9f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:57 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yZDNhOTNjOS05NTM1LTQz
+        MDQtYWY1Yy01OGYyZmYyOTVjOWYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDIwOjQ2OjU2LjkxOTg2M1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yMlQyMDo0Njo1Ny4wNTM3NzVaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQx
+        ZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:57 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/2d3a93c9-9535-4304-af5c-58f2ff295c9f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:57 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yZDNhOTNjOS05NTM1LTQz
+        MDQtYWY1Yy01OGYyZmYyOTVjOWYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDIwOjQ2OjU2LjkxOTg2M1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTIyVDIwOjQ2OjU3LjA1Mzc3NVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjJUMjA6NDY6NTcuMTEyMjgyWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUtY2MxMjUx
+        OGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:57 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/93686ca8-d9b2-44fa-b1e6-bdee5a90667f/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:57 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:57 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/93686ca8-d9b2-44fa-b1e6-bdee5a90667f/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:57 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '793'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy9kMmMzMmUwNS05NzkwLTRmMzUtOWUwZS1kZTI0NzI3YWVkODgv
+        IiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjM5OjM4LjI3NTI5NVoiLCJf
+        dHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2Fw
+        aS92My9hcnRpZmFjdHMvMDk4ZWQ3YzEtNmRhYi00YTM3LTgwZmQtYWUyMzdh
+        MDhlYjc2LyIsImRpZ2VzdCI6InNoYTI1NjphNmVjYmIxNTUzMzUzYTA4OTM2
+        ZjUwYzI3NWIwMTAzODhlZDFiZDZkOWQ4NDc0M2M3ZThlNzQ2OGUyYWNkODJl
+        Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlv
+        bi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwi
+        bGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzcyOGIyN2U4LTk5YzEtNGFjNi1h
+        MTY0LWFiNDdlMTNlZWE4NS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvYmxvYnMvYTgyZTMwNGItYzVjYy00MDQ5LTg0YzgtODA5
+        ZjMwNzE1ZjY3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9i
+        cy81MzZiNTc2MC04YzZiLTQ0YTctYTc5Mi0xYWExMjFhYWQxZDkvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzNkZGFmNDg0LWRkZWMt
+        NGIwMC1hZjEyLWI2Y2ZkNzU1NmE4ZC8iXX1dfQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:57 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/93686ca8-d9b2-44fa-b1e6-bdee5a90667f/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:57 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:57 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifest-tags/?page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/93686ca8-d9b2-44fa-b1e6-bdee5a90667f/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Jul 2019 20:46:58 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '401'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvZTU0NmM4MGItMTk0OS00OWJjLTg5MWYtNDg3MTQ2ZGI4
+        ZDdhLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzozOTozOC4yNzg0MTNa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QtdGFnIiwiX2FydGlmYWN0Ijoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wOThlZDdjMS02ZGFiLTRhMzctODBm
+        ZC1hZTIzN2EwOGViNzYvIiwibmFtZSI6ImxhdGVzdCIsInRhZ2dlZF9tYW5p
+        ZmVzdCI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMv
+        ZDJjMzJlMDUtOTc5MC00ZjM1LTllMGUtZGUyNDcyN2FlZDg4LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 22 Jul 2019 20:46:58 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/5fc530d3-3a1e-49d6-a295-977a7bdbd246/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:50 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY2YWRjYzI2LWJmNjgtNGQ5
+        My1hMjI4LWE1YTYxM2RiMmVjNC8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:50 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/50d53c4a-8db9-442c-b32e-b5aaaf0a67b6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:50 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc5Yjc4MjUyLWY5YWUtNDJj
+        OC1iMTQ4LTQ1Yjc0YWE2NDczZi8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:50 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/815857aa-3a57-4d80-8467-858d87d4b4d8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:50 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UxMmI3MmY0LWIzNGUtNDVi
+        ZS05OTFhLTRjNTU2ZDE2YmYzZi8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:50 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/815857aa-3a57-4d80-8467-858d87d4b4d8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:50 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '23'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:50 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/905e38f9-49a3-4350-b4f5-98da1223273c/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QzOGZjYWVlLTc0NjctNDUy
+        OC04YTNjLWRiNGJiNTJlNzEyNS8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:52 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d38fcaee-7467-4528-8a3c-db4bb52e7125/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '502'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kMzhmY2FlZS03NDY3LTQ1
+        MjgtOGEzYy1kYjRiYjUyZTcxMjUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAxOjUyLjEzMzQzNloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLnJlcG9zaXRvcnkuYWRkX2FuZF9yZW1vdmUi
+        LCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowMTo1Mi4yMjY1OTdaIiwi
+        ZmluaXNoZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJv
+        ciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4
+        ZmMtYzM2YS00MjE2LTgwMjUtZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVs
+        bCwic3Bhd25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJj
+        cmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        LzkwNWUzOGY5LTQ5YTMtNDM1MC1iNGY1LTk4ZGExMjIzMjczYy92ZXJzaW9u
+        cy8xLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:52 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d38fcaee-7467-4528-8a3c-db4bb52e7125/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kMzhmY2FlZS03NDY3LTQ1
+        MjgtOGEzYy1kYjRiYjUyZTcxMjUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAxOjUyLjEzMzQzNloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjAxOjUyLjIyNjU5N1oi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjNUMTM6MDE6NTIuMjY0ODY2WiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUt
+        ZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzkwNWUzOGY5LTQ5YTMtNDM1
+        MC1iNGY1LTk4ZGExMjIzMjczYy92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:52 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/905e38f9-49a3-4350-b4f5-98da1223273c/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOTA1ZTM4Zjkt
+        NDlhMy00MzUwLWI0ZjUtOThkYTEyMjMyNzNjL3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIzVDEzOjAxOjUyLjI0NjY4OVoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:52 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzkwNWUzOGY5LTQ5YTMtNDM1MC1iNGY1LTk4ZGExMjIzMjczYy92ZXJz
+        aW9ucy8xLyIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6
+        YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QwZmJmZDBiLWRlYjktNGE4
+        My1iOGY0LWViNjA4ZTE5NzA0OC8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:52 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d0fbfd0b-deb9-4a83-b8f4-eb608e197048/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kMGZiZmQwYi1kZWI5LTRh
+        ODMtYjhmNC1lYjYwOGUxOTcwNDgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAxOjUyLjcyMDkwM1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowMTo1Mi44MzU2MTJaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2
+        YS00MjE2LTgwMjUtZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:52 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d0fbfd0b-deb9-4a83-b8f4-eb608e197048/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '500'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kMGZiZmQwYi1kZWI5LTRh
+        ODMtYjhmNC1lYjYwOGUxOTcwNDgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAxOjUyLjcyMDkwM1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowMTo1Mi44MzU2MTJaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2
+        YS00MjE2LTgwMjUtZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2Nr
+        ZXIvZG9ja2VyLzUxN2UzY2QxLWQzYWMtNGExZS04MWMzLTZlZDZiNjFjYjQx
+        NC8iXX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:53 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d0fbfd0b-deb9-4a83-b8f4-eb608e197048/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '527'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kMGZiZmQwYi1kZWI5LTRh
+        ODMtYjhmNC1lYjYwOGUxOTcwNDgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAxOjUyLjcyMDkwM1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjAxOjUyLjgzNTYxMloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjNUMTM6MDE6NTMuMDAyODU3WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUtZjRlZmYy
+        NDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzUxN2UzY2Qx
+        LWQzYWMtNGExZS04MWMzLTZlZDZiNjFjYjQxNC8iXX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:53 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/517e3cd1-d3ac-4a1e-81c3-6ed6b61cb414/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '473'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTIzVDEzOjAxOjUyLjk5NDExNVoiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOTA1ZTM4
+        ZjktNDlhMy00MzUwLWI0ZjUtOThkYTEyMjMyNzNjL3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzUxN2UzY2QxLWQzYWMtNGExZS04
+        MWMzLTZlZDZiNjFjYjQxNC8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:53 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/e084b5b2-927b-4ff6-b00c-6684dd581a5b/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85MDVl
+        MzhmOS00OWEzLTQzNTAtYjRmNS05OGRhMTIyMzI3M2MvIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNhOTYxYTFhLWJkN2EtNDZi
+        Yy1hZTlkLWU3NmEzZTRkZjlmZS8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:53 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3a961a1a-bd7a-46bc-ae9d-e76a3e4df9fe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '427'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zYTk2MWExYS1iZDdhLTQ2
+        YmMtYWU5ZC1lNzZhM2U0ZGY5ZmUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAxOjUzLjYwMzY5NloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDE6NTMuNzExMzQ0WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwi
+        Y3JlYXRlZF9yZXNvdXJjZXMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:53 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3a961a1a-bd7a-46bc-ae9d-e76a3e4df9fe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zYTk2MWExYS1iZDdhLTQ2
+        YmMtYWU5ZC1lNzZhM2U0ZGY5ZmUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAxOjUzLjYwMzY5NloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDE6NTMuNzExMzQ0WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:53 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3a961a1a-bd7a-46bc-ae9d-e76a3e4df9fe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:54 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zYTk2MWExYS1iZDdhLTQ2
+        YmMtYWU5ZC1lNzZhM2U0ZGY5ZmUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAxOjUzLjYwMzY5NloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDE6NTMuNzExMzQ0WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:54 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3a961a1a-bd7a-46bc-ae9d-e76a3e4df9fe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:54 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zYTk2MWExYS1iZDdhLTQ2
+        YmMtYWU5ZC1lNzZhM2U0ZGY5ZmUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAxOjUzLjYwMzY5NloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDE6NTMuNzExMzQ0WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:54 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3a961a1a-bd7a-46bc-ae9d-e76a3e4df9fe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:54 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '781'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zYTk2MWExYS1iZDdhLTQ2
+        YmMtYWU5ZC1lNzZhM2U0ZGY5ZmUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAxOjUzLjYwMzY5NloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDE6NTMuNzExMzQ0WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJQcm9jZXNzaW5nIFRhZ3MiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjoxLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
+        d25sb2FkaW5nIEFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jl
+        c291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:54 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3a961a1a-bd7a-46bc-ae9d-e76a3e4df9fe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:54 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '879'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zYTk2MWExYS1iZDdhLTQ2
+        YmMtYWU5ZC1lNzZhM2U0ZGY5ZmUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAxOjUzLjYwMzY5NloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowMTo1My43MTEzNDRa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjAxOjU0LjM1NDMyM1oi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkzZTg2LTg0MWUtNGUxMC1iMmI1
+        LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Npbmcg
+        VGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvOTA1ZTM4ZjktNDlhMy00MzUwLWI0ZjUtOThk
+        YTEyMjMyNzNjL3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:54 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/905e38f9-49a3-4350-b4f5-98da1223273c/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:54 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '1281'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOTA1ZTM4Zjkt
+        NDlhMy00MzUwLWI0ZjUtOThkYTEyMjMyNzNjL3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIzVDEzOjAxOjUzLjczNzMyM1oiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85
+        MDVlMzhmOS00OWEzLTQzNTAtYjRmNS05OGRhMTIyMzI3M2MvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOTA1
+        ZTM4ZjktNDlhMy00MzUwLWI0ZjUtOThkYTEyMjMyNzNjL3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvOTA1ZTM4ZjktNDlhMy00MzUwLWI0ZjUtOThkYTEyMjMyNzNjL3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvOTA1ZTM4ZjktNDlhMy00MzUwLWI0ZjUt
+        OThkYTEyMjMyNzNjL3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzkwNWUzOGY5LTQ5YTMtNDM1MC1iNGY1LTk4ZGExMjIz
+        MjczYy92ZXJzaW9ucy8yLyJ9LCJkb2NrZXIubWFuaWZlc3QtdGFnIjp7ImNv
+        dW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzkwNWUzOGY5LTQ5YTMtNDM1MC1iNGY1LTk4ZGExMjIz
+        MjczYy92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:54 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/517e3cd1-d3ac-4a1e-81c3-6ed6b61cb414/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzkwNWUzOGY5LTQ5YTMtNDM1MC1iNGY1LTk4ZGExMjIzMjczYy92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:54 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAyOTg3M2E3LTZlZTgtNDE2
+        Yi1hYTY4LTljNzlhNjUxMDQyOS8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:54 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/029873a7-6ee8-416b-aa68-9c79a6510429/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:54 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8wMjk4NzNhNy02ZWU4LTQx
+        NmItYWE2OC05Yzc5YTY1MTA0MjkvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAxOjU0LjgzNjAzNFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowMTo1NC45NTI3NDlaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQx
+        ZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:54 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/029873a7-6ee8-416b-aa68-9c79a6510429/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8wMjk4NzNhNy02ZWU4LTQx
+        NmItYWE2OC05Yzc5YTY1MTA0MjkvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAxOjU0LjgzNjAzNFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjAxOjU0Ljk1Mjc0OVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjNUMTM6MDE6NTUuMDI3MjE3WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUtY2MxMjUx
+        OGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:55 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/905e38f9-49a3-4350-b4f5-98da1223273c/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:55 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/905e38f9-49a3-4350-b4f5-98da1223273c/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '793'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy9kMmMzMmUwNS05NzkwLTRmMzUtOWUwZS1kZTI0NzI3YWVkODgv
+        IiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjM5OjM4LjI3NTI5NVoiLCJf
+        dHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2Fw
+        aS92My9hcnRpZmFjdHMvMDk4ZWQ3YzEtNmRhYi00YTM3LTgwZmQtYWUyMzdh
+        MDhlYjc2LyIsImRpZ2VzdCI6InNoYTI1NjphNmVjYmIxNTUzMzUzYTA4OTM2
+        ZjUwYzI3NWIwMTAzODhlZDFiZDZkOWQ4NDc0M2M3ZThlNzQ2OGUyYWNkODJl
+        Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlv
+        bi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwi
+        bGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzcyOGIyN2U4LTk5YzEtNGFjNi1h
+        MTY0LWFiNDdlMTNlZWE4NS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvYmxvYnMvYTgyZTMwNGItYzVjYy00MDQ5LTg0YzgtODA5
+        ZjMwNzE1ZjY3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9i
+        cy81MzZiNTc2MC04YzZiLTQ0YTctYTc5Mi0xYWExMjFhYWQxZDkvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzNkZGFmNDg0LWRkZWMt
+        NGIwMC1hZjEyLWI2Y2ZkNzU1NmE4ZC8iXX1dfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:55 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/905e38f9-49a3-4350-b4f5-98da1223273c/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:55 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifest-tags/?page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/905e38f9-49a3-4350-b4f5-98da1223273c/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:01:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '401'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvZTU0NmM4MGItMTk0OS00OWJjLTg5MWYtNDg3MTQ2ZGI4
+        ZDdhLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzozOTozOC4yNzg0MTNa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QtdGFnIiwiX2FydGlmYWN0Ijoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wOThlZDdjMS02ZGFiLTRhMzctODBm
+        ZC1hZTIzN2EwOGViNzYvIiwibmFtZSI6ImxhdGVzdCIsInRhZ2dlZF9tYW5p
+        ZmVzdCI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMv
+        ZDJjMzJlMDUtOTc5MC00ZjM1LTllMGUtZGUyNDcyN2FlZDg4LyJ9XX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:01:55 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/c7fdd121-79fd-4bee-a665-1ea677c46d05/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:30 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IwYjYxMDFlLTJjM2MtNGI4
+        Ni05Y2YyLWVjMTViMjlkODc3Ny8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:30 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/5b48769e-c4fc-475c-92e9-777b6044fa52/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:30 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVhOTNhNDgyLTMwZjYtNDdm
+        Mi1hOTM1LTUzMmIzYTFjMjg3NC8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:30 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/b30123c4-91a2-4e18-b8ac-2555b63f7ec6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:30 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZiODczMWVmLTZhNzQtNDJj
+        OS05YWQzLTgzYTIxZDY5NGMzNy8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:30 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/b30123c4-91a2-4e18-b8ac-2555b63f7ec6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:30 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '23'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:30 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/5bc969bc-f351-4889-9b1e-3ff75d302399/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:32 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I2Nzk1OTg2LWQ1ZTEtNDY4
+        ZC05NGQ2LWQ5MWZhYTlkYWFkZS8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:32 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/b6795986-d5e1-468d-94d6-d91faa9daade/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:32 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9iNjc5NTk4Ni1kNWUxLTQ2
+        OGQtOTRkNi1kOTFmYWE5ZGFhZGUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjMyLjIwMTExMFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjAyOjMyLjI5MTc0N1oi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjNUMTM6MDI6MzIuMzI4MDU0WiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUt
+        ZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzViYzk2OWJjLWYzNTEtNDg4
+        OS05YjFlLTNmZjc1ZDMwMjM5OS92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:32 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/5bc969bc-f351-4889-9b1e-3ff75d302399/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:32 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNWJjOTY5YmMt
+        ZjM1MS00ODg5LTliMWUtM2ZmNzVkMzAyMzk5L3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIzVDEzOjAyOjMyLjMxMDMxM1oiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:32 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzViYzk2OWJjLWYzNTEtNDg4OS05YjFlLTNmZjc1ZDMwMjM5OS92ZXJz
+        aW9ucy8xLyIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6
+        YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:32 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q5ZmEwZDdmLTNiNjAtNGM1
+        Yi05MGM0LTNkY2NmMTZjMzFiYS8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:32 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d9fa0d7f-3b60-4c5b-90c4-3dccf16c31ba/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:32 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kOWZhMGQ3Zi0zYjYwLTRj
+        NWItOTBjNC0zZGNjZjE2YzMxYmEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjMyLjY2NzI5NVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowMjozMi43NzQ5ODNaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2
+        YS00MjE2LTgwMjUtZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:32 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d9fa0d7f-3b60-4c5b-90c4-3dccf16c31ba/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:32 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '527'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kOWZhMGQ3Zi0zYjYwLTRj
+        NWItOTBjNC0zZGNjZjE2YzMxYmEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjMyLjY2NzI5NVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjAyOjMyLjc3NDk4M1oiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjNUMTM6MDI6MzIuOTQ5NjM3WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUtZjRlZmYy
+        NDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzZkZTQxN2Iw
+        LTEwODQtNDkzMC04ZjY2LWZhNDhkOWEyMjc2NS8iXX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:32 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/6de417b0-1084-4930-8f66-fa48d9a22765/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:33 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '473'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTIzVDEzOjAyOjMyLjk0MTgwN1oiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNWJjOTY5
+        YmMtZjM1MS00ODg5LTliMWUtM2ZmNzVkMzAyMzk5L3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzZkZTQxN2IwLTEwODQtNDkzMC04
+        ZjY2LWZhNDhkOWEyMjc2NS8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:33 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/5c950445-20b8-4884-8cc4-f6ed31408535/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy81YmM5
+        NjliYy1mMzUxLTQ4ODktOWIxZS0zZmY3NWQzMDIzOTkvIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:33 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU2ZGZhMGNjLTM0ZmEtNDQw
+        NC1iNGI1LWY1NDcwOTcyZDQwNi8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:33 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/56dfa0cc-34fa-4404-b4b5-f5470972d406/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:33 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '431'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy81NmRmYTBjYy0zNGZhLTQ0
+        MDQtYjRiNS1mNTQ3MDk3MmQ0MDYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjMzLjUxNzMzN1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDI6MzMuNjI4MDA5WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwi
+        Y3JlYXRlZF9yZXNvdXJjZXMiOltudWxsXX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:33 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/56dfa0cc-34fa-4404-b4b5-f5470972d406/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:33 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy81NmRmYTBjYy0zNGZhLTQ0
+        MDQtYjRiNS1mNTQ3MDk3MmQ0MDYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjMzLjUxNzMzN1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDI6MzMuNjI4MDA5WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:33 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/56dfa0cc-34fa-4404-b4b5-f5470972d406/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:33 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy81NmRmYTBjYy0zNGZhLTQ0
+        MDQtYjRiNS1mNTQ3MDk3MmQ0MDYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjMzLjUxNzMzN1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDI6MzMuNjI4MDA5WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:33 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/56dfa0cc-34fa-4404-b4b5-f5470972d406/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:34 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy81NmRmYTBjYy0zNGZhLTQ0
+        MDQtYjRiNS1mNTQ3MDk3MmQ0MDYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjMzLjUxNzMzN1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDI6MzMuNjI4MDA5WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:34 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/56dfa0cc-34fa-4404-b4b5-f5470972d406/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:34 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '781'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy81NmRmYTBjYy0zNGZhLTQ0
+        MDQtYjRiNS1mNTQ3MDk3MmQ0MDYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjMzLjUxNzMzN1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDI6MzMuNjI4MDA5WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJQcm9jZXNzaW5nIFRhZ3MiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjoxLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
+        d25sb2FkaW5nIEFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jl
+        c291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:34 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/56dfa0cc-34fa-4404-b4b5-f5470972d406/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:34 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '879'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy81NmRmYTBjYy0zNGZhLTQ0
+        MDQtYjRiNS1mNTQ3MDk3MmQ0MDYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjMzLjUxNzMzN1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowMjozMy42MjgwMDla
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjAyOjM0LjI0MTQ4OVoi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkzZTg2LTg0MWUtNGUxMC1iMmI1
+        LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Npbmcg
+        VGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvNWJjOTY5YmMtZjM1MS00ODg5LTliMWUtM2Zm
+        NzVkMzAyMzk5L3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:34 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/5bc969bc-f351-4889-9b1e-3ff75d302399/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:34 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '1281'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNWJjOTY5YmMt
+        ZjM1MS00ODg5LTliMWUtM2ZmNzVkMzAyMzk5L3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIzVDEzOjAyOjMzLjY0NTQ0NloiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy81
+        YmM5NjliYy1mMzUxLTQ4ODktOWIxZS0zZmY3NWQzMDIzOTkvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNWJj
+        OTY5YmMtZjM1MS00ODg5LTliMWUtM2ZmNzVkMzAyMzk5L3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvNWJjOTY5YmMtZjM1MS00ODg5LTliMWUtM2ZmNzVkMzAyMzk5L3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvNWJjOTY5YmMtZjM1MS00ODg5LTliMWUt
+        M2ZmNzVkMzAyMzk5L3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzViYzk2OWJjLWYzNTEtNDg4OS05YjFlLTNmZjc1ZDMw
+        MjM5OS92ZXJzaW9ucy8yLyJ9LCJkb2NrZXIubWFuaWZlc3QtdGFnIjp7ImNv
+        dW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzViYzk2OWJjLWYzNTEtNDg4OS05YjFlLTNmZjc1ZDMw
+        MjM5OS92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:34 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/6de417b0-1084-4930-8f66-fa48d9a22765/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzViYzk2OWJjLWYzNTEtNDg4OS05YjFlLTNmZjc1ZDMwMjM5OS92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:34 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY1Mjk0NDhlLWNlYjMtNGJj
+        Mi05N2FhLTk3MWNiMGU3YmNiZi8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:34 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/6529448e-ceb3-4bc2-97aa-971cb0e7bcbf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:34 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy82NTI5NDQ4ZS1jZWIzLTRi
+        YzItOTdhYS05NzFjYjBlN2JjYmYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjM0LjY0ODM1OFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowMjozNC43NTAwMTBaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2Uw
+        Yy00NDlhLTkzNzgtNDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:34 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/6529448e-ceb3-4bc2-97aa-971cb0e7bcbf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:34 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy82NTI5NDQ4ZS1jZWIzLTRi
+        YzItOTdhYS05NzFjYjBlN2JjYmYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjAyOjM0LjY0ODM1OFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjAyOjM0Ljc1MDAxMFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjNUMTM6MDI6MzQuODA4Mjg3WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2UwYy00NDlhLTkzNzgtNDg3YWZl
+        ZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:34 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/5bc969bc-f351-4889-9b1e-3ff75d302399/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:35 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:35 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/5bc969bc-f351-4889-9b1e-3ff75d302399/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:35 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '793'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy9kMmMzMmUwNS05NzkwLTRmMzUtOWUwZS1kZTI0NzI3YWVkODgv
+        IiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjM5OjM4LjI3NTI5NVoiLCJf
+        dHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2Fw
+        aS92My9hcnRpZmFjdHMvMDk4ZWQ3YzEtNmRhYi00YTM3LTgwZmQtYWUyMzdh
+        MDhlYjc2LyIsImRpZ2VzdCI6InNoYTI1NjphNmVjYmIxNTUzMzUzYTA4OTM2
+        ZjUwYzI3NWIwMTAzODhlZDFiZDZkOWQ4NDc0M2M3ZThlNzQ2OGUyYWNkODJl
+        Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlv
+        bi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwi
+        bGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzcyOGIyN2U4LTk5YzEtNGFjNi1h
+        MTY0LWFiNDdlMTNlZWE4NS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvYmxvYnMvYTgyZTMwNGItYzVjYy00MDQ5LTg0YzgtODA5
+        ZjMwNzE1ZjY3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9i
+        cy81MzZiNTc2MC04YzZiLTQ0YTctYTc5Mi0xYWExMjFhYWQxZDkvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzNkZGFmNDg0LWRkZWMt
+        NGIwMC1hZjEyLWI2Y2ZkNzU1NmE4ZC8iXX1dfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:35 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/5bc969bc-f351-4889-9b1e-3ff75d302399/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:35 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:35 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifest-tags/?page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/5bc969bc-f351-4889-9b1e-3ff75d302399/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:02:35 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '401'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvZTU0NmM4MGItMTk0OS00OWJjLTg5MWYtNDg3MTQ2ZGI4
+        ZDdhLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzozOTozOC4yNzg0MTNa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QtdGFnIiwiX2FydGlmYWN0Ijoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wOThlZDdjMS02ZGFiLTRhMzctODBm
+        ZC1hZTIzN2EwOGViNzYvIiwibmFtZSI6ImxhdGVzdCIsInRhZ2dlZF9tYW5p
+        ZmVzdCI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMv
+        ZDJjMzJlMDUtOTc5MC00ZjM1LTllMGUtZGUyNDcyN2FlZDg4LyJ9XX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:02:35 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/4d841803-2e97-49b8-96a4-9d3ecc28b10e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:59 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM4Y2EyMTcwLWY3ZmYtNDYw
+        Ny1iMjVkLTZmM2VjYzVmNmNjOS8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:59 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/a3a57716-d12b-4584-9c17-3484a2af328d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:03:59 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIwNmQyNjM2LTMyYTYtNGI5
+        OC1iZDlhLWY2ZDE0ZGIyZWI3Zi8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:03:59 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/f8097e1a-baca-437f-b04b-7c15e9e4bcba/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:00 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI1MDA0MmRiLTVkMTgtNGU3
+        NS05ZjllLTZhNWZjYjVlYjhlNi8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:00 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/f8097e1a-baca-437f-b04b-7c15e9e4bcba/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:00 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '23'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:00 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/aaf36d4a-7d10-45a4-a692-f6a2ab1b14cd/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:01 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzMyMGQ3NDVkLTJjYTgtNGM4
+        OC04MjYxLWQ4ZGJmNWE1MmYwNC8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:01 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/320d745d-2ca8-4c88-8261-d8dbf5a52f04/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:01 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '430'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zMjBkNzQ1ZC0yY2E4LTRj
+        ODgtODI2MS1kOGRiZjVhNTJmMDQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA0OjAxLjY1Mzg4NFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLnJlcG9zaXRvcnkuYWRkX2FuZF9yZW1vdmUi
+        LCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowNDowMS43NTY1MTJaIiwi
+        ZmluaXNoZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJv
+        ciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4
+        ZmMtYzM2YS00MjE2LTgwMjUtZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVs
+        bCwic3Bhd25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJj
+        cmVhdGVkX3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:01 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/320d745d-2ca8-4c88-8261-d8dbf5a52f04/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:01 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zMjBkNzQ1ZC0yY2E4LTRj
+        ODgtODI2MS1kOGRiZjVhNTJmMDQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA0OjAxLjY1Mzg4NFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjA0OjAxLjc1NjUxMloi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjNUMTM6MDQ6MDEuNzk4NzcyWiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUt
+        ZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2FhZjM2ZDRhLTdkMTAtNDVh
+        NC1hNjkyLWY2YTJhYjFiMTRjZC92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:01 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/aaf36d4a-7d10-45a4-a692-f6a2ab1b14cd/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYWFmMzZkNGEt
+        N2QxMC00NWE0LWE2OTItZjZhMmFiMWIxNGNkL3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIzVDEzOjA0OjAxLjc3NjkxNFoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:02 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2FhZjM2ZDRhLTdkMTAtNDVhNC1hNjkyLWY2YTJhYjFiMTRjZC92ZXJz
+        aW9ucy8xLyIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6
+        YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJkNzMyYzEzLWRjZDAtNDEy
+        Ny05YTc1LWI1MjgxZmUyODI4NS8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:02 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/2d732c13-dcd0-4127-9a75-b5281fe28285/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yZDczMmMxMy1kY2QwLTQx
+        MjctOWE3NS1iNTI4MWZlMjgyODUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA0OjAyLjI0Mzc1OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowNDowMi4zODE1OTRaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQx
+        ZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:02 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/2d732c13-dcd0-4127-9a75-b5281fe28285/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yZDczMmMxMy1kY2QwLTQx
+        MjctOWE3NS1iNTI4MWZlMjgyODUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA0OjAyLjI0Mzc1OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowNDowMi4zODE1OTRaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQx
+        ZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:02 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/2d732c13-dcd0-4127-9a75-b5281fe28285/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '527'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yZDczMmMxMy1kY2QwLTQx
+        MjctOWE3NS1iNTI4MWZlMjgyODUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA0OjAyLjI0Mzc1OVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjA0OjAyLjM4MTU5NFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjNUMTM6MDQ6MDIuNTM1MDcwWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUtY2MxMjUx
+        OGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyL2Y1MmM0Yzhk
+        LWVjODQtNDhiYS1iODZhLTgyNTRiNGMxMmQwNy8iXX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:02 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/f52c4c8d-ec84-48ba-b86a-8254b4c12d07/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '473'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTIzVDEzOjA0OjAyLjUyNzM2M1oiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYWFmMzZk
+        NGEtN2QxMC00NWE0LWE2OTItZjZhMmFiMWIxNGNkL3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyL2Y1MmM0YzhkLWVjODQtNDhiYS1i
+        ODZhLTgyNTRiNGMxMmQwNy8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:02 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/f94f015a-a885-4058-a16d-44a1411af2eb/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9hYWYz
+        NmQ0YS03ZDEwLTQ1YTQtYTY5Mi1mNmEyYWIxYjE0Y2QvIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhjYzJkYjY4LTBhMmMtNDZk
+        Zi1iOGQwLWI0OTQ2MDk2ODBjZi8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:03 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/8cc2db68-0a2c-46df-b8d0-b494609680cf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '516'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84Y2MyZGI2OC0wYTJjLTQ2
+        ZGYtYjhkMC1iNDk0NjA5NjgwY2YvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA0OjAzLjI0NzE1NloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDQ6MDMuMzUyNjU5WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:03 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/8cc2db68-0a2c-46df-b8d0-b494609680cf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84Y2MyZGI2OC0wYTJjLTQ2
+        ZGYtYjhkMC1iNDk0NjA5NjgwY2YvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA0OjAzLjI0NzE1NloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDQ6MDMuMzUyNjU5WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:03 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/8cc2db68-0a2c-46df-b8d0-b494609680cf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84Y2MyZGI2OC0wYTJjLTQ2
+        ZGYtYjhkMC1iNDk0NjA5NjgwY2YvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA0OjAzLjI0NzE1NloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDQ6MDMuMzUyNjU5WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:03 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/8cc2db68-0a2c-46df-b8d0-b494609680cf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '852'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84Y2MyZGI2OC0wYTJjLTQ2
+        ZGYtYjhkMC1iNDk0NjA5NjgwY2YvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA0OjAzLjI0NzE1NloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDQ6MDMuMzUyNjU5WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBs
+        ZXRlZCIsInRvdGFsIjoxLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IlByb2Nlc3NpbmcgVGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOjEsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoi
+        RG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
+        b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0
+        b3RhbCI6NiwiZG9uZSI6Niwic3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVz
+        b3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYWFmMzZkNGEt
+        N2QxMC00NWE0LWE2OTItZjZhMmFiMWIxNGNkL3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:03 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/8cc2db68-0a2c-46df-b8d0-b494609680cf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '879'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84Y2MyZGI2OC0wYTJjLTQ2
+        ZGYtYjhkMC1iNDk0NjA5NjgwY2YvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA0OjAzLjI0NzE1NloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowNDowMy4zNTI2NTla
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjA0OjAzLjgzNzg5M1oi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTllOGZjLWMzNmEtNDIxNi04MDI1
+        LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Npbmcg
+        VGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvYWFmMzZkNGEtN2QxMC00NWE0LWE2OTItZjZh
+        MmFiMWIxNGNkL3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:04 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/aaf36d4a-7d10-45a4-a692-f6a2ab1b14cd/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '1281'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYWFmMzZkNGEt
+        N2QxMC00NWE0LWE2OTItZjZhMmFiMWIxNGNkL3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIzVDEzOjA0OjAzLjM3MTA4NFoiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9h
+        YWYzNmQ0YS03ZDEwLTQ1YTQtYTY5Mi1mNmEyYWIxYjE0Y2QvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYWFm
+        MzZkNGEtN2QxMC00NWE0LWE2OTItZjZhMmFiMWIxNGNkL3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvYWFmMzZkNGEtN2QxMC00NWE0LWE2OTItZjZhMmFiMWIxNGNkL3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvYWFmMzZkNGEtN2QxMC00NWE0LWE2OTIt
+        ZjZhMmFiMWIxNGNkL3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdC10
+        YWciOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvbWFuaWZlc3QtdGFncy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvYWFmMzZkNGEtN2QxMC00NWE0LWE2OTIt
+        ZjZhMmFiMWIxNGNkL3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2FhZjM2ZDRhLTdkMTAtNDVhNC1hNjkyLWY2YTJhYjFi
+        MTRjZC92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:04 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/f52c4c8d-ec84-48ba-b86a-8254b4c12d07/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2FhZjM2ZDRhLTdkMTAtNDVhNC1hNjkyLWY2YTJhYjFiMTRjZC92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAyYjA1MGE4LWRhODItNDFh
+        ZC1iOTRhLWJiY2U5NGY4NzU4My8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:04 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/02b050a8-da82-41ad-b94a-bbce94f87583/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8wMmIwNTBhOC1kYTgyLTQx
+        YWQtYjk0YS1iYmNlOTRmODc1ODMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA0OjA0LjMzNTg0MloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowNDowNC40NjEzMzZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2Uw
+        Yy00NDlhLTkzNzgtNDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:04 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/02b050a8-da82-41ad-b94a-bbce94f87583/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8wMmIwNTBhOC1kYTgyLTQx
+        YWQtYjk0YS1iYmNlOTRmODc1ODMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA0OjA0LjMzNTg0MloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjA0OjA0LjQ2MTMzNloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjNUMTM6MDQ6MDQuNTIyMjcwWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2UwYy00NDlhLTkzNzgtNDg3YWZl
+        ZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:04 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/aaf36d4a-7d10-45a4-a692-f6a2ab1b14cd/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:04 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/aaf36d4a-7d10-45a4-a692-f6a2ab1b14cd/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '793'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy9kMmMzMmUwNS05NzkwLTRmMzUtOWUwZS1kZTI0NzI3YWVkODgv
+        IiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjM5OjM4LjI3NTI5NVoiLCJf
+        dHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2Fw
+        aS92My9hcnRpZmFjdHMvMDk4ZWQ3YzEtNmRhYi00YTM3LTgwZmQtYWUyMzdh
+        MDhlYjc2LyIsImRpZ2VzdCI6InNoYTI1NjphNmVjYmIxNTUzMzUzYTA4OTM2
+        ZjUwYzI3NWIwMTAzODhlZDFiZDZkOWQ4NDc0M2M3ZThlNzQ2OGUyYWNkODJl
+        Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlv
+        bi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwi
+        bGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzcyOGIyN2U4LTk5YzEtNGFjNi1h
+        MTY0LWFiNDdlMTNlZWE4NS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvYmxvYnMvYTgyZTMwNGItYzVjYy00MDQ5LTg0YzgtODA5
+        ZjMwNzE1ZjY3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9i
+        cy81MzZiNTc2MC04YzZiLTQ0YTctYTc5Mi0xYWExMjFhYWQxZDkvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzNkZGFmNDg0LWRkZWMt
+        NGIwMC1hZjEyLWI2Y2ZkNzU1NmE4ZC8iXX1dfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:04 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/aaf36d4a-7d10-45a4-a692-f6a2ab1b14cd/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:05 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:05 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifest-tags/?page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/aaf36d4a-7d10-45a4-a692-f6a2ab1b14cd/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:04:05 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '401'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvZTU0NmM4MGItMTk0OS00OWJjLTg5MWYtNDg3MTQ2ZGI4
+        ZDdhLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzozOTozOC4yNzg0MTNa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QtdGFnIiwiX2FydGlmYWN0Ijoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wOThlZDdjMS02ZGFiLTRhMzctODBm
+        ZC1hZTIzN2EwOGViNzYvIiwibmFtZSI6ImxhdGVzdCIsInRhZ2dlZF9tYW5p
+        ZmVzdCI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMv
+        ZDJjMzJlMDUtOTc5MC00ZjM1LTllMGUtZGUyNDcyN2FlZDg4LyJ9XX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:04:05 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/aaf36d4a-7d10-45a4-a692-f6a2ab1b14cd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:13 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRhMTgzZDFkLWY3YjUtNGY4
+        ZC1hYWE3LTkyNjMxYWMxNzljZS8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:13 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/f94f015a-a885-4058-a16d-44a1411af2eb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:13 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNhMzBhNTFjLTUzNmYtNDk4
+        Ny04NTk3LWFkMDUwMWQyOTIyNy8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:13 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/f52c4c8d-ec84-48ba-b86a-8254b4c12d07/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:13 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q2YTczOWNkLWRmNDktNDVh
+        My1hM2UzLTllMjlkYTk1MTg1MS8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:13 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/a7096407-d8df-4748-a1c7-66d176f328a6/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZjNzI1MDk5LWQ2MWItNDVi
+        MS1hM2U1LTYwNDc1YzY0ODg5ZC8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:15 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/6c725099-d61b-45b1-a3e5-60475c64889d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '502'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy82YzcyNTA5OS1kNjFiLTQ1
+        YjEtYTNlNS02MDQ3NWM2NDg4OWQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjE1LjA5OTA1OFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLnJlcG9zaXRvcnkuYWRkX2FuZF9yZW1vdmUi
+        LCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowNToxNS4yMDg4ODJaIiwi
+        ZmluaXNoZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJv
+        ciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4
+        ZmMtYzM2YS00MjE2LTgwMjUtZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVs
+        bCwic3Bhd25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJj
+        cmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L2E3MDk2NDA3LWQ4ZGYtNDc0OC1hMWM3LTY2ZDE3NmYzMjhhNi92ZXJzaW9u
+        cy8xLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:15 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/6c725099-d61b-45b1-a3e5-60475c64889d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy82YzcyNTA5OS1kNjFiLTQ1
+        YjEtYTNlNS02MDQ3NWM2NDg4OWQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjE1LjA5OTA1OFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjA1OjE1LjIwODg4Mloi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjNUMTM6MDU6MTUuMjQ3NzMyWiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUt
+        ZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2E3MDk2NDA3LWQ4ZGYtNDc0
+        OC1hMWM3LTY2ZDE3NmYzMjhhNi92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:15 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/a7096407-d8df-4748-a1c7-66d176f328a6/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYTcwOTY0MDct
+        ZDhkZi00NzQ4LWExYzctNjZkMTc2ZjMyOGE2L3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIzVDEzOjA1OjE1LjIyODQ2N1oiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:15 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2E3MDk2NDA3LWQ4ZGYtNDc0OC1hMWM3LTY2ZDE3NmYzMjhhNi92ZXJz
+        aW9ucy8xLyIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6
+        YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNlZTkwNzY3LWFhMjktNDkw
+        Yi05ZjhmLTY2ZDMxOGFhMTk1OC8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:15 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3ee90767-aa29-490b-9f8f-66d318aa1958/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zZWU5MDc2Ny1hYTI5LTQ5
+        MGItOWY4Zi02NmQzMThhYTE5NTgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjE1LjY2NTA5M1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowNToxNS43ODk3NDBaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2Uw
+        Yy00NDlhLTkzNzgtNDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:15 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3ee90767-aa29-490b-9f8f-66d318aa1958/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zZWU5MDc2Ny1hYTI5LTQ5
+        MGItOWY4Zi02NmQzMThhYTE5NTgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjE1LjY2NTA5M1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowNToxNS43ODk3NDBaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2Uw
+        Yy00NDlhLTkzNzgtNDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:15 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3ee90767-aa29-490b-9f8f-66d318aa1958/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:16 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '527'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zZWU5MDc2Ny1hYTI5LTQ5
+        MGItOWY4Zi02NmQzMThhYTE5NTgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjE1LjY2NTA5M1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjA1OjE1Ljc4OTc0MFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjNUMTM6MDU6MTUuOTM4ODA4WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2UwYy00NDlhLTkzNzgtNDg3YWZl
+        ZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyL2I1N2Q5NTRi
+        LTZmY2QtNDlhMi05MGZmLWY0YWNhYzVmMWE2Ny8iXX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:16 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/b57d954b-6fcd-49a2-90ff-f4acac5f1a67/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:16 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '473'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTIzVDEzOjA1OjE1LjkzMDk0MloiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYTcwOTY0
+        MDctZDhkZi00NzQ4LWExYzctNjZkMTc2ZjMyOGE2L3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyL2I1N2Q5NTRiLTZmY2QtNDlhMi05
+        MGZmLWY0YWNhYzVmMWE2Ny8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:16 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/99baa627-903d-427c-87ef-9ed8f437a60e/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9hNzA5
+        NjQwNy1kOGRmLTQ3NDgtYTFjNy02NmQxNzZmMzI4YTYvIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:16 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzc0MGEyNWY5LWY1MTgtNDk2
+        Yi04NWEzLTg2MTZkNTY2ZTZjNi8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:16 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/740a25f9-f518-496b-85a3-8616d566e6c6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:16 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '516'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy83NDBhMjVmOS1mNTE4LTQ5
+        NmItODVhMy04NjE2ZDU2NmU2YzYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjE2LjY0OTE5OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDU6MTYuNzY3MDI1WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:16 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/740a25f9-f518-496b-85a3-8616d566e6c6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:16 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy83NDBhMjVmOS1mNTE4LTQ5
+        NmItODVhMy04NjE2ZDU2NmU2YzYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjE2LjY0OTE5OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDU6MTYuNzY3MDI1WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:16 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/740a25f9-f518-496b-85a3-8616d566e6c6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy83NDBhMjVmOS1mNTE4LTQ5
+        NmItODVhMy04NjE2ZDU2NmU2YzYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjE2LjY0OTE5OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDU6MTYuNzY3MDI1WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:17 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/740a25f9-f518-496b-85a3-8616d566e6c6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy83NDBhMjVmOS1mNTE4LTQ5
+        NmItODVhMy04NjE2ZDU2NmU2YzYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjE2LjY0OTE5OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDU6MTYuNzY3MDI1WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:17 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/740a25f9-f518-496b-85a3-8616d566e6c6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy83NDBhMjVmOS1mNTE4LTQ5
+        NmItODVhMy04NjE2ZDU2NmU2YzYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjE2LjY0OTE5OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjNUMTM6MDU6MTYuNzY3MDI1WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:17 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/740a25f9-f518-496b-85a3-8616d566e6c6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '879'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy83NDBhMjVmOS1mNTE4LTQ5
+        NmItODVhMy04NjE2ZDU2NmU2YzYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjE2LjY0OTE5OVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowNToxNi43NjcwMjVa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjA1OjE3LjQ3NTIzNVoi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkzZTg2LTg0MWUtNGUxMC1iMmI1
+        LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Npbmcg
+        VGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvYTcwOTY0MDctZDhkZi00NzQ4LWExYzctNjZk
+        MTc2ZjMyOGE2L3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:17 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/a7096407-d8df-4748-a1c7-66d176f328a6/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '1281'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYTcwOTY0MDct
+        ZDhkZi00NzQ4LWExYzctNjZkMTc2ZjMyOGE2L3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIzVDEzOjA1OjE2Ljc4NjI5NloiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9h
+        NzA5NjQwNy1kOGRmLTQ3NDgtYTFjNy02NmQxNzZmMzI4YTYvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYTcw
+        OTY0MDctZDhkZi00NzQ4LWExYzctNjZkMTc2ZjMyOGE2L3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvYTcwOTY0MDctZDhkZi00NzQ4LWExYzctNjZkMTc2ZjMyOGE2L3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvbWFuaWZlc3RzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAv
+        YXBpL3YzL3JlcG9zaXRvcmllcy9hNzA5NjQwNy1kOGRmLTQ3NDgtYTFjNy02
+        NmQxNzZmMzI4YTYvdmVyc2lvbnMvMi8ifSwiZG9ja2VyLm1hbmlmZXN0LWJs
+        b2IiOnsiY291bnQiOjQsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvYmxvYnMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2E3MDk2NDA3LWQ4ZGYtNDc0OC1hMWM3LTY2ZDE3NmYz
+        MjhhNi92ZXJzaW9ucy8yLyJ9LCJkb2NrZXIubWFuaWZlc3QtdGFnIjp7ImNv
+        dW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2E3MDk2NDA3LWQ4ZGYtNDc0OC1hMWM3LTY2ZDE3NmYz
+        MjhhNi92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:17 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/b57d954b-6fcd-49a2-90ff-f4acac5f1a67/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2E3MDk2NDA3LWQ4ZGYtNDc0OC1hMWM3LTY2ZDE3NmYzMjhhNi92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ0NWVlZDFkLTE5NDQtNGQ5
+        NC05NGI2LThiZTZiYjkzMjMzZC8ifQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:17 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/445eed1d-1944-4d94-94b6-8be6bb93233d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy80NDVlZWQxZC0xOTQ0LTRk
+        OTQtOTRiNi04YmU2YmI5MzIzM2QvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjE3Ljg1MjU2OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yM1QxMzowNToxNy45NzkxNDdaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQx
+        ZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:17 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/445eed1d-1944-4d94-94b6-8be6bb93233d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563816000/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:18 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy80NDVlZWQxZC0xOTQ0LTRk
+        OTQtOTRiNi04YmU2YmI5MzIzM2QvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIz
+        VDEzOjA1OjE3Ljg1MjU2OVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTIzVDEzOjA1OjE3Ljk3OTE0N1oiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjNUMTM6MDU6MTguMDgxOTc4WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUtY2MxMjUx
+        OGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:18 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/a7096407-d8df-4748-a1c7-66d176f328a6/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:18 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:18 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/a7096407-d8df-4748-a1c7-66d176f328a6/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:18 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '793'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy9kMmMzMmUwNS05NzkwLTRmMzUtOWUwZS1kZTI0NzI3YWVkODgv
+        IiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjM5OjM4LjI3NTI5NVoiLCJf
+        dHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2Fw
+        aS92My9hcnRpZmFjdHMvMDk4ZWQ3YzEtNmRhYi00YTM3LTgwZmQtYWUyMzdh
+        MDhlYjc2LyIsImRpZ2VzdCI6InNoYTI1NjphNmVjYmIxNTUzMzUzYTA4OTM2
+        ZjUwYzI3NWIwMTAzODhlZDFiZDZkOWQ4NDc0M2M3ZThlNzQ2OGUyYWNkODJl
+        Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlv
+        bi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwi
+        bGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzcyOGIyN2U4LTk5YzEtNGFjNi1h
+        MTY0LWFiNDdlMTNlZWE4NS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvYmxvYnMvYTgyZTMwNGItYzVjYy00MDQ5LTg0YzgtODA5
+        ZjMwNzE1ZjY3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9i
+        cy81MzZiNTc2MC04YzZiLTQ0YTctYTc5Mi0xYWExMjFhYWQxZDkvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzNkZGFmNDg0LWRkZWMt
+        NGIwMC1hZjEyLWI2Y2ZkNzU1NmE4ZC8iXX1dfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:18 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/a7096407-d8df-4748-a1c7-66d176f328a6/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:18 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:18 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifest-tags/?page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/a7096407-d8df-4748-a1c7-66d176f328a6/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563801088/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 23 Jul 2019 13:05:18 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '401'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvZTU0NmM4MGItMTk0OS00OWJjLTg5MWYtNDg3MTQ2ZGI4
+        ZDdhLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzozOTozOC4yNzg0MTNa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QtdGFnIiwiX2FydGlmYWN0Ijoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wOThlZDdjMS02ZGFiLTRhMzctODBm
+        ZC1hZTIzN2EwOGViNzYvIiwibmFtZSI6ImxhdGVzdCIsInRhZ2dlZF9tYW5p
+        ZmVzdCI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMv
+        ZDJjMzJlMDUtOTc5MC00ZjM1LTllMGUtZGUyNDcyN2FlZDg4LyJ9XX0=
+    http_version: 
+  recorded_at: Tue, 23 Jul 2019 13:05:18 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/7600dcb6-9f6b-4b38-957d-9bdb20ef941f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:32:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY5MTY2ZWI3LTllZmUtNGFm
+        ZS04YzQ4LTBhZmY5MjVkNmZiYi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:32:04 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/7d15052a-bc84-467c-a965-b10b920b3536/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:32:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE4YTJmOTk0LTEwODQtNGVl
+        ZC04N2QyLWYyOTUxMDk3Y2JhNC8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:32:04 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/c54df0b0-2e01-42a0-8de0-5a48c3cd9a8b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:32:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MxZGNjNGY4LWRlNWItNDQz
+        OS05MTQ3LTZlYTY1NDM2YTAxNC8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:32:04 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/c54df0b0-2e01-42a0-8de0-5a48c3cd9a8b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:32:05 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '23'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:32:05 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/9d9402a0-24c0-43d7-9b68-9fadc5541e09/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:32:05 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlhMzQzNWM2LWJlYWUtNDk1
+        ZS1hNmRjLTBiMmQwOGM0YTkwYi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:32:05 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/f5255599-6c11-49ba-8e84-a4a1db1fbba4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:32:05 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE5NjM1OGFhLWExOGUtNDNk
+        YS1hMzhmLTc1OTkyODc4NGUzZi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:32:05 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/f5255599-6c11-49ba-8e84-a4a1db1fbba4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:32:05 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '23'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:32:05 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/399e0dce-24ed-47d2-8ca8-f67d4ac3e3ff/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:49 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIyNTliMTJhLWRkODgtNGVi
+        Yy04M2ZiLWFlNzU0ZDg4NzJjMi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:49 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/5124aa76-557f-4f13-bc22-0341769d1c18/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:49 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q2NjUyMDQ4LTc0ZDktNDQ3
+        MS05MjBjLWVmOTI3YTQxNzg4OS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:49 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/ad0e361e-320e-4ae0-b5a1-4b40448fb90a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:50 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEyNTNhNDZjLTMxNDAtNDll
+        My04NzU1LTAwOTYwMTE3OGEyMi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:50 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/ad0e361e-320e-4ae0-b5a1-4b40448fb90a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:50 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '23'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:50 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/cdd6fe15-988f-411d-a0b4-8d85952d47ad/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:51 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU5NTc1NTM3LWZjMmMtNDYz
+        NC05Y2MyLWQyNGI0YzRlNjUwYi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:51 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/59575537-fc2c-4634-9cc2-d24b4c4e650b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:51 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '502'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy81OTU3NTUzNy1mYzJjLTQ2
+        MzQtOWNjMi1kMjRiNGM0ZTY1MGIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjUxLjU0NzM0MloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLnJlcG9zaXRvcnkuYWRkX2FuZF9yZW1vdmUi
+        LCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozNDo1MS42NTczOTdaIiwi
+        ZmluaXNoZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJv
+        ciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcy
+        YWItM2UwYy00NDlhLTkzNzgtNDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVs
+        bCwic3Bhd25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJj
+        cmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L2NkZDZmZTE1LTk4OGYtNDExZC1hMGI0LThkODU5NTJkNDdhZC92ZXJzaW9u
+        cy8xLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:51 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/59575537-fc2c-4634-9cc2-d24b4c4e650b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:51 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy81OTU3NTUzNy1mYzJjLTQ2
+        MzQtOWNjMi1kMjRiNGM0ZTY1MGIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjUxLjU0NzM0MloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM0OjUxLjY1NzM5N1oi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjRUMTY6MzQ6NTEuNjg4NjkyWiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2UwYy00NDlhLTkzNzgt
+        NDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NkZDZmZTE1LTk4OGYtNDEx
+        ZC1hMGI0LThkODU5NTJkNDdhZC92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:51 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/cdd6fe15-988f-411d-a0b4-8d85952d47ad/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:51 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY2RkNmZlMTUt
+        OTg4Zi00MTFkLWEwYjQtOGQ4NTk1MmQ0N2FkL3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI0VDE2OjM0OjUxLjY3MjEyOFoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:51 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19E
+        b2NrZXJfMSIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2NkZDZmZTE1LTk4OGYtNDExZC1h
+        MGI0LThkODU5NTJkNDdhZC92ZXJzaW9ucy8xLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFmZGVkZGYzLWQ2ZDMtNDcz
+        ZS05ZjFkLTIwYTY3OWNiZWFkMC8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:52 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/1fdeddf3-d6d3-473e-9f1d-20a679cbead0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '395'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8xZmRlZGRmMy1kNmQzLTQ3
+        M2UtOWYxZC0yMGE2NzljYmVhZDAvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjUyLjEyNTY0NFoiLCJzdGF0ZSI6IndhaXRpbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjpudWxsLCJmaW5pc2hlZF9hdCI6bnVsbCwibm9uX2ZhdGFsX2Vy
+        cm9ycyI6W10sImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
+        d29ya2Vycy8wZjk5ZThmYy1jMzZhLTQyMTYtODAyNS1mNGVmZjI0NWFkNjYv
+        IiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jlc3Nf
+        cmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpbXX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:52 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/1fdeddf3-d6d3-473e-9f1d-20a679cbead0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8xZmRlZGRmMy1kNmQzLTQ3
+        M2UtOWYxZC0yMGE2NzljYmVhZDAvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjUyLjEyNTY0NFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozNDo1Mi4yNzIyNzlaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2
+        YS00MjE2LTgwMjUtZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:52 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/1fdeddf3-d6d3-473e-9f1d-20a679cbead0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '527'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8xZmRlZGRmMy1kNmQzLTQ3
+        M2UtOWYxZC0yMGE2NzljYmVhZDAvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjUyLjEyNTY0NFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM0OjUyLjI3MjI3OVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjRUMTY6MzQ6NTIuNDI1MDc0WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUtZjRlZmYy
+        NDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzMwMDViMDgz
+        LTlmOWUtNGMyOC04OWYwLTgyMDkzMzA3Y2M2Ni8iXX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:52 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/3005b083-9f9e-4c28-89f0-82093307cc66/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '290'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTI0VDE2OjM0OjUyLjQxNTg0M1oiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY2RkNmZl
+        MTUtOTg4Zi00MTFkLWEwYjQtOGQ4NTk1MmQ0N2FkL3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzMwMDViMDgzLTlmOWUtNGMyOC04
+        OWYwLTgyMDkzMzA3Y2M2Ni8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:52 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/9f0876de-48e9-47fa-8cda-8cd06db1bb61/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9jZGQ2
+        ZmUxNS05ODhmLTQxMWQtYTBiNC04ZDg1OTUyZDQ3YWQvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkzYjQzMjEzLWU5NzctNDIw
+        Mi1hNzVhLTU1MWNlZThlYWYzNC8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:52 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/93b43213-e977-4202-a75a-551cee8eaf34/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '427'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85M2I0MzIxMy1lOTc3LTQy
+        MDItYTc1YS01NTFjZWU4ZWFmMzQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjUyLjk5MDkwNloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6MzQ6NTMuMTAwMjc3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwi
+        Y3JlYXRlZF9yZXNvdXJjZXMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:53 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/93b43213-e977-4202-a75a-551cee8eaf34/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85M2I0MzIxMy1lOTc3LTQy
+        MDItYTc1YS01NTFjZWU4ZWFmMzQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjUyLjk5MDkwNloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6MzQ6NTMuMTAwMjc3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:53 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/93b43213-e977-4202-a75a-551cee8eaf34/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85M2I0MzIxMy1lOTc3LTQy
+        MDItYTc1YS01NTFjZWU4ZWFmMzQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjUyLjk5MDkwNloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6MzQ6NTMuMTAwMjc3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:53 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/93b43213-e977-4202-a75a-551cee8eaf34/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85M2I0MzIxMy1lOTc3LTQy
+        MDItYTc1YS01NTFjZWU4ZWFmMzQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjUyLjk5MDkwNloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6MzQ6NTMuMTAwMjc3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:53 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/93b43213-e977-4202-a75a-551cee8eaf34/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '781'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85M2I0MzIxMy1lOTc3LTQy
+        MDItYTc1YS01NTFjZWU4ZWFmMzQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjUyLjk5MDkwNloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6MzQ6NTMuMTAwMjc3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJQcm9jZXNzaW5nIFRhZ3MiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjoxLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
+        d25sb2FkaW5nIEFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jl
+        c291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:53 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/93b43213-e977-4202-a75a-551cee8eaf34/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '879'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85M2I0MzIxMy1lOTc3LTQy
+        MDItYTc1YS01NTFjZWU4ZWFmMzQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjUyLjk5MDkwNloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozNDo1My4xMDAyNzda
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM0OjUzLjczNzc0MFoi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3MmFiLTNlMGMtNDQ5YS05Mzc4
+        LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Npbmcg
+        VGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvY2RkNmZlMTUtOTg4Zi00MTFkLWEwYjQtOGQ4
+        NTk1MmQ0N2FkL3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:53 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/cdd6fe15-988f-411d-a0b4-8d85952d47ad/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:54 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '1281'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY2RkNmZlMTUt
+        OTg4Zi00MTFkLWEwYjQtOGQ4NTk1MmQ0N2FkL3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI0VDE2OjM0OjUzLjEyNDcwM1oiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9j
+        ZGQ2ZmUxNS05ODhmLTQxMWQtYTBiNC04ZDg1OTUyZDQ3YWQvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY2Rk
+        NmZlMTUtOTg4Zi00MTFkLWEwYjQtOGQ4NTk1MmQ0N2FkL3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvY2RkNmZlMTUtOTg4Zi00MTFkLWEwYjQtOGQ4NTk1MmQ0N2FkL3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvY2RkNmZlMTUtOTg4Zi00MTFkLWEwYjQt
+        OGQ4NTk1MmQ0N2FkL3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2NkZDZmZTE1LTk4OGYtNDExZC1hMGI0LThkODU5NTJk
+        NDdhZC92ZXJzaW9ucy8yLyJ9LCJkb2NrZXIubWFuaWZlc3QtdGFnIjp7ImNv
+        dW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2NkZDZmZTE1LTk4OGYtNDExZC1hMGI0LThkODU5NTJk
+        NDdhZC92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:54 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/3005b083-9f9e-4c28-89f0-82093307cc66/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2NkZDZmZTE1LTk4OGYtNDExZC1hMGI0LThkODU5NTJkNDdhZC92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:54 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YzZWM5MTk1LTZiODUtNDM2
+        Ny1iODFiLTU0ZDBkMTk5MzI3YS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:54 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/f3ec9195-6b85-4367-b81b-54d0d199327a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:54 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '395'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9mM2VjOTE5NS02Yjg1LTQz
+        NjctYjgxYi01NGQwZDE5OTMyN2EvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjU0LjIyODg3MloiLCJzdGF0ZSI6IndhaXRpbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjpudWxsLCJmaW5pc2hlZF9hdCI6bnVsbCwibm9uX2ZhdGFsX2Vy
+        cm9ycyI6W10sImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
+        d29ya2Vycy8wZjk5ZThmYy1jMzZhLTQyMTYtODAyNS1mNGVmZjI0NWFkNjYv
+        IiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jlc3Nf
+        cmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpbXX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:54 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/f3ec9195-6b85-4367-b81b-54d0d199327a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:34:54 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9mM2VjOTE5NS02Yjg1LTQz
+        NjctYjgxYi01NGQwZDE5OTMyN2EvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM0OjU0LjIyODg3MloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM0OjU0LjM3MTAwNloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjRUMTY6MzQ6NTQuNDQ1MDU5WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUtZjRlZmYy
+        NDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:34:54 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/52ba30df-33df-46f0-93bd-4a1cca6a5b61/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U4Y2MwNWI0LTlmZjktNDc4
+        Yy04N2ZmLTQwMzUxNDJkZTJhMC8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:25 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/7b1a39c2-d252-45ca-97cb-7624e8092d70/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FjODVjN2JiLWFkZjUtNDlm
+        Zi1iZjU1LTIzNTNiMzhjYWI1OS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:25 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/64d5fc46-f2d9-4c70-903b-8525d002cb24/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:26 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFjNmM1MWYxLTE5OTctNDUx
+        MC1hMjM1LWIwOGU4ZTRiODRiZi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:26 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/fb874738-ef41-4f54-932a-e8952b78c3ad/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:27 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgyNjhlYmNjLTU2YjQtNGI2
+        OS1hZWVjLTBiZDJhNmNiYjQyOC8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:27 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/8268ebcc-56b4-4b69-aeec-0bd2a6cbb428/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:27 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84MjY4ZWJjYy01NmI0LTRi
+        NjktYWVlYy0wYmQyYTZjYmI0MjgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjI3LjU5MzUzMVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM2OjI3LjY5NDM2Nloi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjRUMTY6MzY6MjcuNzM0MzAzWiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUt
+        Y2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZiODc0NzM4LWVmNDEtNGY1
+        NC05MzJhLWU4OTUyYjc4YzNhZC92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:27 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/fb874738-ef41-4f54-932a-e8952b78c3ad/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:27 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmI4NzQ3Mzgt
+        ZWY0MS00ZjU0LTkzMmEtZTg5NTJiNzhjM2FkL3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI0VDE2OjM2OjI3LjcxNDgyOVoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:27 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19E
+        b2NrZXJfMSIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2ZiODc0NzM4LWVmNDEtNGY1NC05
+        MzJhLWU4OTUyYjc4YzNhZC92ZXJzaW9ucy8xLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNmNTczYjVjLTUwNTktNDI5
+        Mi1hYmJjLWJjM2FjMTIxNmQ1Mi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:28 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3f573b5c-5059-4292-abbc-bc3ac1216d52/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zZjU3M2I1Yy01MDU5LTQy
+        OTItYWJiYy1iYzNhYzEyMTZkNTIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjI4LjA1NjI5MVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozNjoyOC4xNzc1MjdaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQx
+        ZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:28 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3f573b5c-5059-4292-abbc-bc3ac1216d52/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '500'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zZjU3M2I1Yy01MDU5LTQy
+        OTItYWJiYy1iYzNhYzEyMTZkNTIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjI4LjA1NjI5MVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozNjoyOC4xNzc1MjdaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQx
+        ZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2Nr
+        ZXIvZG9ja2VyL2U5ZmFlMjE2LTYzYTYtNDI1My1iOGM3LTYxODhjODFmMGUy
+        YS8iXX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:28 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/3f573b5c-5059-4292-abbc-bc3ac1216d52/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '527'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zZjU3M2I1Yy01MDU5LTQy
+        OTItYWJiYy1iYzNhYzEyMTZkNTIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjI4LjA1NjI5MVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM2OjI4LjE3NzUyN1oiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjRUMTY6MzY6MjguMzIyMjQyWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUtY2MxMjUx
+        OGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyL2U5ZmFlMjE2
+        LTYzYTYtNDI1My1iOGM3LTYxODhjODFmMGUyYS8iXX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:28 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/e9fae216-63a6-4253-b8c7-6188c81f0e2a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '290'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTI0VDE2OjM2OjI4LjMxNDYyNloiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmI4NzQ3
+        MzgtZWY0MS00ZjU0LTkzMmEtZTg5NTJiNzhjM2FkL3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyL2U5ZmFlMjE2LTYzYTYtNDI1My1i
+        OGM3LTYxODhjODFmMGUyYS8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:28 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/5fd57129-3c75-4e1d-b8a9-6a23f90a31d6/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9mYjg3
+        NDczOC1lZjQxLTRmNTQtOTMyYS1lODk1MmI3OGMzYWQvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI1NzQ5Y2ZmLTU3MzktNDE0
+        OC04NzllLWM5OTE0YmQ5MzI5YS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:28 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/25749cff-5739-4148-879e-c9914bd9329a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '427'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yNTc0OWNmZi01NzM5LTQx
+        NDgtODc5ZS1jOTkxNGJkOTMyOWEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjI4Ljk4ODgzMloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6MzY6MjkuMDg1NjQyWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwi
+        Y3JlYXRlZF9yZXNvdXJjZXMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:29 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/25749cff-5739-4148-879e-c9914bd9329a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yNTc0OWNmZi01NzM5LTQx
+        NDgtODc5ZS1jOTkxNGJkOTMyOWEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjI4Ljk4ODgzMloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6MzY6MjkuMDg1NjQyWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:29 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/25749cff-5739-4148-879e-c9914bd9329a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yNTc0OWNmZi01NzM5LTQx
+        NDgtODc5ZS1jOTkxNGJkOTMyOWEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjI4Ljk4ODgzMloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6MzY6MjkuMDg1NjQyWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:29 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/25749cff-5739-4148-879e-c9914bd9329a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yNTc0OWNmZi01NzM5LTQx
+        NDgtODc5ZS1jOTkxNGJkOTMyOWEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjI4Ljk4ODgzMloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6MzY6MjkuMDg1NjQyWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:29 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/25749cff-5739-4148-879e-c9914bd9329a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '879'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yNTc0OWNmZi01NzM5LTQx
+        NDgtODc5ZS1jOTkxNGJkOTMyOWEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjI4Ljk4ODgzMloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozNjoyOS4wODU2NDJa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM2OjI5LjY0Mzc4Nloi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTllOGZjLWMzNmEtNDIxNi04MDI1
+        LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Npbmcg
+        VGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvZmI4NzQ3MzgtZWY0MS00ZjU0LTkzMmEtZTg5
+        NTJiNzhjM2FkL3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:29 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/fb874738-ef41-4f54-932a-e8952b78c3ad/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '1281'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmI4NzQ3Mzgt
+        ZWY0MS00ZjU0LTkzMmEtZTg5NTJiNzhjM2FkL3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI0VDE2OjM2OjI5LjExNDI3NloiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9m
+        Yjg3NDczOC1lZjQxLTRmNTQtOTMyYS1lODk1MmI3OGMzYWQvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZmI4
+        NzQ3MzgtZWY0MS00ZjU0LTkzMmEtZTg5NTJiNzhjM2FkL3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvZmI4NzQ3MzgtZWY0MS00ZjU0LTkzMmEtZTg5NTJiNzhjM2FkL3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZmI4NzQ3MzgtZWY0MS00ZjU0LTkzMmEt
+        ZTg5NTJiNzhjM2FkL3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2ZiODc0NzM4LWVmNDEtNGY1NC05MzJhLWU4OTUyYjc4
+        YzNhZC92ZXJzaW9ucy8yLyJ9LCJkb2NrZXIubWFuaWZlc3QtdGFnIjp7ImNv
+        dW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2ZiODc0NzM4LWVmNDEtNGY1NC05MzJhLWU4OTUyYjc4
+        YzNhZC92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:29 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/e9fae216-63a6-4253-b8c7-6188c81f0e2a/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2ZiODc0NzM4LWVmNDEtNGY1NC05MzJhLWU4OTUyYjc4YzNhZC92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:30 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q2Yjk4NjVkLTMyNzQtNGIw
+        Ni1hMzFmLTIxODdlN2I2ZGYxMi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:30 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d6b9865d-3274-4b06-a31f-2187e7b6df12/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:30 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '395'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kNmI5ODY1ZC0zMjc0LTRi
+        MDYtYTMxZi0yMTg3ZTdiNmRmMTIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjMwLjA2OTIxM1oiLCJzdGF0ZSI6IndhaXRpbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjpudWxsLCJmaW5pc2hlZF9hdCI6bnVsbCwibm9uX2ZhdGFsX2Vy
+        cm9ycyI6W10sImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
+        d29ya2Vycy8wNmJkNzJhYi0zZTBjLTQ0OWEtOTM3OC00ODdhZmVlMTllYTUv
+        IiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jlc3Nf
+        cmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpbXX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:30 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/d6b9865d-3274-4b06-a31f-2187e7b6df12/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:36:30 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kNmI5ODY1ZC0zMjc0LTRi
+        MDYtYTMxZi0yMTg3ZTdiNmRmMTIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM2OjMwLjA2OTIxM1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM2OjMwLjIwMTcxMloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjRUMTY6MzY6MzAuMjYyNzQxWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2UwYy00NDlhLTkzNzgtNDg3YWZl
+        ZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:36:30 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/7e75dcbf-5ba9-42a0-aa8f-002942468a11/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QxOGI4NjYwLWQyODctNDMw
+        Yy1iMGI4LWRhZTVmNjYzMmY5Ni8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:17 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/61189ffb-ad18-48b9-997e-0944e58502a3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JhN2UwOGJmLTU1YTItNDI2
+        ZS1hZjVkLWY4YjFhZTgxYTAwYi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:17 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/26fa189e-7044-457d-9a0d-78e751380b2d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y0ZGFiNzQ2LWU1OWMtNGFi
+        Mi1iYTIwLTA5NjAwN2FiNDg2Yi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:17 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/77f0dab4-6871-4a09-a791-9bef077d2bde/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:19 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZhMzY0NGMzLWEzYWMtNDAz
+        NC04NjI0LTdiYTdkZWEzMjRjZS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:19 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/fa3644c3-a3ac-4034-8624-7ba7dea324ce/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:19 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9mYTM2NDRjMy1hM2FjLTQw
+        MzQtODYyNC03YmE3ZGVhMzI0Y2UvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjE5LjM5OTc2M1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM3OjE5LjQ5MjY5Nloi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzc6MTkuNTM4ODU3WiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUt
+        Y2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzc3ZjBkYWI0LTY4NzEtNGEw
+        OS1hNzkxLTliZWYwNzdkMmJkZS92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:19 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/77f0dab4-6871-4a09-a791-9bef077d2bde/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:19 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNzdmMGRhYjQt
+        Njg3MS00YTA5LWE3OTEtOWJlZjA3N2QyYmRlL3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI0VDE2OjM3OjE5LjUxNjAwN1oiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:19 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19E
+        b2NrZXJfMSIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzc3ZjBkYWI0LTY4NzEtNGEwOS1h
+        NzkxLTliZWYwNzdkMmJkZS92ZXJzaW9ucy8xLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:19 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJkOGE0ZGY4LTcwOTctNGQ5
+        ZC1hMWU2LTc3ZGUxYThlNWRhZi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:19 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/2d8a4df8-7097-4d9d-a1e6-77de1a8e5daf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:20 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yZDhhNGRmOC03MDk3LTRk
+        OWQtYTFlNi03N2RlMWE4ZTVkYWYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjE5Ljg1NzA5MloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozNzoxOS45ODMyMjhaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2Uw
+        Yy00NDlhLTkzNzgtNDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:20 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/2d8a4df8-7097-4d9d-a1e6-77de1a8e5daf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:20 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '527'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yZDhhNGRmOC03MDk3LTRk
+        OWQtYTFlNi03N2RlMWE4ZTVkYWYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjE5Ljg1NzA5MloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM3OjE5Ljk4MzIyOFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzc6MjAuMTMzNTQxWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2UwYy00NDlhLTkzNzgtNDg3YWZl
+        ZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyL2FhMTFjNTM2
+        LWIyMjItNDNjMC05MWYwLTk1MDllZTFlYWE0ZC8iXX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:20 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/aa11c536-b222-43c0-91f0-9509ee1eaa4d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:20 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '285'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTI0VDE2OjM3OjIwLjEyNTcxNFoiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNzdmMGRh
+        YjQtNjg3MS00YTA5LWE3OTEtOWJlZjA3N2QyYmRlL3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyL2FhMTFjNTM2LWIyMjItNDNjMC05
+        MWYwLTk1MDllZTFlYWE0ZC8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:20 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/59cd798d-de0a-464f-83c8-512f4b85b98c/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy83N2Yw
+        ZGFiNC02ODcxLTRhMDktYTc5MS05YmVmMDc3ZDJiZGUvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:20 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAwNDRmNmQ5LTk3MjYtNDRi
+        Zi04NmUzLWQwMTc4YjY1MGI2Mi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:20 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/0044f6d9-9726-44bf-86e3-d0178b650b62/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:20 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '427'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8wMDQ0ZjZkOS05NzI2LTQ0
+        YmYtODZlMy1kMDE3OGI2NTBiNjIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjIwLjc1NTMzNloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzc6MjAuODczNjYxWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwi
+        Y3JlYXRlZF9yZXNvdXJjZXMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:20 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/0044f6d9-9726-44bf-86e3-d0178b650b62/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8wMDQ0ZjZkOS05NzI2LTQ0
+        YmYtODZlMy1kMDE3OGI2NTBiNjIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjIwLjc1NTMzNloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzc6MjAuODczNjYxWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:21 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/0044f6d9-9726-44bf-86e3-d0178b650b62/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8wMDQ0ZjZkOS05NzI2LTQ0
+        YmYtODZlMy1kMDE3OGI2NTBiNjIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjIwLjc1NTMzNloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzc6MjAuODczNjYxWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:21 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/0044f6d9-9726-44bf-86e3-d0178b650b62/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8wMDQ0ZjZkOS05NzI2LTQ0
+        YmYtODZlMy1kMDE3OGI2NTBiNjIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjIwLjc1NTMzNloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzc6MjAuODczNjYxWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:21 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/0044f6d9-9726-44bf-86e3-d0178b650b62/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '781'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8wMDQ0ZjZkOS05NzI2LTQ0
+        YmYtODZlMy1kMDE3OGI2NTBiNjIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjIwLjc1NTMzNloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzc6MjAuODczNjYxWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiUHJvY2Vzc2luZyBUYWdzIiwic3RhdGUiOiJjb21wbGV0ZWQi
+        LCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2Ui
+        OiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwidG90
+        YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoi
+        RG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjoxLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
+        d25sb2FkaW5nIEFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jl
+        c291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:21 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/0044f6d9-9726-44bf-86e3-d0178b650b62/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '879'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8wMDQ0ZjZkOS05NzI2LTQ0
+        YmYtODZlMy1kMDE3OGI2NTBiNjIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjIwLjc1NTMzNloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozNzoyMC44NzM2NjFa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM3OjIxLjUyMDA1M1oi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTllOGZjLWMzNmEtNDIxNi04MDI1
+        LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiUHJvY2Vzc2lu
+        ZyBUYWdzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6
+        MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyB0YWcg
+        bGlzdCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvNzdmMGRhYjQtNjg3MS00YTA5LWE3OTEtOWJl
+        ZjA3N2QyYmRlL3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:21 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/77f0dab4-6871-4a09-a791-9bef077d2bde/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '1281'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNzdmMGRhYjQt
+        Njg3MS00YTA5LWE3OTEtOWJlZjA3N2QyYmRlL3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI0VDE2OjM3OjIwLjkwNTU4OVoiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy83
+        N2YwZGFiNC02ODcxLTRhMDktYTc5MS05YmVmMDc3ZDJiZGUvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNzdm
+        MGRhYjQtNjg3MS00YTA5LWE3OTEtOWJlZjA3N2QyYmRlL3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvNzdmMGRhYjQtNjg3MS00YTA5LWE3OTEtOWJlZjA3N2QyYmRlL3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvNzdmMGRhYjQtNjg3MS00YTA5LWE3OTEt
+        OWJlZjA3N2QyYmRlL3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzc3ZjBkYWI0LTY4NzEtNGEwOS1hNzkxLTliZWYwNzdk
+        MmJkZS92ZXJzaW9ucy8yLyJ9LCJkb2NrZXIubWFuaWZlc3QtdGFnIjp7ImNv
+        dW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzc3ZjBkYWI0LTY4NzEtNGEwOS1hNzkxLTliZWYwNzdk
+        MmJkZS92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:21 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/aa11c536-b222-43c0-91f0-9509ee1eaa4d/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzc3ZjBkYWI0LTY4NzEtNGEwOS1hNzkxLTliZWYwNzdkMmJkZS92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NkY2RkNjg2LTI0MmMtNGM5
+        ZC1hMzljLTU0N2I2NzBmMGFiNi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:21 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/cdcdd686-242c-4c9d-a39c-547b670f0ab6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jZGNkZDY4Ni0yNDJjLTRj
+        OWQtYTM5Yy01NDdiNjcwZjBhYjYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjIxLjk0Njg3OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozNzoyMi4wNjg3MTVaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQx
+        ZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:22 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/cdcdd686-242c-4c9d-a39c-547b670f0ab6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:37:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jZGNkZDY4Ni0yNDJjLTRj
+        OWQtYTM5Yy01NDdiNjcwZjBhYjYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM3OjIxLjk0Njg3OVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM3OjIyLjA2ODcxNVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzc6MjIuMTQ0MzIzWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUtY2MxMjUx
+        OGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:37:22 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/a4be8757-25a9-409e-b6e6-59f1a92c741c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:37 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA4YWNlYzQ3LTA2NDItNDgw
+        Zi04YzA2LTdhOTg1ZDk5M2ZmMi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:37 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:37 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '352'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlbW90ZXMvZG9ja2VyL2Rv
+        Y2tlci9hODMwOTljNC02M2I4LTQ0ZjktOGEzNS1hNGQxMTIyYjZkMjcvIiwi
+        X2NyZWF0ZWQiOiIyMDE5LTA3LTI0VDE2OjM5OjMxLjExNzk4NVoiLCJfdHlw
+        ZSI6ImRvY2tlci5kb2NrZXIiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        b24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInVybCI6Imh0dHBzOi8vcmVn
+        aXN0cnktMS5kb2NrZXIuaW8vIiwic3NsX2NhX2NlcnRpZmljYXRlIjpudWxs
+        LCJzc2xfY2xpZW50X2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2tl
+        eSI6bnVsbCwic3NsX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVs
+        bCwiX2xhc3RfdXBkYXRlZCI6IjIwMTktMDctMjRUMTY6Mzk6MzEuMTE4MDA5
+        WiIsImRvd25sb2FkX2NvbmN1cnJlbmN5IjoyMCwicG9saWN5IjoiaW1tZWRp
+        YXRlIiwidXBzdHJlYW1fbmFtZSI6ImZlZG9yYS9zc2giLCJ3aGl0ZWxpc3Rf
+        dGFncyI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:37 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/a83099c4-63b8-44f9-8a35-a4d1122b6d27/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:37 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNmZmYxNzU0LTVjNDQtNDhi
+        Ny04NzMxLWM4NzM4Y2MyMTYxZS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:37 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:37 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '280'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJh
+        cnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5IjpudWxsLCJfY3JlYXRl
+        ZCI6IjIwMTktMDctMjRUMTY6Mzk6MzIuMjQ3ODQ3WiIsIm5hbWUiOiJEZWZh
+        dWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0RvY2tlcl8xIiwicmVw
+        b3NpdG9yeV92ZXJzaW9uIjpudWxsLCJjb250ZW50X2d1YXJkIjpudWxsLCJf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2RvY2tlci9kb2Nr
+        ZXIvYjRkMDgzMTMtNDAxOC00ZjBiLThmYTYtMThhMTJiZDhlZDVlLyIsInJl
+        Z2lzdHJ5X3BhdGgiOiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29t
+        L0RlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRG9ja2VyXzEi
+        fV19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:37 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/b4d08313-4018-4f0b-8fa6-18a12bd8ed5e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:37 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM4NDkwMTZmLWZiY2UtNDlm
+        NC1iOTJkLWViMjI4NjYzYTAxNS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:37 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:37 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '280'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJh
+        cnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5IjpudWxsLCJfY3JlYXRl
+        ZCI6IjIwMTktMDctMjRUMTY6Mzk6MzIuMjQ3ODQ3WiIsIm5hbWUiOiJEZWZh
+        dWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0RvY2tlcl8xIiwicmVw
+        b3NpdG9yeV92ZXJzaW9uIjpudWxsLCJjb250ZW50X2d1YXJkIjpudWxsLCJf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2RvY2tlci9kb2Nr
+        ZXIvYjRkMDgzMTMtNDAxOC00ZjBiLThmYTYtMThhMTJiZDhlZDVlLyIsInJl
+        Z2lzdHJ5X3BhdGgiOiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29t
+        L0RlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRG9ja2VyXzEi
+        fV19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:37 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/b4d08313-4018-4f0b-8fa6-18a12bd8ed5e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:37 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '23'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:37 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:38 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:38 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:38 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:38 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:38 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:38 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/c9fa232e-68cc-4d9a-889b-d616e0752725/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:39 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkzNzhhNzZlLWY5OGUtNDcw
+        MS1hOGY3LTI5YmI3ZTE4ZDNiMS8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:39 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/9378a76e-f98e-4701-a8f7-29bb7e18d3b1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:39 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '529'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85Mzc4YTc2ZS1mOThlLTQ3
+        MDEtYThmNy0yOWJiN2UxOGQzYjEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjM5LjMyNjk4MFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM5OjM5LjQyODQyN1oi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzk6MzkuNDYwMzk5WiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUt
+        Y2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2M5ZmEyMzJlLTY4Y2MtNGQ5
+        YS04ODliLWQ2MTZlMDc1MjcyNS92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:39 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/c9fa232e-68cc-4d9a-889b-d616e0752725/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:39 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '215'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYzlmYTIzMmUt
+        NjhjYy00ZDlhLTg4OWItZDYxNmUwNzUyNzI1L3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI0VDE2OjM5OjM5LjQ0MzU1N1oiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:39 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19E
+        b2NrZXJfMSIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2M5ZmEyMzJlLTY4Y2MtNGQ5YS04
+        ODliLWQ2MTZlMDc1MjcyNS92ZXJzaW9ucy8xLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:39 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzczYjYzZTI2LWRjYjEtNDQ1
+        My1hZGYyLThkNmUxZDE2MGVkZC8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:39 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/73b63e26-dcb1-4453-adf2-8d6e1d160edd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:39 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy83M2I2M2UyNi1kY2IxLTQ0
+        NTMtYWRmMi04ZDZlMWQxNjBlZGQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjM5Ljc4OTg1MloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozOTozOS44OTgzNjdaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQx
+        ZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:39 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/73b63e26-dcb1-4453-adf2-8d6e1d160edd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:40 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '500'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy83M2I2M2UyNi1kY2IxLTQ0
+        NTMtYWRmMi04ZDZlMWQxNjBlZGQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjM5Ljc4OTg1MloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozOTozOS44OTgzNjdaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQx
+        ZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2Nr
+        ZXIvZG9ja2VyL2VkYjFlY2Y3LWFlNTMtNGJiMC04OWU2LWM1OTRjNTlkMzAy
+        NC8iXX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:40 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/73b63e26-dcb1-4453-adf2-8d6e1d160edd/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:40 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '527'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy83M2I2M2UyNi1kY2IxLTQ0
+        NTMtYWRmMi04ZDZlMWQxNjBlZGQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjM5Ljc4OTg1MloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM5OjM5Ljg5ODM2N1oiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzk6NDAuMDg1Mjk1WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUtY2MxMjUx
+        OGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyL2VkYjFlY2Y3
+        LWFlNTMtNGJiMC04OWU2LWM1OTRjNTlkMzAyNC8iXX0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:40 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/edb1ecf7-ae53-4bb0-89e6-c594c59d3024/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:40 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '287'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTI0VDE2OjM5OjQwLjA3NzM3NVoiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYzlmYTIz
+        MmUtNjhjYy00ZDlhLTg4OWItZDYxNmUwNzUyNzI1L3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyL2VkYjFlY2Y3LWFlNTMtNGJiMC04
+        OWU2LWM1OTRjNTlkMzAyNC8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:40 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/fc1f000b-0eac-4aaf-8620-c446e0a09569/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9jOWZh
+        MjMyZS02OGNjLTRkOWEtODg5Yi1kNjE2ZTA3NTI3MjUvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:40 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhhZWUzYzk4LWRlNTItNDJl
+        OS1hNjA5LWQxZGFkY2E3OGJjNi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:40 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/8aee3c98-de52-42e9-a609-d1dadca78bc6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:40 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '427'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84YWVlM2M5OC1kZTUyLTQy
+        ZTktYTYwOS1kMWRhZGNhNzhiYzYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjQwLjgwNTUxMloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzk6NDAuOTI0NDkwWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwi
+        Y3JlYXRlZF9yZXNvdXJjZXMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:40 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/8aee3c98-de52-42e9-a609-d1dadca78bc6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:41 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84YWVlM2M5OC1kZTUyLTQy
+        ZTktYTYwOS1kMWRhZGNhNzhiYzYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjQwLjgwNTUxMloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzk6NDAuOTI0NDkwWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:41 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/8aee3c98-de52-42e9-a609-d1dadca78bc6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:41 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '694'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84YWVlM2M5OC1kZTUyLTQy
+        ZTktYTYwOS1kMWRhZGNhNzhiYzYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjQwLjgwNTUxMloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzk6NDAuOTI0NDkwWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:41 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/8aee3c98-de52-42e9-a609-d1dadca78bc6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:41 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '696'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84YWVlM2M5OC1kZTUyLTQy
+        ZTktYTYwOS1kMWRhZGNhNzhiYzYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjQwLjgwNTUxMloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzk6NDAuOTI0NDkwWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:41 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/8aee3c98-de52-42e9-a609-d1dadca78bc6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:41 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '781'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84YWVlM2M5OC1kZTUyLTQy
+        ZTktYTYwOS1kMWRhZGNhNzhiYzYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjQwLjgwNTUxMloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzk6NDAuOTI0NDkwWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3
+        MmFiLTNlMGMtNDQ5YS05Mzc4LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJQcm9jZXNzaW5nIFRhZ3MiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjoxLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
+        d25sb2FkaW5nIEFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jl
+        c291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:41 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/8aee3c98-de52-42e9-a609-d1dadca78bc6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:41 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '879'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84YWVlM2M5OC1kZTUyLTQy
+        ZTktYTYwOS1kMWRhZGNhNzhiYzYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjQwLjgwNTUxMloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozOTo0MC45MjQ0OTBa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM5OjQxLjYwNzczOFoi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzA2YmQ3MmFiLTNlMGMtNDQ5YS05Mzc4
+        LTQ4N2FmZWUxOWVhNS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Npbmcg
+        VGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvYzlmYTIzMmUtNjhjYy00ZDlhLTg4OWItZDYx
+        NmUwNzUyNzI1L3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:41 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/c9fa232e-68cc-4d9a-889b-d616e0752725/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:41 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '1281'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYzlmYTIzMmUt
+        NjhjYy00ZDlhLTg4OWItZDYxNmUwNzUyNzI1L3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI0VDE2OjM5OjQwLjk1MjIyNFoiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9j
+        OWZhMjMyZS02OGNjLTRkOWEtODg5Yi1kNjE2ZTA3NTI3MjUvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYzlm
+        YTIzMmUtNjhjYy00ZDlhLTg4OWItZDYxNmUwNzUyNzI1L3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvYzlmYTIzMmUtNjhjYy00ZDlhLTg4OWItZDYxNmUwNzUyNzI1L3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtdGFnIjp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZG9ja2VyL21hbmlmZXN0LXRhZ3MvP3JlcG9zaXRvcnlfdmVyc2lv
+        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2M5ZmEyMzJlLTY4Y2MtNGQ5
+        YS04ODliLWQ2MTZlMDc1MjcyNS92ZXJzaW9ucy8yLyJ9LCJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvYzlmYTIzMmUtNjhjYy00ZDlhLTg4OWIt
+        ZDYxNmUwNzUyNzI1L3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2M5ZmEyMzJlLTY4Y2MtNGQ5YS04ODliLWQ2MTZlMDc1
+        MjcyNS92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:41 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/edb1ecf7-ae53-4bb0-89e6-c594c59d3024/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2M5ZmEyMzJlLTY4Y2MtNGQ5YS04ODliLWQ2MTZlMDc1MjcyNS92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:42 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzczZDNkM2Y1LWUzMWItNGVl
+        Mi1hNjM1LWVmYjQ1OGRiZWY0Zi8ifQ==
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:42 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/73d3d3f5-e31b-4ee2-a635-efb458dbef4f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:42 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '420'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy83M2QzZDNmNS1lMzFiLTRl
+        ZTItYTYzNS1lZmI0NThkYmVmNGYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjQyLjAyNTIxM1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yNFQxNjozOTo0Mi4xNDcwNTZaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2
+        YS00MjE2LTgwMjUtZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:42 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/73d3d3f5-e31b-4ee2-a635-efb458dbef4f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc4.dev01563903066/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:42 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '447'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy83M2QzZDNmNS1lMzFiLTRl
+        ZTItYTYzNS1lZmI0NThkYmVmNGYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI0
+        VDE2OjM5OjQyLjAyNTIxM1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI0VDE2OjM5OjQyLjE0NzA1NloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjRUMTY6Mzk6NDIuMjE1OTIyWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUtZjRlZmYy
+        NDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:42 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:42 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '5141'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MzQsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9t
+        YW5pZmVzdHMvOTViZTA1NWYtZmJhNS00NTc0LTg2YWEtOTg2YmNmZTRlZmM0
+        LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xN1QxOToxNzowNS43NzI3MzZaIiwi
+        X3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9h
+        cGkvdjMvYXJ0aWZhY3RzLzhjNzAwMTNjLWRjZDMtNDM3Yy1iNDRmLWJiYTkw
+        N2IwN2E5Ny8iLCJkaWdlc3QiOiJzaGEyNTY6ZGMyYWU2MzYxNjkxNWNlOTUy
+        N2ViOWJiMzg2NDZjYjM3MDBkMWE3OTAyNTI2NmQ2MDcwOWUyMTRiNDI0OGU1
+        NCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRp
+        b24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitq
+        c29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvbWFuaWZlc3RzLzRlMjYxMjJlLTQ1OGItNGI5My04ODQ1LWU1
+        NzUwNjIyY2Q5NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFu
+        aWZlc3RzLzAzY2ZlNzQ3LTFhNDQtNDRmNC1iZjFjLTY0NjI5ZGUxOThiZC8i
+        XSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpbXX0seyJfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvNGUyNjEyMmUt
+        NDU4Yi00YjkzLTg4NDUtZTU3NTA2MjJjZDk1LyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wNy0xN1QxOToxNzowNS43NjkzODhaIiwiX3R5cGUiOiJkb2NrZXIubWFu
+        aWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzAy
+        ZjkyNzcyLWMwOTItNDczYS04MWRmLTg2OTIzNzk3ZmY2OS8iLCJkaWdlc3Qi
+        OiJzaGEyNTY6YjM1MjAwYmU2NzhkNDc1M2ZlNzc5ZWU1NDA2YzFmYzllZWM5
+        ZTllZTU2ZjAyYjc5ZTQ2YzY1ZDVmMGNlNzYyNyIsInNjaGVtYV92ZXJzaW9u
+        IjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0
+        cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMi
+        OltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9ibG9icy8xYmQ0ODBkYy1hNTI5LTQxNjYtYWM0ZC1mNTVlMDFkNWY5ZmIv
+        IiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2Jz
+        LzJjYWQ0Y2Y4LTc0MDctNDhmZS05ZTg5LTBjMDc2MWQ1M2NlZi8iXX0seyJf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMv
+        MDNjZmU3NDctMWE0NC00NGY0LWJmMWMtNjQ2MjlkZTE5OGJkLyIsIl9jcmVh
+        dGVkIjoiMjAxOS0wNy0xN1QxOToxNzowNS43NjMzMjhaIiwiX3R5cGUiOiJk
+        b2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0
+        aWZhY3RzL2E0YTM2YjIyLWJkYzMtNDk3Ni05ZDE3LTZmMmEyNDE5MzI3YS8i
+        LCJkaWdlc3QiOiJzaGEyNTY6OWI4NzRjY2RiNzNlMWFhZjI5ZTFjMGZkM2E1
+        NTBkZGZhNDg2ZDczNTI1ZjJkNzdiNDUyZTMwYTA5ZDNjYjQxNyIsInNjaGVt
+        YV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRv
+        Y2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9t
+        YW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L2RvY2tlci9ibG9icy9mYTBmZDhkMy1hZWI3LTQ5MjgtYjg3Ni05YzM0
+        YWJhOTViYjEvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL2Jsb2JzLzg1YjRjNDk1LWY3NzYtNGViZi04YWRjLWM3ZDFjMmI1NDFk
+        My8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9t
+        YW5pZmVzdHMvZDJjMzJlMDUtOTc5MC00ZjM1LTllMGUtZGUyNDcyN2FlZDg4
+        LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzozOTozOC4yNzUyOTVaIiwi
+        X3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9h
+        cGkvdjMvYXJ0aWZhY3RzLzA5OGVkN2MxLTZkYWItNGEzNy04MGZkLWFlMjM3
+        YTA4ZWI3Ni8iLCJkaWdlc3QiOiJzaGEyNTY6YTZlY2JiMTU1MzM1M2EwODkz
+        NmY1MGMyNzViMDEwMzg4ZWQxYmQ2ZDlkODQ3NDNjN2U4ZTc0NjhlMmFjZDgy
+        ZSIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRp
+        b24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIs
+        Imxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L2RvY2tlci9ibG9icy83MjhiMjdlOC05OWMxLTRhYzYt
+        YTE2NC1hYjQ3ZTEzZWVhODUvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZG9ja2VyL2Jsb2JzL2E4MmUzMDRiLWM1Y2MtNDA0OS04NGM4LTgw
+        OWYzMDcxNWY2Ny8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxv
+        YnMvNTM2YjU3NjAtOGM2Yi00NGE3LWE3OTItMWFhMTIxYWFkMWQ5LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy8zZGRhZjQ4NC1kZGVj
+        LTRiMDAtYWYxMi1iNmNmZDc1NTZhOGQvIl19LHsiX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzL2QzNTJlMzg3LTk1MmIt
+        NDJiMy04Y2UxLTMxM2U1ZjUxMGZiNy8iLCJfY3JlYXRlZCI6IjIwMTktMDct
+        MThUMTc6NDI6MjAuNDk4MjQ0WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0
+        IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8xYzE1ZmE2
+        MC03MTljLTQwZmEtYjE0My0xOWVkNjY4YjcyNDIvIiwiZGlnZXN0Ijoic2hh
+        MjU2OmQ4MjgzYzg1MGFjMmYxYTkwYzVkZDk0YjlhN2FjOTdjY2FiY2I5ZTIw
+        ODJlMzEyN2I0MzJiMjk3ZDJhYmI2YzgiLCJzY2hlbWFfdmVyc2lvbiI6Miwi
+        bWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0
+        aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMi
+        OlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy9kZDAx
+        ZmNmMS02YzUzLTRjNDctYTcyMy0zMmU5OTUzYjUxOWUvIl0sImNvbmZpZ19i
+        bG9iIjpudWxsLCJibG9icyI6W119LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzEzYjBiNWM3LWMxYzktNGM2NS04
+        ZTQ4LWJmNmZiNjk5NTY1ZS8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6
+        NDI6MjAuNTAyMzkxWiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2Fy
+        dGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8zOWI4NTg4Zi1kZGYw
+        LTRmOWEtODUxMi0yMTI1ZjgzMWRlNjQvIiwiZGlnZXN0Ijoic2hhMjU2OjMx
+        YWI5OWI1NWEzMmFiNmRkMGRlYTgwNDRkYzI2Zjg5ZTNjODU0YmYwN2U0N2Uw
+        MjFiZGI2OWY1YzhhOTE4YjMiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFf
+        dHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1h
+        bmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOlsiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy85NWQ5NDRmMS1l
+        NzFkLTQxMWMtYTJhMy02Mjg2Njg5NWZlMDQvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZG9ja2VyL21hbmlmZXN0cy83YTEyODdjZS00ZDM1LTRkMmQtOGU1
+        My0zZWMyNTc5ZTk5N2MvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2Vy
+        L21hbmlmZXN0cy80MjJmNjVkYy00ZmJkLTQyNTgtODRhOS01NmRkNmI2YzRm
+        OGQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy82
+        Y2Q1NWU5Yi1iYjg5LTQyNzMtYWZlZC05NDM0ZDY1ZjI0OWMvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy9hMzQ1M2I3OC03NTlj
+        LTQxMmItYWE4MS01YWUwOTVlZTA0ZDQvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL21hbmlmZXN0cy84ZDg0M2RmYy05NzlkLTQwZjEtOWIxZC1i
+        MDVjMThkOWE1YjIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy85YjY2NDUwNC00MGRhLTRhMzAtOWU5YS02MDhmYjJhYjYwNWEv
+        Il0sImNvbmZpZ19ibG9iIjpudWxsLCJibG9icyI6W119LHsiX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzL2Q2ZWVlYzg2
+        LWQ5MDYtNDhkZS05OGRjLWYwZWQ4ZDAyMWU2OC8iLCJfY3JlYXRlZCI6IjIw
+        MTktMDctMThUMTc6NDI6MjAuNTA2MDgzWiIsIl90eXBlIjoiZG9ja2VyLm1h
+        bmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9j
+        NzNjYzkyOS1hYzBiLTQ3Y2QtOTdmNi1mYjk5MGViNzEzYjEvIiwiZGlnZXN0
+        Ijoic2hhMjU2OjY1NDBmYzA4ZWU2ZTZiN2I2MzQ2OGRjMzMxN2UzMzAzYWFl
+        MTc4Y2I4YTQ1ZWQzMTIzMTgwMzI4YmNjMWQyMGYiLCJzY2hlbWFfdmVyc2lv
+        biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
+        dHJpYnV0aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5p
+        ZmVzdHMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0
+        cy85NWQ5NDRmMS1lNzFkLTQxMWMtYTJhMy02Mjg2Njg5NWZlMDQvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy83YTEyODdjZS00
+        ZDM1LTRkMmQtOGU1My0zZWMyNTc5ZTk5N2MvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZG9ja2VyL21hbmlmZXN0cy8wZTk1ZTcyNS04YTc5LTRlN2QtOTQ4
+        My05ZTA5ZDg0NGQ1OTUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2Vy
+        L21hbmlmZXN0cy80MjJmNjVkYy00ZmJkLTQyNTgtODRhOS01NmRkNmI2YzRm
+        OGQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy9k
+        ZDAxZmNmMS02YzUzLTRjNDctYTcyMy0zMmU5OTUzYjUxOWUvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy9hMzQ1M2I3OC03NTlj
+        LTQxMmItYWE4MS01YWUwOTVlZTA0ZDQvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL21hbmlmZXN0cy84ZDg0M2RmYy05NzlkLTQwZjEtOWIxZC1i
+        MDVjMThkOWE1YjIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy85YjY2NDUwNC00MGRhLTRhMzAtOWU5YS02MDhmYjJhYjYwNWEv
+        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8zOGVj
+        ZDhjYS1lNmI0LTQyNzQtYmE2OS03OTc3NTUxMTlhZGYvIl0sImNvbmZpZ19i
+        bG9iIjpudWxsLCJibG9icyI6W119LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzE4YTk1YWRkLTNkNzMtNDQzMi1i
+        MDNhLWNiOTI4MDgzNTFiZS8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6
+        NDI6MjAuNTA4OTg3WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2Fy
+        dGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8xZjZhMjBkOS0zYWU5
+        LTQ1Y2EtYjU5ZC03NzVjMjM0MDQ3OTIvIiwiZGlnZXN0Ijoic2hhMjU2Ojlk
+        NjZkYjBjNmEzZGU4YTI4MDgxOTc3YTc1YzZmMmE5NjU4MmRiM2VlMGQ4MzNh
+        NTFkMTg0Mzg1NDEyZGJkMjAiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFf
+        dHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1h
+        bmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOlsiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8wZTk1ZTcyNS04
+        YTc5LTRlN2QtOTQ4My05ZTA5ZDg0NGQ1OTUvIl0sImNvbmZpZ19ibG9iIjpu
+        dWxsLCJibG9icyI6W119LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvbWFuaWZlc3RzL2Q5YTUzYjk4LTQyNjEtNGJjYi04ZGQ2LWZk
+        M2RhYTMwN2IwNi8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6NDI6MjAu
+        NTExNzQ3WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0
+        IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy85ZTY5MTNjMi0xODcxLTQ2MTkt
+        OTlmZi0wN2Y0MjdkNzdiODIvIiwiZGlnZXN0Ijoic2hhMjU2OjFkMjk4NmFi
+        ZDkzM2MwYzk3Nzk5YjM0ZTZjZTE2ZjNhMTFmNzQyOWE5MzgzOGM3MDMzY2Ni
+        MmY3ZjAxOTk3OTAiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6
+        ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0
+        Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOlsiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8wM2QyNWJmYy1mOGUzLTQ2
+        YjMtOTZmOS04YjU5Y2UxNzc4YjEvIl0sImNvbmZpZ19ibG9iIjpudWxsLCJi
+        bG9icyI6W119LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvbWFuaWZlc3RzLzhlMDJhZmE2LTE5NDUtNDc5Ny1hYzFjLWExODRlMDFj
+        M2I2MC8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6NDI6MjAuNTE0NTA0
+        WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1
+        bHAvYXBpL3YzL2FydGlmYWN0cy8yZDI3M2IxOS0yNTY2LTQ5NjYtODE4OS1j
+        ZmNmZDFmMjc0MzEvIiwiZGlnZXN0Ijoic2hhMjU2OmUyNmZhOGRiMmNjNDY4
+        MzUwOTRhODRmNTlhNTUxNWMzZTcyN2YxZTVkNzU3OGIyM2ExMTcwYWI4ZjYx
+        ZmJmYWUiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxp
+        Y2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0Lmxpc3Qu
+        djIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOlsiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZG9ja2VyL21hbmlmZXN0cy8wZTk1ZTcyNS04YTc5LTRlN2QtOTQ4
+        My05ZTA5ZDg0NGQ1OTUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2Vy
+        L21hbmlmZXN0cy9kZDAxZmNmMS02YzUzLTRjNDctYTcyMy0zMmU5OTUzYjUx
+        OWUvIl0sImNvbmZpZ19ibG9iIjpudWxsLCJibG9icyI6W119LHsiX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzE0YmEz
+        NzRhLTdiMGUtNDE2MS1iYTdmLThjNDI0MDM0NTI1OC8iLCJfY3JlYXRlZCI6
+        IjIwMTktMDctMThUMTc6NDI6MjAuNTE3MjE1WiIsIl90eXBlIjoiZG9ja2Vy
+        Lm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
+        cy9jMjEwY2Q1NS03NWI1LTQzMDEtYWE3NS0yYjEzYTg4ZjYyYmUvIiwiZGln
+        ZXN0Ijoic2hhMjU2Ojg3OGZkOTEzMDEwZDI2NjEzMzE5ZWM3Y2M4M2I0MDBj
+        YjkyMTEzYzMxNGRhMzI0NjgxZDlmZWNmYjUwODJlZGMiLCJzY2hlbWFfdmVy
+        c2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIu
+        ZGlzdHJpYnV0aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9t
+        YW5pZmVzdHMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlm
+        ZXN0cy83MTAwMTk5Ny00YjQ3LTQ2ODItODk3ZS0yZGUzMGQ3NTk3OTkvIl0s
+        ImNvbmZpZ19ibG9iIjpudWxsLCJibG9icyI6W119LHsiX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzUzZDg4YmRkLTY3
+        YzctNDNjOC04NDUyLWMwNmM5Nzg4MjcxNy8iLCJfY3JlYXRlZCI6IjIwMTkt
+        MDctMThUMTc6NDI6MjAuNTE5NjY1WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlm
+        ZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9iODA1
+        ZDJiMC00YmFlLTQyM2QtYmVhNi1iZmNlZjQ2MjFhZDcvIiwiZGlnZXN0Ijoi
+        c2hhMjU2OmQzYzZhM2JlZTZmZDc2ZjVmZTJiMDU5NjhiZjNhNzBlYzc1YTBk
+        MjZmYmY5OGQyNDI5ZDgyNGI1YjAxOTJmODMiLCJzY2hlbWFfdmVyc2lvbiI6
+        MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJp
+        YnV0aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVz
+        dHMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy9h
+        NGExNmM5OC0wZDdkLTQ2ZTgtYmM3YS05MTNlNDg4ZDhkM2YvIl0sImNvbmZp
+        Z19ibG9iIjpudWxsLCJibG9icyI6W119LHsiX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzhkODQzZGZjLTk3OWQtNDBm
+        MS05YjFkLWIwNWMxOGQ5YTViMi8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThU
+        MTc6NDI6MjAuNzU1MjI1WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0Iiwi
+        X2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy85MzMzOWFmZS02
+        MDZmLTRlMmQtOWFjYy05NjQ0MzczY2FmODUvIiwiZGlnZXN0Ijoic2hhMjU2
+        OjU3N2FkNDMzMWQ0ZmFjOTE4MDczMDhkYTk5ZWNjMTA3ZGNjNmIyMjU0YmM0
+        YzcxNjYzMjVmZDAxMTEzYmVhMmEiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVk
+        aWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9u
+        Lm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29u
+        ZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMv
+        YzhkZjY0YzAtYjU2MC00Mjk2LWIyYjMtOTAwNDA3ZDI4ZjBiLyIsImJsb2Jz
+        IjpbIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy9hMTVkNzZi
+        NS00NzY4LTRlYTAtODRkMS1jNGNjYmU5MjAxZjQvIl19LHsiX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzliNjY0NTA0
+        LTQwZGEtNGEzMC05ZTlhLTYwOGZiMmFiNjA1YS8iLCJfY3JlYXRlZCI6IjIw
+        MTktMDctMThUMTc6NDI6MjAuNjg1OTkwWiIsIl90eXBlIjoiZG9ja2VyLm1h
+        bmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8x
+        NjVhYzFhNy1iYmM4LTRhMTEtOTI5ZS0yZGY5NzAzMmY1ODgvIiwiZGlnZXN0
+        Ijoic2hhMjU2OmQwZDRjNTM4OWI1Mzg3NWIwZjIzNjRmOTRjNDY2Zjc3Y2Y2
+        ZjAyODExZmIwMmYwNDc3Yjk3ZDYwOWZiNTA1NjgiLCJzY2hlbWFfdmVyc2lv
+        biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
+        dHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3Rz
+        IjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvYmxvYnMvZWExZjhmMmMtYzczMy00ZWU4LTliZmQtNzY2ZDEwODY4MmI2
+        LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9i
+        cy9iNjI4YWQ2Ny03NzExLTQzMDktOThhZC1hMzkyMDFiN2NhYmIvIl19LHsi
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3Rz
+        Lzk1ZDk0NGYxLWU3MWQtNDExYy1hMmEzLTYyODY2ODk1ZmUwNC8iLCJfY3Jl
+        YXRlZCI6IjIwMTktMDctMThUMTc6NDI6MjAuNTY3Njk3WiIsIl90eXBlIjoi
+        ZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2Fy
+        dGlmYWN0cy8yOGU2ZDliMy0yNGZlLTRmYmYtOWNlYi1mNjEzZTYxN2QyYmQv
+        IiwiZGlnZXN0Ijoic2hhMjU2OjkyYzdmOWM5Mjg0NGJiYmI1ZDBhMTAxYjIy
+        ZjdjMmE3OTQ5ZTQwZjhlYTkwYzhiM2JjMzk2ODc5ZDk1ZTg5OWEiLCJzY2hl
+        bWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5k
+        b2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRf
+        bWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvYmxvYnMvYTJkYzQ2ZTktM2JmMS00YTQ5LWExNjYtZDc1
+        ZTJmNzM4MTQyLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2Rv
+        Y2tlci9ibG9icy9hNWIxZjQxMy03M2VhLTQyZWYtYWZiYi05ODUzZmQyNjdi
+        NmQvIl19LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIv
+        bWFuaWZlc3RzLzM4ZWNkOGNhLWU2YjQtNDI3NC1iYTY5LTc5Nzc1NTExOWFk
+        Zi8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6NDI6MjAuNzU5MTc4WiIs
+        Il90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAv
+        YXBpL3YzL2FydGlmYWN0cy9lODYzZjUyMi1iNWUyLTQ4ODAtODUwYi05ZWMw
+        ZTJmNGM2NDAvIiwiZGlnZXN0Ijoic2hhMjU2OjVhNGJkYWRkOWFjZDg3Nzll
+        ZDZmY2YwMDdhNGU3ZWQ3ZjkxOTA1NmE5MmMzYzY3ODI0YjRmZGVkMDZlZjBh
+        NmUiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0
+        aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24i
+        LCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvY2NhMGU1NDgtMTcyZi00Yjlm
+        LWFhOTctOGNmYzVmNGQyZmEzLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8wNmQ4MDRiZi0yYjlmLTQ2YmYtOTczMC04
+        YjlhM2I3MzZhNDIvIl19LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvbWFuaWZlc3RzLzBlOTVlNzI1LThhNzktNGU3ZC05NDgzLTll
+        MDlkODQ0ZDU5NS8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6NDI6MjAu
+        Njg3NDAzWiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0
+        IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8xZWFlYTc3ZS1kN2NmLTRiYTQt
+        OGRhOC01MjE5ZjY0MzM3NTYvIiwiZGlnZXN0Ijoic2hhMjU2OjA4NWJhMjll
+        OWFlODdmMTM3ZGQ4Njg2YjliZmZlZTc5YzIzODAwYjYzNTdhMDA1NThiYTY0
+        MzY3YzgwODRmYzMiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6
+        ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0
+        LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2Ii
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvMzQyNGQxMGYt
+        NzYwZS00N2YyLWJlZjktOGJjYzZhMjAxMTg2LyIsImJsb2JzIjpbIi9wdWxw
+        L2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy83M2ZhNGI4OC1mNWU4LTRj
+        NWMtYTE0OC05Y2MyYjk0ODYxMDgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        ZG9ja2VyL2Jsb2JzL2JlYzQxM2E0LTYzYjctNGU4Yi1hYmNhLTkxN2FmZjY4
+        OTYxOS8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvN2ExMjg3Y2UtNGQzNS00ZDJkLThlNTMtM2VjMjU3OWU5
+        OTdjLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41MjIxMzJa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVs
+        cC9hcGkvdjMvYXJ0aWZhY3RzLzI4MWNlNGY5LWUzM2MtNDEzZC1hNWEzLTAw
+        Zjk3YTQ3ZjdlNS8iLCJkaWdlc3QiOiJzaGEyNTY6MTJjZjllZjkwODM1NDY1
+        MzE2Y2IwYjM3MjljMzZiZmQ4NjU0ZDdmMmY2OTdlMjM0MzJmZGRmYWE3ZDdl
+        MzFiNSIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGlj
+        YXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNv
+        biIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy9jMzI0NDc1NS1lNWU2LTRl
+        MTMtOGM3Yy0yY2ZiNzhhMWRjMjYvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvZG9ja2VyL2Jsb2JzL2FmN2JmMGMxLTM2NTgtNGZmOC05MGQw
+        LWJiNzgwZjQxYWI3ZS8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L2RvY2tlci9tYW5pZmVzdHMvNzEwMDE5OTctNGI0Ny00NjgyLTg5N2Ut
+        MmRlMzBkNzU5Nzk5LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0Mjoy
+        MS4wMzE4MzBaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZh
+        Y3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzFhNjZhMzU1LTExZmUtNGE1
+        ZS1hYzM5LTljMDBkZmRlZTIxNi8iLCJkaWdlc3QiOiJzaGEyNTY6YzFiZTZl
+        MTQ2ODQ4NTc1NzY5OGFmNTI4ZmZmNzc0ZDQ3NGU2OWY0NDhlZWY0M2MzNjhm
+        YTJmMmJlMTI4OGI0ZCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBl
+        IjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZl
+        c3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxv
+        YiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy8yMTQwNDNi
+        MC1mNGJiLTQyNTItOGE4OC0zMTQ4N2M2NDRmMDAvIiwiYmxvYnMiOlsiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzL2I2NGJmNDM3LTFkM2Mt
+        NGRhNS04NzE0LWM2ODdiNTFhYjZmOC8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvYmxvYnMvMTI3MGEwNjMtMGMyMS00NmIxLWI4MzEtOTNkMjk1
+        NTBiOTI0LyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL21hbmlmZXN0cy80MjJmNjVkYy00ZmJkLTQyNTgtODRhOS01NmRkNmI2
+        YzRmOGQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjQyOjIwLjczMTc4
+        MFoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9w
+        dWxwL2FwaS92My9hcnRpZmFjdHMvMTczMmVmMGYtMThlNS00ODUzLWJmM2Ut
+        ODkzZDljOTg5ZDUwLyIsImRpZ2VzdCI6InNoYTI1NjoxZTQ0ZDhiY2E2ZmIw
+        NDY0Nzk0NTU1ZTVjY2QzYTMyZTJhNGY2ZTQ0YTIwNjA1ZTRlODI2MDUxODk5
+        MDRmNDRkIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBs
+        aWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitq
+        c29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzL2M4MTliZDJiLWVlMWUt
+        NGM0My04MjJkLTE0MDNkYjg0MDgxNi8iLCJibG9icyI6WyIvcHVscC9hcGkv
+        djMvY29udGVudC9kb2NrZXIvYmxvYnMvNjI5MWI2ZTItZTU0MC00YWY2LWI3
+        YjItZTY4NGY3ZjE3NmFhLyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZG9ja2VyL21hbmlmZXN0cy9kZDAxZmNmMS02YzUzLTRjNDctYTcy
+        My0zMmU5OTUzYjUxOWUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjQy
+        OjIwLjY4NDQyNloiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRp
+        ZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODA3NmI4OTctMTM0Mi00
+        ZTg5LTk1YjItYzZkNTUxNmYyZjU2LyIsImRpZ2VzdCI6InNoYTI1NjphZjM3
+        YjY2ZDAxN2FlMjJkMmRlMWExMjhjZTA0OWRhNjYxZWI3NWEwZjUyMDA3YzU3
+        YzJmNjE2ODFkOTk5ZTUwIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5
+        cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5p
+        ZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19i
+        bG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzEzZWM1
+        MTA4LTJiMmQtNGVkZi1iYzlmLWUzZTFkNTI4NmQ4Mi8iLCJibG9icyI6WyIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvMjc3MTJjMWQtM2Ri
+        Yi00N2JkLWFmZjYtZTBmNGJkZjI5MjRmLyIsIi9wdWxwL2FwaS92My9jb250
+        ZW50L2RvY2tlci9ibG9icy9mN2U5NWJiYS1lMmU5LTRiNzctYTRlMC1mZjk0
+        MjJlMmRjNWMvIl19LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvbWFuaWZlc3RzLzZjZDU1ZTliLWJiODktNDI3My1hZmVkLTk0MzRk
+        NjVmMjQ5Yy8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6NDI6MjAuNzI4
+        ODkzWiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0Ijoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy85YTYxNjViMy04N2IxLTRhNTYtOTc1
+        OC0zNTNhNDc0ZWRiM2UvIiwiZGlnZXN0Ijoic2hhMjU2Ojg1ZGM1ZmJlMTYy
+        MTQzNjY3NDhlYmU5ZDdjYzczYmM0MmQ2MWQxOWQ2MWZlMDVmMDFlMzE3ZDI3
+        OGMyMjg3ZWQiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFw
+        cGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYy
+        K2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2IiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvYjQ0ODE1ODctYTgy
+        MC00MDlhLTkxM2QtZTM1ZWRhMGNlZmZjLyIsImJsb2JzIjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L2RvY2tlci9ibG9icy8yNWJiZWJiYi1hYmViLTQyNjYt
+        YmZhNS0xY2IzMWNkMmYxNjMvIl19LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9kb2NrZXIvbWFuaWZlc3RzL2EzNDUzYjc4LTc1OWMtNDEyYi1h
+        YTgxLTVhZTA5NWVlMDRkNC8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6
+        NDI6MjAuNzI3NzYyWiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2Fy
+        dGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9jMTFlODgzYS1mY2I1
+        LTRmYmYtYmZlYy03NTJjYWNiZThlZTEvIiwiZGlnZXN0Ijoic2hhMjU2OmQx
+        ZmQyZTIwNGFmMGEyYmNhM2FiMDMzYjQxN2IyOWM3NmQ3OTUwZWQyOWE0NGU0
+        MjdkMWM0ZDA3ZDE0ZjA0ZjkiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFf
+        dHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1h
+        bmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmln
+        X2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvY2M0
+        Y2MzZDAtYjNlZS00MDk0LTljNTUtMmQ5ZGZkZWY5ZTFhLyIsImJsb2JzIjpb
+        Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy8yYzc4NzVmYS1k
+        ZTZiLTQxZDctODJhYS1kYzQ4MTQwY2M0N2UvIl19LHsiX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzL2E0YTE2Yzk4LTBk
+        N2QtNDZlOC1iYzdhLTkxM2U0ODhkOGQzZi8iLCJfY3JlYXRlZCI6IjIwMTkt
+        MDctMThUMTc6NDI6MjAuOTg5NTAxWiIsIl90eXBlIjoiZG9ja2VyLm1hbmlm
+        ZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy84NGU3
+        MGJmYS1iYjIyLTQyYjctODcwMS1jZDNlOTFiODA1NGIvIiwiZGlnZXN0Ijoi
+        c2hhMjU2Ojc4NmEyOTk3NDkwODU1MTMzNWYzNzliNzQ0NDM4ZjI1ZGUwYTU3
+        ZTkwNzM1OGQ0MzBlOGNmODViZTVmYzE0NjQiLCJzY2hlbWFfdmVyc2lvbiI6
+        MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJp
+        YnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpb
+        XSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIv
+        YmxvYnMvMTc5OTg2MjMtMzk0Zi00N2IwLTllNDctMWFlNDMyYTcwNGI1LyIs
+        ImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy8z
+        NTIyMjMxMS02Mjg2LTQwNDEtYTlhNS1kNWJlNWZlMDNlMGIvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzhhMjc2MWRmLTBjMzMtNGQz
+        MC05NmUwLTE4ZmQ2NzRlODA3Yi8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvMDNkMjViZmMtZjhlMy00NmIz
+        LTk2ZjktOGI1OWNlMTc3OGIxLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQx
+        Nzo0MjoyMC43NTgxMjdaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJf
+        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzE2MzQyNmZjLWRk
+        NDgtNGRiNy1hZTJlLTc5NDk0Y2U2NTAxNy8iLCJkaWdlc3QiOiJzaGEyNTY6
+        MDhjYTRmMmM0NTMxNmNiMGI3OWZhZjhmMDc2MjUwNDZkYmJjMTZmNmYxNDBi
+        MGM1OWRhMDNmMTMyM2FkYThhNCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRp
+        YV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24u
+        bWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25m
+        aWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy9h
+        ODYyOWE5Yy01ZTBjLTQyNDktOWQ1My02ZTk3MDcxZjAyM2QvIiwiYmxvYnMi
+        OlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzRiNDVlYzNh
+        LTdkOGMtNGIwZi1hMTA3LWExZTZlY2NkMmVkNy8iLCIvcHVscC9hcGkvdjMv
+        Y29udGVudC9kb2NrZXIvYmxvYnMvMzEyYWRmYmYtYmU0MC00OWU1LTkxYWMt
+        NGIwYWNjNDJmODUzLyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL21hbmlmZXN0cy82MzRmNjFiNi1jZGQ2LTRmMGYtOGM4ZS0x
+        Y2UxOWNmYzdlNjgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAx
+        LjkwNDU0MloiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFj
+        dCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNzE3NjU0ZDAtM2VlZC00MzY5
+        LTk0NmEtNGI1N2ZmMzc0YmZlLyIsImRpZ2VzdCI6InNoYTI1Njo5ZjEwMDNj
+        NDgwNjk5YmU1NjgxNWRiMGY4MTQ2YWQyZTIyZWZlYTg1MTI5YjViNTk4M2Qw
+        ZTBmYjUyZDlhYjcwIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUi
+        OiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVz
+        dC5saXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvNTgyOWZlMGMtNGJkYS00
+        N2FmLWE0OWUtNzJmMmNkOTkxYTVlLyIsIi9wdWxwL2FwaS92My9jb250ZW50
+        L2RvY2tlci9tYW5pZmVzdHMvM2JhYjQ2YTgtMjZhOS00ZGVkLThjMjUtOTdl
+        MTUwNmMyZGU2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5p
+        ZmVzdHMvZmY5ODU1MWMtYzBmMC00ZjgyLWFiZWMtMTQwODVmMjllY2ZiLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvNmYwNTYy
+        YWQtZGU1Ny00ZmEyLTliMDgtOGE3MDkxOTIyNWU3LyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvNTMzNGIzZjEtZDU3OC00ZWRk
+        LWJmMzMtZmMwMjgwZjNiNjA4LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2Rv
+        Y2tlci9tYW5pZmVzdHMvMDQxNDJlMWMtZmI4Mi00YTEwLTliZGEtNWZmZTNm
+        NDkwNzM5LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVz
+        dHMvNDQyMDk0ODktMGRmNC00ZTUxLWFjZmUtNDVlNGNjMTJhMjY2LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvYzVjM2QzNGQt
+        NzA3YS00YmI0LWIxMGQtMWMxYWZiZTBmN2YzLyJdLCJjb25maWdfYmxvYiI6
+        bnVsbCwiYmxvYnMiOltdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL21hbmlmZXN0cy80NDIwOTQ4OS0wZGY0LTRlNTEtYWNmZS00
+        NWU0Y2MxMmEyNjYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAx
+        Ljk4MzU2MFoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFj
+        dCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMjNjZWU2NzctYjZhZC00YjUz
+        LTk4YTAtNDVlNzc5YjZiOGRiLyIsImRpZ2VzdCI6InNoYTI1NjplMThjZTUx
+        YjU4YmIxMWVlZDIyMTZjYTNlNWU5NGRjOTA2YmIwNGIzNTkzNzY4ODRiZTEx
+        MGY1MDI2YjFmOWMxIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUi
+        OiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVz
+        dC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9i
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzMzZmQ0MGNj
+        LWYwY2EtNDkzOC1iZDdjLWY5YjAzZjBiZmE0NC8iLCJibG9icyI6WyIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvOGFjNGJlZTgtNjMwYS00
+        Yjg2LThiYTktYzc1ODY1MDQwODIyLyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy9mZjk4NTUxYy1jMGYwLTRm
+        ODItYWJlYy0xNDA4NWYyOWVjZmIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDE5OjQwOjAyLjA3MTg4MFoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIs
+        Il9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYTY4YTc1MzYt
+        ZTA4ZS00YmJmLTlmODMtYmE3N2Y4YzJkYjQzLyIsImRpZ2VzdCI6InNoYTI1
+        NjpmZDg2YWNkNWE5ZjhiMmJkMzRkMzljZDBhZWZhOWM1MDNkYzhmZTYxNTBm
+        ZTE1Y2UzY2Y5MGYyODhlYjE1NWQzIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
+        ZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlv
+        bi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNv
+        bmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2Jz
+        LzY5ZTNiMDdmLTM3NDQtNDU0Yy1iODUzLTM5OWM5NTkzYmE0OC8iLCJibG9i
+        cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvZDE1YjIx
+        MDMtZGVlNi00OTNiLTk3NjEtZGUxNDBmZjJkMWJjLyJdfSx7Il9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8wNDE0MmUx
+        Yy1mYjgyLTRhMTAtOWJkYS01ZmZlM2Y0OTA3MzkvIiwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTIyVDE5OjQwOjAyLjA4Mjk4NVoiLCJfdHlwZSI6ImRvY2tlci5t
+        YW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
+        OWVjNjhhNmUtMDdmYi00Y2MzLTk5YmQtZGVlNWJlYWNiZGY0LyIsImRpZ2Vz
+        dCI6InNoYTI1NjpmM2RlZTk4OGJhOTAxYmQyZjI4MjI2MjUyMzAyOTliYTVl
+        ZTJkZGZiZTJiOGI0NTU4NTZmMmIwNzMzYmFmOGQwIiwic2NoZW1hX3ZlcnNp
+        b24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRp
+        c3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0
+        cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL2Jsb2JzL2EzNmRmNGM0LTJkZmEtNDMzZi1iZDQ4LTE5NjFjZGM5YWJl
+        NC8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxv
+        YnMvM2M4ZDk5OWQtZjFhZi00YjMxLWE1ZGItNzVjYjE3MmUyZjMzLyJdfSx7
+        Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0
+        cy9jNWMzZDM0ZC03MDdhLTRiYjQtYjEwZC0xYzFhZmJlMGY3ZjMvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAxLjk4NDk1NFoiLCJfdHlwZSI6
+        ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9h
+        cnRpZmFjdHMvODZkYjI2N2QtMzNjYy00NTI5LWEyNDctNmZlYWY3OGIwN2Ji
+        LyIsImRpZ2VzdCI6InNoYTI1NjpmYjgyZWY3YjdhZTA5MWY2NzVmNmUwMzRm
+        MzEzNGUyZjEyOWY0ZjdiZWMyYjIwNWU0NTg5NDNhOGYzZWRiNzNiIiwic2No
+        ZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQu
+        ZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVk
+        X21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZG9ja2VyL2Jsb2JzL2VmZGFmYzY3LThhMjUtNGVkNi1hYWQyLTEz
+        ZjhiMDk3ZTg0YS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvYmxvYnMvZjQ4ZDc2OTktZWIwNC00OTEwLTg2YzMtZjExMzAxMjRh
+        ZDZmLyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2Vy
+        L21hbmlmZXN0cy82ZjA1NjJhZC1kZTU3LTRmYTItOWIwOC04YTcwOTE5MjI1
+        ZTcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAxLjk2NTY5Mloi
+        LCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxw
+        L2FwaS92My9hcnRpZmFjdHMvMjY4NTY2NWYtZDZjOC00MGZmLWJlOWUtMDVm
+        ZjBlOTUwMzc0LyIsImRpZ2VzdCI6InNoYTI1Njo4OTVhYjYyMmU5MmUxOGQ2
+        YjQ2MWQ2NzEwODE3NTdhZjdkYmFhM2IwMGUzZTI4ZTEyNTA1YWY3ODE3Zjcz
+        NjQ5Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNh
+        dGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29u
+        IiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzkxMzZiNThkLTRlODktNDhj
+        YS1hYmVkLTE1NTBlOWYzZjg3OS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMv
+        Y29udGVudC9kb2NrZXIvYmxvYnMvZGY4ZmIwN2MtYThjMi00NjRmLWIxNzMt
+        YTYwMzBmNTY2ODA4LyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL21hbmlmZXN0cy8zYmFiNDZhOC0yNmE5LTRkZWQtOGMyNS05
+        N2UxNTA2YzJkZTYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAx
+        Ljk5NTI2NVoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFj
+        dCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZWQyZGE2N2ItYzMzNC00OTVh
+        LWFiNDEtNjE4ZmJkY2UwMTZlLyIsImRpZ2VzdCI6InNoYTI1NjowZDc2MDQ1
+        NThmOTVkY2UwYzE3Y2VlMGNkZjQ1YThjNjhmMzVkN2ZjNzEwYTYwYTU5OGNk
+        NDNmNjUyOTc2ODc4Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUi
+        OiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVz
+        dC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9i
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzc2ZmFmOTMw
+        LTE2NmEtNGM2OS1iYmYwLTc4Y2U2ZjFlMTQ5OS8iLCJibG9icyI6WyIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvYTFhODAzMjItMDhlNi00
+        NGQzLWFkM2YtODU5ODk2ZmY0ZTA1LyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy81ODI5ZmUwYy00YmRhLTQ3
+        YWYtYTQ5ZS03MmYyY2Q5OTFhNWUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDE5OjQwOjAxLjkxMDczNVoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIs
+        Il9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvOGZjZjc3ZDAt
+        ZDgwNy00YTEwLThiNjgtMmQ3NTdmNjNjNDdmLyIsImRpZ2VzdCI6InNoYTI1
+        NjphZGZhYzBjMmJlNGJiODYwMDQ1OTViOGY5OTVkZjg4YmQ5OWIyODkxOTMx
+        NjE3ZGYwNTAxNThiYWE3MDljMzMxIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
+        ZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlv
+        bi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNv
+        bmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2Jz
+        LzA2NmM1YzQ5LTFjY2UtNGE3Yy1hYWQyLTY1Y2RiNDkyYjNjMi8iLCJibG9i
+        cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvNWQ4ZDc2
+        MjAtMDgzMy00MDc2LWE2NTYtOGM5NjgxMTkxYTJlLyJdfSx7Il9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy81MzM0YjNm
+        MS1kNTc4LTRlZGQtYmYzMy1mYzAyODBmM2I2MDgvIiwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTIyVDE5OjQwOjAxLjk4MjE0MVoiLCJfdHlwZSI6ImRvY2tlci5t
+        YW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
+        ZGJhNjA2YWItZjc2Yy00MGY5LWJhM2EtMGRkYTY2M2QzNmRhLyIsImRpZ2Vz
+        dCI6InNoYTI1Njo3OTI4OWMzMTQ2YTc3Y2U1YzdmZTBmYzhmYjA5NGMwYzE3
+        ZjhlZmVlMjkyNjIzZjkwYzUxNjMwZjk0YmI2NTE5Iiwic2NoZW1hX3ZlcnNp
+        b24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRp
+        c3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0
+        cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL2Jsb2JzLzE3MjhjMjAyLWFmMWMtNGU4My04ZmZkLWJjOGNjZTdhMGY3
+        MS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxv
+        YnMvZTAwNTQ0ZjYtMTMzMC00YTNiLWIyNmEtNmY4MzAwNWZiYTQwLyJdfV19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:42 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:43 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '5141'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MzQsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9t
+        YW5pZmVzdHMvOTViZTA1NWYtZmJhNS00NTc0LTg2YWEtOTg2YmNmZTRlZmM0
+        LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xN1QxOToxNzowNS43NzI3MzZaIiwi
+        X3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9h
+        cGkvdjMvYXJ0aWZhY3RzLzhjNzAwMTNjLWRjZDMtNDM3Yy1iNDRmLWJiYTkw
+        N2IwN2E5Ny8iLCJkaWdlc3QiOiJzaGEyNTY6ZGMyYWU2MzYxNjkxNWNlOTUy
+        N2ViOWJiMzg2NDZjYjM3MDBkMWE3OTAyNTI2NmQ2MDcwOWUyMTRiNDI0OGU1
+        NCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRp
+        b24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitq
+        c29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvbWFuaWZlc3RzLzRlMjYxMjJlLTQ1OGItNGI5My04ODQ1LWU1
+        NzUwNjIyY2Q5NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFu
+        aWZlc3RzLzAzY2ZlNzQ3LTFhNDQtNDRmNC1iZjFjLTY0NjI5ZGUxOThiZC8i
+        XSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpbXX0seyJfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvNGUyNjEyMmUt
+        NDU4Yi00YjkzLTg4NDUtZTU3NTA2MjJjZDk1LyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wNy0xN1QxOToxNzowNS43NjkzODhaIiwiX3R5cGUiOiJkb2NrZXIubWFu
+        aWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzAy
+        ZjkyNzcyLWMwOTItNDczYS04MWRmLTg2OTIzNzk3ZmY2OS8iLCJkaWdlc3Qi
+        OiJzaGEyNTY6YjM1MjAwYmU2NzhkNDc1M2ZlNzc5ZWU1NDA2YzFmYzllZWM5
+        ZTllZTU2ZjAyYjc5ZTQ2YzY1ZDVmMGNlNzYyNyIsInNjaGVtYV92ZXJzaW9u
+        IjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0
+        cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMi
+        OltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9ibG9icy8xYmQ0ODBkYy1hNTI5LTQxNjYtYWM0ZC1mNTVlMDFkNWY5ZmIv
+        IiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2Jz
+        LzJjYWQ0Y2Y4LTc0MDctNDhmZS05ZTg5LTBjMDc2MWQ1M2NlZi8iXX0seyJf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMv
+        MDNjZmU3NDctMWE0NC00NGY0LWJmMWMtNjQ2MjlkZTE5OGJkLyIsIl9jcmVh
+        dGVkIjoiMjAxOS0wNy0xN1QxOToxNzowNS43NjMzMjhaIiwiX3R5cGUiOiJk
+        b2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0
+        aWZhY3RzL2E0YTM2YjIyLWJkYzMtNDk3Ni05ZDE3LTZmMmEyNDE5MzI3YS8i
+        LCJkaWdlc3QiOiJzaGEyNTY6OWI4NzRjY2RiNzNlMWFhZjI5ZTFjMGZkM2E1
+        NTBkZGZhNDg2ZDczNTI1ZjJkNzdiNDUyZTMwYTA5ZDNjYjQxNyIsInNjaGVt
+        YV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRv
+        Y2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9t
+        YW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L2RvY2tlci9ibG9icy9mYTBmZDhkMy1hZWI3LTQ5MjgtYjg3Ni05YzM0
+        YWJhOTViYjEvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL2Jsb2JzLzg1YjRjNDk1LWY3NzYtNGViZi04YWRjLWM3ZDFjMmI1NDFk
+        My8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9t
+        YW5pZmVzdHMvZDJjMzJlMDUtOTc5MC00ZjM1LTllMGUtZGUyNDcyN2FlZDg4
+        LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzozOTozOC4yNzUyOTVaIiwi
+        X3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9h
+        cGkvdjMvYXJ0aWZhY3RzLzA5OGVkN2MxLTZkYWItNGEzNy04MGZkLWFlMjM3
+        YTA4ZWI3Ni8iLCJkaWdlc3QiOiJzaGEyNTY6YTZlY2JiMTU1MzM1M2EwODkz
+        NmY1MGMyNzViMDEwMzg4ZWQxYmQ2ZDlkODQ3NDNjN2U4ZTc0NjhlMmFjZDgy
+        ZSIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRp
+        b24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIs
+        Imxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L2RvY2tlci9ibG9icy83MjhiMjdlOC05OWMxLTRhYzYt
+        YTE2NC1hYjQ3ZTEzZWVhODUvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZG9ja2VyL2Jsb2JzL2E4MmUzMDRiLWM1Y2MtNDA0OS04NGM4LTgw
+        OWYzMDcxNWY2Ny8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxv
+        YnMvNTM2YjU3NjAtOGM2Yi00NGE3LWE3OTItMWFhMTIxYWFkMWQ5LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy8zZGRhZjQ4NC1kZGVj
+        LTRiMDAtYWYxMi1iNmNmZDc1NTZhOGQvIl19LHsiX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzL2QzNTJlMzg3LTk1MmIt
+        NDJiMy04Y2UxLTMxM2U1ZjUxMGZiNy8iLCJfY3JlYXRlZCI6IjIwMTktMDct
+        MThUMTc6NDI6MjAuNDk4MjQ0WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0
+        IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8xYzE1ZmE2
+        MC03MTljLTQwZmEtYjE0My0xOWVkNjY4YjcyNDIvIiwiZGlnZXN0Ijoic2hh
+        MjU2OmQ4MjgzYzg1MGFjMmYxYTkwYzVkZDk0YjlhN2FjOTdjY2FiY2I5ZTIw
+        ODJlMzEyN2I0MzJiMjk3ZDJhYmI2YzgiLCJzY2hlbWFfdmVyc2lvbiI6Miwi
+        bWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0
+        aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMi
+        OlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy9kZDAx
+        ZmNmMS02YzUzLTRjNDctYTcyMy0zMmU5OTUzYjUxOWUvIl0sImNvbmZpZ19i
+        bG9iIjpudWxsLCJibG9icyI6W119LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzEzYjBiNWM3LWMxYzktNGM2NS04
+        ZTQ4LWJmNmZiNjk5NTY1ZS8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6
+        NDI6MjAuNTAyMzkxWiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2Fy
+        dGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8zOWI4NTg4Zi1kZGYw
+        LTRmOWEtODUxMi0yMTI1ZjgzMWRlNjQvIiwiZGlnZXN0Ijoic2hhMjU2OjMx
+        YWI5OWI1NWEzMmFiNmRkMGRlYTgwNDRkYzI2Zjg5ZTNjODU0YmYwN2U0N2Uw
+        MjFiZGI2OWY1YzhhOTE4YjMiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFf
+        dHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1h
+        bmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOlsiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy85NWQ5NDRmMS1l
+        NzFkLTQxMWMtYTJhMy02Mjg2Njg5NWZlMDQvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZG9ja2VyL21hbmlmZXN0cy83YTEyODdjZS00ZDM1LTRkMmQtOGU1
+        My0zZWMyNTc5ZTk5N2MvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2Vy
+        L21hbmlmZXN0cy80MjJmNjVkYy00ZmJkLTQyNTgtODRhOS01NmRkNmI2YzRm
+        OGQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy82
+        Y2Q1NWU5Yi1iYjg5LTQyNzMtYWZlZC05NDM0ZDY1ZjI0OWMvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy9hMzQ1M2I3OC03NTlj
+        LTQxMmItYWE4MS01YWUwOTVlZTA0ZDQvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL21hbmlmZXN0cy84ZDg0M2RmYy05NzlkLTQwZjEtOWIxZC1i
+        MDVjMThkOWE1YjIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy85YjY2NDUwNC00MGRhLTRhMzAtOWU5YS02MDhmYjJhYjYwNWEv
+        Il0sImNvbmZpZ19ibG9iIjpudWxsLCJibG9icyI6W119LHsiX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzL2Q2ZWVlYzg2
+        LWQ5MDYtNDhkZS05OGRjLWYwZWQ4ZDAyMWU2OC8iLCJfY3JlYXRlZCI6IjIw
+        MTktMDctMThUMTc6NDI6MjAuNTA2MDgzWiIsIl90eXBlIjoiZG9ja2VyLm1h
+        bmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9j
+        NzNjYzkyOS1hYzBiLTQ3Y2QtOTdmNi1mYjk5MGViNzEzYjEvIiwiZGlnZXN0
+        Ijoic2hhMjU2OjY1NDBmYzA4ZWU2ZTZiN2I2MzQ2OGRjMzMxN2UzMzAzYWFl
+        MTc4Y2I4YTQ1ZWQzMTIzMTgwMzI4YmNjMWQyMGYiLCJzY2hlbWFfdmVyc2lv
+        biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
+        dHJpYnV0aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5p
+        ZmVzdHMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0
+        cy85NWQ5NDRmMS1lNzFkLTQxMWMtYTJhMy02Mjg2Njg5NWZlMDQvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy83YTEyODdjZS00
+        ZDM1LTRkMmQtOGU1My0zZWMyNTc5ZTk5N2MvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZG9ja2VyL21hbmlmZXN0cy8wZTk1ZTcyNS04YTc5LTRlN2QtOTQ4
+        My05ZTA5ZDg0NGQ1OTUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2Vy
+        L21hbmlmZXN0cy80MjJmNjVkYy00ZmJkLTQyNTgtODRhOS01NmRkNmI2YzRm
+        OGQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy9k
+        ZDAxZmNmMS02YzUzLTRjNDctYTcyMy0zMmU5OTUzYjUxOWUvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy9hMzQ1M2I3OC03NTlj
+        LTQxMmItYWE4MS01YWUwOTVlZTA0ZDQvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL21hbmlmZXN0cy84ZDg0M2RmYy05NzlkLTQwZjEtOWIxZC1i
+        MDVjMThkOWE1YjIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy85YjY2NDUwNC00MGRhLTRhMzAtOWU5YS02MDhmYjJhYjYwNWEv
+        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8zOGVj
+        ZDhjYS1lNmI0LTQyNzQtYmE2OS03OTc3NTUxMTlhZGYvIl0sImNvbmZpZ19i
+        bG9iIjpudWxsLCJibG9icyI6W119LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzE4YTk1YWRkLTNkNzMtNDQzMi1i
+        MDNhLWNiOTI4MDgzNTFiZS8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6
+        NDI6MjAuNTA4OTg3WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2Fy
+        dGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8xZjZhMjBkOS0zYWU5
+        LTQ1Y2EtYjU5ZC03NzVjMjM0MDQ3OTIvIiwiZGlnZXN0Ijoic2hhMjU2Ojlk
+        NjZkYjBjNmEzZGU4YTI4MDgxOTc3YTc1YzZmMmE5NjU4MmRiM2VlMGQ4MzNh
+        NTFkMTg0Mzg1NDEyZGJkMjAiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFf
+        dHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1h
+        bmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOlsiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8wZTk1ZTcyNS04
+        YTc5LTRlN2QtOTQ4My05ZTA5ZDg0NGQ1OTUvIl0sImNvbmZpZ19ibG9iIjpu
+        dWxsLCJibG9icyI6W119LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvbWFuaWZlc3RzL2Q5YTUzYjk4LTQyNjEtNGJjYi04ZGQ2LWZk
+        M2RhYTMwN2IwNi8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6NDI6MjAu
+        NTExNzQ3WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0
+        IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy85ZTY5MTNjMi0xODcxLTQ2MTkt
+        OTlmZi0wN2Y0MjdkNzdiODIvIiwiZGlnZXN0Ijoic2hhMjU2OjFkMjk4NmFi
+        ZDkzM2MwYzk3Nzk5YjM0ZTZjZTE2ZjNhMTFmNzQyOWE5MzgzOGM3MDMzY2Ni
+        MmY3ZjAxOTk3OTAiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6
+        ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0
+        Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOlsiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8wM2QyNWJmYy1mOGUzLTQ2
+        YjMtOTZmOS04YjU5Y2UxNzc4YjEvIl0sImNvbmZpZ19ibG9iIjpudWxsLCJi
+        bG9icyI6W119LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvbWFuaWZlc3RzLzhlMDJhZmE2LTE5NDUtNDc5Ny1hYzFjLWExODRlMDFj
+        M2I2MC8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6NDI6MjAuNTE0NTA0
+        WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1
+        bHAvYXBpL3YzL2FydGlmYWN0cy8yZDI3M2IxOS0yNTY2LTQ5NjYtODE4OS1j
+        ZmNmZDFmMjc0MzEvIiwiZGlnZXN0Ijoic2hhMjU2OmUyNmZhOGRiMmNjNDY4
+        MzUwOTRhODRmNTlhNTUxNWMzZTcyN2YxZTVkNzU3OGIyM2ExMTcwYWI4ZjYx
+        ZmJmYWUiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxp
+        Y2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0Lmxpc3Qu
+        djIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOlsiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZG9ja2VyL21hbmlmZXN0cy8wZTk1ZTcyNS04YTc5LTRlN2QtOTQ4
+        My05ZTA5ZDg0NGQ1OTUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2Vy
+        L21hbmlmZXN0cy9kZDAxZmNmMS02YzUzLTRjNDctYTcyMy0zMmU5OTUzYjUx
+        OWUvIl0sImNvbmZpZ19ibG9iIjpudWxsLCJibG9icyI6W119LHsiX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzE0YmEz
+        NzRhLTdiMGUtNDE2MS1iYTdmLThjNDI0MDM0NTI1OC8iLCJfY3JlYXRlZCI6
+        IjIwMTktMDctMThUMTc6NDI6MjAuNTE3MjE1WiIsIl90eXBlIjoiZG9ja2Vy
+        Lm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
+        cy9jMjEwY2Q1NS03NWI1LTQzMDEtYWE3NS0yYjEzYTg4ZjYyYmUvIiwiZGln
+        ZXN0Ijoic2hhMjU2Ojg3OGZkOTEzMDEwZDI2NjEzMzE5ZWM3Y2M4M2I0MDBj
+        YjkyMTEzYzMxNGRhMzI0NjgxZDlmZWNmYjUwODJlZGMiLCJzY2hlbWFfdmVy
+        c2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIu
+        ZGlzdHJpYnV0aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9t
+        YW5pZmVzdHMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlm
+        ZXN0cy83MTAwMTk5Ny00YjQ3LTQ2ODItODk3ZS0yZGUzMGQ3NTk3OTkvIl0s
+        ImNvbmZpZ19ibG9iIjpudWxsLCJibG9icyI6W119LHsiX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzUzZDg4YmRkLTY3
+        YzctNDNjOC04NDUyLWMwNmM5Nzg4MjcxNy8iLCJfY3JlYXRlZCI6IjIwMTkt
+        MDctMThUMTc6NDI6MjAuNTE5NjY1WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlm
+        ZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9iODA1
+        ZDJiMC00YmFlLTQyM2QtYmVhNi1iZmNlZjQ2MjFhZDcvIiwiZGlnZXN0Ijoi
+        c2hhMjU2OmQzYzZhM2JlZTZmZDc2ZjVmZTJiMDU5NjhiZjNhNzBlYzc1YTBk
+        MjZmYmY5OGQyNDI5ZDgyNGI1YjAxOTJmODMiLCJzY2hlbWFfdmVyc2lvbiI6
+        MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJp
+        YnV0aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVz
+        dHMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy9h
+        NGExNmM5OC0wZDdkLTQ2ZTgtYmM3YS05MTNlNDg4ZDhkM2YvIl0sImNvbmZp
+        Z19ibG9iIjpudWxsLCJibG9icyI6W119LHsiX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzhkODQzZGZjLTk3OWQtNDBm
+        MS05YjFkLWIwNWMxOGQ5YTViMi8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThU
+        MTc6NDI6MjAuNzU1MjI1WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0Iiwi
+        X2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy85MzMzOWFmZS02
+        MDZmLTRlMmQtOWFjYy05NjQ0MzczY2FmODUvIiwiZGlnZXN0Ijoic2hhMjU2
+        OjU3N2FkNDMzMWQ0ZmFjOTE4MDczMDhkYTk5ZWNjMTA3ZGNjNmIyMjU0YmM0
+        YzcxNjYzMjVmZDAxMTEzYmVhMmEiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVk
+        aWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9u
+        Lm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29u
+        ZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMv
+        YzhkZjY0YzAtYjU2MC00Mjk2LWIyYjMtOTAwNDA3ZDI4ZjBiLyIsImJsb2Jz
+        IjpbIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy9hMTVkNzZi
+        NS00NzY4LTRlYTAtODRkMS1jNGNjYmU5MjAxZjQvIl19LHsiX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzliNjY0NTA0
+        LTQwZGEtNGEzMC05ZTlhLTYwOGZiMmFiNjA1YS8iLCJfY3JlYXRlZCI6IjIw
+        MTktMDctMThUMTc6NDI6MjAuNjg1OTkwWiIsIl90eXBlIjoiZG9ja2VyLm1h
+        bmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8x
+        NjVhYzFhNy1iYmM4LTRhMTEtOTI5ZS0yZGY5NzAzMmY1ODgvIiwiZGlnZXN0
+        Ijoic2hhMjU2OmQwZDRjNTM4OWI1Mzg3NWIwZjIzNjRmOTRjNDY2Zjc3Y2Y2
+        ZjAyODExZmIwMmYwNDc3Yjk3ZDYwOWZiNTA1NjgiLCJzY2hlbWFfdmVyc2lv
+        biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
+        dHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3Rz
+        IjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvYmxvYnMvZWExZjhmMmMtYzczMy00ZWU4LTliZmQtNzY2ZDEwODY4MmI2
+        LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9i
+        cy9iNjI4YWQ2Ny03NzExLTQzMDktOThhZC1hMzkyMDFiN2NhYmIvIl19LHsi
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3Rz
+        Lzk1ZDk0NGYxLWU3MWQtNDExYy1hMmEzLTYyODY2ODk1ZmUwNC8iLCJfY3Jl
+        YXRlZCI6IjIwMTktMDctMThUMTc6NDI6MjAuNTY3Njk3WiIsIl90eXBlIjoi
+        ZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2Fy
+        dGlmYWN0cy8yOGU2ZDliMy0yNGZlLTRmYmYtOWNlYi1mNjEzZTYxN2QyYmQv
+        IiwiZGlnZXN0Ijoic2hhMjU2OjkyYzdmOWM5Mjg0NGJiYmI1ZDBhMTAxYjIy
+        ZjdjMmE3OTQ5ZTQwZjhlYTkwYzhiM2JjMzk2ODc5ZDk1ZTg5OWEiLCJzY2hl
+        bWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5k
+        b2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRf
+        bWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvYmxvYnMvYTJkYzQ2ZTktM2JmMS00YTQ5LWExNjYtZDc1
+        ZTJmNzM4MTQyLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2Rv
+        Y2tlci9ibG9icy9hNWIxZjQxMy03M2VhLTQyZWYtYWZiYi05ODUzZmQyNjdi
+        NmQvIl19LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIv
+        bWFuaWZlc3RzLzM4ZWNkOGNhLWU2YjQtNDI3NC1iYTY5LTc5Nzc1NTExOWFk
+        Zi8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6NDI6MjAuNzU5MTc4WiIs
+        Il90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAv
+        YXBpL3YzL2FydGlmYWN0cy9lODYzZjUyMi1iNWUyLTQ4ODAtODUwYi05ZWMw
+        ZTJmNGM2NDAvIiwiZGlnZXN0Ijoic2hhMjU2OjVhNGJkYWRkOWFjZDg3Nzll
+        ZDZmY2YwMDdhNGU3ZWQ3ZjkxOTA1NmE5MmMzYzY3ODI0YjRmZGVkMDZlZjBh
+        NmUiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0
+        aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24i
+        LCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvY2NhMGU1NDgtMTcyZi00Yjlm
+        LWFhOTctOGNmYzVmNGQyZmEzLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8wNmQ4MDRiZi0yYjlmLTQ2YmYtOTczMC04
+        YjlhM2I3MzZhNDIvIl19LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvbWFuaWZlc3RzLzBlOTVlNzI1LThhNzktNGU3ZC05NDgzLTll
+        MDlkODQ0ZDU5NS8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6NDI6MjAu
+        Njg3NDAzWiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0
+        IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8xZWFlYTc3ZS1kN2NmLTRiYTQt
+        OGRhOC01MjE5ZjY0MzM3NTYvIiwiZGlnZXN0Ijoic2hhMjU2OjA4NWJhMjll
+        OWFlODdmMTM3ZGQ4Njg2YjliZmZlZTc5YzIzODAwYjYzNTdhMDA1NThiYTY0
+        MzY3YzgwODRmYzMiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6
+        ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0
+        LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2Ii
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvMzQyNGQxMGYt
+        NzYwZS00N2YyLWJlZjktOGJjYzZhMjAxMTg2LyIsImJsb2JzIjpbIi9wdWxw
+        L2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy83M2ZhNGI4OC1mNWU4LTRj
+        NWMtYTE0OC05Y2MyYjk0ODYxMDgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        ZG9ja2VyL2Jsb2JzL2JlYzQxM2E0LTYzYjctNGU4Yi1hYmNhLTkxN2FmZjY4
+        OTYxOS8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvN2ExMjg3Y2UtNGQzNS00ZDJkLThlNTMtM2VjMjU3OWU5
+        OTdjLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41MjIxMzJa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVs
+        cC9hcGkvdjMvYXJ0aWZhY3RzLzI4MWNlNGY5LWUzM2MtNDEzZC1hNWEzLTAw
+        Zjk3YTQ3ZjdlNS8iLCJkaWdlc3QiOiJzaGEyNTY6MTJjZjllZjkwODM1NDY1
+        MzE2Y2IwYjM3MjljMzZiZmQ4NjU0ZDdmMmY2OTdlMjM0MzJmZGRmYWE3ZDdl
+        MzFiNSIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGlj
+        YXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNv
+        biIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy9jMzI0NDc1NS1lNWU2LTRl
+        MTMtOGM3Yy0yY2ZiNzhhMWRjMjYvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvZG9ja2VyL2Jsb2JzL2FmN2JmMGMxLTM2NTgtNGZmOC05MGQw
+        LWJiNzgwZjQxYWI3ZS8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L2RvY2tlci9tYW5pZmVzdHMvNzEwMDE5OTctNGI0Ny00NjgyLTg5N2Ut
+        MmRlMzBkNzU5Nzk5LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0Mjoy
+        MS4wMzE4MzBaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZh
+        Y3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzFhNjZhMzU1LTExZmUtNGE1
+        ZS1hYzM5LTljMDBkZmRlZTIxNi8iLCJkaWdlc3QiOiJzaGEyNTY6YzFiZTZl
+        MTQ2ODQ4NTc1NzY5OGFmNTI4ZmZmNzc0ZDQ3NGU2OWY0NDhlZWY0M2MzNjhm
+        YTJmMmJlMTI4OGI0ZCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBl
+        IjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZl
+        c3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxv
+        YiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy8yMTQwNDNi
+        MC1mNGJiLTQyNTItOGE4OC0zMTQ4N2M2NDRmMDAvIiwiYmxvYnMiOlsiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzL2I2NGJmNDM3LTFkM2Mt
+        NGRhNS04NzE0LWM2ODdiNTFhYjZmOC8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvYmxvYnMvMTI3MGEwNjMtMGMyMS00NmIxLWI4MzEtOTNkMjk1
+        NTBiOTI0LyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL21hbmlmZXN0cy80MjJmNjVkYy00ZmJkLTQyNTgtODRhOS01NmRkNmI2
+        YzRmOGQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjQyOjIwLjczMTc4
+        MFoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9w
+        dWxwL2FwaS92My9hcnRpZmFjdHMvMTczMmVmMGYtMThlNS00ODUzLWJmM2Ut
+        ODkzZDljOTg5ZDUwLyIsImRpZ2VzdCI6InNoYTI1NjoxZTQ0ZDhiY2E2ZmIw
+        NDY0Nzk0NTU1ZTVjY2QzYTMyZTJhNGY2ZTQ0YTIwNjA1ZTRlODI2MDUxODk5
+        MDRmNDRkIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBs
+        aWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitq
+        c29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzL2M4MTliZDJiLWVlMWUt
+        NGM0My04MjJkLTE0MDNkYjg0MDgxNi8iLCJibG9icyI6WyIvcHVscC9hcGkv
+        djMvY29udGVudC9kb2NrZXIvYmxvYnMvNjI5MWI2ZTItZTU0MC00YWY2LWI3
+        YjItZTY4NGY3ZjE3NmFhLyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZG9ja2VyL21hbmlmZXN0cy9kZDAxZmNmMS02YzUzLTRjNDctYTcy
+        My0zMmU5OTUzYjUxOWUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjQy
+        OjIwLjY4NDQyNloiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRp
+        ZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODA3NmI4OTctMTM0Mi00
+        ZTg5LTk1YjItYzZkNTUxNmYyZjU2LyIsImRpZ2VzdCI6InNoYTI1NjphZjM3
+        YjY2ZDAxN2FlMjJkMmRlMWExMjhjZTA0OWRhNjYxZWI3NWEwZjUyMDA3YzU3
+        YzJmNjE2ODFkOTk5ZTUwIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5
+        cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5p
+        ZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19i
+        bG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzEzZWM1
+        MTA4LTJiMmQtNGVkZi1iYzlmLWUzZTFkNTI4NmQ4Mi8iLCJibG9icyI6WyIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvMjc3MTJjMWQtM2Ri
+        Yi00N2JkLWFmZjYtZTBmNGJkZjI5MjRmLyIsIi9wdWxwL2FwaS92My9jb250
+        ZW50L2RvY2tlci9ibG9icy9mN2U5NWJiYS1lMmU5LTRiNzctYTRlMC1mZjk0
+        MjJlMmRjNWMvIl19LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvbWFuaWZlc3RzLzZjZDU1ZTliLWJiODktNDI3My1hZmVkLTk0MzRk
+        NjVmMjQ5Yy8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6NDI6MjAuNzI4
+        ODkzWiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0Ijoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy85YTYxNjViMy04N2IxLTRhNTYtOTc1
+        OC0zNTNhNDc0ZWRiM2UvIiwiZGlnZXN0Ijoic2hhMjU2Ojg1ZGM1ZmJlMTYy
+        MTQzNjY3NDhlYmU5ZDdjYzczYmM0MmQ2MWQxOWQ2MWZlMDVmMDFlMzE3ZDI3
+        OGMyMjg3ZWQiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFw
+        cGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYy
+        K2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2IiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvYjQ0ODE1ODctYTgy
+        MC00MDlhLTkxM2QtZTM1ZWRhMGNlZmZjLyIsImJsb2JzIjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L2RvY2tlci9ibG9icy8yNWJiZWJiYi1hYmViLTQyNjYt
+        YmZhNS0xY2IzMWNkMmYxNjMvIl19LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9kb2NrZXIvbWFuaWZlc3RzL2EzNDUzYjc4LTc1OWMtNDEyYi1h
+        YTgxLTVhZTA5NWVlMDRkNC8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6
+        NDI6MjAuNzI3NzYyWiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2Fy
+        dGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9jMTFlODgzYS1mY2I1
+        LTRmYmYtYmZlYy03NTJjYWNiZThlZTEvIiwiZGlnZXN0Ijoic2hhMjU2OmQx
+        ZmQyZTIwNGFmMGEyYmNhM2FiMDMzYjQxN2IyOWM3NmQ3OTUwZWQyOWE0NGU0
+        MjdkMWM0ZDA3ZDE0ZjA0ZjkiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFf
+        dHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1h
+        bmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmln
+        X2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvY2M0
+        Y2MzZDAtYjNlZS00MDk0LTljNTUtMmQ5ZGZkZWY5ZTFhLyIsImJsb2JzIjpb
+        Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy8yYzc4NzVmYS1k
+        ZTZiLTQxZDctODJhYS1kYzQ4MTQwY2M0N2UvIl19LHsiX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzL2E0YTE2Yzk4LTBk
+        N2QtNDZlOC1iYzdhLTkxM2U0ODhkOGQzZi8iLCJfY3JlYXRlZCI6IjIwMTkt
+        MDctMThUMTc6NDI6MjAuOTg5NTAxWiIsIl90eXBlIjoiZG9ja2VyLm1hbmlm
+        ZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy84NGU3
+        MGJmYS1iYjIyLTQyYjctODcwMS1jZDNlOTFiODA1NGIvIiwiZGlnZXN0Ijoi
+        c2hhMjU2Ojc4NmEyOTk3NDkwODU1MTMzNWYzNzliNzQ0NDM4ZjI1ZGUwYTU3
+        ZTkwNzM1OGQ0MzBlOGNmODViZTVmYzE0NjQiLCJzY2hlbWFfdmVyc2lvbiI6
+        MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJp
+        YnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpb
+        XSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIv
+        YmxvYnMvMTc5OTg2MjMtMzk0Zi00N2IwLTllNDctMWFlNDMyYTcwNGI1LyIs
+        ImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy8z
+        NTIyMjMxMS02Mjg2LTQwNDEtYTlhNS1kNWJlNWZlMDNlMGIvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzhhMjc2MWRmLTBjMzMtNGQz
+        MC05NmUwLTE4ZmQ2NzRlODA3Yi8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvMDNkMjViZmMtZjhlMy00NmIz
+        LTk2ZjktOGI1OWNlMTc3OGIxLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQx
+        Nzo0MjoyMC43NTgxMjdaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJf
+        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzE2MzQyNmZjLWRk
+        NDgtNGRiNy1hZTJlLTc5NDk0Y2U2NTAxNy8iLCJkaWdlc3QiOiJzaGEyNTY6
+        MDhjYTRmMmM0NTMxNmNiMGI3OWZhZjhmMDc2MjUwNDZkYmJjMTZmNmYxNDBi
+        MGM1OWRhMDNmMTMyM2FkYThhNCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRp
+        YV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24u
+        bWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25m
+        aWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy9h
+        ODYyOWE5Yy01ZTBjLTQyNDktOWQ1My02ZTk3MDcxZjAyM2QvIiwiYmxvYnMi
+        OlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzRiNDVlYzNh
+        LTdkOGMtNGIwZi1hMTA3LWExZTZlY2NkMmVkNy8iLCIvcHVscC9hcGkvdjMv
+        Y29udGVudC9kb2NrZXIvYmxvYnMvMzEyYWRmYmYtYmU0MC00OWU1LTkxYWMt
+        NGIwYWNjNDJmODUzLyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL21hbmlmZXN0cy82MzRmNjFiNi1jZGQ2LTRmMGYtOGM4ZS0x
+        Y2UxOWNmYzdlNjgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAx
+        LjkwNDU0MloiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFj
+        dCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNzE3NjU0ZDAtM2VlZC00MzY5
+        LTk0NmEtNGI1N2ZmMzc0YmZlLyIsImRpZ2VzdCI6InNoYTI1Njo5ZjEwMDNj
+        NDgwNjk5YmU1NjgxNWRiMGY4MTQ2YWQyZTIyZWZlYTg1MTI5YjViNTk4M2Qw
+        ZTBmYjUyZDlhYjcwIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUi
+        OiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVz
+        dC5saXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvNTgyOWZlMGMtNGJkYS00
+        N2FmLWE0OWUtNzJmMmNkOTkxYTVlLyIsIi9wdWxwL2FwaS92My9jb250ZW50
+        L2RvY2tlci9tYW5pZmVzdHMvM2JhYjQ2YTgtMjZhOS00ZGVkLThjMjUtOTdl
+        MTUwNmMyZGU2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5p
+        ZmVzdHMvZmY5ODU1MWMtYzBmMC00ZjgyLWFiZWMtMTQwODVmMjllY2ZiLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvNmYwNTYy
+        YWQtZGU1Ny00ZmEyLTliMDgtOGE3MDkxOTIyNWU3LyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvNTMzNGIzZjEtZDU3OC00ZWRk
+        LWJmMzMtZmMwMjgwZjNiNjA4LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2Rv
+        Y2tlci9tYW5pZmVzdHMvMDQxNDJlMWMtZmI4Mi00YTEwLTliZGEtNWZmZTNm
+        NDkwNzM5LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVz
+        dHMvNDQyMDk0ODktMGRmNC00ZTUxLWFjZmUtNDVlNGNjMTJhMjY2LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvYzVjM2QzNGQt
+        NzA3YS00YmI0LWIxMGQtMWMxYWZiZTBmN2YzLyJdLCJjb25maWdfYmxvYiI6
+        bnVsbCwiYmxvYnMiOltdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL21hbmlmZXN0cy80NDIwOTQ4OS0wZGY0LTRlNTEtYWNmZS00
+        NWU0Y2MxMmEyNjYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAx
+        Ljk4MzU2MFoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFj
+        dCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMjNjZWU2NzctYjZhZC00YjUz
+        LTk4YTAtNDVlNzc5YjZiOGRiLyIsImRpZ2VzdCI6InNoYTI1NjplMThjZTUx
+        YjU4YmIxMWVlZDIyMTZjYTNlNWU5NGRjOTA2YmIwNGIzNTkzNzY4ODRiZTEx
+        MGY1MDI2YjFmOWMxIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUi
+        OiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVz
+        dC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9i
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzMzZmQ0MGNj
+        LWYwY2EtNDkzOC1iZDdjLWY5YjAzZjBiZmE0NC8iLCJibG9icyI6WyIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvOGFjNGJlZTgtNjMwYS00
+        Yjg2LThiYTktYzc1ODY1MDQwODIyLyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy9mZjk4NTUxYy1jMGYwLTRm
+        ODItYWJlYy0xNDA4NWYyOWVjZmIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDE5OjQwOjAyLjA3MTg4MFoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIs
+        Il9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYTY4YTc1MzYt
+        ZTA4ZS00YmJmLTlmODMtYmE3N2Y4YzJkYjQzLyIsImRpZ2VzdCI6InNoYTI1
+        NjpmZDg2YWNkNWE5ZjhiMmJkMzRkMzljZDBhZWZhOWM1MDNkYzhmZTYxNTBm
+        ZTE1Y2UzY2Y5MGYyODhlYjE1NWQzIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
+        ZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlv
+        bi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNv
+        bmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2Jz
+        LzY5ZTNiMDdmLTM3NDQtNDU0Yy1iODUzLTM5OWM5NTkzYmE0OC8iLCJibG9i
+        cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvZDE1YjIx
+        MDMtZGVlNi00OTNiLTk3NjEtZGUxNDBmZjJkMWJjLyJdfSx7Il9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8wNDE0MmUx
+        Yy1mYjgyLTRhMTAtOWJkYS01ZmZlM2Y0OTA3MzkvIiwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTIyVDE5OjQwOjAyLjA4Mjk4NVoiLCJfdHlwZSI6ImRvY2tlci5t
+        YW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
+        OWVjNjhhNmUtMDdmYi00Y2MzLTk5YmQtZGVlNWJlYWNiZGY0LyIsImRpZ2Vz
+        dCI6InNoYTI1NjpmM2RlZTk4OGJhOTAxYmQyZjI4MjI2MjUyMzAyOTliYTVl
+        ZTJkZGZiZTJiOGI0NTU4NTZmMmIwNzMzYmFmOGQwIiwic2NoZW1hX3ZlcnNp
+        b24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRp
+        c3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0
+        cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL2Jsb2JzL2EzNmRmNGM0LTJkZmEtNDMzZi1iZDQ4LTE5NjFjZGM5YWJl
+        NC8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxv
+        YnMvM2M4ZDk5OWQtZjFhZi00YjMxLWE1ZGItNzVjYjE3MmUyZjMzLyJdfSx7
+        Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0
+        cy9jNWMzZDM0ZC03MDdhLTRiYjQtYjEwZC0xYzFhZmJlMGY3ZjMvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAxLjk4NDk1NFoiLCJfdHlwZSI6
+        ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9h
+        cnRpZmFjdHMvODZkYjI2N2QtMzNjYy00NTI5LWEyNDctNmZlYWY3OGIwN2Ji
+        LyIsImRpZ2VzdCI6InNoYTI1NjpmYjgyZWY3YjdhZTA5MWY2NzVmNmUwMzRm
+        MzEzNGUyZjEyOWY0ZjdiZWMyYjIwNWU0NTg5NDNhOGYzZWRiNzNiIiwic2No
+        ZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQu
+        ZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVk
+        X21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZG9ja2VyL2Jsb2JzL2VmZGFmYzY3LThhMjUtNGVkNi1hYWQyLTEz
+        ZjhiMDk3ZTg0YS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvYmxvYnMvZjQ4ZDc2OTktZWIwNC00OTEwLTg2YzMtZjExMzAxMjRh
+        ZDZmLyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2Vy
+        L21hbmlmZXN0cy82ZjA1NjJhZC1kZTU3LTRmYTItOWIwOC04YTcwOTE5MjI1
+        ZTcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAxLjk2NTY5Mloi
+        LCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxw
+        L2FwaS92My9hcnRpZmFjdHMvMjY4NTY2NWYtZDZjOC00MGZmLWJlOWUtMDVm
+        ZjBlOTUwMzc0LyIsImRpZ2VzdCI6InNoYTI1Njo4OTVhYjYyMmU5MmUxOGQ2
+        YjQ2MWQ2NzEwODE3NTdhZjdkYmFhM2IwMGUzZTI4ZTEyNTA1YWY3ODE3Zjcz
+        NjQ5Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNh
+        dGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29u
+        IiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzkxMzZiNThkLTRlODktNDhj
+        YS1hYmVkLTE1NTBlOWYzZjg3OS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMv
+        Y29udGVudC9kb2NrZXIvYmxvYnMvZGY4ZmIwN2MtYThjMi00NjRmLWIxNzMt
+        YTYwMzBmNTY2ODA4LyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL21hbmlmZXN0cy8zYmFiNDZhOC0yNmE5LTRkZWQtOGMyNS05
+        N2UxNTA2YzJkZTYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAx
+        Ljk5NTI2NVoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFj
+        dCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZWQyZGE2N2ItYzMzNC00OTVh
+        LWFiNDEtNjE4ZmJkY2UwMTZlLyIsImRpZ2VzdCI6InNoYTI1NjowZDc2MDQ1
+        NThmOTVkY2UwYzE3Y2VlMGNkZjQ1YThjNjhmMzVkN2ZjNzEwYTYwYTU5OGNk
+        NDNmNjUyOTc2ODc4Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUi
+        OiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVz
+        dC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9i
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzc2ZmFmOTMw
+        LTE2NmEtNGM2OS1iYmYwLTc4Y2U2ZjFlMTQ5OS8iLCJibG9icyI6WyIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvYTFhODAzMjItMDhlNi00
+        NGQzLWFkM2YtODU5ODk2ZmY0ZTA1LyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy81ODI5ZmUwYy00YmRhLTQ3
+        YWYtYTQ5ZS03MmYyY2Q5OTFhNWUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDE5OjQwOjAxLjkxMDczNVoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIs
+        Il9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvOGZjZjc3ZDAt
+        ZDgwNy00YTEwLThiNjgtMmQ3NTdmNjNjNDdmLyIsImRpZ2VzdCI6InNoYTI1
+        NjphZGZhYzBjMmJlNGJiODYwMDQ1OTViOGY5OTVkZjg4YmQ5OWIyODkxOTMx
+        NjE3ZGYwNTAxNThiYWE3MDljMzMxIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
+        ZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlv
+        bi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNv
+        bmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2Jz
+        LzA2NmM1YzQ5LTFjY2UtNGE3Yy1hYWQyLTY1Y2RiNDkyYjNjMi8iLCJibG9i
+        cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvNWQ4ZDc2
+        MjAtMDgzMy00MDc2LWE2NTYtOGM5NjgxMTkxYTJlLyJdfSx7Il9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy81MzM0YjNm
+        MS1kNTc4LTRlZGQtYmYzMy1mYzAyODBmM2I2MDgvIiwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTIyVDE5OjQwOjAxLjk4MjE0MVoiLCJfdHlwZSI6ImRvY2tlci5t
+        YW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
+        ZGJhNjA2YWItZjc2Yy00MGY5LWJhM2EtMGRkYTY2M2QzNmRhLyIsImRpZ2Vz
+        dCI6InNoYTI1Njo3OTI4OWMzMTQ2YTc3Y2U1YzdmZTBmYzhmYjA5NGMwYzE3
+        ZjhlZmVlMjkyNjIzZjkwYzUxNjMwZjk0YmI2NTE5Iiwic2NoZW1hX3ZlcnNp
+        b24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRp
+        c3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0
+        cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL2Jsb2JzLzE3MjhjMjAyLWFmMWMtNGU4My04ZmZkLWJjOGNjZTdhMGY3
+        MS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxv
+        YnMvZTAwNTQ0ZjYtMTMzMC00YTNiLWIyNmEtNmY4MzAwNWZiYTQwLyJdfV19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:43 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:43 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '5141'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MzQsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9t
+        YW5pZmVzdHMvOTViZTA1NWYtZmJhNS00NTc0LTg2YWEtOTg2YmNmZTRlZmM0
+        LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xN1QxOToxNzowNS43NzI3MzZaIiwi
+        X3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9h
+        cGkvdjMvYXJ0aWZhY3RzLzhjNzAwMTNjLWRjZDMtNDM3Yy1iNDRmLWJiYTkw
+        N2IwN2E5Ny8iLCJkaWdlc3QiOiJzaGEyNTY6ZGMyYWU2MzYxNjkxNWNlOTUy
+        N2ViOWJiMzg2NDZjYjM3MDBkMWE3OTAyNTI2NmQ2MDcwOWUyMTRiNDI0OGU1
+        NCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRp
+        b24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QubGlzdC52Mitq
+        c29uIiwibGlzdGVkX21hbmlmZXN0cyI6WyIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvbWFuaWZlc3RzLzRlMjYxMjJlLTQ1OGItNGI5My04ODQ1LWU1
+        NzUwNjIyY2Q5NS8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFu
+        aWZlc3RzLzAzY2ZlNzQ3LTFhNDQtNDRmNC1iZjFjLTY0NjI5ZGUxOThiZC8i
+        XSwiY29uZmlnX2Jsb2IiOm51bGwsImJsb2JzIjpbXX0seyJfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvNGUyNjEyMmUt
+        NDU4Yi00YjkzLTg4NDUtZTU3NTA2MjJjZDk1LyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wNy0xN1QxOToxNzowNS43NjkzODhaIiwiX3R5cGUiOiJkb2NrZXIubWFu
+        aWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzAy
+        ZjkyNzcyLWMwOTItNDczYS04MWRmLTg2OTIzNzk3ZmY2OS8iLCJkaWdlc3Qi
+        OiJzaGEyNTY6YjM1MjAwYmU2NzhkNDc1M2ZlNzc5ZWU1NDA2YzFmYzllZWM5
+        ZTllZTU2ZjAyYjc5ZTQ2YzY1ZDVmMGNlNzYyNyIsInNjaGVtYV92ZXJzaW9u
+        IjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0
+        cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMi
+        OltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9ibG9icy8xYmQ0ODBkYy1hNTI5LTQxNjYtYWM0ZC1mNTVlMDFkNWY5ZmIv
+        IiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2Jz
+        LzJjYWQ0Y2Y4LTc0MDctNDhmZS05ZTg5LTBjMDc2MWQ1M2NlZi8iXX0seyJf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMv
+        MDNjZmU3NDctMWE0NC00NGY0LWJmMWMtNjQ2MjlkZTE5OGJkLyIsIl9jcmVh
+        dGVkIjoiMjAxOS0wNy0xN1QxOToxNzowNS43NjMzMjhaIiwiX3R5cGUiOiJk
+        b2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0
+        aWZhY3RzL2E0YTM2YjIyLWJkYzMtNDk3Ni05ZDE3LTZmMmEyNDE5MzI3YS8i
+        LCJkaWdlc3QiOiJzaGEyNTY6OWI4NzRjY2RiNzNlMWFhZjI5ZTFjMGZkM2E1
+        NTBkZGZhNDg2ZDczNTI1ZjJkNzdiNDUyZTMwYTA5ZDNjYjQxNyIsInNjaGVt
+        YV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRv
+        Y2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9t
+        YW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L2RvY2tlci9ibG9icy9mYTBmZDhkMy1hZWI3LTQ5MjgtYjg3Ni05YzM0
+        YWJhOTViYjEvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL2Jsb2JzLzg1YjRjNDk1LWY3NzYtNGViZi04YWRjLWM3ZDFjMmI1NDFk
+        My8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9t
+        YW5pZmVzdHMvZDJjMzJlMDUtOTc5MC00ZjM1LTllMGUtZGUyNDcyN2FlZDg4
+        LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzozOTozOC4yNzUyOTVaIiwi
+        X3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVscC9h
+        cGkvdjMvYXJ0aWZhY3RzLzA5OGVkN2MxLTZkYWItNGEzNy04MGZkLWFlMjM3
+        YTA4ZWI3Ni8iLCJkaWdlc3QiOiJzaGEyNTY6YTZlY2JiMTU1MzM1M2EwODkz
+        NmY1MGMyNzViMDEwMzg4ZWQxYmQ2ZDlkODQ3NDNjN2U4ZTc0NjhlMmFjZDgy
+        ZSIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGljYXRp
+        b24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIs
+        Imxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L2RvY2tlci9ibG9icy83MjhiMjdlOC05OWMxLTRhYzYt
+        YTE2NC1hYjQ3ZTEzZWVhODUvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZG9ja2VyL2Jsb2JzL2E4MmUzMDRiLWM1Y2MtNDA0OS04NGM4LTgw
+        OWYzMDcxNWY2Ny8iLCIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxv
+        YnMvNTM2YjU3NjAtOGM2Yi00NGE3LWE3OTItMWFhMTIxYWFkMWQ5LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy8zZGRhZjQ4NC1kZGVj
+        LTRiMDAtYWYxMi1iNmNmZDc1NTZhOGQvIl19LHsiX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzL2QzNTJlMzg3LTk1MmIt
+        NDJiMy04Y2UxLTMxM2U1ZjUxMGZiNy8iLCJfY3JlYXRlZCI6IjIwMTktMDct
+        MThUMTc6NDI6MjAuNDk4MjQ0WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0
+        IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8xYzE1ZmE2
+        MC03MTljLTQwZmEtYjE0My0xOWVkNjY4YjcyNDIvIiwiZGlnZXN0Ijoic2hh
+        MjU2OmQ4MjgzYzg1MGFjMmYxYTkwYzVkZDk0YjlhN2FjOTdjY2FiY2I5ZTIw
+        ODJlMzEyN2I0MzJiMjk3ZDJhYmI2YzgiLCJzY2hlbWFfdmVyc2lvbiI6Miwi
+        bWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0
+        aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMi
+        OlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy9kZDAx
+        ZmNmMS02YzUzLTRjNDctYTcyMy0zMmU5OTUzYjUxOWUvIl0sImNvbmZpZ19i
+        bG9iIjpudWxsLCJibG9icyI6W119LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzEzYjBiNWM3LWMxYzktNGM2NS04
+        ZTQ4LWJmNmZiNjk5NTY1ZS8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6
+        NDI6MjAuNTAyMzkxWiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2Fy
+        dGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8zOWI4NTg4Zi1kZGYw
+        LTRmOWEtODUxMi0yMTI1ZjgzMWRlNjQvIiwiZGlnZXN0Ijoic2hhMjU2OjMx
+        YWI5OWI1NWEzMmFiNmRkMGRlYTgwNDRkYzI2Zjg5ZTNjODU0YmYwN2U0N2Uw
+        MjFiZGI2OWY1YzhhOTE4YjMiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFf
+        dHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1h
+        bmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOlsiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy85NWQ5NDRmMS1l
+        NzFkLTQxMWMtYTJhMy02Mjg2Njg5NWZlMDQvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZG9ja2VyL21hbmlmZXN0cy83YTEyODdjZS00ZDM1LTRkMmQtOGU1
+        My0zZWMyNTc5ZTk5N2MvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2Vy
+        L21hbmlmZXN0cy80MjJmNjVkYy00ZmJkLTQyNTgtODRhOS01NmRkNmI2YzRm
+        OGQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy82
+        Y2Q1NWU5Yi1iYjg5LTQyNzMtYWZlZC05NDM0ZDY1ZjI0OWMvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy9hMzQ1M2I3OC03NTlj
+        LTQxMmItYWE4MS01YWUwOTVlZTA0ZDQvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL21hbmlmZXN0cy84ZDg0M2RmYy05NzlkLTQwZjEtOWIxZC1i
+        MDVjMThkOWE1YjIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy85YjY2NDUwNC00MGRhLTRhMzAtOWU5YS02MDhmYjJhYjYwNWEv
+        Il0sImNvbmZpZ19ibG9iIjpudWxsLCJibG9icyI6W119LHsiX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzL2Q2ZWVlYzg2
+        LWQ5MDYtNDhkZS05OGRjLWYwZWQ4ZDAyMWU2OC8iLCJfY3JlYXRlZCI6IjIw
+        MTktMDctMThUMTc6NDI6MjAuNTA2MDgzWiIsIl90eXBlIjoiZG9ja2VyLm1h
+        bmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9j
+        NzNjYzkyOS1hYzBiLTQ3Y2QtOTdmNi1mYjk5MGViNzEzYjEvIiwiZGlnZXN0
+        Ijoic2hhMjU2OjY1NDBmYzA4ZWU2ZTZiN2I2MzQ2OGRjMzMxN2UzMzAzYWFl
+        MTc4Y2I4YTQ1ZWQzMTIzMTgwMzI4YmNjMWQyMGYiLCJzY2hlbWFfdmVyc2lv
+        biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
+        dHJpYnV0aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5p
+        ZmVzdHMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0
+        cy85NWQ5NDRmMS1lNzFkLTQxMWMtYTJhMy02Mjg2Njg5NWZlMDQvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy83YTEyODdjZS00
+        ZDM1LTRkMmQtOGU1My0zZWMyNTc5ZTk5N2MvIiwiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZG9ja2VyL21hbmlmZXN0cy8wZTk1ZTcyNS04YTc5LTRlN2QtOTQ4
+        My05ZTA5ZDg0NGQ1OTUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2Vy
+        L21hbmlmZXN0cy80MjJmNjVkYy00ZmJkLTQyNTgtODRhOS01NmRkNmI2YzRm
+        OGQvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy9k
+        ZDAxZmNmMS02YzUzLTRjNDctYTcyMy0zMmU5OTUzYjUxOWUvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy9hMzQ1M2I3OC03NTlj
+        LTQxMmItYWE4MS01YWUwOTVlZTA0ZDQvIiwiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL21hbmlmZXN0cy84ZDg0M2RmYy05NzlkLTQwZjEtOWIxZC1i
+        MDVjMThkOWE1YjIvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy85YjY2NDUwNC00MGRhLTRhMzAtOWU5YS02MDhmYjJhYjYwNWEv
+        IiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8zOGVj
+        ZDhjYS1lNmI0LTQyNzQtYmE2OS03OTc3NTUxMTlhZGYvIl0sImNvbmZpZ19i
+        bG9iIjpudWxsLCJibG9icyI6W119LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzE4YTk1YWRkLTNkNzMtNDQzMi1i
+        MDNhLWNiOTI4MDgzNTFiZS8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6
+        NDI6MjAuNTA4OTg3WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2Fy
+        dGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8xZjZhMjBkOS0zYWU5
+        LTQ1Y2EtYjU5ZC03NzVjMjM0MDQ3OTIvIiwiZGlnZXN0Ijoic2hhMjU2Ojlk
+        NjZkYjBjNmEzZGU4YTI4MDgxOTc3YTc1YzZmMmE5NjU4MmRiM2VlMGQ4MzNh
+        NTFkMTg0Mzg1NDEyZGJkMjAiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFf
+        dHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1h
+        bmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOlsiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8wZTk1ZTcyNS04
+        YTc5LTRlN2QtOTQ4My05ZTA5ZDg0NGQ1OTUvIl0sImNvbmZpZ19ibG9iIjpu
+        dWxsLCJibG9icyI6W119LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvbWFuaWZlc3RzL2Q5YTUzYjk4LTQyNjEtNGJjYi04ZGQ2LWZk
+        M2RhYTMwN2IwNi8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6NDI6MjAu
+        NTExNzQ3WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0
+        IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy85ZTY5MTNjMi0xODcxLTQ2MTkt
+        OTlmZi0wN2Y0MjdkNzdiODIvIiwiZGlnZXN0Ijoic2hhMjU2OjFkMjk4NmFi
+        ZDkzM2MwYzk3Nzk5YjM0ZTZjZTE2ZjNhMTFmNzQyOWE5MzgzOGM3MDMzY2Ni
+        MmY3ZjAxOTk3OTAiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6
+        ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0
+        Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOlsiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8wM2QyNWJmYy1mOGUzLTQ2
+        YjMtOTZmOS04YjU5Y2UxNzc4YjEvIl0sImNvbmZpZ19ibG9iIjpudWxsLCJi
+        bG9icyI6W119LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvbWFuaWZlc3RzLzhlMDJhZmE2LTE5NDUtNDc5Ny1hYzFjLWExODRlMDFj
+        M2I2MC8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6NDI6MjAuNTE0NTA0
+        WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1
+        bHAvYXBpL3YzL2FydGlmYWN0cy8yZDI3M2IxOS0yNTY2LTQ5NjYtODE4OS1j
+        ZmNmZDFmMjc0MzEvIiwiZGlnZXN0Ijoic2hhMjU2OmUyNmZhOGRiMmNjNDY4
+        MzUwOTRhODRmNTlhNTUxNWMzZTcyN2YxZTVkNzU3OGIyM2ExMTcwYWI4ZjYx
+        ZmJmYWUiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxp
+        Y2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0Lmxpc3Qu
+        djIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOlsiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZG9ja2VyL21hbmlmZXN0cy8wZTk1ZTcyNS04YTc5LTRlN2QtOTQ4
+        My05ZTA5ZDg0NGQ1OTUvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2Vy
+        L21hbmlmZXN0cy9kZDAxZmNmMS02YzUzLTRjNDctYTcyMy0zMmU5OTUzYjUx
+        OWUvIl0sImNvbmZpZ19ibG9iIjpudWxsLCJibG9icyI6W119LHsiX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzE0YmEz
+        NzRhLTdiMGUtNDE2MS1iYTdmLThjNDI0MDM0NTI1OC8iLCJfY3JlYXRlZCI6
+        IjIwMTktMDctMThUMTc6NDI6MjAuNTE3MjE1WiIsIl90eXBlIjoiZG9ja2Vy
+        Lm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0
+        cy9jMjEwY2Q1NS03NWI1LTQzMDEtYWE3NS0yYjEzYTg4ZjYyYmUvIiwiZGln
+        ZXN0Ijoic2hhMjU2Ojg3OGZkOTEzMDEwZDI2NjEzMzE5ZWM3Y2M4M2I0MDBj
+        YjkyMTEzYzMxNGRhMzI0NjgxZDlmZWNmYjUwODJlZGMiLCJzY2hlbWFfdmVy
+        c2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIu
+        ZGlzdHJpYnV0aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9t
+        YW5pZmVzdHMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlm
+        ZXN0cy83MTAwMTk5Ny00YjQ3LTQ2ODItODk3ZS0yZGUzMGQ3NTk3OTkvIl0s
+        ImNvbmZpZ19ibG9iIjpudWxsLCJibG9icyI6W119LHsiX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzUzZDg4YmRkLTY3
+        YzctNDNjOC04NDUyLWMwNmM5Nzg4MjcxNy8iLCJfY3JlYXRlZCI6IjIwMTkt
+        MDctMThUMTc6NDI6MjAuNTE5NjY1WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlm
+        ZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9iODA1
+        ZDJiMC00YmFlLTQyM2QtYmVhNi1iZmNlZjQ2MjFhZDcvIiwiZGlnZXN0Ijoi
+        c2hhMjU2OmQzYzZhM2JlZTZmZDc2ZjVmZTJiMDU5NjhiZjNhNzBlYzc1YTBk
+        MjZmYmY5OGQyNDI5ZDgyNGI1YjAxOTJmODMiLCJzY2hlbWFfdmVyc2lvbiI6
+        MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJp
+        YnV0aW9uLm1hbmlmZXN0Lmxpc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVz
+        dHMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy9h
+        NGExNmM5OC0wZDdkLTQ2ZTgtYmM3YS05MTNlNDg4ZDhkM2YvIl0sImNvbmZp
+        Z19ibG9iIjpudWxsLCJibG9icyI6W119LHsiX2hyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzhkODQzZGZjLTk3OWQtNDBm
+        MS05YjFkLWIwNWMxOGQ5YTViMi8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThU
+        MTc6NDI6MjAuNzU1MjI1WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0Iiwi
+        X2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy85MzMzOWFmZS02
+        MDZmLTRlMmQtOWFjYy05NjQ0MzczY2FmODUvIiwiZGlnZXN0Ijoic2hhMjU2
+        OjU3N2FkNDMzMWQ0ZmFjOTE4MDczMDhkYTk5ZWNjMTA3ZGNjNmIyMjU0YmM0
+        YzcxNjYzMjVmZDAxMTEzYmVhMmEiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVk
+        aWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9u
+        Lm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29u
+        ZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMv
+        YzhkZjY0YzAtYjU2MC00Mjk2LWIyYjMtOTAwNDA3ZDI4ZjBiLyIsImJsb2Jz
+        IjpbIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy9hMTVkNzZi
+        NS00NzY4LTRlYTAtODRkMS1jNGNjYmU5MjAxZjQvIl19LHsiX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzliNjY0NTA0
+        LTQwZGEtNGEzMC05ZTlhLTYwOGZiMmFiNjA1YS8iLCJfY3JlYXRlZCI6IjIw
+        MTktMDctMThUMTc6NDI6MjAuNjg1OTkwWiIsIl90eXBlIjoiZG9ja2VyLm1h
+        bmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8x
+        NjVhYzFhNy1iYmM4LTRhMTEtOTI5ZS0yZGY5NzAzMmY1ODgvIiwiZGlnZXN0
+        Ijoic2hhMjU2OmQwZDRjNTM4OWI1Mzg3NWIwZjIzNjRmOTRjNDY2Zjc3Y2Y2
+        ZjAyODExZmIwMmYwNDc3Yjk3ZDYwOWZiNTA1NjgiLCJzY2hlbWFfdmVyc2lv
+        biI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlz
+        dHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3Rz
+        IjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvYmxvYnMvZWExZjhmMmMtYzczMy00ZWU4LTliZmQtNzY2ZDEwODY4MmI2
+        LyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9i
+        cy9iNjI4YWQ2Ny03NzExLTQzMDktOThhZC1hMzkyMDFiN2NhYmIvIl19LHsi
+        X2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3Rz
+        Lzk1ZDk0NGYxLWU3MWQtNDExYy1hMmEzLTYyODY2ODk1ZmUwNC8iLCJfY3Jl
+        YXRlZCI6IjIwMTktMDctMThUMTc6NDI6MjAuNTY3Njk3WiIsIl90eXBlIjoi
+        ZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2Fy
+        dGlmYWN0cy8yOGU2ZDliMy0yNGZlLTRmYmYtOWNlYi1mNjEzZTYxN2QyYmQv
+        IiwiZGlnZXN0Ijoic2hhMjU2OjkyYzdmOWM5Mjg0NGJiYmI1ZDBhMTAxYjIy
+        ZjdjMmE3OTQ5ZTQwZjhlYTkwYzhiM2JjMzk2ODc5ZDk1ZTg5OWEiLCJzY2hl
+        bWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5k
+        b2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRf
+        bWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvYmxvYnMvYTJkYzQ2ZTktM2JmMS00YTQ5LWExNjYtZDc1
+        ZTJmNzM4MTQyLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2Rv
+        Y2tlci9ibG9icy9hNWIxZjQxMy03M2VhLTQyZWYtYWZiYi05ODUzZmQyNjdi
+        NmQvIl19LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIv
+        bWFuaWZlc3RzLzM4ZWNkOGNhLWU2YjQtNDI3NC1iYTY5LTc5Nzc1NTExOWFk
+        Zi8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6NDI6MjAuNzU5MTc4WiIs
+        Il90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAv
+        YXBpL3YzL2FydGlmYWN0cy9lODYzZjUyMi1iNWUyLTQ4ODAtODUwYi05ZWMw
+        ZTJmNGM2NDAvIiwiZGlnZXN0Ijoic2hhMjU2OjVhNGJkYWRkOWFjZDg3Nzll
+        ZDZmY2YwMDdhNGU3ZWQ3ZjkxOTA1NmE5MmMzYzY3ODI0YjRmZGVkMDZlZjBh
+        NmUiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0
+        aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYyK2pzb24i
+        LCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2IiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvY2NhMGU1NDgtMTcyZi00Yjlm
+        LWFhOTctOGNmYzVmNGQyZmEzLyIsImJsb2JzIjpbIi9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8wNmQ4MDRiZi0yYjlmLTQ2YmYtOTczMC04
+        YjlhM2I3MzZhNDIvIl19LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvbWFuaWZlc3RzLzBlOTVlNzI1LThhNzktNGU3ZC05NDgzLTll
+        MDlkODQ0ZDU5NS8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6NDI6MjAu
+        Njg3NDAzWiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0
+        IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8xZWFlYTc3ZS1kN2NmLTRiYTQt
+        OGRhOC01MjE5ZjY0MzM3NTYvIiwiZGlnZXN0Ijoic2hhMjU2OjA4NWJhMjll
+        OWFlODdmMTM3ZGQ4Njg2YjliZmZlZTc5YzIzODAwYjYzNTdhMDA1NThiYTY0
+        MzY3YzgwODRmYzMiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6
+        ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0
+        LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2Ii
+        OiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvMzQyNGQxMGYt
+        NzYwZS00N2YyLWJlZjktOGJjYzZhMjAxMTg2LyIsImJsb2JzIjpbIi9wdWxw
+        L2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy83M2ZhNGI4OC1mNWU4LTRj
+        NWMtYTE0OC05Y2MyYjk0ODYxMDgvIiwiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
+        ZG9ja2VyL2Jsb2JzL2JlYzQxM2E0LTYzYjctNGU4Yi1hYmNhLTkxN2FmZjY4
+        OTYxOS8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvN2ExMjg3Y2UtNGQzNS00ZDJkLThlNTMtM2VjMjU3OWU5
+        OTdjLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41MjIxMzJa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZhY3QiOiIvcHVs
+        cC9hcGkvdjMvYXJ0aWZhY3RzLzI4MWNlNGY5LWUzM2MtNDEzZC1hNWEzLTAw
+        Zjk3YTQ3ZjdlNS8iLCJkaWdlc3QiOiJzaGEyNTY6MTJjZjllZjkwODM1NDY1
+        MzE2Y2IwYjM3MjljMzZiZmQ4NjU0ZDdmMmY2OTdlMjM0MzJmZGRmYWE3ZDdl
+        MzFiNSIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBlIjoiYXBwbGlj
+        YXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNv
+        biIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxvYiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy9jMzI0NDc1NS1lNWU2LTRl
+        MTMtOGM3Yy0yY2ZiNzhhMWRjMjYvIiwiYmxvYnMiOlsiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvZG9ja2VyL2Jsb2JzL2FmN2JmMGMxLTM2NTgtNGZmOC05MGQw
+        LWJiNzgwZjQxYWI3ZS8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L2RvY2tlci9tYW5pZmVzdHMvNzEwMDE5OTctNGI0Ny00NjgyLTg5N2Ut
+        MmRlMzBkNzU5Nzk5LyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0Mjoy
+        MS4wMzE4MzBaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJfYXJ0aWZh
+        Y3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzFhNjZhMzU1LTExZmUtNGE1
+        ZS1hYzM5LTljMDBkZmRlZTIxNi8iLCJkaWdlc3QiOiJzaGEyNTY6YzFiZTZl
+        MTQ2ODQ4NTc1NzY5OGFmNTI4ZmZmNzc0ZDQ3NGU2OWY0NDhlZWY0M2MzNjhm
+        YTJmMmJlMTI4OGI0ZCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRpYV90eXBl
+        IjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZl
+        c3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25maWdfYmxv
+        YiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy8yMTQwNDNi
+        MC1mNGJiLTQyNTItOGE4OC0zMTQ4N2M2NDRmMDAvIiwiYmxvYnMiOlsiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzL2I2NGJmNDM3LTFkM2Mt
+        NGRhNS04NzE0LWM2ODdiNTFhYjZmOC8iLCIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvYmxvYnMvMTI3MGEwNjMtMGMyMS00NmIxLWI4MzEtOTNkMjk1
+        NTBiOTI0LyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL21hbmlmZXN0cy80MjJmNjVkYy00ZmJkLTQyNTgtODRhOS01NmRkNmI2
+        YzRmOGQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjQyOjIwLjczMTc4
+        MFoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9w
+        dWxwL2FwaS92My9hcnRpZmFjdHMvMTczMmVmMGYtMThlNS00ODUzLWJmM2Ut
+        ODkzZDljOTg5ZDUwLyIsImRpZ2VzdCI6InNoYTI1NjoxZTQ0ZDhiY2E2ZmIw
+        NDY0Nzk0NTU1ZTVjY2QzYTMyZTJhNGY2ZTQ0YTIwNjA1ZTRlODI2MDUxODk5
+        MDRmNDRkIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBs
+        aWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitq
+        c29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzL2M4MTliZDJiLWVlMWUt
+        NGM0My04MjJkLTE0MDNkYjg0MDgxNi8iLCJibG9icyI6WyIvcHVscC9hcGkv
+        djMvY29udGVudC9kb2NrZXIvYmxvYnMvNjI5MWI2ZTItZTU0MC00YWY2LWI3
+        YjItZTY4NGY3ZjE3NmFhLyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZG9ja2VyL21hbmlmZXN0cy9kZDAxZmNmMS02YzUzLTRjNDctYTcy
+        My0zMmU5OTUzYjUxOWUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjQy
+        OjIwLjY4NDQyNloiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRp
+        ZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvODA3NmI4OTctMTM0Mi00
+        ZTg5LTk1YjItYzZkNTUxNmYyZjU2LyIsImRpZ2VzdCI6InNoYTI1NjphZjM3
+        YjY2ZDAxN2FlMjJkMmRlMWExMjhjZTA0OWRhNjYxZWI3NWEwZjUyMDA3YzU3
+        YzJmNjE2ODFkOTk5ZTUwIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5
+        cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5p
+        ZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19i
+        bG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzEzZWM1
+        MTA4LTJiMmQtNGVkZi1iYzlmLWUzZTFkNTI4NmQ4Mi8iLCJibG9icyI6WyIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvMjc3MTJjMWQtM2Ri
+        Yi00N2JkLWFmZjYtZTBmNGJkZjI5MjRmLyIsIi9wdWxwL2FwaS92My9jb250
+        ZW50L2RvY2tlci9ibG9icy9mN2U5NWJiYS1lMmU5LTRiNzctYTRlMC1mZjk0
+        MjJlMmRjNWMvIl19LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvbWFuaWZlc3RzLzZjZDU1ZTliLWJiODktNDI3My1hZmVkLTk0MzRk
+        NjVmMjQ5Yy8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6NDI6MjAuNzI4
+        ODkzWiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2FydGlmYWN0Ijoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy85YTYxNjViMy04N2IxLTRhNTYtOTc1
+        OC0zNTNhNDc0ZWRiM2UvIiwiZGlnZXN0Ijoic2hhMjU2Ojg1ZGM1ZmJlMTYy
+        MTQzNjY3NDhlYmU5ZDdjYzczYmM0MmQ2MWQxOWQ2MWZlMDVmMDFlMzE3ZDI3
+        OGMyMjg3ZWQiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFfdHlwZSI6ImFw
+        cGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1hbmlmZXN0LnYy
+        K2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmlnX2Jsb2IiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvYjQ0ODE1ODctYTgy
+        MC00MDlhLTkxM2QtZTM1ZWRhMGNlZmZjLyIsImJsb2JzIjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L2RvY2tlci9ibG9icy8yNWJiZWJiYi1hYmViLTQyNjYt
+        YmZhNS0xY2IzMWNkMmYxNjMvIl19LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        Y29udGVudC9kb2NrZXIvbWFuaWZlc3RzL2EzNDUzYjc4LTc1OWMtNDEyYi1h
+        YTgxLTVhZTA5NWVlMDRkNC8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThUMTc6
+        NDI6MjAuNzI3NzYyWiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0IiwiX2Fy
+        dGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9jMTFlODgzYS1mY2I1
+        LTRmYmYtYmZlYy03NTJjYWNiZThlZTEvIiwiZGlnZXN0Ijoic2hhMjU2OmQx
+        ZmQyZTIwNGFmMGEyYmNhM2FiMDMzYjQxN2IyOWM3NmQ3OTUwZWQyOWE0NGU0
+        MjdkMWM0ZDA3ZDE0ZjA0ZjkiLCJzY2hlbWFfdmVyc2lvbiI6MiwibWVkaWFf
+        dHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJpYnV0aW9uLm1h
+        bmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbXSwiY29uZmln
+        X2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvY2M0
+        Y2MzZDAtYjNlZS00MDk0LTljNTUtMmQ5ZGZkZWY5ZTFhLyIsImJsb2JzIjpb
+        Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy8yYzc4NzVmYS1k
+        ZTZiLTQxZDctODJhYS1kYzQ4MTQwY2M0N2UvIl19LHsiX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzL2E0YTE2Yzk4LTBk
+        N2QtNDZlOC1iYzdhLTkxM2U0ODhkOGQzZi8iLCJfY3JlYXRlZCI6IjIwMTkt
+        MDctMThUMTc6NDI6MjAuOTg5NTAxWiIsIl90eXBlIjoiZG9ja2VyLm1hbmlm
+        ZXN0IiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy84NGU3
+        MGJmYS1iYjIyLTQyYjctODcwMS1jZDNlOTFiODA1NGIvIiwiZGlnZXN0Ijoi
+        c2hhMjU2Ojc4NmEyOTk3NDkwODU1MTMzNWYzNzliNzQ0NDM4ZjI1ZGUwYTU3
+        ZTkwNzM1OGQ0MzBlOGNmODViZTVmYzE0NjQiLCJzY2hlbWFfdmVyc2lvbiI6
+        MiwibWVkaWFfdHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuZGlzdHJp
+        YnV0aW9uLm1hbmlmZXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpb
+        XSwiY29uZmlnX2Jsb2IiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIv
+        YmxvYnMvMTc5OTg2MjMtMzk0Zi00N2IwLTllNDctMWFlNDMyYTcwNGI1LyIs
+        ImJsb2JzIjpbIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy8z
+        NTIyMjMxMS02Mjg2LTQwNDEtYTlhNS1kNWJlNWZlMDNlMGIvIiwiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzhhMjc2MWRmLTBjMzMtNGQz
+        MC05NmUwLTE4ZmQ2NzRlODA3Yi8iXX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvMDNkMjViZmMtZjhlMy00NmIz
+        LTk2ZjktOGI1OWNlMTc3OGIxLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQx
+        Nzo0MjoyMC43NTgxMjdaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QiLCJf
+        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzE2MzQyNmZjLWRk
+        NDgtNGRiNy1hZTJlLTc5NDk0Y2U2NTAxNy8iLCJkaWdlc3QiOiJzaGEyNTY6
+        MDhjYTRmMmM0NTMxNmNiMGI3OWZhZjhmMDc2MjUwNDZkYmJjMTZmNmYxNDBi
+        MGM1OWRhMDNmMTMyM2FkYThhNCIsInNjaGVtYV92ZXJzaW9uIjoyLCJtZWRp
+        YV90eXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24u
+        bWFuaWZlc3QudjIranNvbiIsImxpc3RlZF9tYW5pZmVzdHMiOltdLCJjb25m
+        aWdfYmxvYiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9icy9h
+        ODYyOWE5Yy01ZTBjLTQyNDktOWQ1My02ZTk3MDcxZjAyM2QvIiwiYmxvYnMi
+        OlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzRiNDVlYzNh
+        LTdkOGMtNGIwZi1hMTA3LWExZTZlY2NkMmVkNy8iLCIvcHVscC9hcGkvdjMv
+        Y29udGVudC9kb2NrZXIvYmxvYnMvMzEyYWRmYmYtYmU0MC00OWU1LTkxYWMt
+        NGIwYWNjNDJmODUzLyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL21hbmlmZXN0cy82MzRmNjFiNi1jZGQ2LTRmMGYtOGM4ZS0x
+        Y2UxOWNmYzdlNjgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAx
+        LjkwNDU0MloiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFj
+        dCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvNzE3NjU0ZDAtM2VlZC00MzY5
+        LTk0NmEtNGI1N2ZmMzc0YmZlLyIsImRpZ2VzdCI6InNoYTI1Njo5ZjEwMDNj
+        NDgwNjk5YmU1NjgxNWRiMGY4MTQ2YWQyZTIyZWZlYTg1MTI5YjViNTk4M2Qw
+        ZTBmYjUyZDlhYjcwIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUi
+        OiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVz
+        dC5saXN0LnYyK2pzb24iLCJsaXN0ZWRfbWFuaWZlc3RzIjpbIi9wdWxwL2Fw
+        aS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvNTgyOWZlMGMtNGJkYS00
+        N2FmLWE0OWUtNzJmMmNkOTkxYTVlLyIsIi9wdWxwL2FwaS92My9jb250ZW50
+        L2RvY2tlci9tYW5pZmVzdHMvM2JhYjQ2YTgtMjZhOS00ZGVkLThjMjUtOTdl
+        MTUwNmMyZGU2LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5p
+        ZmVzdHMvZmY5ODU1MWMtYzBmMC00ZjgyLWFiZWMtMTQwODVmMjllY2ZiLyIs
+        Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvNmYwNTYy
+        YWQtZGU1Ny00ZmEyLTliMDgtOGE3MDkxOTIyNWU3LyIsIi9wdWxwL2FwaS92
+        My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvNTMzNGIzZjEtZDU3OC00ZWRk
+        LWJmMzMtZmMwMjgwZjNiNjA4LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2Rv
+        Y2tlci9tYW5pZmVzdHMvMDQxNDJlMWMtZmI4Mi00YTEwLTliZGEtNWZmZTNm
+        NDkwNzM5LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVz
+        dHMvNDQyMDk0ODktMGRmNC00ZTUxLWFjZmUtNDVlNGNjMTJhMjY2LyIsIi9w
+        dWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvYzVjM2QzNGQt
+        NzA3YS00YmI0LWIxMGQtMWMxYWZiZTBmN2YzLyJdLCJjb25maWdfYmxvYiI6
+        bnVsbCwiYmxvYnMiOltdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL21hbmlmZXN0cy80NDIwOTQ4OS0wZGY0LTRlNTEtYWNmZS00
+        NWU0Y2MxMmEyNjYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAx
+        Ljk4MzU2MFoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFj
+        dCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMjNjZWU2NzctYjZhZC00YjUz
+        LTk4YTAtNDVlNzc5YjZiOGRiLyIsImRpZ2VzdCI6InNoYTI1NjplMThjZTUx
+        YjU4YmIxMWVlZDIyMTZjYTNlNWU5NGRjOTA2YmIwNGIzNTkzNzY4ODRiZTEx
+        MGY1MDI2YjFmOWMxIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUi
+        OiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVz
+        dC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9i
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzMzZmQ0MGNj
+        LWYwY2EtNDkzOC1iZDdjLWY5YjAzZjBiZmE0NC8iLCJibG9icyI6WyIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvOGFjNGJlZTgtNjMwYS00
+        Yjg2LThiYTktYzc1ODY1MDQwODIyLyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy9mZjk4NTUxYy1jMGYwLTRm
+        ODItYWJlYy0xNDA4NWYyOWVjZmIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDE5OjQwOjAyLjA3MTg4MFoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIs
+        Il9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYTY4YTc1MzYt
+        ZTA4ZS00YmJmLTlmODMtYmE3N2Y4YzJkYjQzLyIsImRpZ2VzdCI6InNoYTI1
+        NjpmZDg2YWNkNWE5ZjhiMmJkMzRkMzljZDBhZWZhOWM1MDNkYzhmZTYxNTBm
+        ZTE1Y2UzY2Y5MGYyODhlYjE1NWQzIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
+        ZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlv
+        bi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNv
+        bmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2Jz
+        LzY5ZTNiMDdmLTM3NDQtNDU0Yy1iODUzLTM5OWM5NTkzYmE0OC8iLCJibG9i
+        cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvZDE1YjIx
+        MDMtZGVlNi00OTNiLTk3NjEtZGUxNDBmZjJkMWJjLyJdfSx7Il9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8wNDE0MmUx
+        Yy1mYjgyLTRhMTAtOWJkYS01ZmZlM2Y0OTA3MzkvIiwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTIyVDE5OjQwOjAyLjA4Mjk4NVoiLCJfdHlwZSI6ImRvY2tlci5t
+        YW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
+        OWVjNjhhNmUtMDdmYi00Y2MzLTk5YmQtZGVlNWJlYWNiZGY0LyIsImRpZ2Vz
+        dCI6InNoYTI1NjpmM2RlZTk4OGJhOTAxYmQyZjI4MjI2MjUyMzAyOTliYTVl
+        ZTJkZGZiZTJiOGI0NTU4NTZmMmIwNzMzYmFmOGQwIiwic2NoZW1hX3ZlcnNp
+        b24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRp
+        c3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0
+        cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL2Jsb2JzL2EzNmRmNGM0LTJkZmEtNDMzZi1iZDQ4LTE5NjFjZGM5YWJl
+        NC8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxv
+        YnMvM2M4ZDk5OWQtZjFhZi00YjMxLWE1ZGItNzVjYjE3MmUyZjMzLyJdfSx7
+        Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0
+        cy9jNWMzZDM0ZC03MDdhLTRiYjQtYjEwZC0xYzFhZmJlMGY3ZjMvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAxLjk4NDk1NFoiLCJfdHlwZSI6
+        ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9h
+        cnRpZmFjdHMvODZkYjI2N2QtMzNjYy00NTI5LWEyNDctNmZlYWY3OGIwN2Ji
+        LyIsImRpZ2VzdCI6InNoYTI1NjpmYjgyZWY3YjdhZTA5MWY2NzVmNmUwMzRm
+        MzEzNGUyZjEyOWY0ZjdiZWMyYjIwNWU0NTg5NDNhOGYzZWRiNzNiIiwic2No
+        ZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQu
+        ZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVk
+        X21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2Nv
+        bnRlbnQvZG9ja2VyL2Jsb2JzL2VmZGFmYzY3LThhMjUtNGVkNi1hYWQyLTEz
+        ZjhiMDk3ZTg0YS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvYmxvYnMvZjQ4ZDc2OTktZWIwNC00OTEwLTg2YzMtZjExMzAxMjRh
+        ZDZmLyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2Vy
+        L21hbmlmZXN0cy82ZjA1NjJhZC1kZTU3LTRmYTItOWIwOC04YTcwOTE5MjI1
+        ZTcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAxLjk2NTY5Mloi
+        LCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxw
+        L2FwaS92My9hcnRpZmFjdHMvMjY4NTY2NWYtZDZjOC00MGZmLWJlOWUtMDVm
+        ZjBlOTUwMzc0LyIsImRpZ2VzdCI6InNoYTI1Njo4OTVhYjYyMmU5MmUxOGQ2
+        YjQ2MWQ2NzEwODE3NTdhZjdkYmFhM2IwMGUzZTI4ZTEyNTA1YWY3ODE3Zjcz
+        NjQ5Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNh
+        dGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29u
+        IiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzkxMzZiNThkLTRlODktNDhj
+        YS1hYmVkLTE1NTBlOWYzZjg3OS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMv
+        Y29udGVudC9kb2NrZXIvYmxvYnMvZGY4ZmIwN2MtYThjMi00NjRmLWIxNzMt
+        YTYwMzBmNTY2ODA4LyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRl
+        bnQvZG9ja2VyL21hbmlmZXN0cy8zYmFiNDZhOC0yNmE5LTRkZWQtOGMyNS05
+        N2UxNTA2YzJkZTYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjQwOjAx
+        Ljk5NTI2NVoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFj
+        dCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvZWQyZGE2N2ItYzMzNC00OTVh
+        LWFiNDEtNjE4ZmJkY2UwMTZlLyIsImRpZ2VzdCI6InNoYTI1NjowZDc2MDQ1
+        NThmOTVkY2UwYzE3Y2VlMGNkZjQ1YThjNjhmMzVkN2ZjNzEwYTYwYTU5OGNk
+        NDNmNjUyOTc2ODc4Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUi
+        OiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVz
+        dC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9i
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzc2ZmFmOTMw
+        LTE2NmEtNGM2OS1iYmYwLTc4Y2U2ZjFlMTQ5OS8iLCJibG9icyI6WyIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvYTFhODAzMjItMDhlNi00
+        NGQzLWFkM2YtODU5ODk2ZmY0ZTA1LyJdfSx7Il9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy81ODI5ZmUwYy00YmRhLTQ3
+        YWYtYTQ5ZS03MmYyY2Q5OTFhNWUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIy
+        VDE5OjQwOjAxLjkxMDczNVoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdCIs
+        Il9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvOGZjZjc3ZDAt
+        ZDgwNy00YTEwLThiNjgtMmQ3NTdmNjNjNDdmLyIsImRpZ2VzdCI6InNoYTI1
+        NjphZGZhYzBjMmJlNGJiODYwMDQ1OTViOGY5OTVkZjg4YmQ5OWIyODkxOTMx
+        NjE3ZGYwNTAxNThiYWE3MDljMzMxIiwic2NoZW1hX3ZlcnNpb24iOjIsIm1l
+        ZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlv
+        bi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0cyI6W10sImNv
+        bmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2Jz
+        LzA2NmM1YzQ5LTFjY2UtNGE3Yy1hYWQyLTY1Y2RiNDkyYjNjMi8iLCJibG9i
+        cyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvNWQ4ZDc2
+        MjAtMDgzMy00MDc2LWE2NTYtOGM5NjgxMTkxYTJlLyJdfSx7Il9ocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy81MzM0YjNm
+        MS1kNTc4LTRlZGQtYmYzMy1mYzAyODBmM2I2MDgvIiwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTIyVDE5OjQwOjAxLjk4MjE0MVoiLCJfdHlwZSI6ImRvY2tlci5t
+        YW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
+        ZGJhNjA2YWItZjc2Yy00MGY5LWJhM2EtMGRkYTY2M2QzNmRhLyIsImRpZ2Vz
+        dCI6InNoYTI1Njo3OTI4OWMzMTQ2YTc3Y2U1YzdmZTBmYzhmYjA5NGMwYzE3
+        ZjhlZmVlMjkyNjIzZjkwYzUxNjMwZjk0YmI2NTE5Iiwic2NoZW1hX3ZlcnNp
+        b24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRp
+        c3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwibGlzdGVkX21hbmlmZXN0
+        cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL2Jsb2JzLzE3MjhjMjAyLWFmMWMtNGU4My04ZmZkLWJjOGNjZTdhMGY3
+        MS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxv
+        YnMvZTAwNTQ0ZjYtMTMzMC00YTNiLWIyNmEtNmY4MzAwNWZiYTQwLyJdfV19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:43 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifest-tags/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563975458/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 24 Jul 2019 16:39:44 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '1321'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MTQsIm5leHQiOm51bGwsInByZXZpb3VzIjpudWxsLCJyZXN1
+        bHRzIjpbeyJfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9t
+        YW5pZmVzdC10YWdzLzMyNjE4NWJiLThiOTAtNDE3NC1iZDY3LTMzMjkyY2Ix
+        ZDMxYy8iLCJfY3JlYXRlZCI6IjIwMTktMDctMTdUMTk6MTc6MDUuNzY3MDE1
+        WiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0LXRhZyIsIl9hcnRpZmFjdCI6
+        Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvYTRhMzZiMjItYmRjMy00OTc2LTlk
+        MTctNmYyYTI0MTkzMjdhLyIsIm5hbWUiOiJsaW51eCIsInRhZ2dlZF9tYW5p
+        ZmVzdCI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMv
+        MDNjZmU3NDctMWE0NC00NGY0LWJmMWMtNjQ2MjlkZTE5OGJkLyJ9LHsiX2hy
+        ZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFn
+        cy9jZTJiNDAzMS1iZDRiLTRhYzUtOGE4NS1iYjU2YjE2MjRjMWEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTE3VDE5OjE3OjA1Ljc3MTA5M1oiLCJfdHlwZSI6
+        ImRvY2tlci5tYW5pZmVzdC10YWciLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkv
+        djMvYXJ0aWZhY3RzLzAyZjkyNzcyLWMwOTItNDczYS04MWRmLTg2OTIzNzk3
+        ZmY2OS8iLCJuYW1lIjoid2luZG93cyIsInRhZ2dlZF9tYW5pZmVzdCI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvNGUyNjEyMmUt
+        NDU4Yi00YjkzLTg4NDUtZTU3NTA2MjJjZDk1LyJ9LHsiX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy85ZDY3Y2Fi
+        YS00NjZhLTQwZDYtOWM0Ny02ZjM0YWNlNjZjOGYvIiwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTE3VDE5OjE3OjA1Ljc3NDI5M1oiLCJfdHlwZSI6ImRvY2tlci5t
+        YW5pZmVzdC10YWciLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
+        Y3RzLzhjNzAwMTNjLWRjZDMtNDM3Yy1iNDRmLWJiYTkwN2IwN2E5Ny8iLCJu
+        YW1lIjoibGF0ZXN0IiwidGFnZ2VkX21hbmlmZXN0IjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy85NWJlMDU1Zi1mYmE1LTQ1NzQt
+        ODZhYS05ODZiY2ZlNGVmYzQvIn0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9tYW5pZmVzdC10YWdzL2U1NDZjODBiLTE5NDktNDli
+        Yy04OTFmLTQ4NzE0NmRiOGQ3YS8iLCJfY3JlYXRlZCI6IjIwMTktMDctMThU
+        MTc6Mzk6MzguMjc4NDEzWiIsIl90eXBlIjoiZG9ja2VyLm1hbmlmZXN0LXRh
+        ZyIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDk4ZWQ3
+        YzEtNmRhYi00YTM3LTgwZmQtYWUyMzdhMDhlYjc2LyIsIm5hbWUiOiJsYXRl
+        c3QiLCJ0YWdnZWRfbWFuaWZlc3QiOiIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvbWFuaWZlc3RzL2QyYzMyZTA1LTk3OTAtNGYzNS05ZTBlLWRlMjQ3
+        MjdhZWQ4OC8ifSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9j
+        a2VyL21hbmlmZXN0LXRhZ3MvM2I5MzdlMjMtNDBkNi00NDY0LTk5M2ItYzUx
+        Y2UzYWYyNGZiLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41
+        MDA0NDJaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QtdGFnIiwiX2FydGlm
+        YWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8xYzE1ZmE2MC03MTljLTQw
+        ZmEtYjE0My0xOWVkNjY4YjcyNDIvIiwibmFtZSI6Im5hbm9zZXJ2ZXItMTgw
+        MyIsInRhZ2dlZF9tYW5pZmVzdCI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Rv
+        Y2tlci9tYW5pZmVzdHMvZDM1MmUzODctOTUyYi00MmIzLThjZTEtMzEzZTVm
+        NTEwZmI3LyJ9LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvbWFuaWZlc3QtdGFncy8xMmQzOTdmOS0wNmJmLTQ4YjEtYmJkYS0xODg0
+        OTU5NGY3MzYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjQyOjIwLjUw
+        NDI2NFoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdC10YWciLCJfYXJ0aWZh
+        Y3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzM5Yjg1ODhmLWRkZjAtNGY5
+        YS04NTEyLTIxMjVmODMxZGU2NC8iLCJuYW1lIjoibGludXgiLCJ0YWdnZWRf
+        bWFuaWZlc3QiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZl
+        c3RzLzEzYjBiNWM3LWMxYzktNGM2NS04ZTQ4LWJmNmZiNjk5NTY1ZS8ifSx7
+        Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0
+        LXRhZ3MvNDIzNTZiMTQtZmZiZC00MTg1LWJiNWMtNDQ3ODRlYzdlNDk5LyIs
+        Il9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzo0MjoyMC41MDc1ODNaIiwiX3R5
+        cGUiOiJkb2NrZXIubWFuaWZlc3QtdGFnIiwiX2FydGlmYWN0IjoiL3B1bHAv
+        YXBpL3YzL2FydGlmYWN0cy9jNzNjYzkyOS1hYzBiLTQ3Y2QtOTdmNi1mYjk5
+        MGViNzEzYjEvIiwibmFtZSI6ImxhdGVzdCIsInRhZ2dlZF9tYW5pZmVzdCI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvZDZlZWVj
+        ODYtZDkwNi00OGRlLTk4ZGMtZjBlZDhkMDIxZTY4LyJ9LHsiX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy9mMWQy
+        YTA4Mi1iODZmLTRjNTItODAzYS02ZmY1ZWIyZWU1ZDUvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA3LTE4VDE3OjQyOjIwLjUxMDM2M1oiLCJfdHlwZSI6ImRvY2tl
+        ci5tYW5pZmVzdC10YWciLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0
+        aWZhY3RzLzFmNmEyMGQ5LTNhZTktNDVjYS1iNTlkLTc3NWMyMzQwNDc5Mi8i
+        LCJuYW1lIjoibmFub3NlcnZlci0xODA5IiwidGFnZ2VkX21hbmlmZXN0Ijoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8xOGE5NWFk
+        ZC0zZDczLTQ0MzItYjAzYS1jYjkyODA4MzUxYmUvIn0seyJfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdC10YWdzLzYxZjcx
+        YzIyLWI4ZGQtNDI1Mi05NTM3LTdlMGJlOWRhMTQ3Ni8iLCJfY3JlYXRlZCI6
+        IjIwMTktMDctMThUMTc6NDI6MjAuNTEzMTQxWiIsIl90eXBlIjoiZG9ja2Vy
+        Lm1hbmlmZXN0LXRhZyIsIl9hcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRp
+        ZmFjdHMvOWU2OTEzYzItMTg3MS00NjE5LTk5ZmYtMDdmNDI3ZDc3YjgyLyIs
+        Im5hbWUiOiJuYW5vc2VydmVyLTE3MDkiLCJ0YWdnZWRfbWFuaWZlc3QiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzL2Q5YTUzYjk4
+        LTQyNjEtNGJjYi04ZGQ2LWZkM2RhYTMwN2IwNi8ifSx7Il9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0LXRhZ3MvZGY0OWE1
+        MWMtNzlkMS00ZGM3LTk1MWEtYTljY2JjNmU1Y2MwLyIsIl9jcmVhdGVkIjoi
+        MjAxOS0wNy0xOFQxNzo0MjoyMC41MTU5NTdaIiwiX3R5cGUiOiJkb2NrZXIu
+        bWFuaWZlc3QtdGFnIiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlm
+        YWN0cy8yZDI3M2IxOS0yNTY2LTQ5NjYtODE4OS1jZmNmZDFmMjc0MzEvIiwi
+        bmFtZSI6Im5hbm9zZXJ2ZXIiLCJ0YWdnZWRfbWFuaWZlc3QiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzhlMDJhZmE2LTE5NDUt
+        NDc5Ny1hYzFjLWExODRlMDFjM2I2MC8ifSx7Il9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0LXRhZ3MvZDE2OTE3YjktNGJh
+        Ny00OWU1LTk2YjEtOWNiYzg1NjYwNDE2LyIsIl9jcmVhdGVkIjoiMjAxOS0w
+        Ny0xOFQxNzo0MjoyMC41MTg0NDJaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZl
+        c3QtdGFnIiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy9j
+        MjEwY2Q1NS03NWI1LTQzMDEtYWE3NS0yYjEzYTg4ZjYyYmUvIiwibmFtZSI6
+        Im5hbm9zZXJ2ZXItc2FjMjAxNiIsInRhZ2dlZF9tYW5pZmVzdCI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMvMTRiYTM3NGEtN2Iw
+        ZS00MTYxLWJhN2YtOGM0MjQwMzQ1MjU4LyJ9LHsiX2hyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy9lMWY1N2RhMy02
+        YjgxLTRiODktOGJlNy0xODVlMGNhNzUxY2UvIiwiX2NyZWF0ZWQiOiIyMDE5
+        LTA3LTE4VDE3OjQyOjIwLjUyMDkxMVoiLCJfdHlwZSI6ImRvY2tlci5tYW5p
+        ZmVzdC10YWciLCJfYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3Rz
+        L2I4MDVkMmIwLTRiYWUtNDIzZC1iZWE2LWJmY2VmNDYyMWFkNy8iLCJuYW1l
+        IjoibmFub3NlcnZlcjE3MDkiLCJ0YWdnZWRfbWFuaWZlc3QiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLzUzZDg4YmRkLTY3Yzct
+        NDNjOC04NDUyLWMwNmM5Nzg4MjcxNy8ifSx7Il9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0LXRhZ3MvYzA4NDQyMDQtODVj
+        MC00NWYzLWFmYmMtYmVmMTU4ODE1OWU4LyIsIl9jcmVhdGVkIjoiMjAxOS0w
+        Ny0yMlQxOTo0MDowMS45MDc5NTVaIiwiX3R5cGUiOiJkb2NrZXIubWFuaWZl
+        c3QtdGFnIiwiX2FydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy83
+        MTc2NTRkMC0zZWVkLTQzNjktOTQ2YS00YjU3ZmYzNzRiZmUvIiwibmFtZSI6
+        ImxhdGVzdCIsInRhZ2dlZF9tYW5pZmVzdCI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50L2RvY2tlci9tYW5pZmVzdHMvNjM0ZjYxYjYtY2RkNi00ZjBmLThjOGUt
+        MWNlMTljZmM3ZTY4LyJ9LHsiX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kb2NrZXIvbWFuaWZlc3QtdGFncy82ODVmZjg0ZC0yYTQ4LTQzYTUtYmEx
+        NC05NTA2Yjc5YTkwOTAvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTIyVDE5OjU2
+        OjEzLjQ5NzU2MFoiLCJfdHlwZSI6ImRvY2tlci5tYW5pZmVzdC10YWciLCJf
+        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzcxNzY1NGQwLTNl
+        ZWQtNDM2OS05NDZhLTRiNTdmZjM3NGJmZS8iLCJuYW1lIjoibGF0ZXN0Iiwi
+        dGFnZ2VkX21hbmlmZXN0IjpudWxsfV19
+    http_version: 
+  recorded_at: Wed, 24 Jul 2019 16:39:44 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/d66f3ff1-a28a-432f-b84e-e5b62ef50959/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:37 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBlM2IwNTA1LWJmM2QtNDcy
+        Zi04NjY4LTk4OTQ2NDdjZjIwMS8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:37 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/0e3b0505-bf3d-472f-8668-9894647cf201/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:38 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '337'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8wZTNiMDUwNS1iZjNkLTQ3
+        MmYtODY2OC05ODk0NjQ3Y2YyMDEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI3OjM3Ljg5MzI4OFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTI5VDEzOjI3OjM3Ljk4ODEyMloi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjlUMTM6Mjc6MzguMDM1Mzg5WiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2UwYy00NDlhLTkzNzgt
+        NDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2Q2NmYzZmYxLWEyOGEtNDMy
+        Zi1iODRlLWU1YjYyZWY1MDk1OS92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:38 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/d66f3ff1-a28a-432f-b84e-e5b62ef50959/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:38 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '185'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZDY2ZjNmZjEt
+        YTI4YS00MzJmLWI4NGUtZTViNjJlZjUwOTU5L3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI5VDEzOjI3OjM4LjAwOTQ4NVoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:38 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19E
+        b2NrZXJfMSIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2Q2NmYzZmYxLWEyOGEtNDMyZi1i
+        ODRlLWU1YjYyZWY1MDk1OS92ZXJzaW9ucy8xLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:38 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E2NmE5M2RiLWQ1ZDMtNDdh
+        YS04MjAzLTAyMTg1NDUwNDlkOC8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:38 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/a66a93db-d5d3-47aa-8203-0218545049d8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:38 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '276'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hNjZhOTNkYi1kNWQzLTQ3
+        YWEtODIwMy0wMjE4NTQ1MDQ5ZDgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI3OjM4LjMzODgwNloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yOVQxMzoyNzozOC40NDkwMzRaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQx
+        ZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:38 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/a66a93db-d5d3-47aa-8203-0218545049d8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:38 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '331'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hNjZhOTNkYi1kNWQzLTQ3
+        YWEtODIwMy0wMjE4NTQ1MDQ5ZDgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI3OjM4LjMzODgwNloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI5VDEzOjI3OjM4LjQ0OTAzNFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjlUMTM6Mjc6MzguNjI0NjUwWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUtY2MxMjUx
+        OGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyL2RjMDNiMjll
+        LTBjYzItNDM2OS1hOWYzLTFlN2VlY2M1NGMxZS8iXX0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:38 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/dc03b29e-0cc2-4369-a9f3-1e7eecc54c1e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:38 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '473'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTI5VDEzOjI3OjM4LjYxMTAyM1oiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZDY2ZjNm
+        ZjEtYTI4YS00MzJmLWI4NGUtZTViNjJlZjUwOTU5L3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyL2RjMDNiMjllLTBjYzItNDM2OS1h
+        OWYzLTFlN2VlY2M1NGMxZS8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:38 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/d8403b61-b02d-4cf8-a756-7ae5a33e3fd1/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kNjZm
+        M2ZmMS1hMjhhLTQzMmYtYjg0ZS1lNWI2MmVmNTA5NTkvIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:39 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FlMTQ1YjE1LTA2YjMtNDhj
+        MS1hMDM2LTFkZmE2ZjI2YzJkNy8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:39 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/ae145b15-06b3-48c1-a036-1dfa6f26c2d7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:39 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '371'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hZTE0NWIxNS0wNmIzLTQ4
+        YzEtYTAzNi0xZGZhNmYyNmMyZDcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI3OjM5LjE5MjcwM1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjlUMTM6Mjc6MzkuMjk4MDYyWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:39 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/ae145b15-06b3-48c1-a036-1dfa6f26c2d7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:39 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '371'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hZTE0NWIxNS0wNmIzLTQ4
+        YzEtYTAzNi0xZGZhNmYyNmMyZDcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI3OjM5LjE5MjcwM1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjlUMTM6Mjc6MzkuMjk4MDYyWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:39 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/ae145b15-06b3-48c1-a036-1dfa6f26c2d7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:39 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '371'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hZTE0NWIxNS0wNmIzLTQ4
+        YzEtYTAzNi0xZGZhNmYyNmMyZDcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI3OjM5LjE5MjcwM1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjlUMTM6Mjc6MzkuMjk4MDYyWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:39 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/ae145b15-06b3-48c1-a036-1dfa6f26c2d7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:39 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '394'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hZTE0NWIxNS0wNmIzLTQ4
+        YzEtYTAzNi0xZGZhNmYyNmMyZDcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI3OjM5LjE5MjcwM1oiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjlUMTM6Mjc6MzkuMjk4MDYyWiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTll
+        OGZjLWMzNmEtNDIxNi04MDI1LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJQcm9jZXNzaW5nIFRhZ3MiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRv
+        dGFsIjoxLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRv
+        d25sb2FkaW5nIEFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90
+        YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jl
+        c291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:39 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/ae145b15-06b3-48c1-a036-1dfa6f26c2d7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:40 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '443'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hZTE0NWIxNS0wNmIzLTQ4
+        YzEtYTAzNi0xZGZhNmYyNmMyZDcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI3OjM5LjE5MjcwM1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yOVQxMzoyNzozOS4yOTgwNjJa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTI5VDEzOjI3OjM5Ljg3NTk4M1oi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzBmOTllOGZjLWMzNmEtNDIxNi04MDI1
+        LWY0ZWZmMjQ1YWQ2Ni8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Npbmcg
+        VGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvZDY2ZjNmZjEtYTI4YS00MzJmLWI4NGUtZTVi
+        NjJlZjUwOTU5L3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:40 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/d66f3ff1-a28a-432f-b84e-e5b62ef50959/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:40 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '282'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZDY2ZjNmZjEt
+        YTI4YS00MzJmLWI4NGUtZTViNjJlZjUwOTU5L3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI5VDEzOjI3OjM5LjMyMDQxMFoiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9k
+        NjZmM2ZmMS1hMjhhLTQzMmYtYjg0ZS1lNWI2MmVmNTA5NTkvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZDY2
+        ZjNmZjEtYTI4YS00MzJmLWI4NGUtZTViNjJlZjUwOTU5L3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvZDY2ZjNmZjEtYTI4YS00MzJmLWI4NGUtZTViNjJlZjUwOTU5L3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZDY2ZjNmZjEtYTI4YS00MzJmLWI4NGUt
+        ZTViNjJlZjUwOTU5L3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdC10
+        YWciOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9k
+        b2NrZXIvbWFuaWZlc3QtdGFncy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZDY2ZjNmZjEtYTI4YS00MzJmLWI4NGUt
+        ZTViNjJlZjUwOTU5L3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2Q2NmYzZmYxLWEyOGEtNDMyZi1iODRlLWU1YjYyZWY1
+        MDk1OS92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:40 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/dc03b29e-0cc2-4369-a9f3-1e7eecc54c1e/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2Q2NmYzZmYxLWEyOGEtNDMyZi1iODRlLWU1YjYyZWY1MDk1OS92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:40 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YyNDkxZTE0LTE1OGEtNDE1
+        NC04MjNlLTg2ODM5MjJlYmM2OC8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:40 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/f2491e14-158a-4154-823e-8683922ebc68/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:40 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '279'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9mMjQ5MWUxNC0xNThhLTQx
+        NTQtODIzZS04NjgzOTIyZWJjNjgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI3OjQwLjMzOTEyMFoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yOVQxMzoyNzo0MC40NTMwNzBaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQx
+        ZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:40 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/f2491e14-158a-4154-823e-8683922ebc68/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:40 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '287'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9mMjQ5MWUxNC0xNThhLTQx
+        NTQtODIzZS04NjgzOTIyZWJjNjgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjI3OjQwLjMzOTEyMFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI5VDEzOjI3OjQwLjQ1MzA3MFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjlUMTM6Mjc6NDAuNTE5MzU1WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUtY2MxMjUx
+        OGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:40 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/d66f3ff1-a28a-432f-b84e-e5b62ef50959/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:40 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:40 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/d66f3ff1-a28a-432f-b84e-e5b62ef50959/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:41 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '793'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy9kMmMzMmUwNS05NzkwLTRmMzUtOWUwZS1kZTI0NzI3YWVkODgv
+        IiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjM5OjM4LjI3NTI5NVoiLCJf
+        dHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2Fw
+        aS92My9hcnRpZmFjdHMvMDk4ZWQ3YzEtNmRhYi00YTM3LTgwZmQtYWUyMzdh
+        MDhlYjc2LyIsImRpZ2VzdCI6InNoYTI1NjphNmVjYmIxNTUzMzUzYTA4OTM2
+        ZjUwYzI3NWIwMTAzODhlZDFiZDZkOWQ4NDc0M2M3ZThlNzQ2OGUyYWNkODJl
+        Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlv
+        bi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwi
+        bGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzcyOGIyN2U4LTk5YzEtNGFjNi1h
+        MTY0LWFiNDdlMTNlZWE4NS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvYmxvYnMvYTgyZTMwNGItYzVjYy00MDQ5LTg0YzgtODA5
+        ZjMwNzE1ZjY3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9i
+        cy81MzZiNTc2MC04YzZiLTQ0YTctYTc5Mi0xYWExMjFhYWQxZDkvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzNkZGFmNDg0LWRkZWMt
+        NGIwMC1hZjEyLWI2Y2ZkNzU1NmE4ZC8iXX1dfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:41 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/d66f3ff1-a28a-432f-b84e-e5b62ef50959/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:41 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:41 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifest-tags/?page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/d66f3ff1-a28a-432f-b84e-e5b62ef50959/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:27:41 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '401'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvZTU0NmM4MGItMTk0OS00OWJjLTg5MWYtNDg3MTQ2ZGI4
+        ZDdhLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzozOTozOC4yNzg0MTNa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QtdGFnIiwiX2FydGlmYWN0Ijoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wOThlZDdjMS02ZGFiLTRhMzctODBm
+        ZC1hZTIzN2EwOGViNzYvIiwibmFtZSI6ImxhdGVzdCIsInRhZ2dlZF9tYW5p
+        ZmVzdCI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMv
+        ZDJjMzJlMDUtOTc5MC00ZjM1LTllMGUtZGUyNDcyN2FlZDg4LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:27:41 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '236'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy8zMWEw
+        NjNlYi0zYWEwLTRjNmUtYTliNy00ODgzZTA4Y2JlMDkvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA3LTI5VDEzOjI5OjU3LjQ4MzY4MloiLCJfdmVyc2lvbnNfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvMzFhMDYzZWItM2FhMC00
+        YzZlLWE5YjctNDg4M2UwOGNiZTA5L3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVy
+        c2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy8zMWEwNjNl
+        Yi0zYWEwLTRjNmUtYTliNy00ODgzZTA4Y2JlMDkvdmVyc2lvbnMvMi8iLCJu
+        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2Nr
+        ZXJfMSIsImRlc2NyaXB0aW9uIjpudWxsfV19
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:02 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/31a063eb-3aa0-4c6e-a9b7-4883e08cbe09/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FlNzkwZTA5LTc2ZDAtNGZk
+        Ni1iZGE2LThkM2ExNTg0M2M3OS8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:02 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '553'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlbW90ZXMvZG9ja2VyL2Rv
+        Y2tlci8yZjRhNDM0OC02MmY2LTQyNjktYjZjYS1lMDE3MmYzMDQ2YTQvIiwi
+        X2NyZWF0ZWQiOiIyMDE5LTA3LTI5VDEzOjI5OjU3LjYxOTQ2M1oiLCJfdHlw
+        ZSI6ImRvY2tlci5kb2NrZXIiLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        b24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInVybCI6Imh0dHBzOi8vcmVn
+        aXN0cnktMS5kb2NrZXIuaW8vIiwic3NsX2NhX2NlcnRpZmljYXRlIjpudWxs
+        LCJzc2xfY2xpZW50X2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2tl
+        eSI6bnVsbCwic3NsX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVs
+        bCwiX2xhc3RfdXBkYXRlZCI6IjIwMTktMDctMjlUMTM6Mjk6NTcuNjE5NDc3
+        WiIsImRvd25sb2FkX2NvbmN1cnJlbmN5IjoyMCwicG9saWN5IjoiaW1tZWRp
+        YXRlIiwidXBzdHJlYW1fbmFtZSI6ImZlZG9yYS9zc2giLCJ3aGl0ZWxpc3Rf
+        dGFncyI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:02 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/2f4a4348-62f6-4269-b6ca-e0172f3046a4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ0ZGFkMzIwLTIyYTMtNDZh
+        ZS05ZDQzLThmNjUzMDI3NDA4NS8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:02 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:02 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '453'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJh
+        cnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5IjpudWxsLCJfY3JlYXRl
+        ZCI6IjIwMTktMDctMjlUMTM6Mjk6NTguNzIxNjM2WiIsIm5hbWUiOiJEZWZh
+        dWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0RvY2tlcl8xIiwicmVw
+        b3NpdG9yeV92ZXJzaW9uIjpudWxsLCJjb250ZW50X2d1YXJkIjpudWxsLCJf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2RvY2tlci9kb2Nr
+        ZXIvMmJjNDczMDUtNDYxMC00OTQwLWFiNzYtY2U5NmRmMjliZmIwLyIsInJl
+        Z2lzdHJ5X3BhdGgiOiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29t
+        L0RlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRG9ja2VyXzEi
+        fV19
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:02 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/2bc47305-4610-4940-ab76-ce96df29bfb0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA5NGZmMDcyLThlZTgtNGI2
+        OS05ZjAyLTljNTJlYzM1ZTA3Yi8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:03 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/?base_path=Default_Organization/library/pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '453'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJh
+        cnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5IjpudWxsLCJfY3JlYXRl
+        ZCI6IjIwMTktMDctMjlUMTM6Mjk6NTguNzIxNjM2WiIsIm5hbWUiOiJEZWZh
+        dWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0RvY2tlcl8xIiwicmVw
+        b3NpdG9yeV92ZXJzaW9uIjpudWxsLCJjb250ZW50X2d1YXJkIjpudWxsLCJf
+        aHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2RvY2tlci9kb2Nr
+        ZXIvMmJjNDczMDUtNDYxMC00OTQwLWFiNzYtY2U5NmRmMjliZmIwLyIsInJl
+        Z2lzdHJ5X3BhdGgiOiJwdWxwMy1kZXZlbC5jYW5ub2xvLmV4YW1wbGUuY29t
+        L0RlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRG9ja2VyXzEi
+        fV19
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:03 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/2bc47305-4610-4940-ab76-ce96df29bfb0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '23'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkZXRhaWwiOiJOb3QgZm91bmQuIn0=
+
+'
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:03 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:03 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:03 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/?name=Default_Organization-Cabinet-pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:03 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/?base_path=Default_Organization/library/pulp3_Docker_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:03 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:03 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19E
+        b2NrZXJfMSJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/7bc8c3be-c2b3-42c7-a5ad-fcdd7473d2ea/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '308'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvN2JjOGMzYmUt
+        YzJiMy00MmM3LWE1YWQtZmNkZDc0NzNkMmVhLyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wNy0yOVQxMzozMDowMy45OTYzMDBaIiwiX3ZlcnNpb25zX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzdiYzhjM2JlLWMyYjMtNDJjNy1h
+        NWFkLWZjZGQ3NDczZDJlYS92ZXJzaW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25f
+        aHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfRG9ja2VyXzEiLCJkZXNjcmlwdGlvbiI6bnVsbH0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:04 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19E
+        b2NrZXJfMSIsInVybCI6Imh0dHBzOi8vcmVnaXN0cnktMS5kb2NrZXIuaW8v
+        Iiwic3NsX3ZhbGlkYXRpb24iOnRydWUsInBvbGljeSI6ImltbWVkaWF0ZSIs
+        InVwc3RyZWFtX25hbWUiOiJmZWRvcmEvc3NoIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/docker/docker/667b38d2-347b-488a-87bc-e9b6634413f7/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '501'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2RvY2tlci9kb2NrZXIv
+        NjY3YjM4ZDItMzQ3Yi00ODhhLTg3YmMtZTliNjYzNDQxM2Y3LyIsIl9jcmVh
+        dGVkIjoiMjAxOS0wNy0yOVQxMzozMDowNC4xNDQ0MDhaIiwiX3R5cGUiOiJk
+        b2NrZXIuZG9ja2VyIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNh
+        YmluZXQtcHVscDNfRG9ja2VyXzEiLCJ1cmwiOiJodHRwczovL3JlZ2lzdHJ5
+        LTEuZG9ja2VyLmlvLyIsInNzbF9jYV9jZXJ0aWZpY2F0ZSI6bnVsbCwic3Ns
+        X2NsaWVudF9jZXJ0aWZpY2F0ZSI6bnVsbCwic3NsX2NsaWVudF9rZXkiOm51
+        bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsIl9s
+        YXN0X3VwZGF0ZWQiOiIyMDE5LTA3LTI5VDEzOjMwOjA0LjE0NDQyMloiLCJk
+        b3dubG9hZF9jb25jdXJyZW5jeSI6MjAsInBvbGljeSI6ImltbWVkaWF0ZSIs
+        InVwc3RyZWFtX25hbWUiOiJmZWRvcmEvc3NoIiwid2hpdGVsaXN0X3RhZ3Mi
+        Om51bGx9
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:04 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/7bc8c3be-c2b3-42c7-a5ad-fcdd7473d2ea/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JkZWJmYjVlLWY3MzctNGFl
+        Ny1iZjdlLTgyYTcwMDhjN2U4OC8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:04 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/bdebfb5e-f737-4ae7-bf7e-82a7008c7e88/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '333'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9iZGViZmI1ZS1mNzM3LTRh
+        ZTctYmY3ZS04MmE3MDA4YzdlODgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjMwOjA0LjU1NzM4MloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA3LTI5VDEzOjMwOjA0LjY1ODg5M1oi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDctMjlUMTM6MzA6MDQuNjg5OTM4WiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvMDZiZDcyYWItM2UwYy00NDlhLTkzNzgt
+        NDg3YWZlZTE5ZWE1LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzdiYzhjM2JlLWMyYjMtNDJj
+        Ny1hNWFkLWZjZGQ3NDczZDJlYS92ZXJzaW9ucy8xLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:04 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/7bc8c3be-c2b3-42c7-a5ad-fcdd7473d2ea/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '185'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvN2JjOGMzYmUt
+        YzJiMy00MmM3LWE1YWQtZmNkZDc0NzNkMmVhL3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI5VDEzOjMwOjA0LjY3MzM2NVoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:04 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19E
+        b2NrZXJfMSIsImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xp
+        YnJhcnkvcHVscDNfRG9ja2VyXzEiLCJyZXBvc2l0b3J5X3ZlcnNpb24iOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzdiYzhjM2JlLWMyYjMtNDJjNy1h
+        NWFkLWZjZGQ3NDczZDJlYS92ZXJzaW9ucy8xLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:05 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZiYTVjZmNiLTk2NDEtNDJk
+        Mi1hODI4LTk3N2Q3ODNjOTkzZS8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:05 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/6ba5cfcb-9641-42d2-a828-977d783c993e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:05 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '271'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy82YmE1Y2ZjYi05NjQxLTQy
+        ZDItYTgyOC05NzdkNzgzYzk5M2UvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjMwOjA1LjAxMzA5MVoiLCJzdGF0ZSI6IndhaXRpbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjpudWxsLCJmaW5pc2hlZF9hdCI6bnVsbCwibm9uX2ZhdGFsX2Vy
+        cm9ycyI6W10sImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMv
+        d29ya2Vycy8wZjk5ZThmYy1jMzZhLTQyMTYtODAyNS1mNGVmZjI0NWFkNjYv
+        IiwicGFyZW50IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jlc3Nf
+        cmVwb3J0cyI6W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpbXX0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:05 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/6ba5cfcb-9641-42d2-a828-977d783c993e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:05 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '278'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy82YmE1Y2ZjYi05NjQxLTQy
+        ZDItYTgyOC05NzdkNzgzYzk5M2UvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjMwOjA1LjAxMzA5MVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF9jcmVhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yOVQxMzozMDowNS4xNDMxNzJaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2
+        YS00MjE2LTgwMjUtZjRlZmYyNDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:05 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/6ba5cfcb-9641-42d2-a828-977d783c993e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:05 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '330'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy82YmE1Y2ZjYi05NjQxLTQy
+        ZDItYTgyOC05NzdkNzgzYzk5M2UvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjMwOjA1LjAxMzA5MVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI5VDEzOjMwOjA1LjE0MzE3MloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjlUMTM6MzA6MDUuMjkxNjQyWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMGY5OWU4ZmMtYzM2YS00MjE2LTgwMjUtZjRlZmYy
+        NDVhZDY2LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzk0MWM0M2Uw
+        LThjMDktNDI0OC1iOGE5LWVlNWVjY2VjOGNiZS8iXX0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:05 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/941c43e0-8c09-4248-b8a9-ee5eccec8cbe/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:05 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '473'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0RvY2tlcl8xIiwicmVwb3NpdG9yeSI6bnVsbCwiX2NyZWF0ZWQiOiIy
+        MDE5LTA3LTI5VDEzOjMwOjA1LjI4MzgwOVoiLCJuYW1lIjoiRGVmYXVsdF9P
+        cmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsInJlcG9zaXRv
+        cnlfdmVyc2lvbiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvN2JjOGMz
+        YmUtYzJiMy00MmM3LWE1YWQtZmNkZDc0NzNkMmVhL3ZlcnNpb25zLzEvIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwiX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlz
+        dHJpYnV0aW9ucy9kb2NrZXIvZG9ja2VyLzk0MWM0M2UwLThjMDktNDI0OC1i
+        OGE5LWVlNWVjY2VjOGNiZS8iLCJyZWdpc3RyeV9wYXRoIjoicHVscDMtZGV2
+        ZWwuY2Fubm9sby5leGFtcGxlLmNvbS9EZWZhdWx0X09yZ2FuaXphdGlvbi9s
+        aWJyYXJ5L3B1bHAzX0RvY2tlcl8xIn0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:05 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/remotes/docker/docker/667b38d2-347b-488a-87bc-e9b6634413f7/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy83YmM4
+        YzNiZS1jMmIzLTQyYzctYTVhZC1mY2RkNzQ3M2QyZWEvIn0=
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:05 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU0MWY4Zjk5LTI4ZWEtNDU1
+        OC05YWViLTAwODU4ZWVhOTA0NC8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:05 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/541f8f99-28ea-4558-9aeb-00858eea9044/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:06 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '282'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy81NDFmOGY5OS0yOGVhLTQ1
+        NTgtOWFlYi0wMDg1OGVlYTkwNDQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjMwOjA1Ljk3MTYwMloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjlUMTM6MzA6MDYuMDg2NTQ3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwi
+        Y3JlYXRlZF9yZXNvdXJjZXMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:06 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/541f8f99-28ea-4558-9aeb-00858eea9044/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:06 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '372'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy81NDFmOGY5OS0yOGVhLTQ1
+        NTgtOWFlYi0wMDg1OGVlYTkwNDQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjMwOjA1Ljk3MTYwMloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjlUMTM6MzA6MDYuMDg2NTQ3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:06 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/541f8f99-28ea-4558-9aeb-00858eea9044/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:06 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '372'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy81NDFmOGY5OS0yOGVhLTQ1
+        NTgtOWFlYi0wMDg1OGVlYTkwNDQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjMwOjA1Ljk3MTYwMloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjlUMTM6MzA6MDYuMDg2NTQ3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgdGFnIGxpc3QiLCJzdGF0ZSI6InJ1bm5p
+        bmciLCJ0b3RhbCI6MSwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6InJ1bm5pbmci
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJBc3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJydW5uaW5nIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W251bGxdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:06 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/541f8f99-28ea-4558-9aeb-00858eea9044/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:06 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '377'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy81NDFmOGY5OS0yOGVhLTQ1
+        NTgtOWFlYi0wMDg1OGVlYTkwNDQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjMwOjA1Ljk3MTYwMloiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscF9kb2NrZXIuYXBwLnRhc2tzLnN5bmNocm9uaXplLnN5bmNocm9uaXpl
+        Iiwic3RhcnRlZF9hdCI6IjIwMTktMDctMjlUMTM6MzA6MDYuMDg2NTQ3WiIs
+        ImZpbmlzaGVkX2F0IjpudWxsLCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJy
+        b3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkz
+        ZTg2LTg0MWUtNGUxMC1iMmI1LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51
+        bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJt
+        ZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJydW5u
+        aW5nIiwidG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29udGVudCIsInN0YXRlIjoicnVubmlu
+        ZyIsInRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVz
+        c2FnZSI6IkRvd25sb2FkaW5nIHRhZyBsaXN0Iiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfV0sImNyZWF0
+        ZWRfcmVzb3VyY2VzIjpbbnVsbF19
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:06 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/541f8f99-28ea-4558-9aeb-00858eea9044/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:06 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '444'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy81NDFmOGY5OS0yOGVhLTQ1
+        NTgtOWFlYi0wMDg1OGVlYTkwNDQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjMwOjA1Ljk3MTYwMloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2RvY2tlci5hcHAudGFza3Muc3luY2hyb25pemUuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wNy0yOVQxMzozMDowNi4wODY1NDda
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA3LTI5VDEzOjMwOjA2LjYzNjU2N1oi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzdmZTkzZTg2LTg0MWUtNGUxMC1iMmI1
+        LWNjMTI1MThhNzFlMy8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgdGFnIGxpc3QiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlByb2Nlc3Npbmcg
+        VGFncyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRvbmUiOjEs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZh
+        Y3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6NiwiZG9uZSI6Niwi
+        c3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbIi9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvN2JjOGMzYmUtYzJiMy00MmM3LWE1YWQtZmNk
+        ZDc0NzNkMmVhL3ZlcnNpb25zLzIvIl19
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:06 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/repositories/7bc8c3be-c2b3-42c7-a5ad-fcdd7473d2ea/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:06 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '281'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvN2JjOGMzYmUt
+        YzJiMy00MmM3LWE1YWQtZmNkZDc0NzNkMmVhL3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA3LTI5VDEzOjMwOjA2LjExNTgyOFoiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRvY2tlci5tYW5pZmVzdC1ibG9iIjp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy83
+        YmM4YzNiZS1jMmIzLTQyYzctYTVhZC1mY2RkNzQ3M2QyZWEvdmVyc2lvbnMv
+        Mi8ifSwiZG9ja2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvN2Jj
+        OGMzYmUtYzJiMy00MmM3LWE1YWQtZmNkZDc0NzNkMmVhL3ZlcnNpb25zLzIv
+        In0sImRvY2tlci5tYW5pZmVzdC10YWciOnsiY291bnQiOjEsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3QtdGFncy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvN2JjOGMzYmUtYzJiMy00MmM3LWE1YWQtZmNkZDc0NzNkMmVhL3ZlcnNp
+        b25zLzIvIn19LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6eyJkb2NrZXIubWFu
+        aWZlc3QtYmxvYiI6eyJjb3VudCI6NCwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci9ibG9icy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvN2JjOGMzYmUtYzJiMy00MmM3LWE1YWQt
+        ZmNkZDc0NzNkMmVhL3ZlcnNpb25zLzIvIn0sImRvY2tlci5tYW5pZmVzdCI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tl
+        ci9tYW5pZmVzdHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzdiYzhjM2JlLWMyYjMtNDJjNy1hNWFkLWZjZGQ3NDcz
+        ZDJlYS92ZXJzaW9ucy8yLyJ9LCJkb2NrZXIubWFuaWZlc3QtdGFnIjp7ImNv
+        dW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzdiYzhjM2JlLWMyYjMtNDJjNy1hNWFkLWZjZGQ3NDcz
+        ZDJlYS92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:06 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/distributions/docker/docker/941c43e0-8c09-4248-b8a9-ee5eccec8cbe/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzdiYzhjM2JlLWMyYjMtNDJjNy1hNWFkLWZjZGQ3NDczZDJlYS92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:07 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM3MzYxOWNkLTMwZjktNGYw
+        My1hOGVmLWU5MGUwOWQ0MjI5ZS8ifQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:07 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/373619cd-30f9-4f03-a8ef-e90e09d4229e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:07 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '279'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zNzM2MTljZC0zMGY5LTRm
+        MDMtYThlZi1lOTBlMDlkNDIyOWUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjMwOjA3LjAwMzI3OVoiLCJzdGF0ZSI6InJ1bm5pbmciLCJuYW1lIjoi
+        cHVscGNvcmUuYXBwLnRhc2tzLmJhc2UuZ2VuZXJhbF91cGRhdGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wNy0yOVQxMzozMDowNy4xMDgxMzVaIiwiZmluaXNo
+        ZWRfYXQiOm51bGwsIm5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVs
+        bCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQx
+        ZS00ZTEwLWIyYjUtY2MxMjUxOGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bh
+        d25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:07 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/tasks/373619cd-30f9-4f03-a8ef-e90e09d4229e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01564342198/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:07 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+      Content-Length:
+      - '287'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zNzM2MTljZC0zMGY5LTRm
+        MDMtYThlZi1lOTBlMDlkNDIyOWUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTI5
+        VDEzOjMwOjA3LjAwMzI3OVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA3LTI5VDEzOjMwOjA3LjEwODEzNVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDctMjlUMTM6MzA6MDcuMTcyNTUzWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvN2ZlOTNlODYtODQxZS00ZTEwLWIyYjUtY2MxMjUx
+        OGE3MWUzLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W119
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:07 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v1%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/7bc8c3be-c2b3-42c7-a5ad-fcdd7473d2ea/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:07 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:07 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/7bc8c3be-c2b3-42c7-a5ad-fcdd7473d2ea/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:07 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '793'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0cy9kMmMzMmUwNS05NzkwLTRmMzUtOWUwZS1kZTI0NzI3YWVkODgv
+        IiwiX2NyZWF0ZWQiOiIyMDE5LTA3LTE4VDE3OjM5OjM4LjI3NTI5NVoiLCJf
+        dHlwZSI6ImRvY2tlci5tYW5pZmVzdCIsIl9hcnRpZmFjdCI6Ii9wdWxwL2Fw
+        aS92My9hcnRpZmFjdHMvMDk4ZWQ3YzEtNmRhYi00YTM3LTgwZmQtYWUyMzdh
+        MDhlYjc2LyIsImRpZ2VzdCI6InNoYTI1NjphNmVjYmIxNTUzMzUzYTA4OTM2
+        ZjUwYzI3NWIwMTAzODhlZDFiZDZkOWQ4NDc0M2M3ZThlNzQ2OGUyYWNkODJl
+        Iiwic2NoZW1hX3ZlcnNpb24iOjIsIm1lZGlhX3R5cGUiOiJhcHBsaWNhdGlv
+        bi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwi
+        bGlzdGVkX21hbmlmZXN0cyI6W10sImNvbmZpZ19ibG9iIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzcyOGIyN2U4LTk5YzEtNGFjNi1h
+        MTY0LWFiNDdlMTNlZWE4NS8iLCJibG9icyI6WyIvcHVscC9hcGkvdjMvY29u
+        dGVudC9kb2NrZXIvYmxvYnMvYTgyZTMwNGItYzVjYy00MDQ5LTg0YzgtODA5
+        ZjMwNzE1ZjY3LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9ibG9i
+        cy81MzZiNTc2MC04YzZiLTQ0YTctYTc5Mi0xYWExMjFhYWQxZDkvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLzNkZGFmNDg0LWRkZWMt
+        NGIwMC1hZjEyLWI2Y2ZkNzU1NmE4ZC8iXX1dfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:07 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifests/?media_type=application/vnd.docker.distribution.manifest.list.v2%2Bjson&page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/7bc8c3be-c2b3-42c7-a5ad-fcdd7473d2ea/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:07 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:07 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel.cannolo.example.com/pulp/api/v3/content/docker/manifest-tags/?page=1&page_size=2000&repository_version=/pulp/api/v3/repositories/7bc8c3be-c2b3-42c7-a5ad-fcdd7473d2ea/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/4.0.0b6.dev01563887560/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jul 2019 13:30:07 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '401'
+      Via:
+      - 1.1 pulp3-devel.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL21h
+        bmlmZXN0LXRhZ3MvZTU0NmM4MGItMTk0OS00OWJjLTg5MWYtNDg3MTQ2ZGI4
+        ZDdhLyIsIl9jcmVhdGVkIjoiMjAxOS0wNy0xOFQxNzozOTozOC4yNzg0MTNa
+        IiwiX3R5cGUiOiJkb2NrZXIubWFuaWZlc3QtdGFnIiwiX2FydGlmYWN0Ijoi
+        L3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wOThlZDdjMS02ZGFiLTRhMzctODBm
+        ZC1hZTIzN2EwOGViNzYvIiwibmFtZSI6ImxhdGVzdCIsInRhZ2dlZF9tYW5p
+        ZmVzdCI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RvY2tlci9tYW5pZmVzdHMv
+        ZDJjMzJlMDUtOTc5MC00ZjM1LTllMGUtZGUyNDcyN2FlZDg4LyJ9XX0=
+    http_version: 
+  recorded_at: Mon, 29 Jul 2019 13:30:07 GMT
+recorded_with: VCR 3.0.3

--- a/test/services/katello/pulp3/docker_tag_test.rb
+++ b/test/services/katello/pulp3/docker_tag_test.rb
@@ -1,0 +1,43 @@
+require 'katello_test_helper'
+require 'support/pulp3_support'
+
+module Katello
+  module Service
+    class DockerTagTest < ActiveSupport::TestCase
+      include Katello::Pulp3Support
+
+      def setup
+        @master = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+        @repo = katello_repositories(:pulp3_docker_1)
+        ensure_creatable(@repo, @master)
+        create_repo(@repo, @master)
+        ForemanTasks.sync_task(
+            ::Actions::Katello::Repository::MetadataGenerate, @repo,
+            repository_creation: true)
+        @repo.reload
+      end
+
+      def test_index_model
+        Katello::DockerTag.destroy_all
+        sync_args = {:smart_proxy_id => @master.id, :repo_id => @repo.id}
+        ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @master, sync_args)
+        @repo.reload
+        @repo.index_content
+        assert_equal @repo, ::Katello::Repository.find_by(:id => ::Katello::DockerTag.first.repository_id)
+        assert_equal ::Katello::DockerManifest.find_by(id: ::Katello::DockerTag.first.docker_taggable_id).digest, "sha256:a6ecbb1553353a08936f50c275b010388ed1bd6d9d84743c7e8e7468e2acd82e"
+      end
+
+      def test_index_on_sync
+        Katello::DockerTag.destroy_all
+        sync_args = {:smart_proxy_id => @master.id, :repo_id => @repo.id}
+        ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @master, sync_args)
+        index_args = {:id => @repo.id, :contents_changed => true}
+        ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
+        @repo.reload
+
+        assert_equal @repo, ::Katello::Repository.find_by(:id => ::Katello::DockerTag.first.repository_id)
+        assert_equal ::Katello::DockerManifest.find_by(id: ::Katello::DockerTag.first.docker_taggable_id).digest, "sha256:a6ecbb1553353a08936f50c275b010388ed1bd6d9d84743c7e8e7468e2acd82e"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Docker Pulp 3 sync is working, minus the presenters.  Note that, to relate the repository ID properly to a tag, I needed to add the 
```ruby 
model.repository_id = repository.id unless many_repository_associations
```
line to `pulp_database_unit.rb`.  We realized that the `manage_repository_association` method is really just checking if the relation type is many-to-many, so the name was updated to `many_repository_associations` to better suit it.  A test will be added to ensure this doesn't break.

To test this draft PR, try to sync your favourite Docker repo.  See that the repository version was updated in Pulp 3, and see that manifests and tags were created.  

Note that, due to https://pulp.plan.io/issues/5146, there will almost definitely be fewer schema version 1 manifests from the Pulp 3 sync.  Seeing none is normal.

TODO: Add tests and get the sync progress tracking working.