### PR TITLE
Revert "Fixes #26640 - Only reuse unregistered profiles"

### DIFF
--- a/app/lib/katello/api/v2/error_handling.rb
+++ b/app/lib/katello/api/v2/error_handling.rb
@@ -21,7 +21,6 @@ module Katello
           rescue_from Errors::UnsupportedActionException, :with => :rescue_from_unsupported_action_exception
           rescue_from Errors::MaxHostsReachedException, :with => :rescue_from_max_hosts_reached_exception
           rescue_from Errors::CdnSubstitutionError, :with => :rescue_from_bad_data
-          rescue_from Errors::RegistrationError, :with => :rescue_from_bad_data
           rescue_from ActionController::ParameterMissing, :with => :rescue_from_missing_param
         end
 

--- a/app/lib/katello/errors.rb
+++ b/app/lib/katello/errors.rb
@@ -8,8 +8,6 @@ module Katello
 
     class NotFound < StandardError; end
 
-    class RegistrationError < StandardError; end
-
     # unauthorized access
     class SecurityViolation < StandardError; end
 

--- a/test/models/host/subscription_facet_test.rb
+++ b/test/models/host/subscription_facet_test.rb
@@ -17,7 +17,6 @@ module Katello
     end
     let(:subscription_facet) { host.subscription_facet }
     let(:uuid_fact_name) { RhsmFactName.create(name: 'dmi::system::uuid') }
-    let(:find_host_error) { "Please unregister or remove hosts which match this host before registering: %s" }
   end
 
   class SubscriptionFacetSystemPurposeTest < SubscriptionFacetBase
@@ -219,7 +218,6 @@ module Katello
     end
 
     def test_find_host
-      host = FactoryBot.create(:host, organization: org)
       PuppetFactName.where(:name => 'dmi::system::uuid').first_or_create
       org2 = taxonomies(:organization2)
       assert_equal host, Katello::Host::SubscriptionFacet.find_host({'network.hostname' => host.name}, host.organization)
@@ -230,15 +228,7 @@ module Katello
 
       Organization.current = nil
       assert_nil Host::SubscriptionFacet.find_host({'network.hostname' => "the hostest with the mostest"}, host.organization)
-      error = assert_raises(Katello::Errors::RegistrationError) { Katello::Host::SubscriptionFacet.find_host({'network.hostname' => host.name.upcase}, org2) }
-      assert_equal "Host with name %s is currently registered to a different org, please migrate host to %s." % [host.name, org2.name], error.message
-    end
-
-    def test_find_host_registered
-      # the hostname and dmi.system.uuid don't match other hosts but it's registered already
-
-      error = assert_raises(Katello::Errors::RegistrationError) { Katello::Host::SubscriptionFacet.find_host({'network.hostname' => host.name, 'dmi.system.uuid' => nil}, org) }
-      assert_equal find_host_error % host.name, error.message
+      assert_raises(RuntimeError) { Katello::Host::SubscriptionFacet.find_host({'network.hostname' => host.name.upcase}, org2) }
     end
 
     def test_find_host_existing_uuid
@@ -247,20 +237,16 @@ module Katello
 
       facts = {'dmi.system.uuid' => 'existing_system_uuid', 'network.hostname' => 'inexistent'}
 
-      error = assert_raises(Katello::Errors::RegistrationError) { Katello::Host::SubscriptionFacet.find_host(facts, org) }
-      assert_equal find_host_error % host.name, error.message
+      error = assert_raises(RuntimeError) { Katello::Host::SubscriptionFacet.find_host(facts, org) }
+      expected = "The host #{host.name} matches this registration. Remove or rename it to inexistent before registering."
+      assert_equal expected, error.message
     end
 
     def test_find_host_nil_uuid
       # hostname does not match existing record, and the dmi.system.uuid is nil.
-      fv = FactValue.create(value: nil, host: host, fact_name: uuid_fact_name)
-      assert_nil Katello::Host::SubscriptionFacet.find_host({'network.hostname' => 'inexistent'}, org)
+      FactValue.create(value: nil, host: host, fact_name: uuid_fact_name)
 
-      # hostname matches existing record, but existing has a UUID and we passed nothing
-      fv.value = "something"
-      fv.save!
-      error = assert_raises(Katello::Errors::RegistrationError) { Katello::Host::SubscriptionFacet.find_host({'network.hostname' => host.name, 'dmi.system.uuid' => nil}, org) }
-      assert_equal find_host_error % host.name, error.message
+      assert_nil Katello::Host::SubscriptionFacet.find_host({'network.hostname' => 'inexistent'}, org)
     end
 
     def test_find_host_existing_uuid_and_name_multiple
@@ -271,19 +257,9 @@ module Katello
       facts = {'dmi.system.uuid' => 'existing_system_uuid', 'network.hostname' => host.name}
 
       # if we get two matches, raise an error
-      error = assert_raises(Katello::Errors::RegistrationError) { Katello::Host::SubscriptionFacet.find_host(facts, org) }
-      expected = find_host_error % [host.name, host2.name].sort.join(', ')
+      error = assert_raises(RuntimeError) { Katello::Host::SubscriptionFacet.find_host(facts, org) }
+      expected = "Multiple profiles found. Consider removing %s which match this host." % [host.name, host2.name].sort.join(', ')
       assert_equal expected, error.message
-    end
-
-    def test_find_host_existing_name_new_uuid
-      # make sure existing host has a UUID
-      FactValue.create(value: "existing_system_uuid", host: host, fact_name: uuid_fact_name)
-
-      facts = {'dmi.system.uuid' => 'inexistent_uuid', 'network.hostname' => host.name}
-
-      error = assert_raises(Katello::Errors::RegistrationError) { Katello::Host::SubscriptionFacet.find_host(facts, org) }
-      assert_equal find_host_error % host.name, error.message
     end
 
     def test_find_host_existing_uuid_and_name


### PR DESCRIPTION
We decided that [hostname, uuid] being unique is sufficient enough to unregister an existing profile for reuse