### PR TITLE
Fixes #27387 - filter has_many update

### DIFF
--- a/app/models/katello/content_view_filter.rb
+++ b/app/models/katello/content_view_filter.rb
@@ -13,12 +13,8 @@ module Katello
                :class_name => "Katello::ContentView",
                :inverse_of => :filters
 
-    # rubocop:disable HasAndBelongsToMany
-    # TODO: change these into has_many :through associations
-    has_and_belongs_to_many :repositories,
-                            :uniq => true,
-                            :class_name => "Katello::Repository",
-                            :join_table => :katello_content_view_filters_repositories
+    has_many :repository_content_view_filters, :class_name => "Katello::RepositoryContentViewFilter", :dependent => :delete_all, :inverse_of => :filter, :foreign_key => :content_view_filter_id
+    has_many :repositories, :through => :repository_content_view_filters, :class_name => "Katello::Repository"
 
     validates_lengths_from_database
     validate :validate_content_view
@@ -124,8 +120,8 @@ module Katello
     end
 
     def self.applicable(repo)
-      query = %{ (katello_content_view_filters.id in (select content_view_filter_id from katello_content_view_filters_repositories where repository_id = #{repo.id})) or
-                 (katello_content_view_filters.id not in (select content_view_filter_id from katello_content_view_filters_repositories))
+      query = %{ (katello_content_view_filters.id in (select content_view_filter_id from katello_repository_content_view_filters where repository_id = #{repo.id})) or
+                 (katello_content_view_filters.id not in (select content_view_filter_id from katello_repository_content_view_filters))
                }
       where(query).select("DISTINCT katello_content_view_filters.id")
     end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -93,12 +93,9 @@ module Katello
 
     has_many :repository_ansible_collections, :class_name => "Katello::RepositoryAnsibleCollection", :dependent => :delete_all
     has_many :ansible_collections, :through => :repository_ansible_collections
+    has_many :repository_content_view_filters, :class_name => "Katello::RepositoryContentViewFilter", :dependent => :delete_all
+    has_many :filters, :through => :repository_content_view_filters
 
-    # rubocop:disable HasAndBelongsToMany
-    # TODO: change this into has_many :through association
-    has_and_belongs_to_many :filters, :class_name => "Katello::ContentViewFilter",
-                                      :join_table => :katello_content_view_filters_repositories,
-                                      :foreign_key => :content_view_filter_id
     belongs_to :content_view_version, :inverse_of => :repositories, :class_name => "Katello::ContentViewVersion"
 
     validates_with Validators::ContainerImageNameValidator, :attributes => :container_repository_name, :allow_blank => false, :if => :docker?

--- a/app/models/katello/repository_content_view_filter.rb
+++ b/app/models/katello/repository_content_view_filter.rb
@@ -1,0 +1,7 @@
+module Katello
+  class RepositoryContentViewFilter < Katello::Model
+    # Do not use active record callbacks in this join model.  Direct INSERTs and DELETEs are done
+    belongs_to :repository, :inverse_of => :repository_content_view_filters, :class_name => 'Katello::Repository'
+    belongs_to :filter, :inverse_of => :repository_content_view_filters, :class_name => 'Katello::ContentViewFilter', :foreign_key => :content_view_filter_id
+  end
+end

--- a/db/migrate/20190723171639_update_content_view_filters_repositories_join_table.rb
+++ b/db/migrate/20190723171639_update_content_view_filters_repositories_join_table.rb
@@ -1,0 +1,11 @@
+class UpdateContentViewFiltersRepositoriesJoinTable < ActiveRecord::Migration[5.2]
+  def up
+    rename_table :katello_content_view_filters_repositories, :katello_repository_content_view_filters
+    add_column :katello_repository_content_view_filters, :id, :primary_key
+  end
+
+  def down
+    rename_table :katello_repository_content_view_filters, :katello_content_view_filters_repositories
+    remove_column :katello_content_view_filters_repositories, :id
+  end
+end


### PR DESCRIPTION
Content View Filters still used the less-flexible `has_and_belongs_to_many`.  Using `has_many ... :through` is better.  This is the last place Katello uses `has_and_belongs_to_many`.