### PR TITLE
Fixes #27251 - Allow Host profile reuse during kickstart

### DIFF
--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -270,8 +270,11 @@ module Katello
                    {:org_name => organization.name, :host_name => host_name }
         end
 
-        if hosts_size == 1 && hosts.joins(:subscription_facet).empty?
-          return hosts.first
+        if hosts_size == 1
+          host = hosts.first
+          found_uuid = host.fact_values.find { |fv| fv.fact_name_id == uuid_fact_id }
+
+          return host if host.name == host_name && (host.build || found_uuid&.value == host_uuid)
         end
 
         hostnames = hosts.pluck(:name).sort.join(', ')

--- a/test/models/host/subscription_facet_test.rb
+++ b/test/models/host/subscription_facet_test.rb
@@ -234,13 +234,6 @@ module Katello
       assert_equal "Host with name %s is currently registered to a different org, please migrate host to %s." % [host.name, org2.name], error.message
     end
 
-    def test_find_host_registered
-      # the hostname and dmi.system.uuid don't match other hosts but it's registered already
-
-      error = assert_raises(Katello::Errors::RegistrationError) { Katello::Host::SubscriptionFacet.find_host({'network.hostname' => host.name, 'dmi.system.uuid' => nil}, org) }
-      assert_equal find_host_error % host.name, error.message
-    end
-
     def test_find_host_existing_uuid
       # find host by dmi.system.uuid, no hostname match
       FactValue.create(value: "existing_system_uuid", host: host, fact_name: uuid_fact_name)
@@ -306,6 +299,14 @@ module Katello
 
         assert_nil Katello::Host::SubscriptionFacet.find_host(facts, org)
       end
+    end
+
+    def test_find_host_build_matching_hostname_new_uuid
+      host = FactoryBot.create(:host, :managed, organization: org, build: true)
+      FactValue.create(value: SecureRandom.uuid, host: host, fact_name: uuid_fact_name)
+
+      facts = {'network.hostname' => host.name, 'dmi.system.uuid' => SecureRandom.uuid}
+      assert_equal host, Katello::Host::SubscriptionFacet.find_host(facts, org)
     end
 
     def test_find_or_create_host_with_org


### PR DESCRIPTION
The most recent change to our registration process made it a requirement
that a host profile could not be associated to unless it was unregistered first.

This change aims to help with that.

- Unregistering a host is no longer required to assume the profile of
an existing host when registering. The only criteria are that the host's name
and dmi.system.uuid fact match the profile and are sufficiently unique

- If a host's dmi.system.uuid has changed but the hostname is the same, profile reuse is allowed
*if* the build flag is set to true which indicates that the registration is likely happening via kickstart
and rebuild may have changed the dmi.system.uuid

**To test**

**scenario 1**: hostname and dmi.system.uuid haven't changed, but system is still registered results in successful registration

- spin up katello-client so that it registers to your dev box with this change (or client of your choice)
- on the client run `subscription-manager clean`
- `subscription-manager register` should **succeed**

**scenario 2**: hostname is the same, dmi.system.uuid changed, host is not in build mode. Registration fails.

- run `subscription-manager clean`
- using the same client, modify the dmi.system.uuid by creating a custom fact in /etc/rhsm/facts/uuid.facts with content `{"dmi.system.uuid": "my-custom-uuid"}`
- `subscription-manager register` should **fail** since there exists a host profile with the same name but different UUID

**scenario 3**: hostname is the same, dmi.system.uuid changed, host is in build mode. Registration **succeeds**.

- With client configured for scenario 2, set the hosts build flag to true from the rails console:
```
::Host.find_by_name('katello-client.jturel.example.com').update_attributes!(build: true)
```
This simulates that the host is being rebuilt and the next registration will come from the kickstart
- Registering from the client should now succeed even with the altered dmi.system.uuid in place

