### PR TITLE
Fixes #27516 - Create os without spaces

### DIFF
--- a/app/models/katello/rhsm_fact_parser.rb
+++ b/app/models/katello/rhsm_fact_parser.rb
@@ -61,7 +61,7 @@ module Katello
 
     def os_release_name(os_name)
       if os_name.match(::Operatingsystem::FAMILIES['Debian'])
-        facts['distribution.id']
+        facts['distribution.id']&.split&.first&.downcase
       end
     end
 

--- a/test/models/rhsm_fact_parser_test.rb
+++ b/test/models/rhsm_fact_parser_test.rb
@@ -77,12 +77,14 @@ module Katello
 
     def test_operatingsystem_ubuntu
       @facts['distribution.name'] = 'Ubuntu GNU/Linux'
-      @facts['distribution.version'] = '19'
-      @facts['distribution.id'] = 'disco'
+      @facts['distribution.version'] = '19.04'
+      @facts['distribution.id'] = 'Disco Dingo'
 
       assert_equal parser.operatingsystem.release_name, 'disco'
       assert_equal parser.operatingsystem.name, 'Ubuntu'
       assert_equal parser.operatingsystem.type, 'Debian'
+      assert_equal parser.operatingsystem.major, '19'
+      assert_equal parser.operatingsystem.minor, '04'
     end
 
     def test_uname_architecture


### PR DESCRIPTION
This should ensure we only use the first part of Ubuntu release code-names (e.g. 'bionic' instead of 'bionic beaver'). Debian will not be affected, because they only use one word as their code-names.

Not sure if this is the only section that has to be fixed.