### PR TITLE
Fixes #27636 - test fixes for background operations

### DIFF
--- a/test/controllers/api/v2/sync_plans_controller_test.rb
+++ b/test/controllers/api/v2/sync_plans_controller_test.rb
@@ -27,6 +27,10 @@ module Katello
       @update_products_permission = :edit_products
     end
 
+    def teardown
+      SyncPlan.destroy_all
+    end
+
     def setup
       setup_controller_defaults_api
       login_user(users(:admin))

--- a/test/lib/resources/candlepin_test.rb
+++ b/test/lib/resources/candlepin_test.rb
@@ -32,6 +32,7 @@ module Katello
         end
 
         def test_global_proxy
+          ForemanTasks.stubs(:async_task) #prevent global proxy setting callback
           proxy = FactoryBot.create(:http_proxy, :url => 'http://foo.com:1000', :username => 'admin', :password => 'password')
           Setting[:content_default_http_proxy] = proxy.name
 

--- a/test/models/sync_plan_test.rb
+++ b/test/models/sync_plan_test.rb
@@ -8,6 +8,10 @@ module Katello
       @plan_to_audit = SyncPlan.new(:name => 'Test Prod Sync', :organization => @organization, :sync_date => Time.now, :interval => 'daily')
     end
 
+    def teardown
+      SyncPlan.destroy_all
+    end
+
     def valid_attributes
       {:name => 'Sync plan', :organization => @organization, :sync_date => Time.now, :interval => 'daily'}
     end


### PR DESCRIPTION
this change attempts to resolve two issues:
1) a sync plan running in the middle of a test
2) the test to update the http proxy global config
   triggers a background task to update repos, which
   is not needed in test