### PR TITLE
Fixes #27394 - Match checksum type in content_changed

### DIFF
--- a/app/lib/actions/katello/repository/check_matching_content.rb
+++ b/app/lib/actions/katello/repository/check_matching_content.rb
@@ -21,8 +21,10 @@ module Actions
             package_groups = package_groups_match?(source_repo, target_repo)
             distributions = distributions_match?(source_repo, target_repo)
             yum_metadata_files = yum_metadata_files_match?(source_repo, target_repo)
+            checksum_match = (target_repo.saved_checksum_type == source_repo.saved_checksum_type)
 
-            output[:matching_content] = yum_metadata_files && srpms_match && rpms && errata && package_groups && distributions && target_repo.published?
+            output[:checksum_match] = checksum_match
+            output[:matching_content] = yum_metadata_files && srpms_match && rpms && errata && package_groups && distributions && target_repo.published? && checksum_match
           end
 
           if source_repo.content_type == ::Katello::Repository::DEB_TYPE

--- a/app/lib/actions/katello/repository/clone_contents.rb
+++ b/app/lib/actions/katello/repository/clone_contents.rb
@@ -51,6 +51,16 @@ module Actions
           end
 
           plan_action(Katello::Repository::MetadataGenerate, new_repository, metadata_options)
+          unless source_repositories.first.saved_checksum_type == new_repository.saved_checksum_type
+            plan_self(:source_checksum_type => source_repositories.first.saved_checksum_type,
+                      :target_repo_id => new_repository.id)
+          end
+        end
+
+        def finalize
+          repository = ::Katello::Repository.find(input[:target_repo_id])
+          source_checksum_type = input[:source_checksum_type]
+          repository.update_attributes!(saved_checksum_type: source_checksum_type) if (repository && source_checksum_type)
         end
       end
     end

--- a/test/actions/katello/repository/check_matching_content_test.rb
+++ b/test/actions/katello/repository/check_matching_content_test.rb
@@ -35,5 +35,24 @@ module Actions
 
       assert_equal true, run.output[:matching_content]
     end
+
+    def test_check_matching_content_false_checksum
+      action = create_action(action_class)
+      action_class.any_instance.stubs(:srpms_match?).returns(true)
+      action_class.any_instance.stubs(:rpms_match?).returns(true)
+      action_class.any_instance.stubs(:errata_match?).returns(true)
+      action_class.any_instance.stubs(:package_groups_match?).returns(true)
+      action_class.any_instance.stubs(:distributions_match?).returns(true)
+      action_class.any_instance.stubs(:yum_metadata_files_match?).returns(true)
+      ::Katello::Repository.any_instance.expects(:published?).returns(true)
+
+      yum_repo.update_attribute(:saved_checksum_type, "sha1")
+      yum_repo2.update_attribute(:saved_checksum_type, "sha256")
+
+      plan = plan_action(action, :source_repo_id => yum_repo.id, :target_repo_id => yum_repo2.id)
+      run = run_action plan
+
+      assert_equal false, run.output[:matching_content]
+    end
   end
 end

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -555,4 +555,17 @@ module ::Actions::Katello::Repository
       end
     end
   end
+
+  class CloneContentsFinalizeTest < TestBase
+    let(:action_class) { ::Actions::Katello::Repository::CloneContents }
+
+    it 'plans' do
+      custom_repository.saved_checksum_type = "sha1"
+      repository.saved_checksum_type = "sha256"
+      planned_action = plan_action action, [repository], custom_repository, :copy_contents => false
+
+      assert_equal planned_action.execution_plan.planned_finalize_steps.first.class, ::Actions::Katello::Repository::CloneContents
+      assert_equal planned_action.execution_plan.planned_finalize_steps.first.input, "source_checksum_type" => "sha256", "target_repo_id" => custom_repository.id
+    end
+  end
 end


### PR DESCRIPTION
**Background:**
This fix was pushed downstream as a merge request but wasn't implemented upstream post refactoring.
The MR for this is https://gitlab.sat.engineering.redhat.com/satellite6/katello/merge_requests/626/

**Steps to Reproduce:**
1. Create a product and repository with sha256
2. Add this a lifecycle environment related to a capsule and sync it
3. Check the repodata created on the capsule and it will be using sha1256
4. Modify the repository to use sha1 and create a new version for the content view
5. Sync and check the repodata. On the master server, repodata now will have sha1 however the capsule still has sha256

**Actual results:**
Capsule still has sha256

**Expected results:**
The capsule must reflect the configuration on the Satellite server 
