### PR TITLE
Fixes #27518 - proxy options for sync

### DIFF
--- a/app/services/katello/pulp/repository.rb
+++ b/app/services/katello/pulp/repository.rb
@@ -264,7 +264,7 @@ module Katello
         if proxy
           uri = URI(proxy.url)
           proxy_options = {
-            proxy_host: uri.host,
+            proxy_host: uri.scheme + '://' + uri.host,
             proxy_port: uri.port,
             proxy_username: proxy.username,
             proxy_password: proxy.password

--- a/test/fixtures/vcr_cassettes/katello/service/repository/rpm_with_proxy/create_with_global_http_proxy.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/rpm_with_proxy/create_with_global_http_proxy.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:42 GMT
+      - Mon, 05 Aug 2019 17:13:28 GMT
       Server:
       - Apache
       Content-Length:
@@ -44,7 +44,7 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJkZWJpYW5f
         OSJ9fQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:42 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:28 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
@@ -66,7 +66,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:42 GMT
+      - Mon, 05 Aug 2019 17:13:28 GMT
       Server:
       - Apache
       Content-Length:
@@ -89,7 +89,7 @@ http_interactions:
         YmFjayI6IG51bGwsICJyZXNvdXJjZXMiOiB7InJlcG9zaXRvcnkiOiAiRmVk
         b3JhXzE3In19
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:42 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:28 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/2_duplicate/?details=true
@@ -111,7 +111,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:42 GMT
+      - Mon, 05 Aug 2019 17:13:28 GMT
       Server:
       - Apache
       Content-Length:
@@ -134,7 +134,7 @@ http_interactions:
         LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9y
         eSI6ICIyX2R1cGxpY2F0ZSJ9fQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:42 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:28 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/feedless_1/?details=true
@@ -156,7 +156,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:42 GMT
+      - Mon, 05 Aug 2019 17:13:29 GMT
       Server:
       - Apache
       Content-Length:
@@ -179,7 +179,7 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         ImZlZWRsZXNzXzEifX0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:42 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:29 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/9/?details=true
@@ -201,7 +201,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:43 GMT
+      - Mon, 05 Aug 2019 17:13:29 GMT
       Server:
       - Apache
       Content-Length:
@@ -223,7 +223,7 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjkifX0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:43 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:29 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
@@ -245,7 +245,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:43 GMT
+      - Mon, 05 Aug 2019 17:13:29 GMT
       Server:
       - Apache
       Content-Length:
@@ -269,7 +269,7 @@ http_interactions:
         W119LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3Np
         dG9yeSI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCJ9fQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:43 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:29 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/1/?details=true
@@ -291,7 +291,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:43 GMT
+      - Mon, 05 Aug 2019 17:13:29 GMT
       Server:
       - Apache
       Content-Length:
@@ -313,7 +313,7 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjEifX0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:43 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:29 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/9_noarch/?details=true
@@ -335,7 +335,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:43 GMT
+      - Mon, 05 Aug 2019 17:13:29 GMT
       Server:
       - Apache
       Content-Length:
@@ -358,7 +358,7 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICI5X25vYXJj
         aCJ9fQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:43 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:29 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/4/?details=true
@@ -380,7 +380,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:43 GMT
+      - Mon, 05 Aug 2019 17:13:29 GMT
       Server:
       - Apache
       Content-Length:
@@ -402,7 +402,7 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjQifX0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:43 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:29 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/6/?details=true
@@ -424,7 +424,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:44 GMT
+      - Mon, 05 Aug 2019 17:13:29 GMT
       Server:
       - Apache
       Content-Length:
@@ -446,7 +446,7 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjYifX0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:44 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:29 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/7/?details=true
@@ -468,7 +468,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:44 GMT
+      - Mon, 05 Aug 2019 17:13:30 GMT
       Server:
       - Apache
       Content-Length:
@@ -490,7 +490,7 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjcifX0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:44 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:30 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/source_rpm/?details=true
@@ -512,7 +512,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:44 GMT
+      - Mon, 05 Aug 2019 17:13:30 GMT
       Server:
       - Apache
       Content-Length:
@@ -535,7 +535,7 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         InNvdXJjZV9ycG0ifX0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:44 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:30 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
@@ -557,7 +557,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:44 GMT
+      - Mon, 05 Aug 2019 17:13:30 GMT
       Server:
       - Apache
       Content-Length:
@@ -582,7 +582,7 @@ http_interactions:
         Y2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1
         bHRfT3JnYW5pemF0aW9uLVRlc3QtcmVkaXMifX0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:44 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:30 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/?details=true
@@ -604,7 +604,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:44 GMT
+      - Mon, 05 Aug 2019 17:13:30 GMT
       Server:
       - Apache
       Content-Length:
@@ -630,7 +630,7 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSJ9fQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:44 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:30 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox2-dev/?details=true
@@ -652,7 +652,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:44 GMT
+      - Mon, 05 Aug 2019 17:13:31 GMT
       Server:
       - Apache
       Content-Length:
@@ -678,7 +678,7 @@ http_interactions:
         cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1U
         ZXN0LWJ1c3lib3gyLWRldiJ9fQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:44 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:31 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/100/?details=true
@@ -700,7 +700,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:45 GMT
+      - Mon, 05 Aug 2019 17:13:31 GMT
       Server:
       - Apache
       Content-Length:
@@ -722,7 +722,7 @@ http_interactions:
         X2Vycm9ycyI6IFtdfSwgInRyYWNlYmFjayI6IG51bGwsICJyZXNvdXJjZXMi
         OiB7InJlcG9zaXRvcnkiOiAiMTAwIn19
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:45 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:31 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/?details=true
@@ -744,7 +744,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:45 GMT
+      - Mon, 05 Aug 2019 17:13:31 GMT
       Server:
       - Apache
       Content-Length:
@@ -770,7 +770,7 @@ http_interactions:
         IjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
         ZXQtTXlfRmlsZXMifX0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:45 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:31 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_File_1/?details=true
@@ -792,7 +792,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:45 GMT
+      - Mon, 05 Aug 2019 17:13:31 GMT
       Server:
       - Apache
       Content-Length:
@@ -818,7 +818,7 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSJ9fQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:45 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:31 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Docker_1/?details=true
@@ -840,7 +840,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:45 GMT
+      - Mon, 05 Aug 2019 17:13:31 GMT
       Server:
       - Apache
       Content-Length:
@@ -866,7 +866,7 @@ http_interactions:
         ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRl
         ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRG9ja2VyXzEifX0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:45 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:31 GMT
 - request:
     method: post
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/
@@ -879,25 +879,25 @@ http_interactions:
         InJlbW92ZV9taXNzaW5nIjp0cnVlLCJmZWVkIjoiZmlsZTovLy92YXIvd3d3
         L3Rlc3RfcmVwb3Mvem9vIiwidHlwZV9za2lwX2xpc3QiOm51bGwsImJhc2lj
         X2F1dGhfdXNlcm5hbWUiOm51bGwsImJhc2ljX2F1dGhfcGFzc3dvcmQiOm51
-        bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJwcm94eV9ob3N0IjoidXJsXzEi
-        LCJwcm94eV9wb3J0Ijo4MCwicHJveHlfdXNlcm5hbWUiOm51bGwsInByb3h5
-        X3Bhc3N3b3JkIjpudWxsLCJzc2xfY2xpZW50X2NlcnQiOm51bGwsInNzbF9j
-        bGllbnRfa2V5IjpudWxsLCJzc2xfY2FfY2VydCI6bnVsbH0sIm5vdGVzIjp7
-        Il9yZXBvLXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRp
-        c3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmli
-        dXRvcl9jb25maWciOnsicmVsYXRpdmVfdXJsIjoiQUNNRV9Db3Jwb3JhdGlv
-        bi9saWJyYXJ5L2ZlZG9yYV8xN19sYWJlbCIsImh0dHAiOmZhbHNlLCJodHRw
-        cyI6dHJ1ZSwicHJvdGVjdGVkIjp0cnVlLCJjaGVja3N1bV90eXBlIjpudWxs
-        fSwiYXV0b19wdWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9pZCI6IkZlZG9y
-        YV8xNyJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9jbG9uZV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJkZXN0aW5hdGlvbl9k
-        aXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xNyJ9LCJhdXRvX3B1Ymxpc2giOmZh
-        bHNlLCJkaXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xN19jbG9uZSJ9LHsiZGlz
-        dHJpYnV0b3JfdHlwZV9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciIsImRpc3Ry
-        aWJ1dG9yX2NvbmZpZyI6eyJodHRwIjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJy
-        ZWxhdGl2ZV91cmwiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3Jh
-        XzE3X2xhYmVsIn0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9y
-        X2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
+        bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJwcm94eV9ob3N0IjoiaHR0cDov
+        L3VybF8xIiwicHJveHlfcG9ydCI6ODAsInByb3h5X3VzZXJuYW1lIjpudWxs
+        LCJwcm94eV9wYXNzd29yZCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0IjpudWxs
+        LCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3NsX2NhX2NlcnQiOm51bGx9LCJu
+        b3RlcyI6eyJfcmVwby10eXBlIjoicnBtLXJlcG8ifSwiZGlzdHJpYnV0b3Jz
+        IjpbeyJkaXN0cmlidXRvcl90eXBlX2lkIjoieXVtX2Rpc3RyaWJ1dG9yIiwi
+        ZGlzdHJpYnV0b3JfY29uZmlnIjp7InJlbGF0aXZlX3VybCI6IkFDTUVfQ29y
+        cG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwiLCJodHRwIjpmYWxz
+        ZSwiaHR0cHMiOnRydWUsInByb3RlY3RlZCI6dHJ1ZSwiY2hlY2tzdW1fdHlw
+        ZSI6bnVsbH0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3JfaWQi
+        OiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1fY2xv
+        bmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVzdGlu
+        YXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19wdWJs
+        aXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xvbmUi
+        fSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3Ii
+        LCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBzIjpm
+        YWxzZSwicmVsYXRpdmVfdXJsIjoiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5
+        L2ZlZG9yYV8xN19sYWJlbCJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0
+        cmlidXRvcl9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciJ9XX0=
     headers:
       Accept:
       - application/json
@@ -908,14 +908,14 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '1108'
+      - '1115'
   response:
     status:
       code: 201
       message: CREATED
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:46 GMT
+      - Mon, 05 Aug 2019 17:13:32 GMT
       Server:
       - Apache
       Content-Length:
@@ -932,11 +932,11 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWQ0MGJjYTY1ZWFmMGQwNzhlZWIyY2UzIn0sICJpZCI6ICJGZWRvcmFfMTci
+        NWQ0ODYzYmM1ZWFmMGQyOTQxZTAxOGRiIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:46 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:32 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
@@ -958,15 +958,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:46 GMT
+      - Mon, 05 Aug 2019 17:13:32 GMT
       Server:
       - Apache
       Etag:
-      - '"c997e2ff19580c05409af151aed0e148-gzip"'
+      - '"1e9f9a13670cc0573409483f8ae0bf67-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2323'
+      - '2330'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -975,57 +975,57 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
-        MjAxOS0wNy0zMFQyMTo1NDo0NloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        MjAxOS0wOC0wNVQxNzoxMzozMloiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
         L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
         aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
         c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
         cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
         cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWQ0MGJjYTY1ZWFmMGQwNzhlZWIyY2U3In0sICJj
+        aWQiOiB7IiRvaWQiOiAiNWQ0ODYzYmM1ZWFmMGQyOTQxZTAxOGRmIn0sICJj
         b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
         X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
         IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
-        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDct
-        MzBUMjE6NTQ6NDZaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDgt
+        MDVUMTc6MTM6MzJaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
         b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
         IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
         OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
         dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
         Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVkNDBiY2E2NWVhZjBkMDc4ZWViMmNlNiJ9LCAiY29uZmlnIjog
+        b2lkIjogIjVkNDg2M2JjNWVhZjBkMjk0MWUwMThkZSJ9LCAiY29uZmlnIjog
         eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
         ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9LCB7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA3LTMwVDIxOjU0OjQ2WiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE3OjEzOjMyWiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9kaXN0cmlidXRvcnMvRmVkb3JhXzE3LyIsICJsYXN0X292ZXJyaWRlX2Nv
         bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
         X3R5cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6
         IHRydWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmli
-        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVkNDBiY2E2NWVhZjBkMDc4ZWVi
-        MmNlNSJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
+        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVkNDg2M2JjNWVhZjBkMjk0MWUw
+        MThkZCJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
         IGZhbHNlLCAiaHR0cHMiOiB0cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVf
         Q29ycG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwifSwgImlkIjog
         IkZlZG9yYV8xNyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3Rl
         cyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3Jl
         bW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25z
         IjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA3LTMwVDIxOjU0OjQ2WiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE3OjEzOjMyWiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBv
         cnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
         bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGws
-        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQwYmNh
-        NjVlYWYwZDA3OGVlYjJjZTQifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJmaWxl
+        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4NjNi
+        YzVlYWYwZDI5NDFlMDE4ZGMifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJmaWxl
         Oi8vL3Zhci93d3cvdGVzdF9yZXBvcy96b28iLCAicHJveHlfcG9ydCI6IDgw
         LCAiZG93bmxvYWRfcG9saWN5IjogImltbWVkaWF0ZSIsICJyZW1vdmVfbWlz
-        c2luZyI6IHRydWUsICJwcm94eV9ob3N0IjogInVybF8xIiwgInNzbF92YWxp
-        ZGF0aW9uIjogdHJ1ZX0sICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0sICJsb2Nh
-        bGx5X3N0b3JlZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQiOiAiNWQ0MGJj
-        YTY1ZWFmMGQwNzhlZWIyY2UzIn0sICJ0b3RhbF9yZXBvc2l0b3J5X3VuaXRz
-        IjogMCwgImlkIjogIkZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkv
-        djIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8ifQ==
+        c2luZyI6IHRydWUsICJwcm94eV9ob3N0IjogImh0dHA6Ly91cmxfMSIsICJz
+        c2xfdmFsaWRhdGlvbiI6IHRydWV9LCAiaWQiOiAieXVtX2ltcG9ydGVyIn1d
+        LCAibG9jYWxseV9zdG9yZWRfdW5pdHMiOiAwLCAiX2lkIjogeyIkb2lkIjog
+        IjVkNDg2M2JjNWVhZjBkMjk0MWUwMThkYiJ9LCAidG90YWxfcmVwb3NpdG9y
+        eV91bml0cyI6IDAsICJpZCI6ICJGZWRvcmFfMTciLCAiX2hyZWYiOiAiL3B1
+        bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvIn0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:46 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:32 GMT
 - request:
     method: delete
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/Fedora_17/
@@ -1047,7 +1047,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:46 GMT
+      - Mon, 05 Aug 2019 17:13:32 GMT
       Server:
       - Apache
       Content-Length:
@@ -1058,14 +1058,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2U2OTdjN2ViLTJiOTctNDdhYS05MDM5LWY3NDZkMmQ1MTU0MS8iLCAi
-        dGFza19pZCI6ICJlNjk3YzdlYi0yYjk3LTQ3YWEtOTAzOS1mNzQ2ZDJkNTE1
-        NDEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2UyNzZiNzY2LTdlYWUtNDlkYy04NWQ0LTE1ZWY5NDliM2I1ZS8iLCAi
+        dGFza19pZCI6ICJlMjc2Yjc2Ni03ZWFlLTQ5ZGMtODVkNC0xNWVmOTQ5YjNi
+        NWUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:46 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:32 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/e697c7eb-2b97-47aa-9039-f746d2d51541/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/e276b766-7eae-49dc-85d4-15ef949b3b5e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1084,11 +1084,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:46 GMT
+      - Mon, 05 Aug 2019 17:13:32 GMT
       Server:
       - Apache
       Etag:
-      - '"6c0b8f378fc61ae3fa81a9593a7e03b3-gzip"'
+      - '"6db753023db36290fe9700cf24956e16-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -1100,9 +1100,9 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lNjk3YzdlYi0yYjk3LTQ3YWEtOTAzOS1mNzQ2ZDJkNTE1
-        NDEvIiwgInRhc2tfaWQiOiAiZTY5N2M3ZWItMmI5Ny00N2FhLTkwMzktZjc0
-        NmQyZDUxNTQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9lMjc2Yjc2Ni03ZWFlLTQ5ZGMtODVkNC0xNWVmOTQ5YjNi
+        NWUvIiwgInRhc2tfaWQiOiAiZTI3NmI3NjYtN2VhZS00OWRjLTg1ZDQtMTVl
+        Zjk0OWIzYjVlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
         bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
         ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
@@ -1111,14 +1111,14 @@ http_interactions:
         bXBsZS5jb20uZHEyIiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25h
         bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAY2VudG9zNy1rYXRl
         bGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
-        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ0MGJjYTZl
-        MTA4MDMzNjFiOGFiYWZmIn0sICJpZCI6ICI1ZDQwYmNhNmUxMDgwMzM2MWI4
-        YWJhZmYifQ==
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODYzYmNk
+        MmI3MWU3YTM1MTQ2NjFmIn0sICJpZCI6ICI1ZDQ4NjNiY2QyYjcxZTdhMzUx
+        NDY2MWYifQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:46 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:32 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/e697c7eb-2b97-47aa-9039-f746d2d51541/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/e276b766-7eae-49dc-85d4-15ef949b3b5e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1137,11 +1137,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:46 GMT
+      - Mon, 05 Aug 2019 17:13:32 GMT
       Server:
       - Apache
       Etag:
-      - '"cfae300bb6a5913f1fd10118536997aa-gzip"'
+      - '"cbfe592e6f77bf3fadc293d3d4283451-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -1153,25 +1153,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lNjk3YzdlYi0yYjk3LTQ3YWEtOTAzOS1mNzQ2ZDJkNTE1
-        NDEvIiwgInRhc2tfaWQiOiAiZTY5N2M3ZWItMmI5Ny00N2FhLTkwMzktZjc0
-        NmQyZDUxNTQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9lMjc2Yjc2Ni03ZWFlLTQ5ZGMtODVkNC0xNWVmOTQ5YjNi
+        NWUvIiwgInRhc2tfaWQiOiAiZTI3NmI3NjYtN2VhZS00OWRjLTg1ZDQtMTVl
+        Zjk0OWIzYjVlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
         bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5
-        LTA3LTMwVDIxOjU0OjQ2WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        LTA4LTA1VDE3OjEzOjMyWiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
         ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
         ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8t
         ZGV2ZWwuamplZmZlcnMuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1
         bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
         a2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUu
         Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNWQ0MGJjYTZlMTA4MDMzNjFiOGFiYWZmIn0sICJpZCI6ICI1
-        ZDQwYmNhNmUxMDgwMzM2MWI4YWJhZmYifQ==
+        IiRvaWQiOiAiNWQ0ODYzYmNkMmI3MWU3YTM1MTQ2NjFmIn0sICJpZCI6ICI1
+        ZDQ4NjNiY2QyYjcxZTdhMzUxNDY2MWYifQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:46 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:32 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/e697c7eb-2b97-47aa-9039-f746d2d51541/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/e276b766-7eae-49dc-85d4-15ef949b3b5e/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1190,11 +1190,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:54:46 GMT
+      - Mon, 05 Aug 2019 17:13:32 GMT
       Server:
       - Apache
       Etag:
-      - '"8c1898175a4e9556a7f4fe6e107fee9e-gzip"'
+      - '"93216e662a88683e0ce3c4a8bc6e361d-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -1206,20 +1206,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lNjk3YzdlYi0yYjk3LTQ3YWEtOTAzOS1mNzQ2ZDJkNTE1
-        NDEvIiwgInRhc2tfaWQiOiAiZTY5N2M3ZWItMmI5Ny00N2FhLTkwMzktZjc0
-        NmQyZDUxNTQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9lMjc2Yjc2Ni03ZWFlLTQ5ZGMtODVkNC0xNWVmOTQ5YjNi
+        NWUvIiwgInRhc2tfaWQiOiAiZTI3NmI3NjYtN2VhZS00OWRjLTg1ZDQtMTVl
+        Zjk0OWIzYjVlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE5LTA3LTMwVDIxOjU0OjQ2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE5LTA3LTMwVDIxOjU0OjQ2WiIsICJ0cmFjZWJh
+        MDE5LTA4LTA1VDE3OjEzOjMyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE3OjEzOjMyWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
         MUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuamplZmZlcnMuZXhhbXBsZS5jb20u
         ZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
         c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZl
         bC5qamVmZmVycy5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDBiY2E2ZTEwODAzMzYx
-        YjhhYmFmZiJ9LCAiaWQiOiAiNWQ0MGJjYTZlMTA4MDMzNjFiOGFiYWZmIn0=
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDg2M2JjZDJiNzFlN2Ez
+        NTE0NjYxZiJ9LCAiaWQiOiAiNWQ0ODYzYmNkMmI3MWU3YTM1MTQ2NjFmIn0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:54:46 GMT
+  recorded_at: Mon, 05 Aug 2019 17:13:32 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/rpm_with_proxy/sync_with_global_http_proxy.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/rpm_with_proxy/sync_with_global_http_proxy.yml
@@ -2,6 +2,186 @@
 http_interactions:
 - request:
     method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/6/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 05 Aug 2019 17:12:39 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '374'
+      Etag:
+      - '"a9f3e136425fefbf34661510bcc14368"'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkdFVCIsICJleGNlcHRpb24iOiBu
+        dWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiBy
+        ZXBvc2l0b3J5PTYiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRv
+        cmllcy82Lz9kZXRhaWxzPXRydWUiLCAiaHR0cF9zdGF0dXMiOiA0MDQsICJl
+        cnJvciI6IHsiY29kZSI6ICJQTFAwMDA5IiwgImRhdGEiOiB7InJlc291cmNl
+        cyI6IHsicmVwb3NpdG9yeSI6ICI2In19LCAiZGVzY3JpcHRpb24iOiAiTWlz
+        c2luZyByZXNvdXJjZShzKTogcmVwb3NpdG9yeT02IiwgInN1Yl9lcnJvcnMi
+        OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
+        c2l0b3J5IjogIjYifX0=
+    http_version: 
+  recorded_at: Mon, 05 Aug 2019 17:12:39 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/7/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 05 Aug 2019 17:12:39 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '374'
+      Etag:
+      - '"0a8daad01b7d63ef6e6f0f14b08405b4"'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkdFVCIsICJleGNlcHRpb24iOiBu
+        dWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiBy
+        ZXBvc2l0b3J5PTciLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRv
+        cmllcy83Lz9kZXRhaWxzPXRydWUiLCAiaHR0cF9zdGF0dXMiOiA0MDQsICJl
+        cnJvciI6IHsiY29kZSI6ICJQTFAwMDA5IiwgImRhdGEiOiB7InJlc291cmNl
+        cyI6IHsicmVwb3NpdG9yeSI6ICI3In19LCAiZGVzY3JpcHRpb24iOiAiTWlz
+        c2luZyByZXNvdXJjZShzKTogcmVwb3NpdG9yeT03IiwgInN1Yl9lcnJvcnMi
+        OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
+        c2l0b3J5IjogIjcifX0=
+    http_version: 
+  recorded_at: Mon, 05 Aug 2019 17:12:39 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/source_rpm/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 05 Aug 2019 17:12:39 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '419'
+      Etag:
+      - '"02113d4b79baab13a00a64a5315ffcdb"'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkdFVCIsICJleGNlcHRpb24iOiBu
+        dWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiBy
+        ZXBvc2l0b3J5PXNvdXJjZV9ycG0iLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        L3JlcG9zaXRvcmllcy9zb3VyY2VfcnBtLz9kZXRhaWxzPXRydWUiLCAiaHR0
+        cF9zdGF0dXMiOiA0MDQsICJlcnJvciI6IHsiY29kZSI6ICJQTFAwMDA5Iiwg
+        ImRhdGEiOiB7InJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJzb3VyY2Vf
+        cnBtIn19LCAiZGVzY3JpcHRpb24iOiAiTWlzc2luZyByZXNvdXJjZShzKTog
+        cmVwb3NpdG9yeT1zb3VyY2VfcnBtIiwgInN1Yl9lcnJvcnMiOiBbXX0sICJ0
+        cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
+        InNvdXJjZV9ycG0ifX0=
+    http_version: 
+  recorded_at: Mon, 05 Aug 2019 17:12:39 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 05 Aug 2019 17:12:39 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '524'
+      Etag:
+      - '"9e8f48c6e57384bee04b2de884ea20ee"'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkdFVCIsICJleGNlcHRpb24iOiBu
+        dWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiBy
+        ZXBvc2l0b3J5PURlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtcmVkaXMiLCAi
+        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9EZWZhdWx0X09y
+        Z2FuaXphdGlvbi1UZXN0LXJlZGlzLz9kZXRhaWxzPXRydWUiLCAiaHR0cF9z
+        dGF0dXMiOiA0MDQsICJlcnJvciI6IHsiY29kZSI6ICJQTFAwMDA5IiwgImRh
+        dGEiOiB7InJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
+        Z2FuaXphdGlvbi1UZXN0LXJlZGlzIn19LCAiZGVzY3JpcHRpb24iOiAiTWlz
+        c2luZyByZXNvdXJjZShzKTogcmVwb3NpdG9yeT1EZWZhdWx0X09yZ2FuaXph
+        dGlvbi1UZXN0LXJlZGlzIiwgInN1Yl9lcnJvcnMiOiBbXX0sICJ0cmFjZWJh
+        Y2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1
+        bHRfT3JnYW5pemF0aW9uLVRlc3QtcmVkaXMifX0=
+    http_version: 
+  recorded_at: Mon, 05 Aug 2019 17:12:40 GMT
+- request:
+    method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/?details=true
     body:
       encoding: US-ASCII
@@ -21,7 +201,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:13 GMT
+      - Mon, 05 Aug 2019 17:12:40 GMT
       Server:
       - Apache
       Content-Length:
@@ -47,7 +227,7 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSJ9fQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:13 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:40 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox2-dev/?details=true
@@ -69,7 +249,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:13 GMT
+      - Mon, 05 Aug 2019 17:12:40 GMT
       Server:
       - Apache
       Content-Length:
@@ -95,7 +275,7 @@ http_interactions:
         cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1U
         ZXN0LWJ1c3lib3gyLWRldiJ9fQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:13 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:40 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/100/?details=true
@@ -117,7 +297,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:13 GMT
+      - Mon, 05 Aug 2019 17:12:40 GMT
       Server:
       - Apache
       Content-Length:
@@ -139,7 +319,7 @@ http_interactions:
         X2Vycm9ycyI6IFtdfSwgInRyYWNlYmFjayI6IG51bGwsICJyZXNvdXJjZXMi
         OiB7InJlcG9zaXRvcnkiOiAiMTAwIn19
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:13 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:40 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/?details=true
@@ -161,7 +341,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:13 GMT
+      - Mon, 05 Aug 2019 17:12:40 GMT
       Server:
       - Apache
       Content-Length:
@@ -187,7 +367,7 @@ http_interactions:
         IjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
         ZXQtTXlfRmlsZXMifX0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:13 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:40 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_File_1/?details=true
@@ -209,7 +389,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:14 GMT
+      - Mon, 05 Aug 2019 17:12:41 GMT
       Server:
       - Apache
       Content-Length:
@@ -235,7 +415,7 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSJ9fQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:14 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:41 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Docker_1/?details=true
@@ -257,7 +437,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:14 GMT
+      - Mon, 05 Aug 2019 17:12:41 GMT
       Server:
       - Apache
       Content-Length:
@@ -283,7 +463,7 @@ http_interactions:
         ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRl
         ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRG9ja2VyXzEifX0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:14 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:41 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/debian_9/?details=true
@@ -305,7 +485,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:14 GMT
+      - Mon, 05 Aug 2019 17:12:41 GMT
       Server:
       - Apache
       Content-Length:
@@ -328,7 +508,7 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJkZWJpYW5f
         OSJ9fQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:14 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:41 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
@@ -350,7 +530,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:14 GMT
+      - Mon, 05 Aug 2019 17:12:41 GMT
       Server:
       - Apache
       Content-Length:
@@ -373,7 +553,7 @@ http_interactions:
         YmFjayI6IG51bGwsICJyZXNvdXJjZXMiOiB7InJlcG9zaXRvcnkiOiAiRmVk
         b3JhXzE3In19
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:14 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:41 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/2_duplicate/?details=true
@@ -395,7 +575,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:14 GMT
+      - Mon, 05 Aug 2019 17:12:42 GMT
       Server:
       - Apache
       Content-Length:
@@ -418,7 +598,7 @@ http_interactions:
         LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9y
         eSI6ICIyX2R1cGxpY2F0ZSJ9fQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:14 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:42 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/feedless_1/?details=true
@@ -440,7 +620,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:15 GMT
+      - Mon, 05 Aug 2019 17:12:42 GMT
       Server:
       - Apache
       Content-Length:
@@ -463,7 +643,7 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         ImZlZWRsZXNzXzEifX0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:15 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:42 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/9/?details=true
@@ -485,7 +665,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:15 GMT
+      - Mon, 05 Aug 2019 17:12:42 GMT
       Server:
       - Apache
       Content-Length:
@@ -507,7 +687,7 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjkifX0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:15 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:42 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
@@ -529,7 +709,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:15 GMT
+      - Mon, 05 Aug 2019 17:12:42 GMT
       Server:
       - Apache
       Content-Length:
@@ -553,7 +733,7 @@ http_interactions:
         W119LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3Np
         dG9yeSI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCJ9fQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:15 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:42 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/1/?details=true
@@ -575,7 +755,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:15 GMT
+      - Mon, 05 Aug 2019 17:12:42 GMT
       Server:
       - Apache
       Content-Length:
@@ -597,7 +777,7 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjEifX0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:15 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:42 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/9_noarch/?details=true
@@ -619,7 +799,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:15 GMT
+      - Mon, 05 Aug 2019 17:12:42 GMT
       Server:
       - Apache
       Content-Length:
@@ -642,7 +822,7 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICI5X25vYXJj
         aCJ9fQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:15 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:42 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/4/?details=true
@@ -664,7 +844,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:15 GMT
+      - Mon, 05 Aug 2019 17:12:43 GMT
       Server:
       - Apache
       Content-Length:
@@ -686,187 +866,7 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjQifX0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:15 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/6/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Tue, 30 Jul 2019 21:55:16 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '374'
-      Etag:
-      - '"a9f3e136425fefbf34661510bcc14368"'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkdFVCIsICJleGNlcHRpb24iOiBu
-        dWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiBy
-        ZXBvc2l0b3J5PTYiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRv
-        cmllcy82Lz9kZXRhaWxzPXRydWUiLCAiaHR0cF9zdGF0dXMiOiA0MDQsICJl
-        cnJvciI6IHsiY29kZSI6ICJQTFAwMDA5IiwgImRhdGEiOiB7InJlc291cmNl
-        cyI6IHsicmVwb3NpdG9yeSI6ICI2In19LCAiZGVzY3JpcHRpb24iOiAiTWlz
-        c2luZyByZXNvdXJjZShzKTogcmVwb3NpdG9yeT02IiwgInN1Yl9lcnJvcnMi
-        OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
-        c2l0b3J5IjogIjYifX0=
-    http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:16 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/7/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Tue, 30 Jul 2019 21:55:16 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '374'
-      Etag:
-      - '"0a8daad01b7d63ef6e6f0f14b08405b4"'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkdFVCIsICJleGNlcHRpb24iOiBu
-        dWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiBy
-        ZXBvc2l0b3J5PTciLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRv
-        cmllcy83Lz9kZXRhaWxzPXRydWUiLCAiaHR0cF9zdGF0dXMiOiA0MDQsICJl
-        cnJvciI6IHsiY29kZSI6ICJQTFAwMDA5IiwgImRhdGEiOiB7InJlc291cmNl
-        cyI6IHsicmVwb3NpdG9yeSI6ICI3In19LCAiZGVzY3JpcHRpb24iOiAiTWlz
-        c2luZyByZXNvdXJjZShzKTogcmVwb3NpdG9yeT03IiwgInN1Yl9lcnJvcnMi
-        OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
-        c2l0b3J5IjogIjcifX0=
-    http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:16 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/source_rpm/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Tue, 30 Jul 2019 21:55:16 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '419'
-      Etag:
-      - '"02113d4b79baab13a00a64a5315ffcdb"'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkdFVCIsICJleGNlcHRpb24iOiBu
-        dWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiBy
-        ZXBvc2l0b3J5PXNvdXJjZV9ycG0iLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
-        L3JlcG9zaXRvcmllcy9zb3VyY2VfcnBtLz9kZXRhaWxzPXRydWUiLCAiaHR0
-        cF9zdGF0dXMiOiA0MDQsICJlcnJvciI6IHsiY29kZSI6ICJQTFAwMDA5Iiwg
-        ImRhdGEiOiB7InJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJzb3VyY2Vf
-        cnBtIn19LCAiZGVzY3JpcHRpb24iOiAiTWlzc2luZyByZXNvdXJjZShzKTog
-        cmVwb3NpdG9yeT1zb3VyY2VfcnBtIiwgInN1Yl9lcnJvcnMiOiBbXX0sICJ0
-        cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
-        InNvdXJjZV9ycG0ifX0=
-    http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:16 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Date:
-      - Tue, 30 Jul 2019 21:55:16 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '524'
-      Etag:
-      - '"9e8f48c6e57384bee04b2de884ea20ee"'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJodHRwX3JlcXVlc3RfbWV0aG9kIjogIkdFVCIsICJleGNlcHRpb24iOiBu
-        dWxsLCAiZXJyb3JfbWVzc2FnZSI6ICJNaXNzaW5nIHJlc291cmNlKHMpOiBy
-        ZXBvc2l0b3J5PURlZmF1bHRfT3JnYW5pemF0aW9uLVRlc3QtcmVkaXMiLCAi
-        X2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9EZWZhdWx0X09y
-        Z2FuaXphdGlvbi1UZXN0LXJlZGlzLz9kZXRhaWxzPXRydWUiLCAiaHR0cF9z
-        dGF0dXMiOiA0MDQsICJlcnJvciI6IHsiY29kZSI6ICJQTFAwMDA5IiwgImRh
-        dGEiOiB7InJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
-        Z2FuaXphdGlvbi1UZXN0LXJlZGlzIn19LCAiZGVzY3JpcHRpb24iOiAiTWlz
-        c2luZyByZXNvdXJjZShzKTogcmVwb3NpdG9yeT1EZWZhdWx0X09yZ2FuaXph
-        dGlvbi1UZXN0LXJlZGlzIiwgInN1Yl9lcnJvcnMiOiBbXX0sICJ0cmFjZWJh
-        Y2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1
-        bHRfT3JnYW5pemF0aW9uLVRlc3QtcmVkaXMifX0=
-    http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:16 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:43 GMT
 - request:
     method: post
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/
@@ -879,25 +879,25 @@ http_interactions:
         InJlbW92ZV9taXNzaW5nIjp0cnVlLCJmZWVkIjoiZmlsZTovLy92YXIvd3d3
         L3Rlc3RfcmVwb3Mvem9vIiwidHlwZV9za2lwX2xpc3QiOm51bGwsImJhc2lj
         X2F1dGhfdXNlcm5hbWUiOm51bGwsImJhc2ljX2F1dGhfcGFzc3dvcmQiOm51
-        bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJwcm94eV9ob3N0IjoidXJsXzEi
-        LCJwcm94eV9wb3J0Ijo4MCwicHJveHlfdXNlcm5hbWUiOm51bGwsInByb3h5
-        X3Bhc3N3b3JkIjpudWxsLCJzc2xfY2xpZW50X2NlcnQiOm51bGwsInNzbF9j
-        bGllbnRfa2V5IjpudWxsLCJzc2xfY2FfY2VydCI6bnVsbH0sIm5vdGVzIjp7
-        Il9yZXBvLXR5cGUiOiJycG0tcmVwbyJ9LCJkaXN0cmlidXRvcnMiOlt7ImRp
-        c3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1fZGlzdHJpYnV0b3IiLCJkaXN0cmli
-        dXRvcl9jb25maWciOnsicmVsYXRpdmVfdXJsIjoiQUNNRV9Db3Jwb3JhdGlv
-        bi9saWJyYXJ5L2ZlZG9yYV8xN19sYWJlbCIsImh0dHAiOmZhbHNlLCJodHRw
-        cyI6dHJ1ZSwicHJvdGVjdGVkIjp0cnVlLCJjaGVja3N1bV90eXBlIjpudWxs
-        fSwiYXV0b19wdWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9pZCI6IkZlZG9y
-        YV8xNyJ9LHsiZGlzdHJpYnV0b3JfdHlwZV9pZCI6Inl1bV9jbG9uZV9kaXN0
-        cmlidXRvciIsImRpc3RyaWJ1dG9yX2NvbmZpZyI6eyJkZXN0aW5hdGlvbl9k
-        aXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xNyJ9LCJhdXRvX3B1Ymxpc2giOmZh
-        bHNlLCJkaXN0cmlidXRvcl9pZCI6IkZlZG9yYV8xN19jbG9uZSJ9LHsiZGlz
-        dHJpYnV0b3JfdHlwZV9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciIsImRpc3Ry
-        aWJ1dG9yX2NvbmZpZyI6eyJodHRwIjpmYWxzZSwiaHR0cHMiOmZhbHNlLCJy
-        ZWxhdGl2ZV91cmwiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3Jh
-        XzE3X2xhYmVsIn0sImF1dG9fcHVibGlzaCI6ZmFsc2UsImRpc3RyaWJ1dG9y
-        X2lkIjoiZXhwb3J0X2Rpc3RyaWJ1dG9yIn1dfQ==
+        bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJwcm94eV9ob3N0IjoiaHR0cDov
+        L3VybF8xIiwicHJveHlfcG9ydCI6ODAsInByb3h5X3VzZXJuYW1lIjpudWxs
+        LCJwcm94eV9wYXNzd29yZCI6bnVsbCwic3NsX2NsaWVudF9jZXJ0IjpudWxs
+        LCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3NsX2NhX2NlcnQiOm51bGx9LCJu
+        b3RlcyI6eyJfcmVwby10eXBlIjoicnBtLXJlcG8ifSwiZGlzdHJpYnV0b3Jz
+        IjpbeyJkaXN0cmlidXRvcl90eXBlX2lkIjoieXVtX2Rpc3RyaWJ1dG9yIiwi
+        ZGlzdHJpYnV0b3JfY29uZmlnIjp7InJlbGF0aXZlX3VybCI6IkFDTUVfQ29y
+        cG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwiLCJodHRwIjpmYWxz
+        ZSwiaHR0cHMiOnRydWUsInByb3RlY3RlZCI6dHJ1ZSwiY2hlY2tzdW1fdHlw
+        ZSI6bnVsbH0sImF1dG9fcHVibGlzaCI6dHJ1ZSwiZGlzdHJpYnV0b3JfaWQi
+        OiJGZWRvcmFfMTcifSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJ5dW1fY2xv
+        bmVfZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9jb25maWciOnsiZGVzdGlu
+        YXRpb25fZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTcifSwiYXV0b19wdWJs
+        aXNoIjpmYWxzZSwiZGlzdHJpYnV0b3JfaWQiOiJGZWRvcmFfMTdfY2xvbmUi
+        fSx7ImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiJleHBvcnRfZGlzdHJpYnV0b3Ii
+        LCJkaXN0cmlidXRvcl9jb25maWciOnsiaHR0cCI6ZmFsc2UsImh0dHBzIjpm
+        YWxzZSwicmVsYXRpdmVfdXJsIjoiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5
+        L2ZlZG9yYV8xN19sYWJlbCJ9LCJhdXRvX3B1Ymxpc2giOmZhbHNlLCJkaXN0
+        cmlidXRvcl9pZCI6ImV4cG9ydF9kaXN0cmlidXRvciJ9XX0=
     headers:
       Accept:
       - application/json
@@ -908,14 +908,14 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '1108'
+      - '1115'
   response:
     status:
       code: 201
       message: CREATED
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:17 GMT
+      - Mon, 05 Aug 2019 17:12:43 GMT
       Server:
       - Apache
       Content-Length:
@@ -932,11 +932,11 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWQ0MGJjYzU1ZWFmMGQwNzhlZWIyY2U4In0sICJpZCI6ICJGZWRvcmFfMTci
+        NWQ0ODYzOGI1ZWFmMGQyOTQxZTAxOGQ2In0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:17 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:43 GMT
 - request:
     method: post
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
@@ -962,7 +962,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:17 GMT
+      - Mon, 05 Aug 2019 17:12:43 GMT
       Server:
       - Apache
       Content-Length:
@@ -973,14 +973,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzQ1ZGEzYzVmLWE0ZTItNGNjOC04ZDgzLTYwMDRlZWFmNzdhZS8iLCAi
-        dGFza19pZCI6ICI0NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2RhZGFmYjljLTY0ZGItNGMwNS1iZjMxLTcxNTNjMWFiNjIyZi8iLCAi
+        dGFza19pZCI6ICJkYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:17 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:43 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -999,15 +999,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:17 GMT
+      - Mon, 05 Aug 2019 17:12:43 GMT
       Server:
       - Apache
       Etag:
-      - '"d956cf62d5ea8a2e2c22410e3492cbad-gzip"'
+      - '"79a954c6fc2de39dd1c9add5c1352242-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '698'
+      - '540'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1015,25 +1015,21 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAi
-        cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAY2VudG9zNy1rYXRlbGxvLWRl
-        dmVsLmpqZWZmZXJzLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJydW5u
-        aW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtl
-        ci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5qamVmZmVycy5leGFtcGxlLmNv
-        bSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
-        b2lkIjogIjVkNDBiY2M1ZTEwODAzMzYxYjhhYmM1MCJ9LCAiaWQiOiAiNWQ0
-        MGJjYzVlMTA4MDMzNjFiOGFiYzUwIn0=
+        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiBudWxsLCAi
+        dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
+        ZXNzX3JlcG9ydCI6IHt9LCAicXVldWUiOiAiIiwgInN0YXRlIjogIndhaXRp
+        bmciLCAid29ya2VyX25hbWUiOiBudWxsLCAicmVzdWx0IjogbnVsbCwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4NjM4YmQyYjcxZTdh
+        MzUxNDYwODEifSwgImlkIjogIjVkNDg2MzhiZDJiNzFlN2EzNTE0NjA4MSJ9
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:17 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:43 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1052,11 +1048,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:17 GMT
+      - Mon, 05 Aug 2019 17:12:43 GMT
       Server:
       - Apache
       Etag:
-      - '"99c759843fa490faca000de567058cb8-gzip"'
+      - '"cbc06d884c10b1a36fb1f73c0ddb8936-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -1068,12 +1064,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        OC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
         T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
@@ -1091,13 +1087,13 @@ http_interactions:
         InN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRf
         cmVzb3VyY2Vfd29ya2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZm
         ZXJzLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51
-        bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUw
-        In0sICJpZCI6ICI1ZDQwYmNjNWUxMDgwMzM2MWI4YWJjNTAifQ==
+        bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2MDgx
+        In0sICJpZCI6ICI1ZDQ4NjM4YmQyYjcxZTdhMzUxNDYwODEifQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:17 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:43 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1116,75 +1112,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:17 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"99c759843fa490faca000de567058cb8-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1207'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJO
-        T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
-        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
-        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUi
-        OiAiTk9UX1NUQVJURUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiTk9UX1NU
-        QVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJJTl9QUk9HUkVTUyJ9
-        fX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50
-        b3M3LWthdGVsbG8tZGV2ZWwuamplZmZlcnMuZXhhbXBsZS5jb20uZHEyIiwg
-        InN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRf
-        cmVzb3VyY2Vfd29ya2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZm
-        ZXJzLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51
-        bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUw
-        In0sICJpZCI6ICI1ZDQwYmNjNWUxMDgwMzM2MWI4YWJjNTAifQ==
-    http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:17 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 30 Jul 2019 21:55:17 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"c48c917bb3df8d194bda34b4f8384b99-gzip"'
+      - '"81b8eb657928487d824099caea04258b-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -1196,12 +1128,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        OC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
         Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
@@ -1219,13 +1151,13 @@ http_interactions:
         YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
         b3VyY2Vfd29ya2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJz
         LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUwIn0s
-        ICJpZCI6ICI1ZDQwYmNjNWUxMDgwMzM2MWI4YWJjNTAifQ==
+        ICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2MDgxIn0s
+        ICJpZCI6ICI1ZDQ4NjM4YmQyYjcxZTdhMzUxNDYwODEifQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:17 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1244,11 +1176,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:17 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"c48c917bb3df8d194bda34b4f8384b99-gzip"'
+      - '"81b8eb657928487d824099caea04258b-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -1260,12 +1192,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        OC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
         Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
@@ -1283,13 +1215,13 @@ http_interactions:
         YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
         b3VyY2Vfd29ya2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJz
         LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUwIn0s
-        ICJpZCI6ICI1ZDQwYmNjNWUxMDgwMzM2MWI4YWJjNTAifQ==
+        ICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2MDgxIn0s
+        ICJpZCI6ICI1ZDQ4NjM4YmQyYjcxZTdhMzUxNDYwODEifQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:17 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1308,11 +1240,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:17 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"c48c917bb3df8d194bda34b4f8384b99-gzip"'
+      - '"81b8eb657928487d824099caea04258b-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -1324,12 +1256,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        OC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
         Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
@@ -1347,13 +1279,13 @@ http_interactions:
         YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
         b3VyY2Vfd29ya2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJz
         LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUwIn0s
-        ICJpZCI6ICI1ZDQwYmNjNWUxMDgwMzM2MWI4YWJjNTAifQ==
+        ICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2MDgxIn0s
+        ICJpZCI6ICI1ZDQ4NjM4YmQyYjcxZTdhMzUxNDYwODEifQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:17 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1372,11 +1304,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:17 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"c48c917bb3df8d194bda34b4f8384b99-gzip"'
+      - '"81b8eb657928487d824099caea04258b-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -1388,12 +1320,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        OC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
         Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
@@ -1411,13 +1343,13 @@ http_interactions:
         YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
         b3VyY2Vfd29ya2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJz
         LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUwIn0s
-        ICJpZCI6ICI1ZDQwYmNjNWUxMDgwMzM2MWI4YWJjNTAifQ==
+        ICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2MDgxIn0s
+        ICJpZCI6ICI1ZDQ4NjM4YmQyYjcxZTdhMzUxNDYwODEifQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:17 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1436,11 +1368,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:17 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"c48c917bb3df8d194bda34b4f8384b99-gzip"'
+      - '"81b8eb657928487d824099caea04258b-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -1452,12 +1384,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        OC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
         Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
@@ -1475,13 +1407,13 @@ http_interactions:
         YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
         b3VyY2Vfd29ya2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJz
         LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUwIn0s
-        ICJpZCI6ICI1ZDQwYmNjNWUxMDgwMzM2MWI4YWJjNTAifQ==
+        ICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2MDgxIn0s
+        ICJpZCI6ICI1ZDQ4NjM4YmQyYjcxZTdhMzUxNDYwODEifQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:17 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1500,11 +1432,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:17 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"c48c917bb3df8d194bda34b4f8384b99-gzip"'
+      - '"81b8eb657928487d824099caea04258b-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -1516,12 +1448,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        OC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
         Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
@@ -1539,13 +1471,13 @@ http_interactions:
         YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
         b3VyY2Vfd29ya2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJz
         LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUwIn0s
-        ICJpZCI6ICI1ZDQwYmNjNWUxMDgwMzM2MWI4YWJjNTAifQ==
+        ICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2MDgxIn0s
+        ICJpZCI6ICI1ZDQ4NjM4YmQyYjcxZTdhMzUxNDYwODEifQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:17 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1564,11 +1496,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:17 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"c48c917bb3df8d194bda34b4f8384b99-gzip"'
+      - '"81b8eb657928487d824099caea04258b-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -1580,12 +1512,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        OC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
         Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
@@ -1603,13 +1535,13 @@ http_interactions:
         YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
         b3VyY2Vfd29ya2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJz
         LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUwIn0s
-        ICJpZCI6ICI1ZDQwYmNjNWUxMDgwMzM2MWI4YWJjNTAifQ==
+        ICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2MDgxIn0s
+        ICJpZCI6ICI1ZDQ4NjM4YmQyYjcxZTdhMzUxNDYwODEifQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:17 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1628,11 +1560,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:17 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"c48c917bb3df8d194bda34b4f8384b99-gzip"'
+      - '"81b8eb657928487d824099caea04258b-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -1644,12 +1576,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        OC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
         Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
@@ -1667,13 +1599,13 @@ http_interactions:
         YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
         b3VyY2Vfd29ya2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJz
         LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUwIn0s
-        ICJpZCI6ICI1ZDQwYmNjNWUxMDgwMzM2MWI4YWJjNTAifQ==
+        ICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2MDgxIn0s
+        ICJpZCI6ICI1ZDQ4NjM4YmQyYjcxZTdhMzUxNDYwODEifQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:17 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1692,75 +1624,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:17 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"c48c917bb3df8d194bda34b4f8384b99-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1204'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJJ
-        Tl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJOT1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUi
-        OiAiTk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90
-        YWwiOiAwLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
-        cyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUi
-        OiAiTk9UX1NUQVJURUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiTk9UX1NU
-        QVJURUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0s
-        ICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3
-        LWthdGVsbG8tZGV2ZWwuamplZmZlcnMuZXhhbXBsZS5jb20uZHEyIiwgInN0
-        YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
-        b3VyY2Vfd29ya2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJz
-        LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUwIn0s
-        ICJpZCI6ICI1ZDQwYmNjNWUxMDgwMzM2MWI4YWJjNTAifQ==
-    http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:17 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 30 Jul 2019 21:55:17 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"abe4cc71d185167df599e7270106e973-gzip"'
+      - '"1aa22b84a357e9c73e10f77972277e6c-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -1772,12 +1640,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        OC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
@@ -1795,13 +1663,13 @@ http_interactions:
         IjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3Vy
         Y2Vfd29ya2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4
         YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJf
-        aWQiOiB7IiRvaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUwIn0sICJp
-        ZCI6ICI1ZDQwYmNjNWUxMDgwMzM2MWI4YWJjNTAifQ==
+        aWQiOiB7IiRvaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2MDgxIn0sICJp
+        ZCI6ICI1ZDQ4NjM4YmQyYjcxZTdhMzUxNDYwODEifQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:17 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1820,11 +1688,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:17 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"7fe52789f01b04edad90f57138c56246-gzip"'
+      - '"36d7383f26c702d20df41113f553825c-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -1836,12 +1704,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        OC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
@@ -1859,13 +1727,13 @@ http_interactions:
         InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
         d29ya2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1w
         bGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQi
-        OiB7IiRvaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUwIn0sICJpZCI6
-        ICI1ZDQwYmNjNWUxMDgwMzM2MWI4YWJjNTAifQ==
+        OiB7IiRvaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2MDgxIn0sICJpZCI6
+        ICI1ZDQ4NjM4YmQyYjcxZTdhMzUxNDYwODEifQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:17 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1884,11 +1752,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:17 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"7fe52789f01b04edad90f57138c56246-gzip"'
+      - '"36d7383f26c702d20df41113f553825c-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -1900,12 +1768,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        OC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
@@ -1923,13 +1791,13 @@ http_interactions:
         InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
         d29ya2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1w
         bGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQi
-        OiB7IiRvaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUwIn0sICJpZCI6
-        ICI1ZDQwYmNjNWUxMDgwMzM2MWI4YWJjNTAifQ==
+        OiB7IiRvaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2MDgxIn0sICJpZCI6
+        ICI1ZDQ4NjM4YmQyYjcxZTdhMzUxNDYwODEifQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:17 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1948,11 +1816,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:17 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"7fe52789f01b04edad90f57138c56246-gzip"'
+      - '"36d7383f26c702d20df41113f553825c-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -1964,12 +1832,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        OC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
@@ -1987,13 +1855,13 @@ http_interactions:
         InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
         d29ya2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1w
         bGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQi
-        OiB7IiRvaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUwIn0sICJpZCI6
-        ICI1ZDQwYmNjNWUxMDgwMzM2MWI4YWJjNTAifQ==
+        OiB7IiRvaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2MDgxIn0sICJpZCI6
+        ICI1ZDQ4NjM4YmQyYjcxZTdhMzUxNDYwODEifQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:17 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2012,139 +1880,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:17 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"7fe52789f01b04edad90f57138c56246-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1198'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
-        T1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        Tk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwi
-        OiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiSU5f
-        UFJPR1JFU1MifSwgImVycmF0YSI6IHsic3RhdGUiOiAiTk9UX1NUQVJURUQi
-        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1
-        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVs
-        bG8tZGV2ZWwuamplZmZlcnMuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
-        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQi
-        OiB7IiRvaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUwIn0sICJpZCI6
-        ICI1ZDQwYmNjNWUxMDgwMzM2MWI4YWJjNTAifQ==
-    http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:17 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 30 Jul 2019 21:55:17 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"7fe52789f01b04edad90f57138c56246-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1198'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
-        T1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        Tk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwi
-        OiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiSU5f
-        UFJPR1JFU1MifSwgImVycmF0YSI6IHsic3RhdGUiOiAiTk9UX1NUQVJURUQi
-        fSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1
-        ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVs
-        bG8tZGV2ZWwuamplZmZlcnMuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
-        InJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
-        d29ya2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQi
-        OiB7IiRvaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUwIn0sICJpZCI6
-        ICI1ZDQwYmNjNWUxMDgwMzM2MWI4YWJjNTAifQ==
-    http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:17 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 30 Jul 2019 21:55:17 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"1253fd05b7531a4353153722a44bf6dc-gzip"'
+      - '"47b5fc15735ea6b52b4cbe90214a661a-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -2156,12 +1896,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        OC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
@@ -2179,13 +1919,13 @@ http_interactions:
         bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
         a2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUu
         Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUwIn0sICJpZCI6ICI1
-        ZDQwYmNjNWUxMDgwMzM2MWI4YWJjNTAifQ==
+        IiRvaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2MDgxIn0sICJpZCI6ICI1
+        ZDQ4NjM4YmQyYjcxZTdhMzUxNDYwODEifQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2204,11 +1944,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"1253fd05b7531a4353153722a44bf6dc-gzip"'
+      - '"47b5fc15735ea6b52b4cbe90214a661a-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -2220,12 +1960,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        OC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
@@ -2243,13 +1983,13 @@ http_interactions:
         bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
         a2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUu
         Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUwIn0sICJpZCI6ICI1
-        ZDQwYmNjNWUxMDgwMzM2MWI4YWJjNTAifQ==
+        IiRvaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2MDgxIn0sICJpZCI6ICI1
+        ZDQ4NjM4YmQyYjcxZTdhMzUxNDYwODEifQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2268,11 +2008,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"1253fd05b7531a4353153722a44bf6dc-gzip"'
+      - '"47b5fc15735ea6b52b4cbe90214a661a-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -2284,12 +2024,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        OC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
@@ -2307,13 +2047,13 @@ http_interactions:
         bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
         a2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUu
         Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUwIn0sICJpZCI6ICI1
-        ZDQwYmNjNWUxMDgwMzM2MWI4YWJjNTAifQ==
+        IiRvaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2MDgxIn0sICJpZCI6ICI1
+        ZDQ4NjM4YmQyYjcxZTdhMzUxNDYwODEifQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2332,11 +2072,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"f8b8d7f4117983ff62daa03b24d0f010-gzip"'
+      - '"7b0235e46710a17b2ffff89532ff624d-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -2348,76 +2088,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
-        dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
-        IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
-        SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
-        cG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAs
-        ICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9sZWZ0
-        IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6ICJO
-        T1RfU1RBUlRFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        Tk9UX1NUQVJURUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwi
-        OiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
-        LCAiaXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklO
-        SVNIRUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1l
-        dGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJy
-        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2
-        ZWwuamplZmZlcnMuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5p
-        bmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRv
-        aWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUwIn0sICJpZCI6ICI1ZDQw
-        YmNjNWUxMDgwMzM2MWI4YWJjNTAifQ==
-    http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"ed374cd23a85b950a050ad9fa47cc397-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1192'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
-        LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        OC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
@@ -2435,13 +2111,13 @@ http_interactions:
         bmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
         LTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUuY29t
         IiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRv
-        aWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUwIn0sICJpZCI6ICI1ZDQw
-        YmNjNWUxMDgwMzM2MWI4YWJjNTAifQ==
+        aWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2MDgxIn0sICJpZCI6ICI1ZDQ4
+        NjM4YmQyYjcxZTdhMzUxNDYwODEifQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2460,11 +2136,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"c3ba6052c5462bf52e65046d08471731-gzip"'
+      - '"e43a7a16b1bc26014c73cb916a252615-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -2476,12 +2152,12 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiBudWxs
         LCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0w
-        Ny0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
+        OC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRf
         dGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9ydGVy
         IjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogeyJy
@@ -2499,13 +2175,13 @@ http_interactions:
         d29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAY2Vu
         dG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUuY29tIiwgInJl
         c3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAi
-        NWQ0MGJjYzVlMTA4MDMzNjFiOGFiYzUwIn0sICJpZCI6ICI1ZDQwYmNjNWUx
-        MDgwMzM2MWI4YWJjNTAifQ==
+        NWQ0ODYzOGJkMmI3MWU3YTM1MTQ2MDgxIn0sICJpZCI6ICI1ZDQ4NjM4YmQy
+        YjcxZTdhMzUxNDYwODEifQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2524,11 +2200,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"1d1ceda489037e0b3f22a0f1df2fbaae-gzip"'
+      - '"42e5b303bf44f7b6985fdc509dd68fe3-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -2540,16 +2216,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wNy0zMFQyMTo1NToxOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wNy0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNr
+        OS0wOC0wNVQxNzoxMjo0NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvODAwZTJhOGEtZWFlMy00YmFiLTgxNWEtMDA2ZjNmMzcx
-        YTQxLyIsICJ0YXNrX2lkIjogIjgwMGUyYThhLWVhZTMtNGJhYi04MTVhLTAw
-        NmYzZjM3MWE0MSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvYmExYjU5YzAtN2M4MC00ZDAzLWJjNGUtMjk2ODA2NzU5
+        NWM3LyIsICJ0YXNrX2lkIjogImJhMWI1OWMwLTdjODAtNGQwMy1iYzRlLTI5
+        NjgwNjc1OTVjNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -2568,8 +2244,8 @@ http_interactions:
         ICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lk
         IjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
         ZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQi
-        OiAiMjAxOS0wNy0zMFQyMTo1NToxN1oiLCAiX25zIjogInJlcG9fc3luY19y
-        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA3LTMwVDIxOjU1OjE4WiIs
+        OiAiMjAxOS0wOC0wNVQxNzoxMjo0M1oiLCAiX25zIjogInJlcG9fc3luY19y
+        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4LTA1VDE3OjEyOjQ0WiIs
         ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9t
         ZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRl
         IjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
@@ -2578,8 +2254,8 @@ http_interactions:
         aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
         ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
         SEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDQwYmNjNjVlYWYwZDBh
-        NWI1ZWU0MmYiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDQ4NjM4YzVlYWYwZDBh
+        MWE2NGE1NTEiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
         RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRl
         bXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
         U0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
@@ -2590,14 +2266,14 @@ http_interactions:
         bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDBiY2M1ZTEw
-        ODAzMzYxYjhhYmM1MCJ9LCAiaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFi
-        YzUwIn0=
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDg2MzhiZDJi
+        NzFlN2EzNTE0NjA4MSJ9LCAiaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2
+        MDgxIn0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/800e2a8a-eae3-4bab-815a-006f3f371a41/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/ba1b59c0-7c80-4d03-bc4e-2968067595c7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2616,11 +2292,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"e79812139e941da34f68fda3b33027fe-gzip"'
+      - '"1225a795e4057a328563d6921bb7153c-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -2632,25 +2308,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84MDBlMmE4YS1lYWUzLTRiYWItODE1YS0wMDZm
-        M2YzNzFhNDEvIiwgInRhc2tfaWQiOiAiODAwZTJhOGEtZWFlMy00YmFiLTgx
-        NWEtMDA2ZjNmMzcxYTQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy9iYTFiNTljMC03YzgwLTRkMDMtYmM0ZS0yOTY4
+        MDY3NTk1YzcvIiwgInRhc2tfaWQiOiAiYmExYjU5YzAtN2M4MC00ZDAzLWJj
+        NGUtMjk2ODA2NzU5NWM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
         bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxOS0wNy0zMFQyMTo1NToxOFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        OiAiMjAxOS0wOC0wNVQxNzoxMjo0NFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
         InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAi
         cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAY2VudG9zNy1r
         YXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0
         ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291
         cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5qamVmZmVycy5l
         eGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVkNDBiY2M2ZTEwODAzMzYxYjhhYmY0NSJ9LCAi
-        aWQiOiAiNWQ0MGJjYzZlMTA4MDMzNjFiOGFiZjQ1In0=
+        X2lkIjogeyIkb2lkIjogIjVkNDg2MzhjZDJiNzFlN2EzNTE0NjMzOSJ9LCAi
+        aWQiOiAiNWQ0ODYzOGNkMmI3MWU3YTM1MTQ2MzM5In0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2669,11 +2345,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"1d1ceda489037e0b3f22a0f1df2fbaae-gzip"'
+      - '"42e5b303bf44f7b6985fdc509dd68fe3-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -2685,16 +2361,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wNy0zMFQyMTo1NToxOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wNy0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNr
+        OS0wOC0wNVQxNzoxMjo0NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvODAwZTJhOGEtZWFlMy00YmFiLTgxNWEtMDA2ZjNmMzcx
-        YTQxLyIsICJ0YXNrX2lkIjogIjgwMGUyYThhLWVhZTMtNGJhYi04MTVhLTAw
-        NmYzZjM3MWE0MSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvYmExYjU5YzAtN2M4MC00ZDAzLWJjNGUtMjk2ODA2NzU5
+        NWM3LyIsICJ0YXNrX2lkIjogImJhMWI1OWMwLTdjODAtNGQwMy1iYzRlLTI5
+        NjgwNjc1OTVjNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -2713,8 +2389,8 @@ http_interactions:
         ICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lk
         IjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
         ZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQi
-        OiAiMjAxOS0wNy0zMFQyMTo1NToxN1oiLCAiX25zIjogInJlcG9fc3luY19y
-        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA3LTMwVDIxOjU1OjE4WiIs
+        OiAiMjAxOS0wOC0wNVQxNzoxMjo0M1oiLCAiX25zIjogInJlcG9fc3luY19y
+        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4LTA1VDE3OjEyOjQ0WiIs
         ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9t
         ZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRl
         IjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
@@ -2723,8 +2399,8 @@ http_interactions:
         aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
         ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
         SEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDQwYmNjNjVlYWYwZDBh
-        NWI1ZWU0MmYiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDQ4NjM4YzVlYWYwZDBh
+        MWE2NGE1NTEiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
         RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRl
         bXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
         U0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
@@ -2735,14 +2411,14 @@ http_interactions:
         bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDBiY2M1ZTEw
-        ODAzMzYxYjhhYmM1MCJ9LCAiaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFi
-        YzUwIn0=
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDg2MzhiZDJi
+        NzFlN2EzNTE0NjA4MSJ9LCAiaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2
+        MDgxIn0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/800e2a8a-eae3-4bab-815a-006f3f371a41/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/ba1b59c0-7c80-4d03-bc4e-2968067595c7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2761,11 +2437,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"8e479f779ecbcf84a910362da456918f-gzip"'
+      - '"d96540799678de4985ad90908f67a933-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -2777,106 +2453,106 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84MDBlMmE4YS1lYWUzLTRiYWItODE1YS0wMDZm
-        M2YzNzFhNDEvIiwgInRhc2tfaWQiOiAiODAwZTJhOGEtZWFlMy00YmFiLTgx
-        NWEtMDA2ZjNmMzcxYTQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy9iYTFiNTljMC03YzgwLTRkMDMtYmM0ZS0yOTY4
+        MDY3NTk1YzcvIiwgInRhc2tfaWQiOiAiYmExYjU5YzAtN2M4MC00ZDAzLWJj
+        NGUtMjk2ODA2NzU5NWM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
         bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxOS0wNy0zMFQyMTo1NToxOFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        OiAiMjAxOS0wOC0wNVQxNzoxMjo0NFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
         InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
         b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
         SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
         aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZTNm
-        ZWNlZS1lZWY2LTRiMzQtYTBmNy1mOTdlZjQzYzI4NDEiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NzNi
+        ZWZjNi1jYjc2LTQyOWYtYjdiMi1iZTllOTQ3OTVkNDQiLCAibnVtX3Byb2Nl
         c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
         ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
         RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzZhYzY3NjktMmMy
-        Yy00M2M0LWIyOGQtYTY3ZDY0ZGMwOTkwIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2M1Njg0MzUtM2Rj
+        NC00NDU1LWE0NTgtOGYyYmUxNzJiN2MxIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
         aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
         OiAxOCwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMi
         OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjdlN2FjMzQ5LWFkMzQtNGJhZS04ZDdjLWE4MjI4OTFhZWFkYyIs
-        ICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
+        X2lkIjogIjk5ODZiNWMzLTZlZTctNDVhNi05YTdmLWUwMDIxMTRjYjU3YSIs
+        ICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
         Y3JpcHRpb24iOiAiUHVibGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlw
         ZSI6ICJkcnBtcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
         U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyNjI3NzdmNS1kOWE3
-        LTRjZjUtOTQ3ZC04OTg3M2IwMWYxNDIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjN2E2MGZjMi1mOWUx
+        LTQyMGYtYmEyNy1mODdmN2Y2YjgxYWUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
         LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
         bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
         cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
-        ZXBfaWQiOiAiOTRjYjUzOGYtMzRjMy00NDNmLTkyYTktYmI1ZTg4ODljMTJl
+        ZXBfaWQiOiAiYWZkYTdkM2MtZmRkMC00ZjczLWI5NmYtMTA2ODc5NDM3M2M4
         IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
         ZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBl
         IjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
         X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2E1YTE5NGYtOGY0
-        NC00YWJmLWIxODMtMmE5YjkyNzk4ZTA1IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmE4ZWFkMzctZGIx
+        Mi00Y2QxLTg0NzYtMjZjNjAwNDA2ZTZiIiwgIm51bV9wcm9jZXNzZWQiOiAw
         fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
         aW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1z
         X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjFhYTczY2EwLTY3YWYtNDM0ZS1iOGY2LWE4ZGJkM2I0
-        MDU1YyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        ICJzdGVwX2lkIjogImVjNTM4MzcyLTE3ZTAtNGI5NS05MzM4LTAxMmU2ZDY1
+        ZGMxNyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
         LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3Rl
         cF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
         IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI5MzMw
-        NjczLTZjODctNGYzZC05ZWNmLTQ1ZWYxNTNjYzA3OCIsICJudW1fcHJvY2Vz
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUyZmE3
+        ZjU3LThiNzYtNDg5Yi05NDllLTVkNmM1NzkxNTMwOSIsICJudW1fcHJvY2Vz
         c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
         Q2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9y
         ZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
         VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI2MDk5YzA5LWM1
-        ZjctNGIxNy1iYWM0LWUzOGRiOGVjOGNiZSIsICJudW1fcHJvY2Vzc2VkIjog
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJkM2ZmYzUwLTg2
+        YjUtNGNkNi05NWZiLTRlMTc1MTJhMmNiMiIsICJudW1fcHJvY2Vzc2VkIjog
         MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
         dGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNx
         bGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
         RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YWUyYjFjYS0xZjI5LTQ0Yzgt
-        Yjc1ZS0wZjUwMTk2YmM4N2UiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4MmI5ZTcwMy02OWNkLTRkNWYt
+        OWI2MC01MzlkZWIxYzBiZDUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
         bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCBy
         ZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI5YTY5YWVjMC01OTYxLTQ0OWMtOTFlNy1h
-        ODY2YjUzMzIyMTUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJlNTY4ZTJjOS0yNDdkLTQ5MzMtYWM1My1l
+        NzE5ZGUwYzlhZDkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
         ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxl
         cyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAx
         LCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
         LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiZTE4ZmE3ZTAtOTI2YS00ZDc4LWIwN2EtMGFmNGI0MzQ4NTczIiwgIm51
+        OiAiYmE2MGQ3YjUtYjk3MC00YjU0LWIyMGEtYThiZTQyOWRjYjM4IiwgIm51
         bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
         dGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUi
         OiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
         dGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOWY0
-        YjNkYzQtY2M0NS00YTMxLWE2NDgtNzgwYTZmY2MzZmVmIiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOWMy
+        MDk4ZTAtNjlhYi00MzU5LTlhZjMtYTFhNTk2NGExOGUzIiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
         ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRp
         YWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
         ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZmZk
-        Zjg4Zi1kNDA3LTQ0OGEtOGVhOS04MzlkYmQ0YzQzZmMiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlOTBj
+        NTQxMC1iM2Q3LTQ5ZDUtOGE5MS0zYmU2NDY2MTI0ODEiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
         ZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuamplZmZlcnMuZXhhbXBsZS5j
         b20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAi
         cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAY2VudG9zNy1rYXRlbGxvLWRl
         dmVsLmpqZWZmZXJzLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
-        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ0MGJjYzZlMTA4MDMz
-        NjFiOGFiZjQ1In0sICJpZCI6ICI1ZDQwYmNjNmUxMDgwMzM2MWI4YWJmNDUi
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODYzOGNkMmI3MWU3
+        YTM1MTQ2MzM5In0sICJpZCI6ICI1ZDQ4NjM4Y2QyYjcxZTdhMzUxNDYzMzki
         fQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2895,11 +2571,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"1d1ceda489037e0b3f22a0f1df2fbaae-gzip"'
+      - '"42e5b303bf44f7b6985fdc509dd68fe3-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -2911,16 +2587,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wNy0zMFQyMTo1NToxOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wNy0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNr
+        OS0wOC0wNVQxNzoxMjo0NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvODAwZTJhOGEtZWFlMy00YmFiLTgxNWEtMDA2ZjNmMzcx
-        YTQxLyIsICJ0YXNrX2lkIjogIjgwMGUyYThhLWVhZTMtNGJhYi04MTVhLTAw
-        NmYzZjM3MWE0MSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvYmExYjU5YzAtN2M4MC00ZDAzLWJjNGUtMjk2ODA2NzU5
+        NWM3LyIsICJ0YXNrX2lkIjogImJhMWI1OWMwLTdjODAtNGQwMy1iYzRlLTI5
+        NjgwNjc1OTVjNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -2939,8 +2615,8 @@ http_interactions:
         ICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lk
         IjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
         ZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQi
-        OiAiMjAxOS0wNy0zMFQyMTo1NToxN1oiLCAiX25zIjogInJlcG9fc3luY19y
-        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA3LTMwVDIxOjU1OjE4WiIs
+        OiAiMjAxOS0wOC0wNVQxNzoxMjo0M1oiLCAiX25zIjogInJlcG9fc3luY19y
+        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4LTA1VDE3OjEyOjQ0WiIs
         ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9t
         ZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRl
         IjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
@@ -2949,8 +2625,8 @@ http_interactions:
         aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
         ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
         SEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDQwYmNjNjVlYWYwZDBh
-        NWI1ZWU0MmYiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDQ4NjM4YzVlYWYwZDBh
+        MWE2NGE1NTEiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
         RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRl
         bXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
         U0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
@@ -2961,14 +2637,14 @@ http_interactions:
         bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDBiY2M1ZTEw
-        ODAzMzYxYjhhYmM1MCJ9LCAiaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFi
-        YzUwIn0=
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDg2MzhiZDJi
+        NzFlN2EzNTE0NjA4MSJ9LCAiaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2
+        MDgxIn0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/800e2a8a-eae3-4bab-815a-006f3f371a41/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/ba1b59c0-7c80-4d03-bc4e-2968067595c7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2987,11 +2663,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"9204185100d72abfde644c35423db0c9-gzip"'
+      - '"9ff9ed15e2fcfae1c0ca108c878651f1-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -3003,106 +2679,106 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84MDBlMmE4YS1lYWUzLTRiYWItODE1YS0wMDZm
-        M2YzNzFhNDEvIiwgInRhc2tfaWQiOiAiODAwZTJhOGEtZWFlMy00YmFiLTgx
-        NWEtMDA2ZjNmMzcxYTQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy9iYTFiNTljMC03YzgwLTRkMDMtYmM0ZS0yOTY4
+        MDY3NTk1YzcvIiwgInRhc2tfaWQiOiAiYmExYjU5YzAtN2M4MC00ZDAzLWJj
+        NGUtMjk2ODA2NzU5NWM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
         bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxOS0wNy0zMFQyMTo1NToxOFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        OiAiMjAxOS0wOC0wNVQxNzoxMjo0NFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
         InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
         b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
         SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
         aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZTNm
-        ZWNlZS1lZWY2LTRiMzQtYTBmNy1mOTdlZjQzYzI4NDEiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NzNi
+        ZWZjNi1jYjc2LTQyOWYtYjdiMi1iZTllOTQ3OTVkNDQiLCAibnVtX3Byb2Nl
         c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
         ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
         RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzZhYzY3NjktMmMy
-        Yy00M2M0LWIyOGQtYTY3ZDY0ZGMwOTkwIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDksICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2M1Njg0MzUtM2Rj
+        NC00NDU1LWE0NTgtOGYyYmUxNzJiN2MxIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
         aW5nIFJQTXMiLCAic3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwi
         OiAxOCwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMi
         OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjdlN2FjMzQ5LWFkMzQtNGJhZS04ZDdjLWE4MjI4OTFhZWFkYyIs
-        ICJudW1fcHJvY2Vzc2VkIjogOX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
+        X2lkIjogIjk5ODZiNWMzLTZlZTctNDVhNi05YTdmLWUwMDIxMTRjYjU3YSIs
+        ICJudW1fcHJvY2Vzc2VkIjogOH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVz
         Y3JpcHRpb24iOiAiUHVibGlzaGluZyBEZWx0YSBSUE1zIiwgInN0ZXBfdHlw
         ZSI6ICJkcnBtcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
         U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyNjI3NzdmNS1kOWE3
-        LTRjZjUtOTQ3ZC04OTg3M2IwMWYxNDIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjN2E2MGZjMi1mOWUx
+        LTQyMGYtYmEyNy1mODdmN2Y2YjgxYWUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
         LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hp
         bmcgRXJyYXRhIiwgInN0ZXBfdHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
         cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
-        ZXBfaWQiOiAiOTRjYjUzOGYtMzRjMy00NDNmLTkyYTktYmI1ZTg4ODljMTJl
+        ZXBfaWQiOiAiYWZkYTdkM2MtZmRkMC00ZjczLWI5NmYtMTA2ODc5NDM3M2M4
         IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
         ZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1vZHVsZXMiLCAic3RlcF90eXBl
         IjogIm1vZHVsZXMiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
         X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2E1YTE5NGYtOGY0
-        NC00YWJmLWIxODMtMmE5YjkyNzk4ZTA1IiwgIm51bV9wcm9jZXNzZWQiOiAw
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmE4ZWFkMzctZGIx
+        Mi00Y2QxLTg0NzYtMjZjNjAwNDA2ZTZiIiwgIm51bV9wcm9jZXNzZWQiOiAw
         fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
         aW5nIENvbXBzIGZpbGUiLCAic3RlcF90eXBlIjogImNvbXBzIiwgIml0ZW1z
         X3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2Rl
         dGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAs
-        ICJzdGVwX2lkIjogIjFhYTczY2EwLTY3YWYtNDM0ZS1iOGY2LWE4ZGJkM2I0
-        MDU1YyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
+        ICJzdGVwX2lkIjogImVjNTM4MzcyLTE3ZTAtNGI5NS05MzM4LTAxMmU2ZDY1
+        ZGMxNyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAw
         LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNZXRhZGF0YS4iLCAic3Rl
         cF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
         IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI5MzMw
-        NjczLTZjODctNGYzZC05ZWNmLTQ1ZWYxNTNjYzA3OCIsICJudW1fcHJvY2Vz
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUyZmE3
+        ZjU3LThiNzYtNDg5Yi05NDllLTVkNmM1NzkxNTMwOSIsICJudW1fcHJvY2Vz
         c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
         Q2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBfdHlwZSI6ICJjbG9zZV9y
         ZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
         VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImI2MDk5YzA5LWM1
-        ZjctNGIxNy1iYWM0LWUzOGRiOGVjOGNiZSIsICJudW1fcHJvY2Vzc2VkIjog
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJkM2ZmYzUwLTg2
+        YjUtNGNkNi05NWZiLTRlMTc1MTJhMmNiMiIsICJudW1fcHJvY2Vzc2VkIjog
         MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJh
         dGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjogImdlbmVyYXRlIHNx
         bGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
         RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YWUyYjFjYS0xZjI5LTQ0Yzgt
-        Yjc1ZS0wZjUwMTk2YmM4N2UiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4MmI5ZTcwMy02OWNkLTRkNWYt
+        OWI2MC01MzlkZWIxYzBiZDUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
         bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCBy
         ZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIs
         ICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI5YTY5YWVjMC01OTYxLTQ0OWMtOTFlNy1h
-        ODY2YjUzMzIyMTUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJlNTY4ZTJjOS0yNDdkLTQ5MzMtYWM1My1l
+        NzE5ZGUwYzlhZDkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
         ZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxl
         cyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAx
         LCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
         LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
-        OiAiZTE4ZmE3ZTAtOTI2YS00ZDc4LWIwN2EtMGFmNGI0MzQ4NTczIiwgIm51
+        OiAiYmE2MGQ3YjUtYjk3MC00YjU0LWIyMGEtYThiZTQyOWRjYjM4IiwgIm51
         bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
         dGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVzIHRvIHdlYiIsICJzdGVwX3R5cGUi
         OiAicHVibGlzaF9kaXJlY3RvcnkiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
         dGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOWY0
-        YjNkYzQtY2M0NS00YTMxLWE2NDgtNzgwYTZmY2MzZmVmIiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOWMy
+        MDk4ZTAtNjlhYi00MzU5LTlhZjMtYTFhNTk2NGExOGUzIiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
         ICJXcml0aW5nIExpc3RpbmdzIEZpbGUiLCAic3RlcF90eXBlIjogImluaXRp
         YWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
         ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZmZk
-        Zjg4Zi1kNDA3LTQ0OGEtOGVhOS04MzlkYmQ0YzQzZmMiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlOTBj
+        NTQxMC1iM2Q3LTQ5ZDUtOGE5MS0zYmU2NDY2MTI0ODEiLCAibnVtX3Byb2Nl
         c3NlZCI6IDB9XX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
         ZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuamplZmZlcnMuZXhhbXBsZS5j
         b20uZHEyIiwgInN0YXRlIjogInJ1bm5pbmciLCAid29ya2VyX25hbWUiOiAi
         cmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAY2VudG9zNy1rYXRlbGxvLWRl
         dmVsLmpqZWZmZXJzLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
-        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ0MGJjYzZlMTA4MDMz
-        NjFiOGFiZjQ1In0sICJpZCI6ICI1ZDQwYmNjNmUxMDgwMzM2MWI4YWJmNDUi
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODYzOGNkMmI3MWU3
+        YTM1MTQ2MzM5In0sICJpZCI6ICI1ZDQ4NjM4Y2QyYjcxZTdhMzUxNDYzMzki
         fQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3121,11 +2797,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"1d1ceda489037e0b3f22a0f1df2fbaae-gzip"'
+      - '"42e5b303bf44f7b6985fdc509dd68fe3-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -3137,16 +2813,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wNy0zMFQyMTo1NToxOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wNy0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNr
+        OS0wOC0wNVQxNzoxMjo0NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvODAwZTJhOGEtZWFlMy00YmFiLTgxNWEtMDA2ZjNmMzcx
-        YTQxLyIsICJ0YXNrX2lkIjogIjgwMGUyYThhLWVhZTMtNGJhYi04MTVhLTAw
-        NmYzZjM3MWE0MSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvYmExYjU5YzAtN2M4MC00ZDAzLWJjNGUtMjk2ODA2NzU5
+        NWM3LyIsICJ0YXNrX2lkIjogImJhMWI1OWMwLTdjODAtNGQwMy1iYzRlLTI5
+        NjgwNjc1OTVjNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -3165,8 +2841,8 @@ http_interactions:
         ICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lk
         IjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
         ZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQi
-        OiAiMjAxOS0wNy0zMFQyMTo1NToxN1oiLCAiX25zIjogInJlcG9fc3luY19y
-        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA3LTMwVDIxOjU1OjE4WiIs
+        OiAiMjAxOS0wOC0wNVQxNzoxMjo0M1oiLCAiX25zIjogInJlcG9fc3luY19y
+        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4LTA1VDE3OjEyOjQ0WiIs
         ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9t
         ZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRl
         IjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
@@ -3175,8 +2851,8 @@ http_interactions:
         aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
         ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
         SEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDQwYmNjNjVlYWYwZDBh
-        NWI1ZWU0MmYiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDQ4NjM4YzVlYWYwZDBh
+        MWE2NGE1NTEiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
         RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRl
         bXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
         U0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
@@ -3187,14 +2863,14 @@ http_interactions:
         bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDBiY2M1ZTEw
-        ODAzMzYxYjhhYmM1MCJ9LCAiaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFi
-        YzUwIn0=
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDg2MzhiZDJi
+        NzFlN2EzNTE0NjA4MSJ9LCAiaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2
+        MDgxIn0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/800e2a8a-eae3-4bab-815a-006f3f371a41/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/ba1b59c0-7c80-4d03-bc4e-2968067595c7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3213,11 +2889,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"fd797d3f5671dc33c1795d7d5d4bed88-gzip"'
+      - '"ffb6901e8a13881e5affdbf8dcc23ae8-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -3229,106 +2905,106 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84MDBlMmE4YS1lYWUzLTRiYWItODE1YS0wMDZm
-        M2YzNzFhNDEvIiwgInRhc2tfaWQiOiAiODAwZTJhOGEtZWFlMy00YmFiLTgx
-        NWEtMDA2ZjNmMzcxYTQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy9iYTFiNTljMC03YzgwLTRkMDMtYmM0ZS0yOTY4
+        MDY3NTk1YzcvIiwgInRhc2tfaWQiOiAiYmExYjU5YzAtN2M4MC00ZDAzLWJj
+        NGUtMjk2ODA2NzU5NWM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
         bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxOS0wNy0zMFQyMTo1NToxOFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        OiAiMjAxOS0wOC0wNVQxNzoxMjo0NFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
         InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
         b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
         SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
         aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZTNm
-        ZWNlZS1lZWY2LTRiMzQtYTBmNy1mOTdlZjQzYzI4NDEiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NzNi
+        ZWZjNi1jYjc2LTQyOWYtYjdiMi1iZTllOTQ3OTVkNDQiLCAibnVtX3Byb2Nl
         c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
         ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
         RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzZhYzY3NjktMmMy
-        Yy00M2M0LWIyOGQtYTY3ZDY0ZGMwOTkwIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDE3LCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2M1Njg0MzUtM2Rj
+        NC00NDU1LWE0NTgtOGYyYmUxNzJiN2MxIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        fSwgeyJudW1fc3VjY2VzcyI6IDE2LCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
         aGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFs
         IjogMTgsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI3ZTdhYzM0OS1hZDM0LTRiYWUtOGQ3Yy1hODIyODkxYWVhZGMi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDE3fSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        cF9pZCI6ICI5OTg2YjVjMy02ZWU3LTQ1YTYtOWE3Zi1lMDAyMTE0Y2I1N2Ei
+        LCAibnVtX3Byb2Nlc3NlZCI6IDE2fSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
         ZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90
         eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
         VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjI2Mjc3N2Y1LWQ5
-        YTctNGNmNS05NDdkLTg5ODczYjAxZjE0MiIsICJudW1fcHJvY2Vzc2VkIjog
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM3YTYwZmMyLWY5
+        ZTEtNDIwZi1iYTI3LWY4N2Y3ZjZiODFhZSIsICJudW1fcHJvY2Vzc2VkIjog
         MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
         aGluZyBFcnJhdGEiLCAic3RlcF90eXBlIjogImVycmF0YSIsICJpdGVtc190
         b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICI5NGNiNTM4Zi0zNGMzLTQ0M2YtOTJhOS1iYjVlODg4OWMx
-        MmUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICJhZmRhN2QzYy1mZGQwLTRmNzMtYjk2Zi0xMDY4Nzk0Mzcz
+        YzgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTW9kdWxlcyIsICJzdGVwX3R5
         cGUiOiAibW9kdWxlcyIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJO
         T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzYTVhMTk0Zi04
-        ZjQ0LTRhYmYtYjE4My0yYTliOTI3OThlMDUiLCAibnVtX3Byb2Nlc3NlZCI6
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJmYThlYWQzNy1k
+        YjEyLTRjZDEtODQ3Ni0yNmM2MDA0MDZlNmIiLCAibnVtX3Byb2Nlc3NlZCI6
         IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
         c2hpbmcgQ29tcHMgZmlsZSIsICJzdGVwX3R5cGUiOiAiY29tcHMiLCAiaXRl
         bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
         ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiMWFhNzNjYTAtNjdhZi00MzRlLWI4ZjYtYThkYmQz
-        YjQwNTVjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        MCwgInN0ZXBfaWQiOiAiZWM1MzgzNzItMTdlMC00Yjk1LTkzMzgtMDEyZTZk
+        NjVkYzE3IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
         IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIE1ldGFkYXRhLiIsICJz
         dGVwX3R5cGUiOiAibWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3Rh
         dGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0
-        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjkz
-        MzA2NzMtNmM4Ny00ZjNkLTllY2YtNDVlZjE1M2NjMDc4IiwgIm51bV9wcm9j
+        YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTJm
+        YTdmNTctOGI3Ni00ODliLTk0OWUtNWQ2YzU3OTE1MzA5IiwgIm51bV9wcm9j
         ZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6
         ICJDbG9zaW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImNsb3Nl
         X3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
         Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYjYwOTljMDkt
-        YzVmNy00YjE3LWJhYzQtZTM4ZGI4ZWM4Y2JlIiwgIm51bV9wcm9jZXNzZWQi
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYmQzZmZjNTAt
+        ODZiNS00Y2Q2LTk1ZmItNGUxNzUxMmEyY2IyIiwgIm51bV9wcm9jZXNzZWQi
         OiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5l
         cmF0aW5nIHNxbGl0ZSBmaWxlcyIsICJzdGVwX3R5cGUiOiAiZ2VuZXJhdGUg
         c3FsaXRlIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFS
         VEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjdhZTJiMWNhLTFmMjktNDRj
-        OC1iNzVlLTBmNTAxOTZiYzg3ZSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjgyYjllNzAzLTY5Y2QtNGQ1
+        Zi05YjYwLTUzOWRlYjFjMGJkNSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
         bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zpbmcgb2xk
         IHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3JlcG9kYXRh
         IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjlhNjlhZWMwLTU5NjEtNDQ5Yy05MWU3
-        LWE4NjZiNTMzMjIxNSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImU1NjhlMmM5LTI0N2QtNDkzMy1hYzUz
+        LWU3MTlkZTBjOWFkOSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1
         Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1MIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3RhbCI6
         IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICJlMThmYTdlMC05MjZhLTRkNzgtYjA3YS0wYWY0YjQzNDg1NzMiLCAi
+        ZCI6ICJiYTYwZDdiNS1iOTcwLTRiNTQtYjIwYS1hOGJlNDI5ZGNiMzgiLCAi
         bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
         aXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlw
         ZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
         ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5
-        ZjRiM2RjNC1jYzQ1LTRhMzEtYTY0OC03ODBhNmZjYzNmZWYiLCAibnVtX3By
+        YzIwOThlMC02OWFiLTQzNTktOWFmMy1hMWE1OTY0YTE4ZTMiLCAibnVtX3By
         b2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
         IjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5p
         dGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
         YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFm
-        ZmRmODhmLWQ0MDctNDQ4YS04ZWE5LTgzOWRiZDRjNDNmYyIsICJudW1fcHJv
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImU5
+        MGM1NDEwLWIzZDctNDlkNS04YTkxLTNiZTY0NjYxMjQ4MSIsICJudW1fcHJv
         Y2Vzc2VkIjogMH1dfSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291cmNlX3dv
         cmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5qamVmZmVycy5leGFtcGxl
         LmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJfbmFtZSI6
         ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8t
         ZGV2ZWwuamplZmZlcnMuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogbnVsbCwg
-        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQwYmNjNmUxMDgw
-        MzM2MWI4YWJmNDUifSwgImlkIjogIjVkNDBiY2M2ZTEwODAzMzYxYjhhYmY0
-        NSJ9
+        ImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4NjM4Y2QyYjcx
+        ZTdhMzUxNDYzMzkifSwgImlkIjogIjVkNDg2MzhjZDJiNzFlN2EzNTE0NjMz
+        OSJ9
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3347,11 +3023,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"1d1ceda489037e0b3f22a0f1df2fbaae-gzip"'
+      - '"42e5b303bf44f7b6985fdc509dd68fe3-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -3363,16 +3039,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wNy0zMFQyMTo1NToxOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wNy0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNr
+        OS0wOC0wNVQxNzoxMjo0NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvODAwZTJhOGEtZWFlMy00YmFiLTgxNWEtMDA2ZjNmMzcx
-        YTQxLyIsICJ0YXNrX2lkIjogIjgwMGUyYThhLWVhZTMtNGJhYi04MTVhLTAw
-        NmYzZjM3MWE0MSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvYmExYjU5YzAtN2M4MC00ZDAzLWJjNGUtMjk2ODA2NzU5
+        NWM3LyIsICJ0YXNrX2lkIjogImJhMWI1OWMwLTdjODAtNGQwMy1iYzRlLTI5
+        NjgwNjc1OTVjNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -3391,8 +3067,8 @@ http_interactions:
         ICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lk
         IjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
         ZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQi
-        OiAiMjAxOS0wNy0zMFQyMTo1NToxN1oiLCAiX25zIjogInJlcG9fc3luY19y
-        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA3LTMwVDIxOjU1OjE4WiIs
+        OiAiMjAxOS0wOC0wNVQxNzoxMjo0M1oiLCAiX25zIjogInJlcG9fc3luY19y
+        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4LTA1VDE3OjEyOjQ0WiIs
         ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9t
         ZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRl
         IjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
@@ -3401,8 +3077,8 @@ http_interactions:
         aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
         ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
         SEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDQwYmNjNjVlYWYwZDBh
-        NWI1ZWU0MmYiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDQ4NjM4YzVlYWYwZDBh
+        MWE2NGE1NTEiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
         RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRl
         bXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
         U0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
@@ -3413,14 +3089,14 @@ http_interactions:
         bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDBiY2M1ZTEw
-        ODAzMzYxYjhhYmM1MCJ9LCAiaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFi
-        YzUwIn0=
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDg2MzhiZDJi
+        NzFlN2EzNTE0NjA4MSJ9LCAiaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2
+        MDgxIn0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/800e2a8a-eae3-4bab-815a-006f3f371a41/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/ba1b59c0-7c80-4d03-bc4e-2968067595c7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3439,11 +3115,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"27725688d3e5d8f61c3b72e071157668-gzip"'
+      - '"7f4e3df69bb52351343f152364b93f1f-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -3455,105 +3131,105 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84MDBlMmE4YS1lYWUzLTRiYWItODE1YS0wMDZm
-        M2YzNzFhNDEvIiwgInRhc2tfaWQiOiAiODAwZTJhOGEtZWFlMy00YmFiLTgx
-        NWEtMDA2ZjNmMzcxYTQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy9iYTFiNTljMC03YzgwLTRkMDMtYmM0ZS0yOTY4
+        MDY3NTk1YzcvIiwgInRhc2tfaWQiOiAiYmExYjU5YzAtN2M4MC00ZDAzLWJj
+        NGUtMjk2ODA2NzU5NWM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
         bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxOS0wNy0zMFQyMTo1NToxOFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        OiAiMjAxOS0wOC0wNVQxNzoxMjo0NFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
         InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
         b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
         SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
         aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZTNm
-        ZWNlZS1lZWY2LTRiMzQtYTBmNy1mOTdlZjQzYzI4NDEiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NzNi
+        ZWZjNi1jYjc2LTQyOWYtYjdiMi1iZTllOTQ3OTVkNDQiLCAibnVtX3Byb2Nl
         c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
         ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
         RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzZhYzY3NjktMmMy
-        Yy00M2M0LWIyOGQtYTY3ZDY0ZGMwOTkwIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2M1Njg0MzUtM2Rj
+        NC00NDU1LWE0NTgtOGYyYmUxNzJiN2MxIiwgIm51bV9wcm9jZXNzZWQiOiAx
         fSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
         aGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFs
         IjogMTgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI3ZTdhYzM0OS1hZDM0LTRiYWUtOGQ3Yy1hODIyODkxYWVhZGMiLCAi
+        ZCI6ICI5OTg2YjVjMy02ZWU3LTQ1YTYtOWE3Zi1lMDAyMTE0Y2I1N2EiLCAi
         bnVtX3Byb2Nlc3NlZCI6IDE4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
         IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQ
         RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjYyNzc3ZjUtZDlhNy00Y2Y1
-        LTk0N2QtODk4NzNiMDFmMTQyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
-        dW1fc3VjY2VzcyI6IDUsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVy
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzdhNjBmYzItZjllMS00MjBm
+        LWJhMjctZjg3ZjdmNmI4MWFlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        dW1fc3VjY2VzcyI6IDMsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVy
         cmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjog
         NiwgInN0YXRlIjogIklOX1BST0dSRVNTIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjk0Y2I1MzhmLTM0YzMtNDQzZi05MmE5LWJiNWU4ODg5YzEyZSIsICJu
-        dW1fcHJvY2Vzc2VkIjogNX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
+        IjogImFmZGE3ZDNjLWZkZDAtNGY3My1iOTZmLTEwNjg3OTQzNzNjOCIsICJu
+        dW1fcHJvY2Vzc2VkIjogM30sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3Jp
         cHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJt
         b2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFS
         VEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
-        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNhNWExOTRmLThmNDQtNGFi
-        Zi1iMTgzLTJhOWI5Mjc5OGUwNSIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZhOGVhZDM3LWRiMTItNGNk
+        MS04NDc2LTI2YzYwMDQwNmU2YiIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsi
         bnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBD
         b21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3Rh
         bCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIxYWE3M2NhMC02N2FmLTQzNGUtYjhmNi1hOGRiZDNiNDA1NWMi
+        cF9pZCI6ICJlYzUzODM3Mi0xN2UwLTRiOTUtOTMzOC0wMTJlNmQ2NWRjMTci
         LCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRl
         c2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlw
         ZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJO
         T1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiOTMzMDY3My02
-        Yzg3LTRmM2QtOWVjZi00NWVmMTUzY2MwNzgiLCAibnVtX3Byb2Nlc3NlZCI6
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlMmZhN2Y1Ny04
+        Yjc2LTQ4OWItOTQ5ZS01ZDZjNTc5MTUzMDkiLCAibnVtX3Byb2Nlc3NlZCI6
         IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkNsb3Np
         bmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19t
         ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RB
         UlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNjA5OWMwOS1jNWY3LTRi
-        MTctYmFjNC1lMzhkYjhlYzhjYmUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZDNmZmM1MC04NmI1LTRj
+        ZDYtOTVmYi00ZTE3NTEyYTJjYjIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7
         Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcg
         c3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUi
         LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAi
         ZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1
-        cmVzIjogMCwgInN0ZXBfaWQiOiAiN2FlMmIxY2EtMWYyOS00NGM4LWI3NWUt
-        MGY1MDE5NmJjODdlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
+        cmVzIjogMCwgInN0ZXBfaWQiOiAiODJiOWU3MDMtNjljZC00ZDVmLTliNjAt
+        NTM5ZGViMWMwYmQ1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3Vj
         Y2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVwb2Rh
         dGEiLCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAiaXRl
         bXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3Jf
         ZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjog
-        MCwgInN0ZXBfaWQiOiAiOWE2OWFlYzAtNTk2MS00NDljLTkxZTctYTg2NmI1
-        MzMyMjE1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
+        MCwgInN0ZXBfaWQiOiAiZTU2OGUyYzktMjQ3ZC00OTMzLWFjNTMtZTcxOWRl
+        MGM5YWQ5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6
         IDAsICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAi
         c3RlcF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
         YXRlIjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRl
-        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUx
-        OGZhN2UwLTkyNmEtNGQ3OC1iMDdhLTBhZjRiNDM0ODU3MyIsICJudW1fcHJv
+        dGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJh
+        NjBkN2I1LWI5NzAtNGI1NC1iMjBhLWE4YmU0MjlkY2IzOCIsICJudW1fcHJv
         Y2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24i
         OiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1
         Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
         Ik5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
-        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjlmNGIzZGM0
-        LWNjNDUtNGEzMS1hNjQ4LTc4MGE2ZmNjM2ZlZiIsICJudW1fcHJvY2Vzc2Vk
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjljMjA5OGUw
+        LTY5YWItNDM1OS05YWYzLWExYTU5NjRhMThlMyIsICJudW1fcHJvY2Vzc2Vk
         IjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiV3Jp
         dGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXpl
         X3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
         Tk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
-        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWZmZGY4OGYt
-        ZDQwNy00NDhhLThlYTktODM5ZGJkNGM0M2ZjIiwgIm51bV9wcm9jZXNzZWQi
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTkwYzU0MTAt
+        YjNkNy00OWQ1LThhOTEtM2JlNjQ2NjEyNDgxIiwgIm51bV9wcm9jZXNzZWQi
         OiAwfV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFA
         Y2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUuY29tLmRx
         MiIsICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
         dmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5q
         amVmZmVycy5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3Ii
-        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDBiY2M2ZTEwODAzMzYxYjhh
-        YmY0NSJ9LCAiaWQiOiAiNWQ0MGJjYzZlMTA4MDMzNjFiOGFiZjQ1In0=
+        OiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDg2MzhjZDJiNzFlN2EzNTE0
+        NjMzOSJ9LCAiaWQiOiAiNWQ0ODYzOGNkMmI3MWU3YTM1MTQ2MzM5In0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3572,11 +3248,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"1d1ceda489037e0b3f22a0f1df2fbaae-gzip"'
+      - '"42e5b303bf44f7b6985fdc509dd68fe3-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -3588,16 +3264,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wNy0zMFQyMTo1NToxOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wNy0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNr
+        OS0wOC0wNVQxNzoxMjo0NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvODAwZTJhOGEtZWFlMy00YmFiLTgxNWEtMDA2ZjNmMzcx
-        YTQxLyIsICJ0YXNrX2lkIjogIjgwMGUyYThhLWVhZTMtNGJhYi04MTVhLTAw
-        NmYzZjM3MWE0MSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvYmExYjU5YzAtN2M4MC00ZDAzLWJjNGUtMjk2ODA2NzU5
+        NWM3LyIsICJ0YXNrX2lkIjogImJhMWI1OWMwLTdjODAtNGQwMy1iYzRlLTI5
+        NjgwNjc1OTVjNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -3616,8 +3292,8 @@ http_interactions:
         ICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lk
         IjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
         ZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQi
-        OiAiMjAxOS0wNy0zMFQyMTo1NToxN1oiLCAiX25zIjogInJlcG9fc3luY19y
-        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA3LTMwVDIxOjU1OjE4WiIs
+        OiAiMjAxOS0wOC0wNVQxNzoxMjo0M1oiLCAiX25zIjogInJlcG9fc3luY19y
+        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4LTA1VDE3OjEyOjQ0WiIs
         ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9t
         ZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRl
         IjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
@@ -3626,8 +3302,8 @@ http_interactions:
         aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
         ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
         SEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDQwYmNjNjVlYWYwZDBh
-        NWI1ZWU0MmYiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDQ4NjM4YzVlYWYwZDBh
+        MWE2NGE1NTEiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
         RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRl
         bXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
         U0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
@@ -3638,14 +3314,14 @@ http_interactions:
         bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDBiY2M1ZTEw
-        ODAzMzYxYjhhYmM1MCJ9LCAiaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFi
-        YzUwIn0=
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDg2MzhiZDJi
+        NzFlN2EzNTE0NjA4MSJ9LCAiaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2
+        MDgxIn0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/800e2a8a-eae3-4bab-815a-006f3f371a41/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/ba1b59c0-7c80-4d03-bc4e-2968067595c7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3664,11 +3340,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"79271841914a3f07451cf89fcebc2b12-gzip"'
+      - '"f98d11000d75385354c7bacb9b142d15-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -3680,105 +3356,105 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84MDBlMmE4YS1lYWUzLTRiYWItODE1YS0wMDZm
-        M2YzNzFhNDEvIiwgInRhc2tfaWQiOiAiODAwZTJhOGEtZWFlMy00YmFiLTgx
-        NWEtMDA2ZjNmMzcxYTQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy9iYTFiNTljMC03YzgwLTRkMDMtYmM0ZS0yOTY4
+        MDY3NTk1YzcvIiwgInRhc2tfaWQiOiAiYmExYjU5YzAtN2M4MC00ZDAzLWJj
+        NGUtMjk2ODA2NzU5NWM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
         bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxOS0wNy0zMFQyMTo1NToxOFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        OiAiMjAxOS0wOC0wNVQxNzoxMjo0NFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
         InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
         b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
         SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
         aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZTNm
-        ZWNlZS1lZWY2LTRiMzQtYTBmNy1mOTdlZjQzYzI4NDEiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NzNi
+        ZWZjNi1jYjc2LTQyOWYtYjdiMi1iZTllOTQ3OTVkNDQiLCAibnVtX3Byb2Nl
         c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
         ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
         RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzZhYzY3NjktMmMy
-        Yy00M2M0LWIyOGQtYTY3ZDY0ZGMwOTkwIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2M1Njg0MzUtM2Rj
+        NC00NDU1LWE0NTgtOGYyYmUxNzJiN2MxIiwgIm51bV9wcm9jZXNzZWQiOiAx
         fSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
         aGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFs
         IjogMTgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI3ZTdhYzM0OS1hZDM0LTRiYWUtOGQ3Yy1hODIyODkxYWVhZGMiLCAi
+        ZCI6ICI5OTg2YjVjMy02ZWU3LTQ1YTYtOWE3Zi1lMDAyMTE0Y2I1N2EiLCAi
         bnVtX3Byb2Nlc3NlZCI6IDE4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
         IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQ
         RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjYyNzc3ZjUtZDlhNy00Y2Y1
-        LTk0N2QtODk4NzNiMDFmMTQyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzdhNjBmYzItZjllMS00MjBm
+        LWJhMjctZjg3ZjdmNmI4MWFlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
         dW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVy
         cmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjog
         NiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
         ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        Ijk0Y2I1MzhmLTM0YzMtNDQzZi05MmE5LWJiNWU4ODg5YzEyZSIsICJudW1f
-        cHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nlc3MiOiA5LCAiZGVzY3JpcHRp
+        ImFmZGE3ZDNjLWZkZDAtNGY3My1iOTZmLTEwNjg3OTQzNzNjOCIsICJudW1f
+        cHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nlc3MiOiA4LCAiZGVzY3JpcHRp
         b24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1
         bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0YXRlIjogIklOX1BST0dSRVNT
         IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
-        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNhNWExOTRmLThmNDQtNGFiZi1i
-        MTgzLTJhOWI5Mjc5OGUwNSIsICJudW1fcHJvY2Vzc2VkIjogOX0sIHsibnVt
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZhOGVhZDM3LWRiMTItNGNkMS04
+        NDc2LTI2YzYwMDQwNmU2YiIsICJudW1fcHJvY2Vzc2VkIjogOH0sIHsibnVt
         X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21w
         cyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6
         IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICIxYWE3M2NhMC02N2FmLTQzNGUtYjhmNi1hOGRiZDNiNDA1NWMiLCAi
+        ZCI6ICJlYzUzODM3Mi0xN2UwLTRiOTUtOTMzOC0wMTJlNmQ2NWRjMTciLCAi
         bnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2Ny
         aXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6
         ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1Rf
         U1RBUlRFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiOTMzMDY3My02Yzg3
-        LTRmM2QtOWVjZi00NWVmMTUzY2MwNzgiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlMmZhN2Y1Ny04Yjc2
+        LTQ4OWItOTQ5ZS01ZDZjNTc5MTUzMDkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
         LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkNsb3Npbmcg
         cmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRh
         ZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRF
         RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNjA5OWMwOS1jNWY3LTRiMTct
-        YmFjNC1lMzhkYjhlYzhjYmUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZDNmZmM1MC04NmI1LTRjZDYt
+        OTVmYi00ZTE3NTEyYTJjYjIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51
         bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3Fs
         aXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAi
         aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJy
         b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiN2FlMmIxY2EtMWYyOS00NGM4LWI3NWUtMGY1
-        MDE5NmJjODdlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
+        IjogMCwgInN0ZXBfaWQiOiAiODJiOWU3MDMtNjljZC00ZDVmLTliNjAtNTM5
+        ZGViMWMwYmQ1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
         cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVwb2RhdGEi
         LCAic3RlcF90eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAiaXRlbXNf
         dG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0
         YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiOWE2OWFlYzAtNTk2MS00NDljLTkxZTctYTg2NmI1MzMy
-        MjE1IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
+        InN0ZXBfaWQiOiAiZTU2OGUyYzktMjQ3ZC00OTMzLWFjNTMtZTcxOWRlMGM5
+        YWQ5IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAs
         ICJkZXNjcmlwdGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAic3Rl
         cF90eXBlIjogInJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRl
         IjogIk5PVF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUxOGZh
-        N2UwLTkyNmEtNGQ3OC1iMDdhLTBhZjRiNDM0ODU3MyIsICJudW1fcHJvY2Vz
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJhNjBk
+        N2I1LWI5NzAtNGI1NC1iMjBhLWE4YmU0MjlkY2IzOCIsICJudW1fcHJvY2Vz
         c2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAi
         UHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxp
         c2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5P
         VF9TVEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjlmNGIzZGM0LWNj
-        NDUtNGEzMS1hNjQ4LTc4MGE2ZmNjM2ZlZiIsICJudW1fcHJvY2Vzc2VkIjog
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjljMjA5OGUwLTY5
+        YWItNDM1OS05YWYzLWExYTU5NjRhMThlMyIsICJudW1fcHJvY2Vzc2VkIjog
         MH0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiV3JpdGlu
         ZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3Jl
         cG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9U
         X1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYWZmZGY4OGYtZDQw
-        Ny00NDhhLThlYTktODM5ZGJkNGM0M2ZjIiwgIm51bV9wcm9jZXNzZWQiOiAw
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTkwYzU0MTAtYjNk
+        Ny00OWQ1LThhOTEtM2JlNjQ2NjEyNDgxIiwgIm51bV9wcm9jZXNzZWQiOiAw
         fV19LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAY2Vu
         dG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUuY29tLmRxMiIs
         ICJzdGF0ZSI6ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVk
         X3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5qamVm
         ZmVycy5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDBiY2M2ZTEwODAzMzYxYjhhYmY0
-        NSJ9LCAiaWQiOiAiNWQ0MGJjYzZlMTA4MDMzNjFiOGFiZjQ1In0=
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDg2MzhjZDJiNzFlN2EzNTE0NjMz
+        OSJ9LCAiaWQiOiAiNWQ0ODYzOGNkMmI3MWU3YTM1MTQ2MzM5In0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3797,11 +3473,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"1d1ceda489037e0b3f22a0f1df2fbaae-gzip"'
+      - '"42e5b303bf44f7b6985fdc509dd68fe3-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -3813,16 +3489,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wNy0zMFQyMTo1NToxOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wNy0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNr
+        OS0wOC0wNVQxNzoxMjo0NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvODAwZTJhOGEtZWFlMy00YmFiLTgxNWEtMDA2ZjNmMzcx
-        YTQxLyIsICJ0YXNrX2lkIjogIjgwMGUyYThhLWVhZTMtNGJhYi04MTVhLTAw
-        NmYzZjM3MWE0MSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvYmExYjU5YzAtN2M4MC00ZDAzLWJjNGUtMjk2ODA2NzU5
+        NWM3LyIsICJ0YXNrX2lkIjogImJhMWI1OWMwLTdjODAtNGQwMy1iYzRlLTI5
+        NjgwNjc1OTVjNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -3841,8 +3517,8 @@ http_interactions:
         ICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lk
         IjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
         ZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQi
-        OiAiMjAxOS0wNy0zMFQyMTo1NToxN1oiLCAiX25zIjogInJlcG9fc3luY19y
-        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA3LTMwVDIxOjU1OjE4WiIs
+        OiAiMjAxOS0wOC0wNVQxNzoxMjo0M1oiLCAiX25zIjogInJlcG9fc3luY19y
+        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4LTA1VDE3OjEyOjQ0WiIs
         ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9t
         ZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRl
         IjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
@@ -3851,8 +3527,8 @@ http_interactions:
         aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
         ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
         SEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDQwYmNjNjVlYWYwZDBh
-        NWI1ZWU0MmYiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDQ4NjM4YzVlYWYwZDBh
+        MWE2NGE1NTEiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
         RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRl
         bXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
         U0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
@@ -3863,14 +3539,14 @@ http_interactions:
         bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDBiY2M1ZTEw
-        ODAzMzYxYjhhYmM1MCJ9LCAiaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFi
-        YzUwIn0=
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDg2MzhiZDJi
+        NzFlN2EzNTE0NjA4MSJ9LCAiaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2
+        MDgxIn0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/800e2a8a-eae3-4bab-815a-006f3f371a41/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/ba1b59c0-7c80-4d03-bc4e-2968067595c7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3889,15 +3565,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"ac4a0299f637fffae5752e80a30e2161-gzip"'
+      - '"6680df1831314cd6dccb0a9220c721d1-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '4297'
+      - '4304'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3905,105 +3581,105 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84MDBlMmE4YS1lYWUzLTRiYWItODE1YS0wMDZm
-        M2YzNzFhNDEvIiwgInRhc2tfaWQiOiAiODAwZTJhOGEtZWFlMy00YmFiLTgx
-        NWEtMDA2ZjNmMzcxYTQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy9iYTFiNTljMC03YzgwLTRkMDMtYmM0ZS0yOTY4
+        MDY3NTk1YzcvIiwgInRhc2tfaWQiOiAiYmExYjU5YzAtN2M4MC00ZDAzLWJj
+        NGUtMjk2ODA2NzU5NWM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
         bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxOS0wNy0zMFQyMTo1NToxOFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        OiAiMjAxOS0wOC0wNVQxNzoxMjo0NFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
         InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
         b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
         SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
         aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZTNm
-        ZWNlZS1lZWY2LTRiMzQtYTBmNy1mOTdlZjQzYzI4NDEiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NzNi
+        ZWZjNi1jYjc2LTQyOWYtYjdiMi1iZTllOTQ3OTVkNDQiLCAibnVtX3Byb2Nl
         c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
         ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
         RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzZhYzY3NjktMmMy
-        Yy00M2M0LWIyOGQtYTY3ZDY0ZGMwOTkwIiwgIm51bV9wcm9jZXNzZWQiOiAx
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2M1Njg0MzUtM2Rj
+        NC00NDU1LWE0NTgtOGYyYmUxNzJiN2MxIiwgIm51bV9wcm9jZXNzZWQiOiAx
         fSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
         aGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFs
         IjogMTgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI3ZTdhYzM0OS1hZDM0LTRiYWUtOGQ3Yy1hODIyODkxYWVhZGMiLCAi
+        ZCI6ICI5OTg2YjVjMy02ZWU3LTQ1YTYtOWE3Zi1lMDAyMTE0Y2I1N2EiLCAi
         bnVtX3Byb2Nlc3NlZCI6IDE4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
         cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
         IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQ
         RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjYyNzc3ZjUtZDlhNy00Y2Y1
-        LTk0N2QtODk4NzNiMDFmMTQyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
+        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYzdhNjBmYzItZjllMS00MjBm
+        LWJhMjctZjg3ZjdmNmI4MWFlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
         dW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVy
         cmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjog
         NiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
         ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        Ijk0Y2I1MzhmLTM0YzMtNDQzZi05MmE5LWJiNWU4ODg5YzEyZSIsICJudW1f
+        ImFmZGE3ZDNjLWZkZDAtNGY3My1iOTZmLTEwNjg3OTQzNzNjOCIsICJudW1f
         cHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nlc3MiOiA5LCAiZGVzY3JpcHRp
         b24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1
         bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjNhNWExOTRmLThmNDQtNGFiZi1iMTgz
-        LTJhOWI5Mjc5OGUwNSIsICJudW1fcHJvY2Vzc2VkIjogOX0sIHsibnVtX3N1
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImZhOGVhZDM3LWRiMTItNGNkMS04NDc2
+        LTI2YzYwMDQwNmU2YiIsICJudW1fcHJvY2Vzc2VkIjogOX0sIHsibnVtX3N1
         Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBm
         aWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMs
         ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIx
-        YWE3M2NhMC02N2FmLTQzNGUtYjhmNi1hOGRiZDNiNDA1NWMiLCAibnVtX3By
+        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJl
+        YzUzODM3Mi0xN2UwLTRiOTUtOTMzOC0wMTJlNmQ2NWRjMTciLCAibnVtX3By
         b2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMiwgImRlc2NyaXB0aW9u
         IjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRh
         ZGF0YSIsICJpdGVtc190b3RhbCI6IDIsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiOTMzMDY3My02Yzg3LTRmM2QtOWVj
-        Zi00NWVmMTUzY2MwNzgiLCAibnVtX3Byb2Nlc3NlZCI6IDJ9LCB7Im51bV9z
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlMmZhN2Y1Ny04Yjc2LTQ4OWItOTQ5
+        ZS01ZDZjNTc5MTUzMDkiLCAibnVtX3Byb2Nlc3NlZCI6IDJ9LCB7Im51bV9z
         dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRh
         ZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJiNjA5OWMwOS1jNWY3LTRiMTctYmFjNC1lMzhkYjhl
-        YzhjYmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwg
-        InN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwi
-        OiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI3YWUyYjFjYS0xZjI5LTQ0YzgtYjc1ZS0wZjUwMTk2YmM4N2UiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0
-        aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAi
-        cmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
-        ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5YTY5
-        YWVjMC01OTYxLTQ0OWMtOTFlNy1hODY2YjUzMzIyMTUiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjog
-        IkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3Zp
-        ZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQi
+        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJJTl9QUk9HUkVTUyIsICJlcnJv
+        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
+        OiAwLCAic3RlcF9pZCI6ICJiZDNmZmM1MC04NmI1LTRjZDYtOTVmYi00ZTE3
+        NTEyYTJjYjIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNz
+        IjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVz
+        IiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90
+        YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiODJiOWU3MDMtNjljZC00ZDVmLTliNjAtNTM5ZGViMWMwYmQ1
+        IiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJk
+        ZXNjcmlwdGlvbiI6ICJSZW1vdmluZyBvbGQgcmVwb2RhdGEiLCAic3RlcF90
+        eXBlIjogInJlbW92ZV9vbGRfcmVwb2RhdGEiLCAiaXRlbXNfdG90YWwiOiAx
+        LCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJyb3JfZGV0YWlscyI6IFtd
+        LCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQi
+        OiAiZTU2OGUyYzktMjQ3ZC00OTMzLWFjNTMtZTcxOWRlMGM5YWQ5IiwgIm51
+        bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlw
+        dGlvbiI6ICJHZW5lcmF0aW5nIEhUTUwgZmlsZXMiLCAic3RlcF90eXBlIjog
+        InJlcG92aWV3IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9T
+        VEFSVEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJhNjBkN2I1LWI5NzAt
+        NGI1NC1iMjBhLWE4YmU0MjlkY2IzOCIsICJudW1fcHJvY2Vzc2VkIjogMH0s
+        IHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBlIjogInB1Ymxpc2hfZGlyZWN0
+        b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIk5PVF9TVEFSVEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjljMjA5OGUwLTY5YWItNDM1OS05
+        YWYzLWExYTU5NjRhMThlMyIsICJudW1fcHJvY2Vzc2VkIjogMH0sIHsibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiV3JpdGluZyBMaXN0aW5n
+        cyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFsaXplX3JlcG9fbWV0YWRh
+        dGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQi
         LCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2Zh
-        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTE4ZmE3ZTAtOTI2YS00ZDc4LWIw
-        N2EtMGFmNGI0MzQ4NTczIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1f
-        c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIGZpbGVz
-        IHRvIHdlYiIsICJzdGVwX3R5cGUiOiAicHVibGlzaF9kaXJlY3RvcnkiLCAi
-        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiTk9UX1NUQVJURUQiLCAiZXJy
-        b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiOWY0YjNkYzQtY2M0NS00YTMxLWE2NDgtNzgw
-        YTZmY2MzZmVmIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2Vz
-        cyI6IDAsICJkZXNjcmlwdGlvbiI6ICJXcml0aW5nIExpc3RpbmdzIEZpbGUi
-        LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJOT1RfU1RBUlRFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJhZmZkZjg4Zi1kNDA3LTQ0OGEtOGVhOS04Mzlk
-        YmQ0YzQzZmMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9XX0sICJxdWV1ZSI6ICJy
-        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2
-        ZWwuamplZmZlcnMuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1bm5p
-        bmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2Vy
-        LTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUuY29t
-        IiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRv
-        aWQiOiAiNWQ0MGJjYzZlMTA4MDMzNjFiOGFiZjQ1In0sICJpZCI6ICI1ZDQw
-        YmNjNmUxMDgwMzM2MWI4YWJmNDUifQ==
+        aWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZTkwYzU0MTAtYjNkNy00OWQ1LThh
+        OTEtM2JlNjQ2NjEyNDgxIiwgIm51bV9wcm9jZXNzZWQiOiAwfV19LCAicXVl
+        dWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAY2VudG9zNy1rYXRl
+        bGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6
+        ICJydW5uaW5nIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5qamVmZmVycy5leGFt
+        cGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lk
+        IjogeyIkb2lkIjogIjVkNDg2MzhjZDJiNzFlN2EzNTE0NjMzOSJ9LCAiaWQi
+        OiAiNWQ0ODYzOGNkMmI3MWU3YTM1MTQ2MzM5In0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/dadafb9c-64db-4c05-bf31-7153c1ab622f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4022,11 +3698,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"1d1ceda489037e0b3f22a0f1df2fbaae-gzip"'
+      - '"42e5b303bf44f7b6985fdc509dd68fe3-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -4038,16 +3714,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kYWRhZmI5Yy02NGRiLTRjMDUtYmYzMS03MTUzYzFhYjYy
+        MmYvIiwgInRhc2tfaWQiOiAiZGFkYWZiOWMtNjRkYi00YzA1LWJmMzEtNzE1
+        M2MxYWI2MjJmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wNy0zMFQyMTo1NToxOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wNy0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNr
+        OS0wOC0wNVQxNzoxMjo0NFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxNzoxMjo0M1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvODAwZTJhOGEtZWFlMy00YmFiLTgxNWEtMDA2ZjNmMzcx
-        YTQxLyIsICJ0YXNrX2lkIjogIjgwMGUyYThhLWVhZTMtNGJhYi04MTVhLTAw
-        NmYzZjM3MWE0MSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvYmExYjU5YzAtN2M4MC00ZDAzLWJjNGUtMjk2ODA2NzU5
+        NWM3LyIsICJ0YXNrX2lkIjogImJhMWI1OWMwLTdjODAtNGQwMy1iYzRlLTI5
+        NjgwNjc1OTVjNyJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -4066,8 +3742,8 @@ http_interactions:
         ICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lk
         IjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
         ZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQi
-        OiAiMjAxOS0wNy0zMFQyMTo1NToxN1oiLCAiX25zIjogInJlcG9fc3luY19y
-        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA3LTMwVDIxOjU1OjE4WiIs
+        OiAiMjAxOS0wOC0wNVQxNzoxMjo0M1oiLCAiX25zIjogInJlcG9fc3luY19y
+        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4LTA1VDE3OjEyOjQ0WiIs
         ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9t
         ZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRl
         IjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
@@ -4076,8 +3752,8 @@ http_interactions:
         aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
         ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
         SEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDQwYmNjNjVlYWYwZDBh
-        NWI1ZWU0MmYiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
+        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDQ4NjM4YzVlYWYwZDBh
+        MWE2NGE1NTEiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
         RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRl
         bXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
         U0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
@@ -4088,14 +3764,14 @@ http_interactions:
         bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
         W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
         TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDBiY2M1ZTEw
-        ODAzMzYxYjhhYmM1MCJ9LCAiaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFi
-        YzUwIn0=
+        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDg2MzhiZDJi
+        NzFlN2EzNTE0NjA4MSJ9LCAiaWQiOiAiNWQ0ODYzOGJkMmI3MWU3YTM1MTQ2
+        MDgxIn0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/800e2a8a-eae3-4bab-815a-006f3f371a41/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/ba1b59c0-7c80-4d03-bc4e-2968067595c7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4114,236 +3790,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:44 GMT
       Server:
       - Apache
       Etag:
-      - '"ff38ed3cf25e5b55e0f3f7e7f72efffa-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4284'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84MDBlMmE4YS1lYWUzLTRiYWItODE1YS0wMDZm
-        M2YzNzFhNDEvIiwgInRhc2tfaWQiOiAiODAwZTJhOGEtZWFlMy00YmFiLTgx
-        NWEtMDA2ZjNmMzcxYTQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
-        ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiBudWxsLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxOS0wNy0zMFQyMTo1NToxOFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
-        InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHsiRmVk
-        b3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZTNm
-        ZWNlZS1lZWY2LTRiMzQtYTBmNy1mOTdlZjQzYzI4NDEiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzZhYzY3NjktMmMy
-        Yy00M2M0LWIyOGQtYTY3ZDY0ZGMwOTkwIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFs
-        IjogMTgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI3ZTdhYzM0OS1hZDM0LTRiYWUtOGQ3Yy1hODIyODkxYWVhZGMiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDE4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
-        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQ
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjYyNzc3ZjUtZDlhNy00Y2Y1
-        LTk0N2QtODk4NzNiMDFmMTQyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
-        dW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVy
-        cmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjog
-        NiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        Ijk0Y2I1MzhmLTM0YzMtNDQzZi05MmE5LWJiNWU4ODg5YzEyZSIsICJudW1f
-        cHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nlc3MiOiA5LCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1
-        bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjNhNWExOTRmLThmNDQtNGFiZi1iMTgz
-        LTJhOWI5Mjc5OGUwNSIsICJudW1fcHJvY2Vzc2VkIjogOX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBm
-        aWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIx
-        YWE3M2NhMC02N2FmLTQzNGUtYjhmNi1hOGRiZDNiNDA1NWMiLCAibnVtX3By
-        b2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMiwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRh
-        ZGF0YSIsICJpdGVtc190b3RhbCI6IDIsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiOTMzMDY3My02Yzg3LTRmM2QtOWVj
-        Zi00NWVmMTUzY2MwNzgiLCAibnVtX3Byb2Nlc3NlZCI6IDJ9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRh
-        ZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
-        ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJiNjA5OWMwOS1jNWY3LTRiMTctYmFjNC1lMzhkYjhl
-        YzhjYmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwg
-        InN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwi
-        OiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI3YWUyYjFjYS0xZjI5LTQ0YzgtYjc1ZS0wZjUwMTk2YmM4N2UiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0
-        aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAi
-        cmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5YTY5YWVj
-        MC01OTYxLTQ0OWMtOTFlNy1hODY2YjUzMzIyMTUiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdl
-        bmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXci
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJlMThmYTdlMC05MjZhLTRkNzgtYjA3YS0wYWY0
-        YjQzNDg1NzMiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2Vi
-        IiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI5ZjRiM2RjNC1jYzQ1LTRhMzEtYTY0OC03ODBhNmZjYzNmZWYi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
-        c2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
-        XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImFmZmRmODhmLWQ0MDctNDQ4YS04ZWE5LTgzOWRiZDRjNDNmYyIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVlIjogInJlc2VydmVkX3Jlc291
-        cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZlbC5qamVmZmVycy5l
-        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAicnVubmluZyIsICJ3b3JrZXJf
-        bmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWth
-        dGVsbG8tZGV2ZWwuamplZmZlcnMuZXhhbXBsZS5jb20iLCAicmVzdWx0Ijog
-        bnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQwYmNj
-        NmUxMDgwMzM2MWI4YWJmNDUifSwgImlkIjogIjVkNDBiY2M2ZTEwODAzMzYx
-        YjhhYmY0NSJ9
-    http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/45da3c5f-a4e2-4cc8-8d83-6004eeaf77ae/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"1d1ceda489037e0b3f22a0f1df2fbaae-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2435'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80NWRhM2M1Zi1hNGUyLTRjYzgtOGQ4My02MDA0ZWVhZjc3
-        YWUvIiwgInRhc2tfaWQiOiAiNDVkYTNjNWYtYTRlMi00Y2M4LThkODMtNjAw
-        NGVlYWY3N2FlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wNy0zMFQyMTo1NToxOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wNy0zMFQyMTo1NToxN1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvODAwZTJhOGEtZWFlMy00YmFiLTgxNWEtMDA2ZjNmMzcx
-        YTQxLyIsICJ0YXNrX2lkIjogIjgwMGUyYThhLWVhZTMtNGJhYi04MTVhLTAw
-        NmYzZjM3MWE0MSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwu
-        amplZmZlcnMuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVk
-        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0x
-        QGNlbnRvczcta2F0ZWxsby1kZXZlbC5qamVmZmVycy5leGFtcGxlLmNvbSIs
-        ICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImltcG9ydGVyX2lk
-        IjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxsLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwgInN0YXJ0ZWQi
-        OiAiMjAxOS0wNy0zMFQyMTo1NToxN1oiLCAiX25zIjogInJlcG9fc3luY19y
-        ZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA3LTMwVDIxOjU1OjE4WiIs
-        ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJlcnJvcl9t
-        ZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMiOiB7InN0YXRl
-        IjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9k
-        dXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0
-        aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRhIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJlbW92ZWRfY291bnQiOiAw
-        LCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDQwYmNjNjVlYWYwZDBh
-        NWI1ZWU0MmYiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwiOiAwLCAiaXRl
-        bXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5J
-        U0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWlscyI6IHsicnBtX3RvdGFs
-        IjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90YWwiOiAwLCAiZHJwbV9k
-        b25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119LCAiY29tcHMiOiB7InN0
-        YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0
-        ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJpdGVtc190b3Rh
-        bCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJ
-        TklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19
-        LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDBiY2M1ZTEw
-        ODAzMzYxYjhhYmM1MCJ9LCAiaWQiOiAiNWQ0MGJjYzVlMTA4MDMzNjFiOGFi
-        YzUwIn0=
-    http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/800e2a8a-eae3-4bab-815a-006f3f371a41/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"2f77254f424554f42fa2b461abf6f0b9-gzip"'
+      - '"dbec63765de1c1e9869172af235423e5-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -4355,102 +3806,102 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy84MDBlMmE4YS1lYWUzLTRiYWItODE1YS0wMDZm
-        M2YzNzFhNDEvIiwgInRhc2tfaWQiOiAiODAwZTJhOGEtZWFlMy00YmFiLTgx
-        NWEtMDA2ZjNmMzcxYTQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy9iYTFiNTljMC03YzgwLTRkMDMtYmM0ZS0yOTY4
+        MDY3NTk1YzcvIiwgInRhc2tfaWQiOiAiYmExYjU5YzAtN2M4MC00ZDAzLWJj
+        NGUtMjk2ODA2NzU5NWM3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxOS0wNy0zMFQyMTo1NToxOFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0wNy0zMFQyMTo1NToxOFoiLCAi
+        bWUiOiAiMjAxOS0wOC0wNVQxNzoxMjo0NFoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxNzoxMjo0NFoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJiZTNmZWNlZS1lZWY2LTRiMzQtYTBmNy1mOTdlZjQz
-        YzI4NDEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICI0NzNiZWZjNi1jYjc2LTQyOWYtYjdiMi1iZTllOTQ3
+        OTVkNDQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiNzZhYzY3NjktMmMyYy00M2M0LWIyOGQtYTY3ZDY0ZGMwOTkwIiwg
+        aWQiOiAiY2M1Njg0MzUtM2RjNC00NDU1LWE0NTgtOGYyYmUxNzJiN2MxIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVz
         Y3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJy
         cG1zIiwgIml0ZW1zX3RvdGFsIjogMTgsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3ZTdhYzM0OS1hZDM0LTRiYWUtOGQ3
-        Yy1hODIyODkxYWVhZGMiLCAibnVtX3Byb2Nlc3NlZCI6IDE4fSwgeyJudW1f
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5OTg2YjVjMy02ZWU3LTQ1YTYtOWE3
+        Zi1lMDAyMTE0Y2I1N2EiLCAibnVtX3Byb2Nlc3NlZCI6IDE4fSwgeyJudW1f
         c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRh
         IFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjog
         MSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        MjYyNzc3ZjUtZDlhNy00Y2Y1LTk0N2QtODk4NzNiMDFmMTQyIiwgIm51bV9w
+        YzdhNjBmYzItZjllMS00MjBmLWJhMjctZjg3ZjdmNmI4MWFlIiwgIm51bV9w
         cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlv
         biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
         IiwgIml0ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
         cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjk0Y2I1MzhmLTM0YzMtNDQzZi05MmE5LWJi
-        NWU4ODg5YzEyZSIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
+        cyI6IDAsICJzdGVwX2lkIjogImFmZGE3ZDNjLWZkZDAtNGY3My1iOTZmLTEw
+        Njg3OTQzNzNjOCIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
         c3MiOiA5LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwg
         InN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0
         YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjNhNWEx
-        OTRmLThmNDQtNGFiZi1iMTgzLTJhOWI5Mjc5OGUwNSIsICJudW1fcHJvY2Vz
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZhOGVh
+        ZDM3LWRiMTItNGNkMS04NDc2LTI2YzYwMDQwNmU2YiIsICJudW1fcHJvY2Vz
         c2VkIjogOX0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAi
         UHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIs
         ICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIxYWE3M2NhMC02N2FmLTQzNGUtYjhmNi1hOGRi
-        ZDNiNDA1NWMiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICJlYzUzODM3Mi0xN2UwLTRiOTUtOTMzOC0wMTJl
+        NmQ2NWRjMTciLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNz
         IjogMiwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwg
         InN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDIsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiOTMz
-        MDY3My02Yzg3LTRmM2QtOWVjZi00NWVmMTUzY2MwNzgiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlMmZh
+        N2Y1Ny04Yjc2LTQ4OWItOTQ5ZS01ZDZjNTc5MTUzMDkiLCAibnVtX3Byb2Nl
         c3NlZCI6IDJ9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2Vf
         cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNjA5OWMwOS1jNWY3
-        LTRiMTctYmFjNC1lMzhkYjhlYzhjYmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZDNmZmM1MC04NmI1
+        LTRjZDYtOTVmYi00ZTE3NTEyYTJjYjIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRp
         bmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxp
         dGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI3YWUyYjFjYS0xZjI5LTQ0YzgtYjc1ZS0w
-        ZjUwMTk2YmM4N2UiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI4MmI5ZTcwMy02OWNkLTRkNWYtOWI2MC01
+        MzlkZWIxYzBiZDUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0
         YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVt
         c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICI5YTY5YWVjMC01OTYxLTQ0OWMtOTFlNy1hODY2YjUzMzIy
-        MTUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICJlNTY4ZTJjOS0yNDdkLTQ5MzMtYWM1My1lNzE5ZGUwYzlh
+        ZDkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVw
         X3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
         OiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlMThmYTdlMC05
-        MjZhLTRkNzgtYjA3YS0wYWY0YjQzNDg1NzMiLCAibnVtX3Byb2Nlc3NlZCI6
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiYTYwZDdiNS1i
+        OTcwLTRiNTQtYjIwYS1hOGJlNDI5ZGNiMzgiLCAibnVtX3Byb2Nlc3NlZCI6
         IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
         c2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2Rp
         cmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
         RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5ZjRiM2RjNC1jYzQ1LTRhMzEt
-        YTY0OC03ODBhNmZjYzNmZWYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5YzIwOThlMC02OWFiLTQzNTkt
+        OWFmMy1hMWE1OTY0YTE4ZTMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
         bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGlu
         Z3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
         YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImFmZmRmODhmLWQ0MDctNDQ4YS04ZWE5
-        LTgzOWRiZDRjNDNmYyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImU5MGM1NDEwLWIzZDctNDlkNS04YTkx
+        LTNiZTY0NjYxMjQ4MSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
         IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxs
         by1kZXZlbC5qamVmZmVycy5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAi
         ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
         d29ya2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1w
         bGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhj
         ZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgInN0YXJ0
-        ZWQiOiAiMjAxOS0wNy0zMFQyMTo1NToxOFoiLCAiX25zIjogInJlcG9fcHVi
-        bGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA3LTMwVDIxOjU1
-        OjE4WiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9p
+        ZWQiOiAiMjAxOS0wOC0wNVQxNzoxMjo0NFoiLCAiX25zIjogInJlcG9fcHVi
+        bGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4LTA1VDE3OjEy
+        OjQ0WiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9p
         ZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFyeSI6IHsiZ2VuZXJhdGUg
         c3FsaXRlIjogIlNLSVBQRUQiLCAicnBtcyI6ICJGSU5JU0hFRCIsICJpbml0
         aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNIRUQiLCAicmVtb3ZlX29s
@@ -4461,91 +3912,91 @@ http_interactions:
         aXNoX2RpcmVjdG9yeSI6ICJGSU5JU0hFRCIsICJlcnJhdGEiOiAiRklOSVNI
         RUQiLCAibWV0YWRhdGEiOiAiRklOSVNIRUQifSwgImVycm9yX21lc3NhZ2Ui
         OiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiRmVkb3JhXzE3IiwgImlkIjog
-        IjVkNDBiY2M2NWVhZjBkMGE1YjVlZTQzMCIsICJkZXRhaWxzIjogW3sibnVt
+        IjVkNDg2MzhjNWVhZjBkMGExYTY0YTU1MiIsICJkZXRhaWxzIjogW3sibnVt
         X3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJl
         cG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19t
         ZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
         RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZTNmZWNlZS1lZWY2LTRiMzQt
-        YTBmNy1mOTdlZjQzYzI4NDEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NzNiZWZjNi1jYjc2LTQyOWYt
+        YjdiMi1iZTllOTQ3OTVkNDQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
         bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlz
         dHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24i
         LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJy
         b3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVz
-        IjogMCwgInN0ZXBfaWQiOiAiNzZhYzY3NjktMmMyYy00M2M0LWIyOGQtYTY3
-        ZDY0ZGMwOTkwIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2Vz
+        IjogMCwgInN0ZXBfaWQiOiAiY2M1Njg0MzUtM2RjNC00NDU1LWE0NTgtOGYy
+        YmUxNzJiN2MxIiwgIm51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2Vz
         cyI6IDE4LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0
         ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFsIjogMTgsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3ZTdhYzM0OS1h
-        ZDM0LTRiYWUtOGQ3Yy1hODIyODkxYWVhZGMiLCAibnVtX3Byb2Nlc3NlZCI6
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5OTg2YjVjMy02
+        ZWU3LTQ1YTYtOWE3Zi1lMDAyMTE0Y2I1N2EiLCAibnVtX3Byb2Nlc3NlZCI6
         IDE4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJs
         aXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0
         ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0
         YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwg
-        InN0ZXBfaWQiOiAiMjYyNzc3ZjUtZDlhNy00Y2Y1LTk0N2QtODk4NzNiMDFm
-        MTQyIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYs
+        InN0ZXBfaWQiOiAiYzdhNjBmYzItZjllMS00MjBmLWJhMjctZjg3ZjdmNmI4
+        MWFlIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYs
         ICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5
         cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJ
         TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
-        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjk0Y2I1MzhmLTM0YzMt
-        NDQzZi05MmE5LWJiNWU4ODg5YzEyZSIsICJudW1fcHJvY2Vzc2VkIjogNn0s
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFmZGE3ZDNjLWZkZDAt
+        NGY3My1iOTZmLTEwNjg3OTQzNzNjOCIsICJudW1fcHJvY2Vzc2VkIjogNn0s
         IHsibnVtX3N1Y2Nlc3MiOiA5LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
         ZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3Rv
         dGFsIjogOSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
         OiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVw
-        X2lkIjogIjNhNWExOTRmLThmNDQtNGFiZi1iMTgzLTJhOWI5Mjc5OGUwNSIs
+        X2lkIjogImZhOGVhZDM3LWRiMTItNGNkMS04NDc2LTI2YzYwMDQwNmU2YiIs
         ICJudW1fcHJvY2Vzc2VkIjogOX0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVz
         Y3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlw
         ZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5J
         U0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJu
-        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxYWE3M2NhMC02N2FmLTQz
-        NGUtYjhmNi1hOGRiZDNiNDA1NWMiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7
+        dW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlYzUzODM3Mi0xN2UwLTRi
+        OTUtOTMzOC0wMTJlNmQ2NWRjMTciLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7
         Im51bV9zdWNjZXNzIjogMiwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcg
         TWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190
         b3RhbCI6IDIsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
         IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJiOTMzMDY3My02Yzg3LTRmM2QtOWVjZi00NWVmMTUzY2MwNzgi
+        cF9pZCI6ICJlMmZhN2Y1Ny04Yjc2LTQ4OWItOTQ5ZS01ZDZjNTc5MTUzMDki
         LCAibnVtX3Byb2Nlc3NlZCI6IDJ9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
         c2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5
         cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEs
         ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
         ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJi
-        NjA5OWMwOS1jNWY3LTRiMTctYmFjNC1lMzhkYjhlYzhjYmUiLCAibnVtX3By
+        ZDNmZmM1MC04NmI1LTRjZDYtOTVmYi00ZTE3NTEyYTJjYjIiLCAibnVtX3By
         b2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9u
         IjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJn
         ZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
         U0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3YWUyYjFjYS0xZjI5
-        LTQ0YzgtYjc1ZS0wZjUwMTk2YmM4N2UiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4MmI5ZTcwMy02OWNk
+        LTRkNWYtOWI2MC01MzlkZWIxYzBiZDUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9
         LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5n
         IG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBv
         ZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5YTY5YWVjMC01OTYxLTQ0OWMtOTFl
-        Ny1hODY2YjUzMzIyMTUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9z
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlNTY4ZTJjOS0yNDdkLTQ5MzMtYWM1
+        My1lNzE5ZGUwYzlhZDkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9z
         dWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBm
         aWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwi
         OiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
         ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICJlMThmYTdlMC05MjZhLTRkNzgtYjA3YS0wYWY0YjQzNDg1NzMiLCAibnVt
+        ICJiYTYwZDdiNS1iOTcwLTRiNTQtYjIwYS1hOGJlNDI5ZGNiMzgiLCAibnVt
         X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0
         aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6
         ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0
         ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5ZjRiM2Rj
-        NC1jYzQ1LTRhMzEtYTY0OC03ODBhNmZjYzNmZWYiLCAibnVtX3Byb2Nlc3Nl
+        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5YzIwOThl
+        MC02OWFiLTQzNTktOWFmMy1hMWE1OTY0YTE4ZTMiLCAibnVtX3Byb2Nlc3Nl
         ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldy
         aXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6
         ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjog
         IkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
-        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFmZmRmODhmLWQ0
-        MDctNDQ4YS04ZWE5LTgzOWRiZDRjNDNmYyIsICJudW1fcHJvY2Vzc2VkIjog
-        MX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQwYmNj
-        NmUxMDgwMzM2MWI4YWJmNDUifSwgImlkIjogIjVkNDBiY2M2ZTEwODAzMzYx
-        YjhhYmY0NSJ9
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImU5MGM1NDEwLWIz
+        ZDctNDlkNS04YTkxLTNiZTY0NjYxMjQ4MSIsICJudW1fcHJvY2Vzc2VkIjog
+        MX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4NjM4
+        Y2QyYjcxZTdhMzUxNDYzMzkifSwgImlkIjogIjVkNDg2MzhjZDJiNzFlN2Ez
+        NTE0NjMzOSJ9
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:44 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
@@ -4567,15 +4018,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:45 GMT
       Server:
       - Apache
       Etag:
-      - '"5e280cb2b44de6a00c6a895e9118d4a0-gzip"'
+      - '"4f05e642995d158c053abb18fe13e5c1-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2671'
+      - '2678'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -4584,65 +4035,65 @@ http_interactions:
         eyJzY3JhdGNocGFkIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiJ9LCAi
         ZGlzcGxheV9uYW1lIjogIkZlZG9yYSAxNyB4ODZfNjQiLCAiZGVzY3JpcHRp
         b24iOiBudWxsLCAiZGlzdHJpYnV0b3JzIjogW3sicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDctMzBUMjE6NTU6MTda
+        cmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDgtMDVUMTc6MTI6NDNa
         IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvRmVkb3Jh
         XzE3L2Rpc3RyaWJ1dG9ycy9leHBvcnRfZGlzdHJpYnV0b3IvIiwgImxhc3Rf
         b3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAi
         ZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJleHBvcnRfZGlzdHJpYnV0b3IiLCAi
         YXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFkIjoge30sICJfbnMi
-        OiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVkNDBi
-        Y2M1NWVhZjBkMDc4ZWViMmNlYyJ9LCAiY29uZmlnIjogeyJodHRwIjogZmFs
+        OiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVkNDg2
+        MzhiNWVhZjBkMjk0MWUwMThkYSJ9LCAiY29uZmlnIjogeyJodHRwIjogZmFs
         c2UsICJyZWxhdGl2ZV91cmwiOiAiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5
         L2ZlZG9yYV8xN19sYWJlbCIsICJodHRwcyI6IGZhbHNlfSwgImlkIjogImV4
         cG9ydF9kaXN0cmlidXRvciJ9LCB7InJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        Imxhc3RfdXBkYXRlZCI6ICIyMDE5LTA3LTMwVDIxOjU1OjE3WiIsICJfaHJl
+        Imxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE3OjEyOjQzWiIsICJfaHJl
         ZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy9kaXN0
         cmlidXRvcnMvRmVkb3JhXzE3X2Nsb25lLyIsICJsYXN0X292ZXJyaWRlX2Nv
         bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
         X3R5cGVfaWQiOiAieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVi
         bGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9f
-        ZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQwYmNjNTVlYWYw
-        ZDA3OGVlYjJjZWIifSwgImNvbmZpZyI6IHsiZGVzdGluYXRpb25fZGlzdHJp
+        ZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4NjM4YjVlYWYw
+        ZDI5NDFlMDE4ZDkifSwgImNvbmZpZyI6IHsiZGVzdGluYXRpb25fZGlzdHJp
         YnV0b3JfaWQiOiAiRmVkb3JhXzE3In0sICJpZCI6ICJGZWRvcmFfMTdfY2xv
         bmUifSwgeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQi
-        OiAiMjAxOS0wNy0zMFQyMTo1NToxN1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
+        OiAiMjAxOS0wOC0wNVQxNzoxMjo0M1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
         L3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL0ZlZG9y
         YV8xNy8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVi
-        bGlzaCI6ICIyMDE5LTA3LTMwVDIxOjU1OjE4WiIsICJkaXN0cmlidXRvcl90
+        bGlzaCI6ICIyMDE5LTA4LTA1VDE3OjEyOjQ0WiIsICJkaXN0cmlidXRvcl90
         eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0
         cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0
-        b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQwYmNjNTVlYWYwZDA3OGVlYjJj
-        ZWEifSwgImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBm
+        b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4NjM4YjVlYWYwZDI5NDFlMDE4
+        ZDgifSwgImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBm
         YWxzZSwgImh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0Nv
         cnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIn0sICJpZCI6ICJG
-        ZWRvcmFfMTcifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAxOS0wNy0zMFQy
-        MTo1NToxOFoiLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        ZWRvcmFfMTcifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAxOS0wOC0wNVQx
+        NzoxMjo0NFoiLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7Im1vZHVsZW1kX2RlZmF1bHRzIjogMywgImVycmF0dW0iOiA2
         LCAicGFja2FnZV9ncm91cCI6IDIsICJwYWNrYWdlX2NhdGVnb3J5IjogMSwg
         ImRpc3RyaWJ1dGlvbiI6IDEsICJtb2R1bGVtZCI6IDYsICJycG0iOiAxOCwg
         Inl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiOiAyfSwgIl9ucyI6ICJyZXBvcyIs
         ICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0
-        X3VwZGF0ZWQiOiAiMjAxOS0wNy0zMFQyMTo1NToxN1oiLCAiX2hyZWYiOiAi
+        X3VwZGF0ZWQiOiAiMjAxOS0wOC0wNVQxNzoxMjo0M1oiLCAiX2hyZWYiOiAi
         L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvaW1wb3J0ZXJz
         L3l1bV9pbXBvcnRlci8iLCAiX25zIjogInJlcG9faW1wb3J0ZXJzIiwgImlt
         cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImxhc3Rfb3ZlcnJp
-        ZGVfY29uZmlnIjoge30sICJsYXN0X3N5bmMiOiAiMjAxOS0wNy0zMFQyMTo1
-        NToxOFoiLCAic2NyYXRjaHBhZCI6IHsicmVwb21kX3JldmlzaW9uIjogMTU2
+        ZGVfY29uZmlnIjoge30sICJsYXN0X3N5bmMiOiAiMjAxOS0wOC0wNVQxNzox
+        Mjo0NFoiLCAic2NyYXRjaHBhZCI6IHsicmVwb21kX3JldmlzaW9uIjogMTU2
         Mjc4MzM0NSwgInJlcG9tZF9jaGVja3N1bSI6ICIyOTFhZjNkN2M2ZGNlZTQ1
         YWM1ODdmYWEwYTIxZjdjNzI2NGMxNTZhYzQ4MDY3YjkxODFmMzk1ZDVlMjVi
-        MTA5In0sICJfaWQiOiB7IiRvaWQiOiAiNWQ0MGJjYzU1ZWFmMGQwNzhlZWIy
-        Y2U5In0sICJjb25maWciOiB7ImZlZWQiOiAiZmlsZTovLy92YXIvd3d3L3Rl
+        MTA5In0sICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODYzOGI1ZWFmMGQyOTQxZTAx
+        OGQ3In0sICJjb25maWciOiB7ImZlZWQiOiAiZmlsZTovLy92YXIvd3d3L3Rl
         c3RfcmVwb3Mvem9vIiwgInByb3h5X3BvcnQiOiA4MCwgImRvd25sb2FkX3Bv
         bGljeSI6ICJpbW1lZGlhdGUiLCAicmVtb3ZlX21pc3NpbmciOiB0cnVlLCAi
-        cHJveHlfaG9zdCI6ICJ1cmxfMSIsICJzc2xfdmFsaWRhdGlvbiI6IHRydWV9
-        LCAiaWQiOiAieXVtX2ltcG9ydGVyIn1dLCAibG9jYWxseV9zdG9yZWRfdW5p
-        dHMiOiAzOSwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQwYmNjNTVlYWYwZDA3OGVl
-        YjJjZTgifSwgInRvdGFsX3JlcG9zaXRvcnlfdW5pdHMiOiAzOSwgImlkIjog
-        IkZlZG9yYV8xNyIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
-        aWVzL0ZlZG9yYV8xNy8ifQ==
+        cHJveHlfaG9zdCI6ICJodHRwOi8vdXJsXzEiLCAic3NsX3ZhbGlkYXRpb24i
+        OiB0cnVlfSwgImlkIjogInl1bV9pbXBvcnRlciJ9XSwgImxvY2FsbHlfc3Rv
+        cmVkX3VuaXRzIjogMzksICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODYzOGI1ZWFm
+        MGQyOTQxZTAxOGQ2In0sICJ0b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMzks
+        ICJpZCI6ICJGZWRvcmFfMTciLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Jl
+        cG9zaXRvcmllcy9GZWRvcmFfMTcvIn0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:45 GMT
 - request:
     method: delete
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/repositories/Fedora_17/
@@ -4664,7 +4115,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:45 GMT
       Server:
       - Apache
       Content-Length:
@@ -4675,14 +4126,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzRhNWY5YTA4LWM5ZWEtNDViMy05NjM5LTU0MDZiMjQyMTVmZi8iLCAi
-        dGFza19pZCI6ICI0YTVmOWEwOC1jOWVhLTQ1YjMtOTYzOS01NDA2YjI0MjE1
-        ZmYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzk5NDdkN2U2LWY3YjYtNDljZS1hOTRjLWI4YWY1NmFhMWYzNi8iLCAi
+        dGFza19pZCI6ICI5OTQ3ZDdlNi1mN2I2LTQ5Y2UtYTk0Yy1iOGFmNTZhYTFm
+        MzYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:45 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/4a5f9a08-c9ea-45b3-9639-5406b24215ff/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/9947d7e6-f7b6-49ce-a94c-b8af56aa1f36/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4701,15 +4152,15 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:45 GMT
       Server:
       - Apache
       Etag:
-      - '"b7d0b9547c3e80e3c2e1807022bedc1f-gzip"'
+      - '"9a38cd960573883054d80fb1fdc2ebd5-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '542'
+      - '682'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -4717,22 +4168,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80YTVmOWEwOC1jOWVhLTQ1YjMtOTYzOS01NDA2YjI0MjE1
-        ZmYvIiwgInRhc2tfaWQiOiAiNGE1ZjlhMDgtYzllYS00NWIzLTk2MzktNTQw
-        NmIyNDIxNWZmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy85OTQ3ZDdlNi1mN2I2LTQ5Y2UtYTk0Yy1iOGFmNTZhYTFm
+        MzYvIiwgInRhc2tfaWQiOiAiOTk0N2Q3ZTYtZjdiNi00OWNlLWE5NGMtYjhh
+        ZjU2YWExZjM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
         bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6IG51bGws
         ICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJv
-        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICIiLCAic3RhdGUiOiAid2Fp
-        dGluZyIsICJ3b3JrZXJfbmFtZSI6IG51bGwsICJyZXN1bHQiOiBudWxsLCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDBiY2M2ZTEwODAz
-        MzYxYjhhYzA5ZiJ9LCAiaWQiOiAiNWQ0MGJjYzZlMTA4MDMzNjFiOGFjMDlm
-        In0=
+        Z3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJj
+        ZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuamplZmZlcnMuZXhh
+        bXBsZS5jb20uZHEyIiwgInN0YXRlIjogIndhaXRpbmciLCAid29ya2VyX25h
+        bWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTFAY2VudG9zNy1rYXRl
+        bGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51
+        bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODYzOGRk
+        MmI3MWU3YTM1MTQ2NDg1In0sICJpZCI6ICI1ZDQ4NjM4ZGQyYjcxZTdhMzUx
+        NDY0ODUifQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:45 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/4a5f9a08-c9ea-45b3-9639-5406b24215ff/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/9947d7e6-f7b6-49ce-a94c-b8af56aa1f36/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4751,11 +4205,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:45 GMT
       Server:
       - Apache
       Etag:
-      - '"62f6fdb630aa72942e6d7bf34b734d63-gzip"'
+      - '"b38508d0d2f1421436ad376220df6dea-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -4767,25 +4221,25 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80YTVmOWEwOC1jOWVhLTQ1YjMtOTYzOS01NDA2YjI0MjE1
-        ZmYvIiwgInRhc2tfaWQiOiAiNGE1ZjlhMDgtYzllYS00NWIzLTk2MzktNTQw
-        NmIyNDIxNWZmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy85OTQ3ZDdlNi1mN2I2LTQ5Y2UtYTk0Yy1iOGFmNTZhYTFm
+        MzYvIiwgInRhc2tfaWQiOiAiOTk0N2Q3ZTYtZjdiNi00OWNlLWE5NGMtYjhh
+        ZjU2YWExZjM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6IG51
         bGwsICJfbnMiOiAidGFza19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5
-        LTA3LTMwVDIxOjU1OjE4WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
+        LTA4LTA1VDE3OjEyOjQ1WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25l
         ZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6
         ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMUBjZW50b3M3LWthdGVsbG8t
         ZGV2ZWwuamplZmZlcnMuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogInJ1
         bm5pbmciLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29y
         a2VyLTFAY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUu
         Y29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNWQ0MGJjYzZlMTA4MDMzNjFiOGFjMDlmIn0sICJpZCI6ICI1
-        ZDQwYmNjNmUxMDgwMzM2MWI4YWMwOWYifQ==
+        IiRvaWQiOiAiNWQ0ODYzOGRkMmI3MWU3YTM1MTQ2NDg1In0sICJpZCI6ICI1
+        ZDQ4NjM4ZGQyYjcxZTdhMzUxNDY0ODUifQ==
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:45 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/4a5f9a08-c9ea-45b3-9639-5406b24215ff/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v2/tasks/9947d7e6-f7b6-49ce-a94c-b8af56aa1f36/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4804,11 +4258,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 30 Jul 2019 21:55:18 GMT
+      - Mon, 05 Aug 2019 17:12:45 GMT
       Server:
       - Apache
       Etag:
-      - '"a0f018bf801730ee028cc4046f24be30-gzip"'
+      - '"d4320093302523058443cca2805f6410-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
@@ -4820,20 +4274,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80YTVmOWEwOC1jOWVhLTQ1YjMtOTYzOS01NDA2YjI0MjE1
-        ZmYvIiwgInRhc2tfaWQiOiAiNGE1ZjlhMDgtYzllYS00NWIzLTk2MzktNTQw
-        NmIyNDIxNWZmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy85OTQ3ZDdlNi1mN2I2LTQ5Y2UtYTk0Yy1iOGFmNTZhYTFm
+        MzYvIiwgInRhc2tfaWQiOiAiOTk0N2Q3ZTYtZjdiNi00OWNlLWE5NGMtYjhh
+        ZjU2YWExZjM2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE5LTA3LTMwVDIxOjU1OjE4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE5LTA3LTMwVDIxOjU1OjE4WiIsICJ0cmFjZWJh
+        MDE5LTA4LTA1VDE3OjEyOjQ1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE3OjEyOjQ1WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
         MUBjZW50b3M3LWthdGVsbG8tZGV2ZWwuamplZmZlcnMuZXhhbXBsZS5jb20u
         ZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJl
         c2VydmVkX3Jlc291cmNlX3dvcmtlci0xQGNlbnRvczcta2F0ZWxsby1kZXZl
         bC5qamVmZmVycy5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
-        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDBiY2M2ZTEwODAzMzYx
-        YjhhYzA5ZiJ9LCAiaWQiOiAiNWQ0MGJjYzZlMTA4MDMzNjFiOGFjMDlmIn0=
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDg2MzhkZDJiNzFlN2Ez
+        NTE0NjQ4NSJ9LCAiaWQiOiAiNWQ0ODYzOGRkMmI3MWU3YTM1MTQ2NDg1In0=
     http_version: 
-  recorded_at: Tue, 30 Jul 2019 21:55:18 GMT
+  recorded_at: Mon, 05 Aug 2019 17:12:45 GMT
 recorded_with: VCR 3.0.3

--- a/test/services/katello/pulp/repository/yum_test.rb
+++ b/test/services/katello/pulp/repository/yum_test.rb
@@ -184,7 +184,7 @@ module Katello
           importers = backend_data['importers']
           config = importers.first['config']
           uri = URI(@default_proxy.url)
-          assert_equal uri.host, config['proxy_host']
+          assert_equal "http://" + uri.host, config['proxy_host']
         end
 
         def test_sync_with_global_http_proxy
@@ -195,7 +195,7 @@ module Katello
           importers = backend_data['importers']
           config = importers.first['config']
           uri = URI(@default_proxy.url)
-          assert_equal uri.host, config['proxy_host']
+          assert_equal "http://" + uri.host, config['proxy_host']
         end
 
         def teardown

--- a/test/services/katello/pulp/repository_test.rb
+++ b/test/services/katello/pulp/repository_test.rb
@@ -38,7 +38,7 @@ module Katello
         assert @repo.root.http_proxy_id
         uri = URI(@default_proxy.url)
         expected_options = {
-          proxy_host: uri.host,
+          proxy_host: uri.scheme + '://' + uri.host,
           proxy_port: uri.port,
           proxy_username: @default_proxy.username,
           proxy_password: @default_proxy.password
@@ -51,7 +51,7 @@ module Katello
         assert_nil @repo.root.http_proxy_id
         uri = URI(@default_proxy.url)
         expected_options = {
-          proxy_host: uri.host,
+          proxy_host: uri.scheme + '://' + uri.host,
           proxy_port: uri.port,
           proxy_username: @default_proxy.username,
           proxy_password: @default_proxy.password
@@ -66,7 +66,7 @@ module Katello
         assert @repo.root.http_proxy_id
         uri = URI(another_proxy.url)
         expected_options = {
-          proxy_host: uri.host,
+          proxy_host: uri.scheme + '://' + uri.host,
           proxy_port: uri.port,
           proxy_username: another_proxy.username,
           proxy_password: another_proxy.password


### PR DESCRIPTION
This change fixes a problem where pulp2 requires the proxy_host value in an importer config for to use the format of "scheme://host", and not just "host".