### PR TITLE
Fixes #27612 - Broken inc. update with puppet module

### DIFF
--- a/app/lib/actions/katello/content_view_version/incremental_update.rb
+++ b/app/lib/actions/katello/content_view_version/incremental_update.rb
@@ -264,11 +264,10 @@ module Actions
           ::Katello::PuppetModule.with_identifiers(ids)
         end
 
-        def copy_puppet_modules(new_repo, module_id)
+        def copy_puppet_module(new_repo, module_id)
           puppet_module = find_puppet_modules([module_id]).first
-          possible_repos = puppet_module.repositories.in_organization(new_repo.organization).in_default_vie
-          plan_action(Pulp::Repository::CopyUnits, possible_repos.first, new_repo,
-                                                  [puppet_module])
+          possible_repos = puppet_module.repositories.in_organization(new_repo.organization).in_default_view
+          plan_action(Pulp::ContentViewPuppetEnvironment::CopyContents, new_repo, source_repository_id: possible_repos.first.id, puppet_modules: [puppet_module])
         end
 
         def plan_copy(action_class, source_repo, target_repo, clauses = nil, override_config = nil)


### PR DESCRIPTION
This regressed with a refactor a while ago.

> hammer content-view version incremental-update --propagate-all-composites=true --content-view-version-id=419 --lifecycle-environments=Library --puppet-module-ids=7 --organization-id=1

```
2019-08-13T11:26:23 [E|app|] NoMethodError: undefined method `copy_puppet_module' for #<Actions::Katello::ContentViewVersion::IncrementalUpdate:0x00000000093e2750>
Did you mean?  copy_puppet_modules
/opt/theforeman/tfm/root/usr/share/gems/gems/katello-3.12.0.7/app/lib/actions/katello/content_view_version/incremental_update.rb:257:in `block in copy_puppet_content'
/opt/theforeman/tfm/root/usr/share/gems/gems/katello-3.12.0.7/app/lib/actions/katello/content_view_version/incremental_update.rb:257:in `map'
/opt/theforeman/tfm/root/usr/share/gems/gems/katello-3.12.0.7/app/lib/actions/katello/content_view_version/incremental_update.rb:257:in `copy_puppet_content'
/opt/theforeman/tfm/root/usr/share/gems/gems/katello-3.12.0.7/app/lib/actions/katello/content_view_version/incremental_update.rb:49:in `block (3 levels) in plan'
/opt/theforeman/tfm/root/usr/share/gems/gems/dynflow-1.2.3/lib/dynflow/execution_plan.rb:383:in `switch_flow'
```

However, when running incremental update now I'm getting another error. Not sure if it's my environment or another problem:

Actions::Pulp::Repository::CopyUnits
```
---
source_repo_id: 56
target_repo_id: 219
class_name: Katello::PuppetModule
unit_ids:
- 1394
resolve_dependencies: 
remote_user: admin
remote_cp_user: admin
locale: en
current_request_id: 
current_timezone: UTC
current_user_id: 4
current_organization_id: 
current_location_id: 
```
```
---
pulp_tasks:
- exception: 
  task_type: pulp.server.managers.repo.unit_association.associate_from_repo
  _href: "/pulp/api/v2/tasks/871a847e-58fa-4464-abc8-e24c2d2785e5/"
  task_id: 871a847e-58fa-4464-abc8-e24c2d2785e5
  tags:
  - pulp:repository:2-CompositeCV3-v17_0-75dee594-c50b-454d-a6b1-e742d2b71a33
  - pulp:repository:aa3b1b4d-705c-45d0-8455-59bdb324deff
  - pulp:action:associate
  finish_time: '2019-08-13T17:34:20Z'
  _ns: task_status
  start_time: '2019-08-13T17:34:20Z'
  traceback: |
    Traceback (most recent call last):
      File "/usr/lib/python2.7/site-packages/celery/app/trace.py", line 367, in trace_task
        R = retval = fun(*args, **kwargs)
      File "/usr/lib/python2.7/site-packages/pulp/server/async/tasks.py", line 529, in __call__
        return super(Task, self).__call__(*args, **kwargs)
      File "/usr/lib/python2.7/site-packages/pulp/server/async/tasks.py", line 107, in __call__
        return super(PulpTask, self).__call__(*args, **kwargs)
      File "/usr/lib/python2.7/site-packages/celery/app/trace.py", line 622, in __protected_call__
        return self.run(*args, **kwargs)
      File "/usr/lib/python2.7/site-packages/pulp/server/managers/repo/unit_association.py", line 238, in associate_from_repo
        raise exceptions.PulpCodedException(error_code=error_codes.PLP0044)
    PulpCodedException: The target importer does not support the types from the source
  spawned_tasks: []
  progress_report: {}
  queue: reserved_resource_worker-1@centos7-devel.jturel.example.com.dq2
  state: error
  worker_name: reserved_resource_worker-1@centos7-devel.jturel.example.com
  result: 
  error:
    code: PLP0044
    data: {}
    description: The target importer does not support the types from the source
    sub_errors: []
  _id:
    "$oid": 5d52f49c83675e9441c8c7f2
  id: 5d52f49c83675e9441c8c7f2
poll_attempts:
  total: 1
  failed: 1
```