### PR TITLE
Fixes #25113: ensure subscription pages have org

### DIFF
--- a/webpack/components/SelectOrg/SetOrganization.js
+++ b/webpack/components/SelectOrg/SetOrganization.js
@@ -25,25 +25,15 @@ class SetOrganization extends Component {
 
   onSelectItem(e) {
     this.setState({
-      item: e.target.options[e.target.selectedIndex].text,
       id: e.target.value,
       disabled: false,
     });
   }
 
   onSend() {
-    const {
-      history,
-      changeCurrentOrganization,
-      redirectPath,
-    } = this.props;
-    const { id } = this.state;
-
-    changeCurrentOrganization(`${id}`).then(() =>
-      history.push({
-        pathname: redirectPath,
-        state: { orgChanged: this.state.item },
-      }));
+    this.setState({
+      disabled: true,
+    });
   }
 
   render() {
@@ -51,6 +41,8 @@ class SetOrganization extends Component {
       list,
       loading,
     } = this.props;
+
+    const { id } = this.state;
 
     return (
       <div id="select-org" className="well col-sm-6 col-sm-offset-3">
@@ -79,9 +71,11 @@ class SetOrganization extends Component {
               </div>
 
               <div className="col-sm-3">
-                <Button disabled={this.state.disabled} className="btn btn-primary" onClick={this.onSend}>
-                  {__('Select')}
-                </Button>
+                <a href={`/organizations/${id}/select`}>
+                  <Button disabled={this.state.disabled} className="btn btn-primary" onClick={this.onSend}>
+                    {__('Select')}
+                  </Button>
+                </a>
               </div>
             </div>
           </Form>
@@ -95,11 +89,9 @@ class SetOrganization extends Component {
 SetOrganization.propTypes = {
   list: PropTypes.arrayOf(PropTypes.object),
   loading: PropTypes.bool.isRequired,
-  changeCurrentOrganization: PropTypes.func.isRequired,
   history: PropTypes.shape({
     push: PropTypes.func,
   }).isRequired,
-  redirectPath: PropTypes.string.isRequired,
   getOrganiztionsList: PropTypes.func.isRequired,
 };
 

--- a/webpack/components/WithOrganization/__snapshots__/withOrganization.test.js.snap
+++ b/webpack/components/WithOrganization/__snapshots__/withOrganization.test.js.snap
@@ -72,9 +72,7 @@ exports[`subscriptions page should render select org page 1`] = `
         </SideEffect(NullComponent)>
       </HelmetWrapper>
     </Header>
-    <Connect(withRouter(SetOrganization))
-      redirectPath="/test"
-    />
+    <Connect(withRouter(SetOrganization)) />
   </CheckOrg>
 </Connect(CheckOrg)>
 `;

--- a/webpack/components/WithOrganization/withOrganization.js
+++ b/webpack/components/WithOrganization/withOrganization.js
@@ -15,7 +15,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => bindActionCreators({ ...organizationActions }, dispatch);
 
-function withOrganization(WrappedComponent, redirectPath) {
+function withOrganization(WrappedComponent) {
   class CheckOrg extends Component {
     constructor(props) {
       super(props);
@@ -52,7 +52,7 @@ function withOrganization(WrappedComponent, redirectPath) {
         return (
           <React.Fragment>
             <Header title={__('Select Organization')} />
-            <SetOrganization redirectPath={redirectPath} />
+            <SetOrganization />
           </React.Fragment>);
       }
       return <WrappedComponent {...this.props} />;

--- a/webpack/components/WithOrganization/withOrganization.test.js
+++ b/webpack/components/WithOrganization/withOrganization.test.js
@@ -15,7 +15,7 @@ describe('subscriptions page', () => {
   it('should render the wrapped component', () => {
     global.document.getElementById = () => ({ dataset: { id: 1 } });
 
-    const Component = withOrganization(WrappedComponent, '/test');
+    const Component = withOrganization(WrappedComponent);
     const page = mount(<Component store={store} />);
     expect(toJson(page)).toMatchSnapshot();
   });
@@ -23,7 +23,7 @@ describe('subscriptions page', () => {
   it('should render select org page', () => {
     global.document.getElementById = () => ({ dataset: { id: '' } });
 
-    const Component = withOrganization(WrappedComponent, '/test');
+    const Component = withOrganization(WrappedComponent);
     const page = mount(<Component store={store} />);
     expect(toJson(page)).toMatchSnapshot();
   });

--- a/webpack/containers/Application/config.js
+++ b/webpack/containers/Application/config.js
@@ -13,26 +13,20 @@ import withHeader from './withHeaders';
 export const links = [
   {
     path: 'redhat_repositories',
-    component: WithOrganization(
-      withHeader(Repos, { title: __('RH Repos') }),
-      '/redhat_repositories',
-    ),
+    component: WithOrganization(withHeader(Repos, { title: __('RH Repos') })),
   },
   {
     path: 'subscriptions',
-    component: WithOrganization(
-      withHeader(Subscriptions, { title: __('Subscriptions') }),
-      '/subscriptions',
-    ),
+    component: WithOrganization(withHeader(Subscriptions, { title: __('Subscriptions') })),
   },
   {
     path: 'subscriptions/add',
-    component: withHeader(UpstreamSubscriptions, { title: __('Add Subscriptions') }),
+    component: WithOrganization(withHeader(UpstreamSubscriptions, { title: __('Add Subscriptions') })),
   },
   {
     // eslint-disable-next-line no-useless-escape
     path: 'subscriptions/:id([0-9]+)',
-    component: withHeader(SubscriptionDetails, { title: __('Subscription Details') }),
+    component: WithOrganization(withHeader(SubscriptionDetails, { title: __('Subscription Details') })),
   },
   {
     path: 'organization_select',


### PR DESCRIPTION
Subscription pages that require an organization to be selected weren't
working properly when 'Any Organization' was selected in the top
toolbar.

* Use WithOrganization HOC to ensure org is selected when required
* Enclose the submit button in `<a>` tag (removes the need for
`redirectPath` because redirects are handled by the 302 response returned
to the browser)
* Update test & snapshot

https://projects.theforeman.org/issues/25113