### PR TITLE
Fixes #26975 - Errata/package repository filter

### DIFF
--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -90,6 +90,7 @@ module Katello
     param :description, String, :desc => N_("description of the repository")
     param :available_for, String, :desc => N_("interpret specified object to return only Repositories that can be associated with specified object.  Only 'content_view' & 'content_view_version' are supported."),
           :required => false
+    param :with_content, RepositoryTypeManager.enabled_content_types, :desc => N_("only repositories having at least one of the specified content type ex: rpm , erratum")
     param_group :search, Api::V2::ApiController
     add_scoped_search_description_for(Repository)
     def index
@@ -119,6 +120,7 @@ module Katello
 
     def index_relation
       query = Repository.readable
+      query = query.with_content(params[:with_content]) if params[:with_content]
       query = index_relation_product(query)
       query = query.with_type(params[:content_type]) if params[:content_type]
       query = query.where(:root_id => RootRepository.where(:name => params[:name])) if params[:name]

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -123,6 +123,7 @@ module Katello
     scope :archived, -> { where('environment_id is NULL') }
     scope :in_published_environments, -> { in_content_views(Katello::ContentView.non_default).where.not(:environment_id => nil) }
     scope :order_by_root, ->(attr) { joins(:root).order("#{Katello::RootRepository.table_name}.#{attr}") }
+    scope :with_content, ->(content) { joins(Katello::RepositoryTypeManager.find_content_type(content).model_class.repository_association_class.name.demodulize.underscore.pluralize.to_sym).distinct }
 
     scoped_search :on => :name, :relation => :root, :complete_value => true
     scoped_search :rename => :product, :on => :name, :relation => :product, :complete_value => true

--- a/app/services/katello/repository_type_manager.rb
+++ b/app/services/katello/repository_type_manager.rb
@@ -21,6 +21,13 @@ module Katello
         end
       end
 
+      def enabled_content_types
+        list = repository_types.values.map do |type|
+          type.content_types.map(&:model_class).flatten.map { |ct| ct::CONTENT_TYPE }
+        end
+        list.flatten
+      end
+
       def creatable_by_user?(repository_type)
         return false unless (type = find(repository_type))
         type.allow_creation_by_user

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata.controller.js
@@ -40,7 +40,7 @@ angular.module('Bastion.errata').controller('ErrataController',
 
         $scope.repository = {name: translate('All Repositories'), id: 'all'};
 
-        Repository.queryUnpaged({'organization_id': CurrentOrganization, 'content_type': 'yum'}, function (response) {
+        Repository.queryUnpaged({'organization_id': CurrentOrganization, 'content_type': 'yum', 'with_content': 'erratum'}, function (response) {
             $scope.repositories = [$scope.repository];
             $scope.repositories = $scope.repositories.concat(response.results);
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/packages.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/packages/packages.controller.js
@@ -32,7 +32,7 @@ angular.module('Bastion.packages').controller('PackagesController',
 
         $scope.repository = {name: translate('All Repositories'), id: 'all'};
 
-        Repository.queryUnpaged({'organization_id': CurrentOrganization, 'content_type': 'yum'}, function (response) {
+        Repository.queryUnpaged({'organization_id': CurrentOrganization, 'content_type': 'yum', 'with_content': 'rpm'}, function (response) {
             $scope.repositories = [$scope.repository];
             $scope.repositories = $scope.repositories.concat(response.results);
 

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -229,6 +229,18 @@ module Katello
       assert_response_ids response, ids
     end
 
+    def test_index_with_content
+      ids = Katello::Repository.joins(:repository_rpms).where(
+          :content_view_version_id => @organization.default_content_view.versions.first.id
+      ).pluck(:id).uniq
+
+      response = get :index, params: { :with_content => 'rpm' }
+
+      assert_response :success
+      assert_template 'api/v2/repositories/index'
+      assert_response_ids response, ids
+    end
+
     def test_index_protected
       allowed_perms = [@read_permission]
       denied_perms = [@create_permission, @update_permission, @destroy_permission]


### PR DESCRIPTION
**To Test**

1. Create a yum repository "Repo1" with errata content. (ex: https://fedorapeople.org/groups/katello/fakerepos/zoo)
2. Create a yum repository "Repo2" without errata content. (ex: https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/rpm-with-vendor/)
3. Sync Repo1 and Repo2
4. Go to Content > Errata > 
5. In the repository filter, you should see only Repo1.
Earlier, you would see both Repo1 and Repo2.

You can also create an empty yum repo and verify that it doesn't show up in either Errata or Packages page repository filter.