### PR TITLE
Fixes #27452 - Autoload LCE Content Views table

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/content.service.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/content.service.js
@@ -28,7 +28,8 @@
                 state: 'content-views',
                 resource: 'ContentView',
                 display: translate('Content Views'),
-                params: {nondefault: true}
+                params: {nondefault: true},
+                autoLoad: true
             }, {
                 state: 'repositories',
                 resource: 'Repository',
@@ -87,11 +88,13 @@
         };
 
         this.buildNutupane = function (params) {
-            var nutupane;
+            var nutupane, type;
+
+            type = this.getCurrentContentType();
 
             params = params || {};
-            params = angular.extend(params, getContentType(currentState()).params);
-            nutupane = new Nutupane($injector.get(getContentType(currentState()).resource), params, 'queryPaged', { 'disableAutoLoad': true });
+            params = angular.extend(params, type.params);
+            nutupane = new Nutupane($injector.get(type.resource), params, 'queryPaged', { 'disableAutoLoad': !type.autoLoad });
 
             return nutupane;
         };

--- a/engines/bastion_katello/test/environments/content.service.test.js
+++ b/engines/bastion_katello/test/environments/content.service.test.js
@@ -16,8 +16,8 @@ describe('Service: ContentService', function() {
         $state.current = {name: 'environment.packages'};
         var nutupane = ContentService.buildNutupane({environmentId: 1});
 
-        expect(nutupane).toBeDefined();
         expect(nutupane.getParams()['environmentId']).toBe(1);
+        expect(nutupane.disableAutoLoad).toBe(true);
     });
 
     describe ('Package', function() {
@@ -33,8 +33,8 @@ describe('Service: ContentService', function() {
         it("should provide a method to build a nutupane based on the current state", function () {
             var nutupane = ContentService.buildNutupane();
 
-            expect(nutupane).toBeDefined();
             expect(nutupane.table.resource).toBe(Package);
+            expect(nutupane.disableAutoLoad).toBe(true);
         });
     });
 
@@ -51,8 +51,22 @@ describe('Service: ContentService', function() {
         it("should provide a method to build a nutupane based on the current state", function () {
             var nutupane = ContentService.buildNutupane();
 
-            expect(nutupane).toBeDefined();
             expect(nutupane.table.resource).toBe(ModuleStream);
+            expect(nutupane.disableAutoLoad).toBe(true);
+        });
+    });
+
+    describe('Content Views', function() {
+        beforeEach(inject(function ($injector) {
+            $state.current = {name: 'environment.content-views'};
+            ContentView = $injector.get('ContentView');
+        }));
+
+        it("auto loads nutupane", function () {
+            var nutupane = ContentService.buildNutupane();
+
+            expect(nutupane.disableAutoLoad).toBe(false);
+            expect(nutupane.table.resource).toBe(ContentView);
         });
     });
 });


### PR DESCRIPTION
https://github.com/Katello/katello/pull/7969 took steps to remove duplicate repos from showing under the various tabs when looking at the detail view of a Lifecycle Environment. It unintentionally stopped the Content Views tab from loading data in its table. This change restores that functionality.

**To test**

- Promote a Content View with some repos to any Lifecycle Environment
- Click Content -> Lifecycle Environments and click on the name of the destination environment
- Observe that under the Content Views tab the one promoted in the first step is shown. This was previously not working.

This change **does not** affect the intended behavior introduced by #7969 in that the other tabs require a CV to be selected before showing any data in the table.