### PR TITLE
Fixes #27370 - Pulp3 Presenter

### DIFF
--- a/app/lib/actions/pulp3/repository/presenters/abstract_sync_presenter.rb
+++ b/app/lib/actions/pulp3/repository/presenters/abstract_sync_presenter.rb
@@ -18,7 +18,7 @@ module Actions
           def sync_task
             tasks = action.external_task.select do |task|
               if task.key? 'name'
-                task['name'].include?("synchronizing.synchronize")
+                task['name'].include?("sync")
               end
             end
             tasks.first

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -465,6 +465,95 @@ module ::Actions::Katello::Repository
         end
       end
     end
+
+    describe 'pulp3 progress' do
+      let(:pulp3_action_class) { ::Actions::Pulp3::Repository::Sync }
+      let(:pulp3_action) { fixture_action(pulp3_action_class, input: {repo_id: repository.id}, output: fixture_variant) }
+      let :action do
+        create_action(action_class).tap do |action|
+          action.stubs(all_planned_actions: [pulp3_action])
+        end
+      end
+
+      describe 'successfully synchronized pulp3 file' do
+        let(:fixture_variant) { :success_file }
+
+        specify do
+          action.humanized_output.must_equal "Total tasks: : 5/5\n"\
+                                             "--------------------------------\n"\
+                                             "Downloading Metadata: 1/1\n"\
+                                             "Downloading Artifacts: 0/0\n"\
+                                             "Associating Content: 1/1\n"\
+                                             "Parsing Metadata Lines: 3/3"
+        end
+
+        specify do
+          pulp3_action.run_progress.must_be_within_delta 1
+        end
+      end
+
+      describe 'successfully synchronized pulp3 ansible collection' do
+        let(:fixture_variant) { :success_ansible_collection }
+
+        specify do
+          action.humanized_output.must_equal "Total tasks: : 2/2\n"\
+                                             "--------------------------------\n"\
+                                             "Importing Collections: 1/1\n"\
+                                             "Downloading Collections: 1/1"
+        end
+
+        specify do
+          pulp3_action.run_progress.must_be_within_delta 1
+        end
+      end
+
+      describe 'successfully synchronized pulp3 docker repo' do
+        let(:fixture_variant) { :success_docker }
+
+        specify do
+          action.humanized_output.must_equal "Total tasks: : 1192/1192\n"\
+                                             "--------------------------------\n"\
+                                             "Downloading tag list: 1/1\n"\
+                                             "Downloading Artifacts: 415/415\n"\
+                                             "Associating Content: 641/641\n"\
+                                             "Processing Tags: 135/135"
+        end
+
+        specify do
+          pulp3_action.run_progress.must_be_within_delta 1
+        end
+      end
+
+      describe 'syncing files in progress' do
+        let(:fixture_variant) { :progress_units_file }
+
+        specify do
+          action.humanized_output.must_equal "Total tasks: : 15/30\n"\
+                                             "--------------------------------\n"\
+                                             "Downloading Metadata: 5/10\n"\
+                                             "Downloading Artifacts: 5/10\n"\
+                                             "Associating Content: 5/10"
+        end
+
+        specify do
+          pulp3_action.run_progress.must_be_within_delta 0.50
+        end
+      end
+
+      describe 'syncing ansible collections in progress' do
+        let(:fixture_variant) { :progress_units_ansible_collection }
+
+        specify do
+          action.humanized_output.must_equal "Total tasks: : 1/2\n"\
+                                             "--------------------------------\n"\
+                                             "Downloading Collections: 1/2"
+        end
+
+        specify do
+          pulp3_action.run_progress.must_be_within_delta 0.5
+        end
+      end
+    end
   end
 
   class CapsuleSyncTest < TestBase

--- a/test/fixtures/actions/pulp3/repository/sync/progress_units_ansible_collection.yaml
+++ b/test/fixtures/actions/pulp3/repository/sync/progress_units_ansible_collection.yaml
@@ -1,0 +1,21 @@
+---
+  pulp_tasks:
+    - _href: "/pulp/api/v3/tasks/346d72eb-618f-454d-a910-c4b173e1af65/"
+      _created: '2019-07-24T15:12:40.177414Z'
+      state: running
+      name: pulp_ansible.app.tasks.collections.sync
+      started_at: '2019-07-24T15:12:40.561211Z'
+      finished_at:
+      non_fatal_errors: []
+      error:
+      worker: "/pulp/api/v3/workers/6402256a-a060-42d0-a427-b43c59edb577/"
+      parent:
+      spawned_tasks: []
+      progress_reports:
+      - message: Downloading Collections
+        state: running
+        total: 2
+        done: 1
+        suffix:
+      created_resources:
+      -

