### PR TITLE
Fixes #26914 - ignore OS facts if applicable

### DIFF
--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -34,16 +34,10 @@ module Katello
       attr_accessor :facts
 
       DMI_UUID_ALLOWED_DUPS = ['', 'Not Settable', 'Not Present'].freeze
-      DMI_UUID_OVERRIDE_PARAM = 'dmi_uuid_override'.freeze
 
       def host_type
         host_facts = self.host.facts
         host_facts["virt::host_type"] || host_facts["hypervisor::type"]
-      end
-
-      def dmi_system_uuid
-        host_facts = self.host.facts
-        host_facts["dmi::system::uuid"]
       end
 
       def update_from_consumer_attributes(consumer_params)
@@ -170,17 +164,6 @@ module Katello
         self.host.organization
       end
 
-      def dmi_uuid_override
-        HostParameter.find_by(name: DMI_UUID_OVERRIDE_PARAM, host: host)
-      end
-
-      def update_dmi_uuid_override(host_uuid = nil)
-        host_uuid ||= SecureRandom.uuid
-        param = HostParameter.find_or_create_by(name: DMI_UUID_OVERRIDE_PARAM, host: host)
-        param.update_attributes!(value: host_uuid)
-        param
-      end
-
       def update_subscription_status(status_override = nil)
         update_status(::Katello::SubscriptionStatus, status_override: status_override)
 
@@ -199,10 +182,6 @@ module Katello
         host.refresh_global_status!
       end
 
-      def self.override_dmi_uuid?(host_uuid)
-        Setting[:host_dmi_uuid_duplicates].include?(host_uuid)
-      end
-
       def self.new_host_from_facts(facts, org, location)
         name = propose_name_from_facts(facts)
         ::Host::Managed.new(:name => name, :organization => org, :location => location, :managed => false)
@@ -219,14 +198,12 @@ module Katello
       end
 
       def self.ignore_os?(host_os, rhsm_facts)
-
         if host_os.nil?
           return false
         end
 
         name = rhsm_facts['distribution.name']
         version = rhsm_facts['distribution.version']
-        os_name = ::Katello::Candlepin::Consumer.distribution_to_puppet_os(name)
         major, minor = version.split('.')
         return host_os.name == 'CentOS' &&
           host_os.major != nil &&
@@ -289,6 +266,45 @@ module Katello
 
       def remove_subscriptions(pools_with_quantities)
         ForemanTasks.sync_task(Actions::Katello::Host::RemoveSubscriptions, self.host, pools_with_quantities)
+      end
+
+      def self.find_host(facts, organization)
+        host_name = propose_existing_hostname(facts)
+        host_uuid = facts['dmi.system.uuid']
+        uuid_fact_id = RhsmFactName.find_by(name: 'dmi::system::uuid')&.id || -1
+
+        hosts = ::Host.unscoped.distinct.left_outer_joins(:fact_values)
+                .where("#{::Host.table_name}.name = ? OR (#{FactValue.table_name}.fact_name_id = ?
+               AND #{FactValue.table_name}.value = ? AND #{FactValue.table_name}.value NOT IN (?))", host_name, uuid_fact_id, host_uuid, DMI_UUID_ALLOWED_DUPS)
+
+        return if hosts.empty?
+
+        hosts = hosts.where(organization_id: [organization.id, nil])
+        hosts_size = hosts.size
+
+        if hosts_size == 0 # not in the correct org
+          #TODO: http://projects.theforeman.org/issues/11532
+          fail Katello::Errors::RegistrationError, _("Host with name %{host_name} is currently registered to a different org, please migrate host to %{org_name}.") %
+                   {:org_name => organization.name, :host_name => host_name }
+        end
+
+        if hosts_size == 1
+          host = hosts.first
+
+          if host.name == host_name
+            unless host.build
+              found_uuid = host.fact_values.where(fact_name_id: uuid_fact_id).first
+              if found_uuid && found_uuid.value != host_uuid
+                fail Katello::Errors::RegistrationError, _("This host is reporting a DMI UUID that differs from the existing registration.")
+              end
+            end
+
+            return host
+          end
+        end
+
+        hostnames = hosts.pluck(:name).sort.join(', ')
+        fail Katello::Errors::RegistrationError, _("Please unregister or remove hosts which match this host before registering: %{existing}") % {existing: hostnames}
       end
 
       def self.sanitize_name(name)

--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -206,7 +206,7 @@ module Katello
         version = rhsm_facts['distribution.version']
         major, minor = version.split('.')
         return host_os.name == 'CentOS' &&
-          host_os.major != nil &&
+          !host_os.major.nil? &&
           name == 'CentOS' &&
           minor.blank? &&
           host_os.major == major

--- a/app/models/katello/rhsm_fact_parser.rb
+++ b/app/models/katello/rhsm_fact_parser.rb
@@ -53,7 +53,8 @@ module Katello
 
       os_name = ::Katello::Candlepin::Consumer.distribution_to_puppet_os(name)
       major, minor = version.split('.')
-      if os_name && !invalid_centos_os?(os_name, minor)
+
+      unless facts['ignore_os']
         os_attributes = {:major => major, :minor => minor || '', :name => os_name, :release_name => os_release_name(os_name)}
         ::Operatingsystem.find_by(os_attributes) || ::Operatingsystem.create!(os_attributes)
       end
@@ -63,10 +64,6 @@ module Katello
       if os_name.match(::Operatingsystem::FAMILIES['Debian'])
         facts['distribution.id']&.split&.first&.downcase
       end
-    end
-
-    def invalid_centos_os?(name, minor_version)
-      name == 'CentOS' && minor_version.blank?
     end
 
     #required to be defined, even if they return nil

--- a/test/models/host/subscription_facet_test.rb
+++ b/test/models/host/subscription_facet_test.rb
@@ -234,7 +234,6 @@ module Katello
       assert_equal '6', host.operatingsystem.minor
     end
 
-
     def test_update_foreman_facts_with_no_centos_different_major_and_no_minor_version
       host.operatingsystem = ::Operatingsystem.create(
         name: 'CentOS',

--- a/test/models/rhsm_fact_parser_test.rb
+++ b/test/models/rhsm_fact_parser_test.rb
@@ -59,6 +59,7 @@ module Katello
     end
 
     def test_invalid_centos_os
+      @facts['ignore_os'] = true
       @facts['distribution.name'] = 'CentOS'
       @facts['distribution.version'] = '7'
 


### PR DESCRIPTION
This PR addresses a long standing issue concerning distribution facts sent by hosts.

At some point CentOS stopped reporting minor versions and the fact parser considers a missing minor version as a fact to be ignored. This has the side effect of showing a "blank" when a CentOS host is registered with Katello.

If not ignored, then hosts with an updated operating system fact would revert to the minorless operating system, created during the fact parsing. This might lead to hosts "reverting" to the wrong version.

The compromise is to ignore operating system fact updates _if_ the current host has an operating system with a major version and the incoming OS fact is "Centos <major version>". 

Otherwise, it's possible the host has a different OS or perhaps the CentOS major version has changed, say from "7" to "8".

Manual test suggested:
- register a CentOS host with `subscription-manager register`
- observer the operating system with either `hammer` or via the UI, it should report "CentOS 7", where the "7" is whatever major version you are using.
- Create a new operating system with a minor version, say "CentOS 7.6"
- update the host as managed, then assign the new operating system with the minor version
- run the `subscription-manager facts --update`
- the reported OS in Katello should not change to the "Centos 7", where the minor version is missing

