### PR TITLE
Refs #26135 - Update srpm rabl for hammer listing/info

### DIFF
--- a/app/views/katello/api/v2/srpms/show.json.rabl
+++ b/app/views/katello/api/v2/srpms/show.json.rabl
@@ -1,5 +1,5 @@
 object @resource
 
-attributes :id, :pulp_id
+attributes :id, :pulp_id, :name, :filename
 attributes :created_at, :updated, :version, :arch, :release
-attributes :epoch, :filname, :sourcerpm, :checksum, :summary, :nvra
+attributes :epoch, :checksum, :summary, :nvra


### PR DESCRIPTION
Without this, the listing command is incomplete, also removed sourcerpm since it does not relate to srpms, this was copied from the rpm rabl. I moved filename to the top since it was not seeing it in the index