### PR TITLE
Fixes #27614 - Add Sub page loads no resource

### DIFF
--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsTableSchema.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsTableSchema.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { FormGroup, FormControl, ControlLabel, HelpBlock } from 'react-bootstrap';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { urlBuilder } from 'foremanReact/common/urlHelpers';
 import {
   headerFormatter,
   cellFormatter,
@@ -32,7 +31,7 @@ export const columns = (controller, selectionController) => [
       formatters: [
         (value, { rowData }) => (
           <td>
-            <a href={urlBuilder('subscriptions', '', rowData.id)}>
+            <a href={`https://access.redhat.com/management/subscriptions/${rowData.subscription_id}`} rel="noopener noreferrer" target="_blank">
               {rowData.product_name}
             </a>
           </td>


### PR DESCRIPTION
Changes in this PR -
1. Filtered the subscriptions that are displayed when "Add Subscriptions" button is clicked on the Subsciptions page
2. Removed hyperlinks from subscription name because we locally do not have the subscription information that are pulled from the customer portal. We could redirect to the Red Hat Customer Portal.
Any feedback would be appreciated. 

To check this PR:
1. Navigate to "Subscriptions" under "Content"
2. Import a manifest
3. Click on "Add Subscriptions" 
4. The Subscriptions that are displayed should not contain the Subscriptions that are already added. That is this page should only contain the new subscriptions that are loaded from the Red Hat Customer Portal.
5. Subscription names should not be hyperlinked.
