### PR TITLE
Fixes #26914 - ingore os fact if applicable

### DIFF
--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -212,7 +212,25 @@ module Katello
         return if host.build? || rhsm_facts.nil?
         rhsm_facts[:_type] = RhsmFactName::FACT_TYPE
         rhsm_facts[:_timestamp] = Time.now.to_s
+        if ignore_os?(host.operatingsystem, rhsm_facts)
+          rhsm_facts[:ignore_os] = true
+        end
         host.import_facts(rhsm_facts)
+      end
+
+      def self.ignore_os?(host_os, rhsm_facts)
+        if host_os.nil?
+          return false
+        end
+
+        name = rhsm_facts['distribution.name']
+        version = rhsm_facts['distribution.version']
+        major, minor = version.split('.')
+        return host_os.name == 'CentOS' &&
+          !host_os.major.nil? &&
+          name == 'CentOS' &&
+          minor.blank? &&
+          host_os.major == major
       end
 
       def self.propose_name_from_facts(facts)

--- a/app/models/katello/rhsm_fact_parser.rb
+++ b/app/models/katello/rhsm_fact_parser.rb
@@ -53,7 +53,7 @@ module Katello
 
       os_name = ::Katello::Candlepin::Consumer.distribution_to_puppet_os(name)
       major, minor = version.split('.')
-      if os_name && !invalid_centos_os?(os_name, minor)
+      unless facts['ignore_os']
         os_attributes = {:major => major, :minor => minor || '', :name => os_name, :release_name => os_release_name(os_name)}
         ::Operatingsystem.find_by(os_attributes) || ::Operatingsystem.create!(os_attributes)
       end
@@ -63,10 +63,6 @@ module Katello
       if os_name.match(::Operatingsystem::FAMILIES['Debian'])
         facts['distribution.id']&.split&.first&.downcase
       end
-    end
-
-    def invalid_centos_os?(name, minor_version)
-      name == 'CentOS' && minor_version.blank?
     end
 
     #required to be defined, even if they return nil

--- a/test/models/host/subscription_facet_test.rb
+++ b/test/models/host/subscription_facet_test.rb
@@ -15,6 +15,15 @@ module Katello
                                      :lifecycle_environment => library, :organization => org)
     end
     let(:subscription_facet) { host.subscription_facet }
+    let(:centos_76) do
+      FactoryBot.create(:operatingsystem,
+        :with_os_defaults, :with_associations,
+        name: 'CentOS',
+        major: 7,
+        minor: 6,
+        type: "Redhat",
+        title: "CentOS 7.6")
+    end
   end
 
   class SubscriptionFacetSystemPurposeTest < SubscriptionFacetBase
@@ -215,15 +224,8 @@ module Katello
       assert_includes values.map(&:name), '_timestamp'
     end
 
