### PR TITLE
Fixes #27210 - support more generic remove on pulp3

### DIFF
--- a/app/lib/actions/pulp3/repository/remove_units.rb
+++ b/app/lib/actions/pulp3/repository/remove_units.rb
@@ -11,11 +11,11 @@ module Actions
         def invoke_external_task
           repo = ::Katello::Repository.find(input[:repository_id])
           content_unit_ids = input[:options][:contents]
-          file_units = ::Katello::RepositoryFile.where(
-            id: content_unit_ids,
-            repository_id: repo.id)
-          content_units = ::Katello::FileUnit.find(file_units.map(&:file_id))
-          output[:pulp_tasks] = repo.backend_service(smart_proxy).remove_content(content_units)
+
+          content_type = ::Katello::RepositoryTypeManager.find_content_type(input[:options][:content_unit_type].downcase)
+          units = content_type.model_class.where(:id => content_unit_ids)
+
+          output[:pulp_tasks] = repo.backend_service(smart_proxy).remove_content(units)
         end
       end
     end


### PR DESCRIPTION
this adds support for more generic content
removal from a repo with pulp3
