### PR TITLE
Fixes #27198 - correct URL upon enabling repo

### DIFF
--- a/webpack/scenes/RedHatRepositories/components/EnabledRepository/EnabledRepository.js
+++ b/webpack/scenes/RedHatRepositories/components/EnabledRepository/EnabledRepository.js
@@ -100,7 +100,7 @@ EnabledRepository.propTypes = {
   pagination: PropTypes.shape({
     page: PropTypes.number,
     perPage: PropTypes.number,
-  }).isRequired,
+  }),
   loading: PropTypes.bool,
   releasever: PropTypes.string,
   orphaned: PropTypes.bool,
@@ -114,6 +114,10 @@ EnabledRepository.defaultProps = {
   orphaned: false,
   search: {},
   loading: false,
+  pagination: PropTypes.shape({
+    page: 0,
+    perPage: 0,
+  }),
 };
 
 export default EnabledRepository;


### PR DESCRIPTION
**To reporduce:**
*****
1. Content > Subscriptions > Manage Manifest :Upload a manifest.
2. Open browser console
3. Content > Red Hat Repositories > Enable the first repo
4. Notice error in console with per_page param as NaN and the enabled repo does not show up on the UI.
****
**With PR**
The first enabled repository should show up on the UI correctly. 