-    def test_update_foreman_facts_with_centos_no_minor_version
-      host.operatingsystem = ::Operatingsystem.create(
-        name: 'CentOS',
-        major: 7,
-        minor: 6,
-        type: "Redhat",
-        architectures: [architectures(:x86_64)],
-        title: "CentOS 7.6")
-
+    def test_update_facts_with_centos_no_minor_version
+      host.operatingsystem = centos_76
       Katello::Host::SubscriptionFacet.update_facts(
         host,
         'distribution.name' => 'CentOS',
@@ -235,13 +237,7 @@ module Katello
     end
 
     def test_update_foreman_facts_with_no_centos_different_major_and_no_minor_version
-      host.operatingsystem = ::Operatingsystem.create(
-        name: 'CentOS',
-        major: 7,
-        minor: 6,
-        type: "Redhat",
-        architectures: [architectures(:x86_64)],
-        title: "CentOS 7.6")
+      host.operatingsystem = centos_76
 
       Katello::Host::SubscriptionFacet.update_facts(
         host,
@@ -254,21 +250,15 @@ module Katello
     end
 
     def test_update_foreman_facts_with_os_version
-      ::Operatingsystem.create(
+      FactoryBot.create(:operatingsystem,
+        :with_os_defaults, :with_associations,
         name: 'Redhat',
         major: 8,
         minor: 2,
         type: "Redhat",
-        architectures: [architectures(:x86_64)],
         title: "RHEL 8.2")
 
-      host.operatingsystem = ::Operatingsystem.create(
-        name: 'CentOS',
-        major: 7,
-        minor: 6,
-        type: "Redhat",
-        architectures: [architectures(:x86_64)],
-        title: "CentOS 7.6")
+      host.operatingsystem = centos_76
 
       Katello::Host::SubscriptionFacet.update_facts(
         host,

--- a/test/models/host/subscription_facet_test.rb
+++ b/test/models/host/subscription_facet_test.rb
@@ -215,6 +215,71 @@ module Katello
       assert_includes values.map(&:name), '_timestamp'
     end
 
+    def test_update_foreman_facts_with_centos_no_minor_version
+      host.operatingsystem = ::Operatingsystem.create(
+        name: 'CentOS',
+        major: 7,
+        minor: 6,
+        type: "Redhat",
+        architectures: [architectures(:x86_64)],
+        title: "CentOS 7.6")
+
+      Katello::Host::SubscriptionFacet.update_facts(
+        host,
+        'distribution.name' => 'CentOS',
+        'distribution.version' => '7')
+
+      assert_equal 'CentOS', host.operatingsystem.name
+      assert_equal '7', host.operatingsystem.major
+      assert_equal '6', host.operatingsystem.minor
+    end
+
+    def test_update_foreman_facts_with_no_centos_different_major_and_no_minor_version
+      host.operatingsystem = ::Operatingsystem.create(
+        name: 'CentOS',
+        major: 7,
+        minor: 6,
+        type: "Redhat",
+        architectures: [architectures(:x86_64)],
+        title: "CentOS 7.6")
+
+      Katello::Host::SubscriptionFacet.update_facts(
+        host,
+        'distribution.name' => 'CentOS',
+        'distribution.version' => '8')
+
+      assert_equal 'CentOS', host.operatingsystem.name
+      assert_equal '8', host.operatingsystem.major
+      assert_equal "", host.operatingsystem.minor
+    end
+
+    def test_update_foreman_facts_with_os_version
+      ::Operatingsystem.create(
+        name: 'Redhat',
+        major: 8,
+        minor: 2,
+        type: "Redhat",
+        architectures: [architectures(:x86_64)],
+        title: "RHEL 8.2")
+
+      host.operatingsystem = ::Operatingsystem.create(
+        name: 'CentOS',
+        major: 7,
+        minor: 6,
+        type: "Redhat",
+        architectures: [architectures(:x86_64)],
+        title: "CentOS 7.6")
+
+      Katello::Host::SubscriptionFacet.update_facts(
+        host,
+        'distribution.name' => 'Redhat',
+        'distribution.version' => '8.2')
+
+      assert_equal 'RedHat', host.operatingsystem.name
+      assert_equal '8', host.operatingsystem.major
+      assert_equal '2', host.operatingsystem.minor
+    end
+
     def test_subscription_status
       status = Katello::SubscriptionStatus.new(:host => host)
       status.status = Katello::SubscriptionStatus::INVALID

--- a/test/models/rhsm_fact_parser_test.rb
+++ b/test/models/rhsm_fact_parser_test.rb
@@ -59,6 +59,7 @@ module Katello
     end
 
     def test_invalid_centos_os
+      @facts['ignore_os'] = true
       @facts['distribution.name'] = 'CentOS'
       @facts['distribution.version'] = '7'
 


### PR DESCRIPTION
This PR addresses a long standing issue concerning distribution facts sent by hosts.

At some point CentOS stopped reporting minor versions and the fact parser considers a missing minor version as a fact to be ignored. This has the side effect of showing a "blank" when a CentOS host is registered with Katello.

If not ignored, then hosts with an updated operating system fact would revert to the minorless operating system, created during the fact parsing. This might lead to hosts "reverting" to the wrong version.

The compromise is to ignore operating system fact updates if the current host has an operating system with a major version and the incoming OS fact is "Centos ".

Otherwise, it's possible the host has a different OS or perhaps the CentOS major version has changed, say from "7" to "8".

1. Manual test suggested:
- register a CentOS host with subscription-manager register
- observe the operating system with either hammer or via the UI, it should report "CentOS 7", where the "7" is whatever major version you are using.
- Create a new operating system with a minor version, say "CentOS 7.6"
- update the host as managed, then assign the new operating system with the minor version
- run the subscription-manager facts --update
- the reported OS in Katello should not change to the "Centos 7", where the minor version is missing

2. Manual test suggested:
- register a CentOS host with subscription-manager register
- observe the operating system with either hammer or via the UI, it should report "CentOS 7", where the "7" is whatever major version you are using - in other words, it's not blank or missing in the hosts summary
