### PR TITLE
Fixes #27479 - Republish migrated deb repos on upgrade

### DIFF
--- a/db/seeds.d/111-upgrade_tasks.rb
+++ b/db/seeds.d/111-upgrade_tasks.rb
@@ -9,6 +9,7 @@ UpgradeTask.define_tasks(:katello) do
     {:name => 'katello:upgrades:3.11:import_yum_metadata'},
     {:name => 'katello:upgrades:3.11:update_puppet_repos'},
     {:name => 'katello:upgrades:3.11:clear_checksum_type', :task_name => 'katello:upgrades:3.8:clear_checksum_type'},
-    {:name => 'katello:upgrades:3.12:remove_pulp2_notifier'}
+    {:name => 'katello:upgrades:3.12:remove_pulp2_notifier'},
+    {:name => 'katello:upgrades:3.13:republish_deb_metadata'}
   ]
 end

--- a/lib/katello/tasks/upgrades/3.13/republish_deb_metadata.rake
+++ b/lib/katello/tasks/upgrades/3.13/republish_deb_metadata.rake
@@ -1,0 +1,22 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '3.13' do
+      desc "Regenerate the metadata for repositories affected by pulp_deb migration 0004"
+      task :republish_deb_metadata, [:input_file] => ["environment"] do |task, args|
+        User.current = User.anonymous_api_admin
+        input_file = args[:input_file] || "/var/lib/pulp/0004_deb_repo_republish_candidates.txt"
+        if File.readable?(input_file)
+          pulp_ids = File.read(input_file).each_line.map(&:strip) || []
+          repos = Katello::Repository.where(:pulp_id => pulp_ids)
+          puts _("Starting BulkMetadataGenerate task.")
+          task = ForemanTasks.async_task(Actions::Katello::Repository::BulkMetadataGenerate, repos, :force => true)
+          puts _("Please check that the task #{task.id} completes successfully.")
+          puts _('You can manually re-trigger this task by running "foreman-rake katello:upgrades:3.13:republish_deb_metadata"')
+        else
+          puts _("Input file #{input_file} was not readable.")
+          puts _('You can manually use an alternate input file by running "foreman-rake katello:upgrades:3.13:republish_deb_metadata[<path>]"')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Some future Katello version (as yet unknown?) will include pulp version `2.20.0`.
Pulp version `2.20.0` includes pulp_deb `1.10.0`.
In pulp_deb `1.10.0` we fixed a bug (https://pulp.plan.io/issues/4138) that necessitates a best effort db migration.

This migration is capable of fixing the bug for affected Katello repos. (CV version repos, LCENV repos, katello root repos, etc.)
However, once these repos have been migrated in the database, they should be republished ("republish repository metadata") for the bug fix to take full effect.
To facilitate this the migration records all affected repos in `/var/lib/pulp/0004_deb_repo_republish_candidates.txt`.

The rake task added by this PR will automatically trigger the needed publish tasks during upgrade.
Since I do not yet know what Katello version will include Pulp `2.20.0`, I have assumed Katello `3.14` for now, and made this a "Draft pull request".