--- a/test/fixtures/actions/pulp3/repository/sync/progress_units_file.yaml
+++ b/test/fixtures/actions/pulp3/repository/sync/progress_units_file.yaml
@@ -1,0 +1,31 @@
+---
+  pulp_tasks:
+    - _href: "/pulp/api/v3/tasks/8156ecaf-e66e-432c-83a2-6738175a3a02/"
+      _created: '2019-07-24T15:09:32.710756Z'
+      state: running
+      name: pulp_file.app.tasks.synchronizing.synchronize
+      started_at: '2019-07-24T15:09:32.978203Z'
+      finished_at:
+      non_fatal_errors: []
+      error:
+      worker: "/pulp/api/v3/workers/6181dd2b-8dd6-4110-8b45-f809a148f8d6/"
+      parent:
+      spawned_tasks: []
+      progress_reports:
+      - message: Downloading Metadata
+        state: running
+        total: 10
+        done: 5
+        suffix:
+      - message: Downloading Artifacts
+        state: running
+        total: 10
+        done: 5
+        suffix:
+      - message: Associating Content
+        state: running
+        total: 10
+        done: 5
+        suffix:
+      created_resources:
+      -

--- a/test/fixtures/actions/pulp3/repository/sync/success_ansible_collection.yaml
+++ b/test/fixtures/actions/pulp3/repository/sync/success_ansible_collection.yaml
@@ -1,0 +1,26 @@
+---
+  pulp_tasks:
+    - _href: "/pulp/api/v3/tasks/1a5242eb-1a50-4024-bf23-9aa4babaef63/"
+      _created: '2019-07-11T17:16:22.135859Z'
+      state: completed
+      name: pulp_ansible.app.tasks.collections.sync
+      started_at: '2019-07-11T17:16:22.646600Z'
+      finished_at: '2019-07-11T17:16:24.813053Z'
+      non_fatal_errors: []
+      error:
+      worker: "/pulp/api/v3/workers/6181dd2b-8dd6-4110-8b45-f809a148f8d6/"
+      parent:
+      spawned_tasks: []
+      progress_reports:
+      - message: Importing Collections
+        state: completed
+        total: 1
+        done: 1
+        suffix:
+      - message: Downloading Collections
+        state: completed
+        total: 1
+        done: 1
+        suffix:
+      created_resources:
+      - "/pulp/api/v3/repositories/96658291-4b2d-4bb5-9b98-f8c04052dcdd/versions/5/"

--- a/test/fixtures/actions/pulp3/repository/sync/success_docker.yaml
+++ b/test/fixtures/actions/pulp3/repository/sync/success_docker.yaml
@@ -1,0 +1,28 @@
+---
+  pulp_tasks:
+    - _href: "/pulp/api/v3/tasks/1a5242eb-1a50-4024-bf23-9aa4babaef63/"
+      _created: '2019-07-11T17:16:22.135859Z'
+      state: completed
+      name: pulp_ansible.app.tasks.collections.sync
+      started_at: '2019-07-11T17:16:22.646600Z'
+      finished_at: '2019-07-11T17:16:24.813053Z'
+      non_fatal_errors: []
+      error:
+      worker: "/pulp/api/v3/workers/6181dd2b-8dd6-4110-8b45-f809a148f8d6/"
+      parent:
+      spawned_tasks: []
+      progress_reports:
+      - message: Downloading tag list
+        state: completed
+        total: 1
+        done: 1
+      - message: Downloading Artifacts
+        state: completed
+        done: 415
+      - message: Associating Content
+        state: completed
+        done: 641
+      - message: Processing Tags
+        state: completed
+        total: 135
+        done: 135

--- a/test/fixtures/actions/pulp3/repository/sync/success_file.yaml
+++ b/test/fixtures/actions/pulp3/repository/sync/success_file.yaml
@@ -1,0 +1,36 @@
+---
+  pulp_tasks:
+    - _href: "/pulp/api/v3/tasks/247ef5ac-e0cf-4180-861b-2855f1d76045/"
+      _created: '2019-07-11T16:45:08.459860Z'
+      state: completed
+      name: pulp_file.app.tasks.synchronizing.synchronize
+      started_at: '2019-07-11T16:45:08.720729Z'
+      finished_at: '2019-07-11T16:45:09.294850Z'
+      non_fatal_errors: []
+      error:
+      worker: "/pulp/api/v3/workers/6181dd2b-8dd6-4110-8b45-f809a148f8d6/"
+      parent:
+      spawned_tasks: []
+      progress_reports:
+      - message: Downloading Metadata
+        state: completed
+        total: 1
+        done: 1
+        suffix:
+      - message: Downloading Artifacts
+        state: completed
+        total:
+        done: 0
+        suffix:
+      - message: Associating Content
+        state: completed
+        total: 1
+        done: 1
+        suffix:
+      - message: Parsing Metadata Lines
+        state: completed
+        total: 3
+        done: 3
+        suffix:
+      created_resources:
+      - "/pulp/api/v3/repositories/6003054e-3c15-40b8-9752-8d93359c1d85/versions/6/"


### PR DESCRIPTION
To test:

Create and sync repos in Pulp3
The progress presenter should look like screenshots below:
****
**1st time file sync:**
![file_1](https://user-images.githubusercontent.com/21146741/61644709-2dbba700-ac73-11e9-99fe-55cb89a1a156.png)
*******
**2nd time file sync** : Ignores tasks that dont run in pulp, i.e total is null
![file_2](https://user-images.githubusercontent.com/21146741/61644769-52178380-ac73-11e9-89da-50dab4908ad6.png)
*****
**Ansible Sync**
![ansible](https://user-images.githubusercontent.com/21146741/61644794-5e9bdc00-ac73-11e9-9ce9-45221dab324e.png)
