### PR TITLE
Fixes #27580 - Allow register to profile without DMI UUID

### DIFF
--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -272,9 +272,17 @@ module Katello
 
         if hosts_size == 1
           host = hosts.first
-          found_uuid = host.fact_values.find { |fv| fv.fact_name_id == uuid_fact_id }
 
-          return host if host.name == host_name && (host.build || found_uuid&.value == host_uuid)
+          if host.name == host_name
+            unless host.build
+              found_uuid = host.fact_values.where(fact_name_id: uuid_fact_id).first
+              if found_uuid && found_uuid.value != host_uuid
+                fail Katello::Errors::RegistrationError, _("This host is reporting a DMI UUID that differs from the existing registration.")
+              end
+            end
+
+            return host
+          end
         end
 
         hostnames = hosts.pluck(:name).sort.join(', ')


### PR DESCRIPTION
bootstrap.py usage was broken by #8232 since we didn't have a test case for the workflow used by the script. This issue is high priority in the downstream context and while #8248 fixes the problem we likely need to deliver a minimal changeset. ie this must be merged before #8242 

**To test (without change)**

- Spin up katello-client
- attempt to register it with bootstrap.py (get it from /pub/ of your katello instance) example:
```
python /root/bootstrap.py --login=admin --password=changeme --server=centos7-devel.jturel.example.com --location='Default Location' --organization='Default Organization' -g MyHostGroup -a testkey --add-domain --force
```

It will fail with error: `Please unregister or remove hosts which match this host before registering`

Check out this PR and run the bootstrap.py command again and the registration will succeed!