### PR TITLE
Fixes #27426: katello sends invalid page number request

### DIFF
--- a/webpack/redux/reducers/RedHatRepositories/enabled.js
+++ b/webpack/redux/reducers/RedHatRepositories/enabled.js
@@ -74,7 +74,7 @@ export default (state = initialState, action) => {
     return Immutable({
       repositories: mapRepositories(results),
       pagination: {
-        page: Number(page) || 0,
+        page: Number(page) || 1,
         // server can return per_page: null when there's error in the search query,
         // don't store it in such case
         // eslint-disable-next-line camelcase


### PR DESCRIPTION
When you have no Red Hat Repositories enabled and try to enable one, the 
newly enabled repository would not show until after a page refresh.  
This was due to an invalid page number (0) in the request