### PR TITLE
Fixes #26792: fix autocomplete search selection.

### DIFF
--- a/engines/bastion/app/assets/javascripts/bastion/layouts/partials/table.html
+++ b/engines/bastion/app/assets/javascripts/bastion/layouts/partials/table.html
@@ -16,6 +16,7 @@
                    ng-trim="false"
                    stop-event="click"
                    uib-typeahead="item.label for item in table.autocomplete($viewValue)"
+                   typeahead-focus-first="false"
                    typeahead-template-url="components/views/autocomplete-scoped-search.html"
                    typeahead-min-length="0"/>
 

--- a/webpack/move_to_pf/TypeAhead/TypeAhead.js
+++ b/webpack/move_to_pf/TypeAhead/TypeAhead.js
@@ -81,6 +81,7 @@ class TypeAhead extends Component {
                       case KEYCODES.ENTER:
                         if (!isOpen || !activeItems[highlightedIndex]) {
                           onSearch(this.state.inputValue);
+                          e.nativeEvent.preventDownshiftDefault = true;
                           e.preventDefault();
                         }
 


### PR DESCRIPTION
Do not automatically select the first autocomplete result which will
prevent enter from being interpreted as "search for the first result".

https://projects.theforeman.org/issues/26792