### PR TITLE
Fixes #27598: Refactor Katello to use async/await

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jest": "^21.18.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
+    "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.4.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^23.4.1",

--- a/webpack/.eslintrc
+++ b/webpack/.eslintrc
@@ -11,7 +11,8 @@
   "plugins": [
     "jest",
     "react",
-    "babel"
+    "babel",
+    "promise"
   ],
   "parser": "babel-eslint",
   "rules": {
@@ -23,6 +24,8 @@
     "jsx-a11y/anchor-is-valid": [ "error", {
       "components": [ "Link", "LinkContainer" ],
       "specialLink": [ "to" ]
-    }]
+    }],
+    "promise/prefer-await-to-then": "error",
+    "promise/prefer-await-to-callbacks": "error"
   }
 }

--- a/webpack/components/Search/index.js
+++ b/webpack/components/Search/index.js
@@ -19,7 +19,7 @@ class Search extends Component {
     this.onInputUpdate();
   }
 
-  onInputUpdate(searchTerm = '') {
+  async onInputUpdate(searchTerm = '') {
     const items = this.state.items.filter(({ text }) => stringIncludes(text, searchTerm));
 
     if (items.length !== this.state.items.length) {
@@ -34,12 +34,11 @@ class Search extends Component {
     ];
 
     if (autoCompleteParams[0] !== '') {
-      api.get(...autoCompleteParams).then(({ data }) => {
-        this.setState({
-          items: data.filter(({ error }) => !error).map(({ label }) => ({
-            text: label.trim(),
-          })),
-        });
+      const { data } = await api.get(...autoCompleteParams);
+      this.setState({
+        items: data.filter(({ error }) => !error).map(({ label }) => ({
+          text: label.trim(),
+        })),
       });
     }
   }

--- a/webpack/components/SelectOrg/SelectOrgAction.js
+++ b/webpack/components/SelectOrg/SelectOrgAction.js
@@ -7,35 +7,33 @@ import {
   GET_ORGANIZATIONS_LIST_REQUEST,
 } from '../../redux/consts';
 
-export const getOrganiztionsList = () => (dispatch) => {
+export const getOrganiztionsList = () => async (dispatch) => {
   dispatch({ type: GET_ORGANIZATIONS_LIST_REQUEST });
-  foremanApi
-    .get('/organizations')
-    .then(({ data }) => {
-      dispatch({
-        type: GET_ORGANIZATIONS_LIST_SUCCESS,
-        payload: data,
-      });
-    })
-    .catch((result) => {
-      dispatch({
-        type: GET_ORGANIZATIONS_LIST_FAILURE,
-        payload: result,
-      });
+  try {
+    const { data } = await foremanApi.get('/organizations');
+    return dispatch({
+      type: GET_ORGANIZATIONS_LIST_SUCCESS,
+      payload: data,
     });
+  } catch (error) {
+    return dispatch({
+      type: GET_ORGANIZATIONS_LIST_FAILURE,
+      payload: error,
+    });
+  }
 };
 
-export const changeCurrentOrganization = orgID => dispatch => foremanEndpoint
-  .get(`organizations/${orgID}/select`)
-  .then(() => {
-    dispatch({
+export const changeCurrentOrganization = orgID => async (dispatch) => {
+  try {
+    await foremanEndpoint.get(`organizations/${orgID}/select`);
+    return dispatch({
       type: CHANGE_CURRENT_ORGANIZATION_SUCCESS,
       payload: orgID,
     });
-  })
-  .catch(() => {
-    dispatch({
+  } catch (e) {
+    return dispatch({
       type: CHANGE_CURRENT_ORGANIZATION_FAILURE,
       payload: orgID,
     });
-  });
+  }
+};

--- a/webpack/move_to_foreman/common/helpers.js
+++ b/webpack/move_to_foreman/common/helpers.js
@@ -23,7 +23,7 @@ const getCustomMessage = (actionType, message) => {
   return customMessage;
 };
 
-export const getResponseErrorMsgs = ({ data, actionType }) => {
+export const getResponseErrorMsgs = ({ data, actionType } = {}) => {
   if (data) {
     const customMessage = getCustomMessage(actionType, data.displayMessage);
     const messages =

--- a/webpack/redux/OrganizationProducts/OrganizationProductsActions.js
+++ b/webpack/redux/OrganizationProducts/OrganizationProductsActions.js
@@ -7,18 +7,18 @@ import {
 } from './OrganizationProductsConstants';
 import { apiError } from '../../move_to_foreman/common/helpers';
 
-export const loadOrganizationProducts = (params = {}, orgId = getOrgId()) => (dispatch) => {
+export const loadOrganizationProducts = (params = {}, orgId = getOrgId()) => async (dispatch) => {
   dispatch({ type: ORGANIZATION_PRODUCTS_REQUEST });
 
-  return api
-    .get(`/organizations/${orgId}/products/`, {}, params)
-    .then(({ data }) => {
-      dispatch({
-        type: ORGANIZATION_PRODUCTS_SUCCESS,
-        payload: { orgId, ...data },
-      });
-    })
-    .catch(result => dispatch(apiError(ORGANIZATION_PRODUCTS_FAILURE, result)));
+  try {
+    const { data } = await api.get(`/organizations/${orgId}/products/`, {}, params);
+    return dispatch({
+      type: ORGANIZATION_PRODUCTS_SUCCESS,
+      payload: { orgId, ...data },
+    });
+  } catch (error) {
+    return dispatch(apiError(ORGANIZATION_PRODUCTS_FAILURE, error));
+  }
 };
 
 export default loadOrganizationProducts;

--- a/webpack/redux/actions/RedHatRepositories/__tests__/enabled.test.js
+++ b/webpack/redux/actions/RedHatRepositories/__tests__/enabled.test.js
@@ -1,0 +1,39 @@
+import thunk from 'redux-thunk';
+import Immutable from 'seamless-immutable';
+import configureMockStore from 'redux-mock-store';
+import { disableRepository, loadEnabledRepos } from '../enabled.js';
+import {
+  ENABLED_REPOSITORIES_REQUEST,
+  DISABLE_REPOSITORY_REQUEST,
+} from '../../../consts';
+
+const mockStore = configureMockStore([thunk]);
+const store = mockStore({ e: Immutable({}) });
+
+describe('RedHatRepositories enabled actions', () => {
+  describe('disableRepository', () => {
+    it('dispatches DISABLE_REPOSITORY_REQUEST', async () => {
+      const mockRepo = { // don't need actual values because just checking that the action matches
+        productId: null,
+        contentId: null,
+        basearch: null,
+        releasever: null,
+      };
+      await store.dispatch(disableRepository(mockRepo));
+      expect(store.getActions()).toContainEqual({
+        type: DISABLE_REPOSITORY_REQUEST,
+        repository: mockRepo,
+      });
+    });
+  });
+  describe('loadEnabledRepos', () => {
+    it('dispatches ENABLED_REPOSITORIES_REQUEST', async () => {
+      await store.dispatch(loadEnabledRepos());
+      expect(store.getActions()).toContainEqual({
+        type: ENABLED_REPOSITORIES_REQUEST,
+        silent: false,
+        params: {},
+      });
+    });
+  });
+});

--- a/webpack/scenes/AnsibleCollections/AnsibleCollectionsActions.js
+++ b/webpack/scenes/AnsibleCollections/AnsibleCollectionsActions.js
@@ -8,7 +8,7 @@ import {
 } from './AnsibleCollectionsConstants';
 import { apiError } from '../../move_to_foreman/common/helpers';
 
-export const getAnsibleCollections = (extendedParams = {}) => (dispatch) => {
+export const getAnsibleCollections = (extendedParams = {}) => async (dispatch) => {
   dispatch({ type: ANSIBLE_COLLECTIONS_REQUEST });
 
   const params = {
@@ -16,16 +16,15 @@ export const getAnsibleCollections = (extendedParams = {}) => (dispatch) => {
     ...propsToSnakeCase(extendedParams),
   };
 
-  return api
-    .get('/ansible_collections', {}, params)
-    .then(({ data }) => {
-      dispatch({
-        type: ANSIBLE_COLLECTIONS_SUCCESS,
-        response: data,
-      });
-    })
-    .catch(result => dispatch(apiError(ANSIBLE_COLLECTIONS_ERROR, result)));
+  try {
+    const { data } = await api.get('/ansible_collections', {}, params);
+    return dispatch({
+      type: ANSIBLE_COLLECTIONS_SUCCESS,
+      response: data,
+    });
+  } catch (error) {
+    return dispatch(apiError(ANSIBLE_COLLECTIONS_ERROR, error));
+  }
 };
 
 export default getAnsibleCollections;
-

--- a/webpack/scenes/AnsibleCollections/Details/AnsibleCollectionDetailsActions.js
+++ b/webpack/scenes/AnsibleCollections/Details/AnsibleCollectionDetailsActions.js
@@ -6,20 +6,18 @@ import {
 } from './AnsibleCollectionDetailsConstants';
 import { apiError } from '../../../move_to_foreman/common/helpers';
 
-export const getAnsibleCollectionDetails = ansibleCollectionId => (dispatch) => {
+export const getAnsibleCollectionDetails = ansibleCollectionId => async (dispatch) => {
   dispatch({ type: ANSIBLE_COLLECTION_DETAILS_REQUEST });
 
-  return api
-    .get(`/ansible_collections/${ansibleCollectionId}`)
-    .then(({ data }) => {
-      dispatch({
-        type: ANSIBLE_COLLECTION_DETAILS_SUCCESS,
-        response: data,
-      });
-    })
-    .catch((result) => {
-      dispatch(apiError(ANSIBLE_COLLECTION_DETAILS_ERROR, result));
+  try {
+    const { data } = await api.get(`/ansible_collections/${ansibleCollectionId}`);
+    return dispatch({
+      type: ANSIBLE_COLLECTION_DETAILS_SUCCESS,
+      response: data,
     });
+  } catch (error) {
+    return dispatch(apiError(ANSIBLE_COLLECTION_DETAILS_ERROR, error));
+  }
 };
 
 export default getAnsibleCollectionDetails;

--- a/webpack/scenes/AnsibleCollections/__tests__/AnsibleCollectionsActions.test.js
+++ b/webpack/scenes/AnsibleCollections/__tests__/AnsibleCollectionsActions.test.js
@@ -22,28 +22,27 @@ describe('ansible collections actions', () => {
   describe('getAnsibleCollections', () => {
     it(
       'creates ANSIBLE_COLLECTIONS_REQUEST and then fails with 500 on bad request',
-      () => {
+      async () => {
         mockErrorRequest({
           url: endpoint,
         });
-        return store.dispatch(getAnsibleCollections())
-          .then(() => expect(store.getActions())
-            .toEqual(ansibleCollectionsErrorActions));
+        await store.dispatch(getAnsibleCollections());
+        expect(store.getActions())
+          .toEqual(ansibleCollectionsErrorActions);
       },
     );
 
     it(
       'creates ANSIBLE_COLLECTIONS_REQUEST and then return successfully',
-      () => {
+      async () => {
         mockRequest({
           url: endpoint,
           response: results,
         });
-        return store.dispatch(getAnsibleCollections())
-          .then(() => expect(store.getActions())
-            .toEqual(ansibleCollectionsSuccessActions));
+        await store.dispatch(getAnsibleCollections());
+        expect(store.getActions())
+          .toEqual(ansibleCollectionsSuccessActions);
       },
     );
   });
 });
-

--- a/webpack/scenes/ModuleStreams/Details/ModuleStreamDetailsActions.js
+++ b/webpack/scenes/ModuleStreams/Details/ModuleStreamDetailsActions.js
@@ -6,20 +6,18 @@ import {
 } from './ModuleStreamDetailsConstants';
 import { apiError } from '../../../move_to_foreman/common/helpers.js';
 
-export const loadModuleStreamDetails = moduleStreamId => (dispatch) => {
+export const loadModuleStreamDetails = moduleStreamId => async (dispatch) => {
   dispatch({ type: MODULE_STREAM_DETAILS_REQUEST });
 
-  return api
-    .get(`/module_streams/${moduleStreamId}`)
-    .then(({ data }) => {
-      dispatch({
-        type: MODULE_STREAM_DETAILS_SUCCESS,
-        response: data,
-      });
-    })
-    .catch((result) => {
-      dispatch(apiError(MODULE_STREAM_DETAILS_FAILURE, result));
+  try {
+    const { data } = await api.get(`/module_streams/${moduleStreamId}`);
+    return dispatch({
+      type: MODULE_STREAM_DETAILS_SUCCESS,
+      response: data,
     });
+  } catch (error) {
+    return dispatch(apiError(MODULE_STREAM_DETAILS_FAILURE, error));
+  }
 };
 
 export default loadModuleStreamDetails;

--- a/webpack/scenes/ModuleStreams/ModuleStreamsActions.js
+++ b/webpack/scenes/ModuleStreams/ModuleStreamsActions.js
@@ -8,23 +8,22 @@ import {
 } from './ModuleStreamsConstants';
 import { apiError } from '../../move_to_foreman/common/helpers.js';
 
-export const getModuleStreams = (extendedParams = {}) => (dispatch) => {
+export const getModuleStreams = (extendedParams = {}) => async (dispatch) => {
   dispatch({ type: MODULE_STREAMS_REQUEST });
 
   const params = {
     organization_id: orgId(),
     ...propsToSnakeCase(extendedParams),
   };
-
-  return api
-    .get('/module_streams', {}, params)
-    .then(({ data }) => {
-      dispatch({
-        type: MODULE_STREAMS_SUCCESS,
-        response: data,
-      });
-    })
-    .catch(result => dispatch(apiError(MODULE_STREAMS_FAILURE, result)));
+  try {
+    const { data } = await api.get('/module_streams', {}, params);
+    return dispatch({
+      type: MODULE_STREAMS_SUCCESS,
+      response: data,
+    });
+  } catch (error) {
+    return dispatch(apiError(MODULE_STREAMS_FAILURE, error));
+  }
 };
 
 export default getModuleStreams;

--- a/webpack/scenes/ModuleStreams/__tests__/ModuleStreamsActions.test.js
+++ b/webpack/scenes/ModuleStreams/__tests__/ModuleStreamsActions.test.js
@@ -22,28 +22,27 @@ describe('module stream actions', () => {
   describe('getModuleStreams', () => {
     it(
       'creates MODULE_STREAMS_REQUEST and then fails with 500 on bad request',
-      () => {
+      async () => {
         mockErrorRequest({
           url: endpoint,
         });
-        return store.dispatch(getModuleStreams())
-          .then(() => expect(store.getActions())
-            .toEqual(moduleStreamsFailureActions));
+        await store.dispatch(getModuleStreams());
+        expect(store.getActions())
+          .toEqual(moduleStreamsFailureActions);
       },
     );
 
     it(
       'creates MODULE_STREAMS_REQUEST and then return successfully',
-      () => {
+      async () => {
         mockRequest({
           url: endpoint,
           response: results,
         });
-        return store.dispatch(getModuleStreams())
-          .then(() => expect(store.getActions())
-            .toEqual(moduleStreamsSuccessActions));
+        await store.dispatch(getModuleStreams());
+        expect(store.getActions())
+          .toEqual(moduleStreamsSuccessActions);
       },
     );
   });
 });
-

--- a/webpack/scenes/Organizations/OrganizationActions.js
+++ b/webpack/scenes/Organizations/OrganizationActions.js
@@ -11,54 +11,49 @@ import {
   SAVE_ORGANIZATION_FAILURE,
 } from './OrganizationConstants';
 
-export const loadOrganization = (extendedParams = {}) => (dispatch) => {
+export const loadOrganization = (extendedParams = {}) => async (dispatch) => {
   dispatch({ type: GET_ORGANIZATION_REQUEST });
 
   const params = {
     ...propsToSnakeCase(extendedParams),
   };
 
-  return api
-    .get(`/organizations/${orgId()}`, {}, params)
-    .then(({ data }) => {
-      dispatch({
-        type: GET_ORGANIZATION_SUCCESS,
-        response: data,
-      });
-    })
-    .catch((result) => {
-      dispatch({
-        type: GET_ORGANIZATION_FAILURE,
-        result,
-      });
+  try {
+    const { data } = await api.get(`/organizations/${orgId()}`, {}, params);
+    return dispatch({
+      type: GET_ORGANIZATION_SUCCESS,
+      response: data,
     });
+  } catch (error) {
+    return dispatch({
+      type: GET_ORGANIZATION_FAILURE,
+      error,
+    });
+  }
 };
 
-export const saveOrganization = (extendedParams = {}) => (dispatch) => {
+export const saveOrganization = (extendedParams = {}) => async (dispatch) => {
   dispatch({ type: SAVE_ORGANIZATION_REQUEST });
 
   const params = {
     ...{ id: orgId() },
     ...propsToSnakeCase(extendedParams),
   };
-
-  return api
-    .put(`/organizations/${orgId()}`, params)
-    .then(({ data }) => {
-      dispatch({
-        type: SAVE_ORGANIZATION_SUCCESS,
-        response: data,
-      });
-
-      // TODO: Necessary because of https://projects.theforeman.org/issues/26420
-      dispatch(loadOrganization());
-    })
-    .catch((result) => {
-      dispatch({
-        type: SAVE_ORGANIZATION_FAILURE,
-        result,
-      });
+  try {
+    const { data } = await api.put(`/organizations/${orgId()}`, params);
+    const result = dispatch({
+      type: SAVE_ORGANIZATION_SUCCESS,
+      response: data,
     });
+    // TODO: Necessary because of https://projects.theforeman.org/issues/26420
+    dispatch(loadOrganization());
+    return result;
+  } catch (error) {
+    return dispatch({
+      type: SAVE_ORGANIZATION_FAILURE,
+      result: error,
+    });
+  }
 };
 
 export default loadOrganization;

--- a/webpack/scenes/Organizations/__tests__/OrganizationActions.test.js
+++ b/webpack/scenes/Organizations/__tests__/OrganizationActions.test.js
@@ -23,37 +23,37 @@ beforeEach(() => {
 });
 
 describe('organization actions', () => {
-  it('creates GET_ORGANIZATION_REQUEST and then fails with 422', () => {
+  it('creates GET_ORGANIZATION_REQUEST and then fails with 422', async () => {
     mockRequest({
       url: '/katello/api/v2/organizations/1',
       status: 422,
     });
-    return store.dispatch(loadOrganization())
-      .then(() => expect(store.getActions()).toEqual(getFailureActions));
+    await store.dispatch(loadOrganization());
+    expect(store.getActions()).toEqual(getFailureActions);
   });
 
-  it('creates GET_ORGANIZATION_REQUEST and ends with success', () => {
+  it('creates GET_ORGANIZATION_REQUEST and ends with success', async () => {
     mockRequest({
       url: '/katello/api/v2/organizations/1',
       response: requestSuccessResponse,
     });
-    return store.dispatch(loadOrganization())
-      .then(() => expect(store.getActions()).toEqual(getSuccessActions));
+    await store.dispatch(loadOrganization());
+    expect(store.getActions()).toEqual(getSuccessActions);
   });
 
-  it('creates SAVE_ORGANIZATION_REQUEST and then fails with 422', () => {
+  it('creates SAVE_ORGANIZATION_REQUEST and then fails with 422', async () => {
     const mock = new MockAdapter(axios);
     mock.onPut('/katello/api/v2/organizations/1').reply(422);
 
-    return store.dispatch(saveOrganization())
-      .then(() => expect(store.getActions()).toEqual(saveFailureActions));
+    await store.dispatch(saveOrganization());
+    expect(store.getActions()).toEqual(saveFailureActions);
   });
 
-  it('creates SAVE_ORGANIZATION_REQUEST and ends with success', () => {
+  it('creates SAVE_ORGANIZATION_REQUEST and ends with success', async () => {
     const mock = new MockAdapter(axios);
     mock.onPut('/katello/api/v2/organizations/1').reply(200, requestSuccessResponse);
 
-    return store.dispatch(saveOrganization())
-      .then(() => expect(store.getActions()).toEqual(saveSuccessActions));
+    await store.dispatch(saveOrganization());
+    expect(store.getActions()).toEqual(saveSuccessActions);
   });
 });

--- a/webpack/scenes/Organizations/__tests__/organizations.fixtures.js
+++ b/webpack/scenes/Organizations/__tests__/organizations.fixtures.js
@@ -73,7 +73,7 @@ export const getFailureActions = [
     type: 'GET_ORGANIZATION_REQUEST',
   },
   {
-    result: new Error('Request failed with status code 422'),
+    error: new Error('Request failed with status code 422'),
     type: 'GET_ORGANIZATION_FAILURE',
   },
 ];

--- a/webpack/scenes/Products/ProductActions.js
+++ b/webpack/scenes/Products/ProductActions.js
@@ -7,18 +7,18 @@ import {
 } from './ProductConstants';
 import { apiError } from '../../move_to_foreman/common/helpers.js';
 
-export const loadProducts = (params = {}) => (dispatch) => {
+export const loadProducts = (params = {}) => async (dispatch) => {
   dispatch({ type: PRODUCTS_REQUEST });
 
-  return api
-    .get(`/organizations/${orgId()}/products/`, {}, params)
-    .then(({ data }) => {
-      dispatch({
-        type: PRODUCTS_SUCCESS,
-        response: data,
-      });
-    })
-    .catch(result => dispatch(apiError(PRODUCTS_FAILURE, result)));
+  try {
+    const { data } = await api.get(`/organizations/${orgId()}/products/`, {}, params);
+    return dispatch({
+      type: PRODUCTS_SUCCESS,
+      response: data,
+    });
+  } catch (error) {
+    return dispatch(apiError(PRODUCTS_FAILURE, error));
+  }
 };
 
 export default loadProducts;

--- a/webpack/scenes/Products/__tests__/ProductActions.test.js
+++ b/webpack/scenes/Products/__tests__/ProductActions.test.js
@@ -19,22 +19,22 @@ beforeEach(() => {
 
 describe('product actions', () => {
   describe('loadProducts', () => {
-    it('handles failed PRODUCTS_REQUEST', () => {
+    it('handles failed PRODUCTS_REQUEST', async () => {
       mockErrorRequest({
         url: '/katello/api/v2/organizations/1/products/',
         status: 422,
       });
-      return store.dispatch(loadProducts())
-        .then(() => expect(store.getActions()).toEqual(failureActions));
+      await store.dispatch(loadProducts());
+      expect(store.getActions()).toEqual(failureActions);
     });
 
-    it('handles successful PRODUCTS_REQUEST', () => {
+    it('handles successful PRODUCTS_REQUEST', async () => {
       mockRequest({
         url: '/katello/api/v2/organizations/1/products/',
         response: requestSuccessResponse,
       });
-      return store.dispatch(loadProducts())
-        .then(() => expect(store.getActions()).toEqual(successActions));
+      await store.dispatch(loadProducts());
+      expect(store.getActions()).toEqual(successActions);
     });
   });
 });

--- a/webpack/scenes/RedHatRepositories/components/EnabledRepository/EnabledRepository.js
+++ b/webpack/scenes/RedHatRepositories/components/EnabledRepository/EnabledRepository.js
@@ -10,55 +10,54 @@ import EnabledRepositoryContent from './EnabledRepositoryContent';
 class EnabledRepository extends Component {
   constructor(props) {
     super(props);
-
-    this.repoForAction = () => {
-      const {
-        productId, contentId, arch, releasever, name, type,
-      } = this.props;
-
-      return {
-        contentId,
-        productId,
-        name,
-        type,
-        arch,
-        releasever,
-      };
-    };
-
-    this.setDisabled = () => {
-      this.props.setRepositoryDisabled(this.repoForAction());
-    };
-
-    this.reload = () => (
-      this.props.loadEnabledRepos({
-        ...this.props.pagination,
-        search: this.props.search,
-      }, true)
-    );
-
-    this.notifyDisabled = () => {
-      window.tfm.toastNotifications.notify({
-        message: sprintf(__("Repository '%(repoName)s' has been disabled."), { repoName: this.props.name }),
-        type: 'success',
-      });
-    };
-
-    this.reloadAndNotify = (result) => {
-      if (result.success) {
-        this.reload()
-          .then(this.setDisabled)
-          .then(this.notifyDisabled);
-      }
-    };
-
-    this.disableRepository = () => {
-      this.props.disableRepository(this.repoForAction())
-        .then(this.reloadAndNotify);
-    };
-
     this.disableTooltipId = `disable-${props.id}`;
   }
+
+  setDisabled = () => {
+    this.props.setRepositoryDisabled(this.repoForAction());
+  };
+
+  repoForAction = () => {
+    const {
+      productId, contentId, arch, releasever, name, type,
+    } = this.props;
+
+    return {
+      contentId,
+      productId,
+      name,
+      type,
+      arch,
+      releasever,
+    };
+  };
+
+  reload = () => (
+    this.props.loadEnabledRepos({
+      ...this.props.pagination,
+      search: this.props.search,
+    }, true)
+  );
+
+  notifyDisabled = () => {
+    window.tfm.toastNotifications.notify({
+      message: sprintf(__("Repository '%(repoName)s' has been disabled."), { repoName: this.props.name }),
+      type: 'success',
+    });
+  };
+
+  reloadAndNotify = async (result) => {
+    if (result && result.success) {
+      await this.reload();
+      await this.setDisabled();
+      await this.notifyDisabled();
+    }
+  };
+
+  disableRepository = async () => {
+    await this.props.disableRepository(this.repoForAction());
+    this.reloadAndNotify();
+  };
 
   render() {
     const {

--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepository/RepositorySetRepository.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepository/RepositorySetRepository.js
@@ -10,56 +10,55 @@ import '../../index.scss';
 class RepositorySetRepository extends Component {
   constructor(props) {
     super(props);
-
     this.state = {};
-
-    this.repoForAction = () => {
-      const {
-        productId, contentId, arch, displayArch, releasever, label,
-      } = this.props;
-
-      const derivedArch = arch || displayArch;
-      return {
-        arch: derivedArch,
-        productId,
-        contentId,
-        releasever,
-        label,
-      };
-    };
-
-    this.setEnabled = () => {
-      this.props.setRepositoryEnabled(this.repoForAction());
-    };
-
-    this.reloadEnabledRepos = () => (
-      this.props.loadEnabledRepos({
-        ...this.props.enabledPagination,
-        search: this.props.enabledSearch,
-      }, true)
-    );
-
-    this.notifyEnabled = (data) => {
-      const repoName = data.output.repository.name;
-      window.tfm.toastNotifications.notify({
-        message: sprintf(__("Repository '%(repoName)s' has been enabled."), { repoName }),
-        type: 'success',
-      });
-    };
-
-    this.reloadAndNotify = (result) => {
-      if (result.success) {
-        this.reloadEnabledRepos()
-          .then(this.setEnabled)
-          .then(() => this.notifyEnabled(result.data));
-      }
-    };
-
-    this.enableRepository = () => {
-      this.props.enableRepository(this.repoForAction())
-        .then(this.reloadAndNotify);
-    };
   }
+
+  setEnabled = () => {
+    this.props.setRepositoryEnabled(this.repoForAction());
+  };
+
+  repoForAction = () => {
+    const {
+      productId, contentId, arch, displayArch, releasever, label,
+    } = this.props;
+
+    const derivedArch = arch || displayArch;
+    return {
+      arch: derivedArch,
+      productId,
+      contentId,
+      releasever,
+      label,
+    };
+  };
+
+  reloadEnabledRepos = () => (
+    this.props.loadEnabledRepos({
+      ...this.props.enabledPagination,
+      search: this.props.enabledSearch,
+    }, true)
+  );
+
+  notifyEnabled = (data) => {
+    const repoName = data.output.repository.name;
+    window.tfm.toastNotifications.notify({
+      message: sprintf(__("Repository '%(repoName)s' has been enabled."), { repoName }),
+      type: 'success',
+    });
+  };
+
+  reloadAndNotify = async (result) => {
+    if (result.success) {
+      await this.reloadEnabledRepos();
+      await this.setEnabled();
+      await this.notifyEnabled(result.data);
+    }
+  };
+
+  enableRepository = async () => {
+    await this.props.enableRepository(this.repoForAction());
+    this.reloadAndNotify();
+  };
 
   render() {
     const { displayArch, releasever, type } = this.props;

--- a/webpack/scenes/RedHatRepositories/index.js
+++ b/webpack/scenes/RedHatRepositories/index.js
@@ -100,7 +100,7 @@ RedHatRepositoriesPage.propTypes = {
     search: PropTypes.shape({}),
   }).isRequired,
   repositorySets: PropTypes.shape({
-    recommended: PropTypes.array,
+    recommended: PropTypes.bool,
     loading: PropTypes.bool,
     search: PropTypes.shape({}),
   }).isRequired,

--- a/webpack/scenes/Settings/Tables/TableActions.js
+++ b/webpack/scenes/Settings/Tables/TableActions.js
@@ -14,60 +14,59 @@ import {
 
 const getResponseError = ({ data }) => data && (data.displayMessage || data.error);
 
-export const loadTables = () => (dispatch) => {
+export const loadTables = () => async (dispatch) => {
   dispatch({ type: TABLES_REQUEST, params: {} });
 
-  return foremanApi
-    .get(`/users/${userId()}/table_preferences`, {})
-    .then(({ data }) => {
-      dispatch({
-        type: TABLES_SUCCESS,
-        payload: data,
-      });
-    })
-    .catch((result) => {
-      const { response } = result;
-      dispatch({
-        type: TABLES_FAILURE,
-        error: getResponseError(response),
-      });
+  try {
+    const { data } = await foremanApi.get(`/users/${userId()}/table_preferences`, {});
+    return dispatch({
+      type: TABLES_SUCCESS,
+      payload: data,
     });
+  } catch (error) {
+    const { response } = error;
+    return dispatch({
+      type: TABLES_FAILURE,
+      error: getResponseError(response),
+    });
+  }
 };
 
-export const createColumns = (params = {}) => (dispatch) => {
+export const createColumns = (params = {}) => async (dispatch) => {
   dispatch({ type: CREATE_TABLE, params });
 
-  return foremanApi
-    .post(`/users/${userId()}/table_preferences`, params)
-    .then(({ data }) => {
-      dispatch({
-        type: CREATE_TABLE_SUCCESS,
-        payload: [data],
-      });
-    })
-    .catch((result) => {
-      dispatch({
-        type: CREATE_TABLE_FAILURE,
-        error: getResponseError(result.response),
-      });
+  try {
+    const { data } = await foremanApi.post(`/users/${userId()}/table_preferences`, params);
+    return dispatch({
+      type: CREATE_TABLE_SUCCESS,
+      payload: [data],
     });
+  } catch (error) {
+    const { response } = error;
+    return dispatch({
+      type: CREATE_TABLE_FAILURE,
+      error: getResponseError(response),
+    });
+  }
 };
-export const updateColumns = (params = {}) => (dispatch) => {
+
+export const updateColumns = (params = {}) => async (dispatch) => {
   dispatch({ type: UPDATE_TABLE, params });
   const updateParams = { columns: params.columns };
-  return foremanApi
-    .put(`/users/${userId()}/table_preferences/${params.name}`, updateParams)
-    .then(({ data }) => {
-      dispatch({
-        type: UPDATE_TABLE_SUCCESS,
-        payload: [data],
-      });
-    })
-    .catch((result) => {
-      dispatch({
-        type: UPDATE_TABLE_FAILURE,
-        error: getResponseError(result.response),
-      });
+
+  try {
+    const { data } = await foremanApi
+      .put(`/users/${userId()}/table_preferences/${params.name}`, updateParams);
+    return dispatch({
+      type: UPDATE_TABLE_SUCCESS,
+      payload: [data],
     });
+  } catch (error) {
+    const { response } = error;
+    return dispatch({
+      type: UPDATE_TABLE_FAILURE,
+      error: getResponseError(response),
+    });
+  }
 };
 export default loadTables;

--- a/webpack/scenes/Settings/Tables/__tests__/TableActions.test.js
+++ b/webpack/scenes/Settings/Tables/__tests__/TableActions.test.js
@@ -32,53 +32,53 @@ beforeEach(() => {
 });
 
 describe('table actions', () => {
-  it('creates TABLES_REQUEST with success', () => {
+  it('creates TABLES_REQUEST with success', async () => {
     mockRequest({
       url: '/api/v2/users/1/table_preferences',
       status: 200,
       response: requestSuccessResponse,
     });
-    return store.dispatch(loadTables())
-      .then(() => expect(store.getActions()).toEqual(getSuccessActions));
+    await store.dispatch(loadTables());
+    expect(store.getActions()).toEqual(getSuccessActions);
   });
-  it('creates TABLES_REQUEST with failure', () => {
+  it('creates TABLES_REQUEST with failure', async () => {
     mockRequest({
       url: '/api/v2/users/1/table_preferences',
       status: 403,
       response: accessDenied,
     });
-    return store.dispatch(loadTables())
-      .then(() => expect(store.getActions()).toEqual(getFailureActions));
+    await store.dispatch(loadTables());
+    expect(store.getActions()).toEqual(getFailureActions);
   });
 
-  it('creates SAVE_CREATE_TABLE and ends with success', () => {
+  it('creates SAVE_CREATE_TABLE and ends with success', async () => {
     const mock = new MockAdapter(axios);
     mock.onPost('/api/v2/users/1/table_preferences').reply(200, tableRecord);
 
-    return store.dispatch(createColumns())
-      .then(() => expect(store.getActions()).toEqual(createSuccessActions));
+    await store.dispatch(createColumns());
+    expect(store.getActions()).toEqual(createSuccessActions);
   });
 
-  it('creates CREATE_TABLE with failure', () => {
+  it('creates CREATE_TABLE with failure', async () => {
     const mock = new MockAdapter(axios);
     mock.onPost('/api/v2/users/1/table_preferences').reply(403, accessDenied);
 
-    return store.dispatch(createColumns({ name: 'Test', columns: [] }))
-      .then(() => expect(store.getActions()).toEqual(createFailureActions));
+    await store.dispatch(createColumns({ name: 'Test', columns: [] }));
+    expect(store.getActions()).toEqual(createFailureActions);
   });
 
-  it('creates UPDATE_TABLE and ends with success', () => {
+  it('creates UPDATE_TABLE and ends with success', async () => {
     const mock = new MockAdapter(axios);
     mock.onPut(`/api/v2/users/1/table_preferences/${testTableName}`).reply(200, tableRecord);
 
-    return store.dispatch(updateColumns(tableRecord))
-      .then(() => expect(store.getActions()).toEqual(updateSuccessActions));
+    await store.dispatch(updateColumns(tableRecord));
+    expect(store.getActions()).toEqual(updateSuccessActions);
   });
-  it('creates UPDATE_TABLE with failure', () => {
+  it('creates UPDATE_TABLE with failure', async () => {
     const mock = new MockAdapter(axios);
     mock.onPut(`/api/v2/users/1/table_preferences/${testTableName}`).reply(403, accessDenied);
 
-    return store.dispatch(updateColumns(tableRecord))
-      .then(() => expect(store.getActions()).toEqual(updateFailureActions));
+    await store.dispatch(updateColumns(tableRecord));
+    expect(store.getActions()).toEqual(updateFailureActions);
   });
 });

--- a/webpack/scenes/Subscriptions/Details/SubscriptionDetailActions.js
+++ b/webpack/scenes/Subscriptions/Details/SubscriptionDetailActions.js
@@ -6,18 +6,18 @@ import {
 } from './SubscriptionDetailConstants';
 import { apiError } from '../../../move_to_foreman/common/helpers.js';
 
-export const loadSubscriptionDetails = subscriptionId => (dispatch) => {
+export const loadSubscriptionDetails = subscriptionId => async (dispatch) => {
   dispatch({ type: SUBSCRIPTION_DETAILS_REQUEST });
 
-  return api
-    .get(`/organizations/${orgId()}/subscriptions/${subscriptionId}`)
-    .then(({ data }) => {
-      dispatch({
-        type: SUBSCRIPTION_DETAILS_SUCCESS,
-        response: data,
-      });
-    })
-    .catch(result => dispatch(apiError(SUBSCRIPTION_DETAILS_FAILURE, result)));
+  try {
+    const { data } = await api.get(`/organizations/${orgId()}/subscriptions/${subscriptionId}`);
+    return dispatch({
+      type: SUBSCRIPTION_DETAILS_SUCCESS,
+      response: data,
+    });
+  } catch (error) {
+    return dispatch(apiError(SUBSCRIPTION_DETAILS_FAILURE, error));
+  }
 };
 
 export default loadSubscriptionDetails;

--- a/webpack/scenes/Subscriptions/Details/__tests__/SubscriptionDetailActions.test.js
+++ b/webpack/scenes/Subscriptions/Details/__tests__/SubscriptionDetailActions.test.js
@@ -22,25 +22,25 @@ describe('subscription detail actions', () => {
   describe('loadSubscriptionDetails', () => {
     it(
       'creates SUBSCRIPTION_DETAILS_REQUEST and then fails with 500',
-      () => {
+      async () => {
         mockErrorRequest({
           url: endpoint,
         });
-        return store.dispatch(loadSubscriptionDetails(1))
-          .then(() => expect(store.getActions())
-            .toEqual(loadSubscriptionsDetailsFailureActions));
+        await store.dispatch(loadSubscriptionDetails(1));
+        expect(store.getActions())
+          .toEqual(loadSubscriptionsDetailsFailureActions);
       },
     );
     it(
       'creates SUBSCRIPTION_DETAILS_SUCCESS and ends with success',
-      () => {
+      async () => {
         mockRequest({
           url: endpoint,
           response: subDetails,
         });
-        return store.dispatch(loadSubscriptionDetails(1))
-          .then(() => expect(store.getActions())
-            .toEqual(loadSubscriptionsDetailsSuccessActions));
+        await store.dispatch(loadSubscriptionDetails(1));
+        expect(store.getActions())
+          .toEqual(loadSubscriptionsDetailsSuccessActions);
       },
     );
   });

--- a/webpack/scenes/Subscriptions/Manifest/ManifestActions.js
+++ b/webpack/scenes/Subscriptions/Manifest/ManifestActions.js
@@ -18,7 +18,7 @@ import {
   MANIFEST_HISTORY_FAILURE,
 } from './ManifestConstants';
 
-export const uploadManifest = file => (dispatch) => {
+export const uploadManifest = file => async (dispatch) => {
   dispatch({ type: UPLOAD_MANIFEST_REQUEST });
 
   const formData = new FormData();
@@ -28,69 +28,69 @@ export const uploadManifest = file => (dispatch) => {
     'Content-Type': 'multipart/form-data',
   };
 
-  return api
-    .post(`/organizations/${orgId()}/subscriptions/upload`, formData, config)
-    .then(({ data }) => {
-      dispatch({
-        type: UPLOAD_MANIFEST_SUCCESS,
-        response: data,
-      });
-    })
-    .catch(result => dispatch(apiError(UPLOAD_MANIFEST_FAILURE, result)));
+  try {
+    const { data } = await api.post(`/organizations/${orgId()}/subscriptions/upload`, formData, config);
+    return dispatch({
+      type: UPLOAD_MANIFEST_SUCCESS,
+      response: data,
+    });
+  } catch (error) {
+    return dispatch(apiError(UPLOAD_MANIFEST_FAILURE, error));
+  }
 };
 
-export const refreshManifest = (extendedParams = {}) => (dispatch) => {
+export const refreshManifest = (extendedParams = {}) => async (dispatch) => {
   dispatch({ type: REFRESH_MANIFEST_REQUEST });
 
   const params = {
     ...propsToSnakeCase(extendedParams),
   };
 
-  return api
-    .put(`/organizations/${orgId()}/subscriptions/refresh_manifest`, {}, params)
-    .then(({ data }) => {
-      dispatch({
-        type: REFRESH_MANIFEST_SUCCESS,
-        response: data,
-      });
-    })
-    .catch(result => dispatch(apiError(REFRESH_MANIFEST_FAILURE, result)));
+  try {
+    const { data } = await api.put(`/organizations/${orgId()}/subscriptions/refresh_manifest`, {}, params);
+    return dispatch({
+      type: REFRESH_MANIFEST_SUCCESS,
+      response: data,
+    });
+  } catch (error) {
+    return dispatch(apiError(REFRESH_MANIFEST_FAILURE, error));
+  }
 };
 
-export const deleteManifest = (extendedParams = {}) => (dispatch) => {
+export const deleteManifest = (extendedParams = {}) => async (dispatch) => {
   dispatch({ type: DELETE_MANIFEST_REQUEST });
 
   const params = {
     ...propsToSnakeCase(extendedParams),
   };
 
-  return api
-    .post(`/organizations/${orgId()}/subscriptions/delete_manifest`, {}, params)
-    .then(({ data }) => {
-      dispatch({
-        type: DELETE_MANIFEST_SUCCESS,
-        response: data,
-      });
-    })
-    .catch(result => dispatch(apiError(DELETE_MANIFEST_FAILURE, result)));
+  try {
+    const { data } = await api.post(`/organizations/${orgId()}/subscriptions/delete_manifest`, {}, params);
+    return dispatch({
+      type: DELETE_MANIFEST_SUCCESS,
+      response: data,
+    });
+  } catch (error) {
+    return dispatch(apiError(DELETE_MANIFEST_FAILURE, error));
+  }
 };
 
-export const loadManifestHistory = (extendedParams = {}) => (dispatch) => {
+export const loadManifestHistory = (extendedParams = {}) => async (dispatch) => {
   dispatch({ type: MANIFEST_HISTORY_REQUEST });
 
   const params = {
     ...propsToSnakeCase(extendedParams),
   };
 
-  return api
-    .get(`/organizations/${orgId()}/subscriptions/manifest_history`, {}, params)
-    .then(({ data }) => {
-      dispatch({
-        type: MANIFEST_HISTORY_SUCCESS,
-        response: data,
-      });
-    })
-    .catch(result => dispatch(apiError(MANIFEST_HISTORY_FAILURE, result)));
+  try {
+    const { data } = await api.get(`/organizations/${orgId()}/subscriptions/manifest_history`, {}, params);
+    return dispatch({
+      type: MANIFEST_HISTORY_SUCCESS,
+      response: data,
+    });
+  } catch (error) {
+    return dispatch(apiError(MANIFEST_HISTORY_FAILURE, error));
+  }
 };
 
 export default loadManifestHistory;

--- a/webpack/scenes/Subscriptions/Manifest/__tests__/ManifestActions.test.js
+++ b/webpack/scenes/Subscriptions/Manifest/__tests__/ManifestActions.test.js
@@ -39,87 +39,87 @@ describe('manifest actions', () => {
   describe('creates GET_MANIFEST_HISTORY_REQUEST', () => {
     const url = '/katello/api/v2/organizations/1/subscriptions/manifest_history';
 
-    it('and then fails with 422', () => {
+    it('and then fails with 422', async () => {
       mockErrorRequest({
         url,
         status: 422,
       });
 
-      return store.dispatch(loadManifestHistory())
-        .then(() => expect(store.getActions()).toEqual(manifestHistoryFailureActions));
+      await store.dispatch(loadManifestHistory());
+      expect(store.getActions()).toEqual(manifestHistoryFailureActions);
     });
 
-    it('and ends with success', () => {
+    it('and ends with success', async () => {
       mockApi.onGet(url).reply(200, manifestHistorySuccessResponse);
 
-      return store.dispatch(loadManifestHistory())
-        .then(() => expect(store.getActions()).toEqual(manifestHistorySuccessActions));
+      await store.dispatch(loadManifestHistory());
+      expect(store.getActions()).toEqual(manifestHistorySuccessActions);
     });
   });
 
   describe('creates UPLOAD_MANIFEST_REQUEST', () => {
     const url = '/katello/api/v2/organizations/1/subscriptions/upload';
 
-    it('and then fails with 422', () => {
+    it('and then fails with 422', async () => {
       mockErrorRequest({
         url,
         status: 422,
         method: 'POST',
       });
 
-      return store.dispatch(uploadManifest())
-        .then(() => expect(store.getActions()).toEqual(uploadManifestFailureActions));
+      await store.dispatch(uploadManifest());
+      expect(store.getActions()).toEqual(uploadManifestFailureActions);
     });
 
-    it('and ends with success', () => {
+    it('and ends with success', async () => {
       mockApi.onPost(url).reply(200, taskSuccessResponse);
 
-      return store.dispatch(uploadManifest())
-        .then(() => expect(store.getActions()).toEqual(uploadManifestSuccessActions));
+      await store.dispatch(uploadManifest());
+      expect(store.getActions()).toEqual(uploadManifestSuccessActions);
     });
   });
 
   describe('creates REFRESH_MANIFEST_REQUEST', () => {
     const url = '/katello/api/v2/organizations/1/subscriptions/refresh_manifest';
 
-    it('and then fails with 422', () => {
+    it('and then fails with 422', async () => {
       mockErrorRequest({
         url,
         status: 422,
         method: 'PUT',
       });
 
-      return store.dispatch(refreshManifest())
-        .then(() => expect(store.getActions()).toEqual(refreshManifestFailureActions));
+      await store.dispatch(refreshManifest());
+      expect(store.getActions()).toEqual(refreshManifestFailureActions);
     });
 
-    it('and ends with success', () => {
+    it('and ends with success', async () => {
       mockApi.onPut(url).reply(200, taskSuccessResponse);
 
-      return store.dispatch(refreshManifest())
-        .then(() => expect(store.getActions()).toEqual(refreshManifestSuccessActions));
+      await store.dispatch(refreshManifest());
+      expect(store.getActions()).toEqual(refreshManifestSuccessActions);
     });
   });
 
   describe('creates DELETE_MANIFEST_REQUEST', () => {
     const url = '/katello/api/v2/organizations/1/subscriptions/delete_manifest';
 
-    it('and then fails with 422', () => {
+    it('and then fails with 422', async () => {
       mockErrorRequest({
         url,
         status: 422,
         method: 'POST',
       });
 
-      return store.dispatch(deleteManifest())
-        .then(() => expect(store.getActions()).toEqual(deleteManifestFailureActions));
+      await store.dispatch(deleteManifest());
+      expect(store.getActions()).toEqual(deleteManifestFailureActions);
     });
 
-    it('and ends with success', () => {
+    it('and ends with success', async () => {
       mockApi.onPost(url).reply(200, taskSuccessResponse);
 
-      return store.dispatch(deleteManifest())
-        .then(() => expect(store.getActions()).toEqual(deleteManifestSuccessActions));
+      await store.dispatch(deleteManifest());
+      expect(store.getActions()).toEqual(deleteManifestSuccessActions);
     });
   });
 });

--- a/webpack/scenes/Subscriptions/SubscriptionActions.js
+++ b/webpack/scenes/Subscriptions/SubscriptionActions.js
@@ -41,57 +41,60 @@ export const createSubscriptionParams = (extendedParams = {}) => ({
   ...propsToSnakeCase(extendedParams),
 });
 
-export const loadAvailableQuantities = (extendedParams = {}) => (dispatch) => {
+export const loadAvailableQuantities = (extendedParams = {}) => async (dispatch) => {
   dispatch({ type: SUBSCRIPTIONS_QUANTITIES_REQUEST });
 
   const params = createSubscriptionParams(extendedParams);
-  return api
-    .get(`/organizations/${orgId()}/upstream_subscriptions`, {}, params)
-    .then(({ data }) => {
-      dispatch({
-        type: SUBSCRIPTIONS_QUANTITIES_SUCCESS,
-        payload: selectSubscriptionsQuantitiesFromResponse(data),
-      });
-    })
-    .catch(result => dispatch(apiError(SUBSCRIPTIONS_QUANTITIES_FAILURE, result)));
+
+  try {
+    const { data } = await api.get(`/organizations/${orgId()}/upstream_subscriptions`, {}, params);
+    return dispatch({
+      type: SUBSCRIPTIONS_QUANTITIES_SUCCESS,
+      payload: selectSubscriptionsQuantitiesFromResponse(data),
+    });
+  } catch (error) {
+    return dispatch(apiError(SUBSCRIPTIONS_QUANTITIES_FAILURE, error));
+  }
 };
 
-export const loadSubscriptions = (extendedParams = {}) => (dispatch) => {
+export const loadSubscriptions = (extendedParams = {}) => async (dispatch) => {
   dispatch({ type: SUBSCRIPTIONS_REQUEST });
 
   const params = createSubscriptionParams(extendedParams);
-  return api
-    .get('/subscriptions', {}, params)
-    .then(({ data }) => {
-      dispatch({
-        type: SUBSCRIPTIONS_SUCCESS,
-        response: data,
-        search: extendedParams.search,
-      });
-      const poolIds = filterRHSubscriptions(data.results).map(subs => subs.id);
-      if (poolIds.length > 0) {
-        dispatch(loadAvailableQuantities({ poolIds }));
-      }
-    })
-    .catch(result => dispatch(apiError(SUBSCRIPTIONS_FAILURE, result)));
+
+  try {
+    const { data } = await api.get('/subscriptions', {}, params);
+    const result = dispatch({
+      type: SUBSCRIPTIONS_SUCCESS,
+      response: data,
+      search: extendedParams.search,
+    });
+    const poolIds = filterRHSubscriptions(data.results).map(subs => subs.id);
+    if (poolIds.length > 0) {
+      dispatch(loadAvailableQuantities({ poolIds }));
+    }
+    return result;
+  } catch (error) {
+    return dispatch(apiError(SUBSCRIPTIONS_FAILURE, error));
+  }
 };
 
-export const updateQuantity = (quantities = {}) => (dispatch) => {
+export const updateQuantity = (quantities = {}) => async (dispatch) => {
   dispatch({ type: UPDATE_QUANTITY_REQUEST, quantities });
 
   const params = {
     pools: quantities,
   };
 
-  return api
-    .put(`/organizations/${orgId()}/upstream_subscriptions`, params)
-    .then(({ data }) => {
-      dispatch({
-        type: UPDATE_QUANTITY_SUCCESS,
-        response: data,
-      });
-    })
-    .catch(result => dispatch(apiError(UPDATE_QUANTITY_FAILURE, result)));
+  try {
+    const { data } = await api.put(`/organizations/${orgId()}/upstream_subscriptions`, params);
+    return dispatch({
+      type: UPDATE_QUANTITY_SUCCESS,
+      response: data,
+    });
+  } catch (error) {
+    return dispatch(apiError(UPDATE_QUANTITY_FAILURE, error));
+  }
 };
 
 export const loadTableColumns = selectedColumns => (dispatch) => {
@@ -115,22 +118,22 @@ export const loadTableColumns = selectedColumns => (dispatch) => {
   });
 };
 
-export const deleteSubscriptions = poolIds => (dispatch) => {
+export const deleteSubscriptions = poolIds => async (dispatch) => {
   dispatch({ type: DELETE_SUBSCRIPTIONS_REQUEST });
 
   const params = {
     pool_ids: poolIds,
   };
 
-  return api
-    .delete(`/organizations/${(orgId())}/upstream_subscriptions`, {}, params)
-    .then(({ data }) => {
-      dispatch({
-        type: DELETE_SUBSCRIPTIONS_SUCCESS,
-        response: data,
-      });
-    })
-    .catch(result => dispatch(apiError(DELETE_SUBSCRIPTIONS_FAILURE, result)));
+  try {
+    const { data } = await api.delete(`/organizations/${(orgId())}/upstream_subscriptions`, {}, params);
+    return dispatch({
+      type: DELETE_SUBSCRIPTIONS_SUCCESS,
+      response: data,
+    });
+  } catch (error) {
+    return dispatch(apiError(DELETE_SUBSCRIPTIONS_FAILURE, error));
+  }
 };
 
 export const updateSearchQuery = query => ({

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsActions.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsActions.js
@@ -12,7 +12,7 @@ import {
   SAVE_UPSTREAM_SUBSCRIPTIONS_FAILURE,
 } from './UpstreamSubscriptionsContstants';
 
-export const loadUpstreamSubscriptions = (extendedParams = {}) => (dispatch) => {
+export const loadUpstreamSubscriptions = (extendedParams = {}) => async (dispatch) => {
   dispatch({ type: UPSTREAM_SUBSCRIPTIONS_REQUEST });
 
   const params = {
@@ -20,34 +20,34 @@ export const loadUpstreamSubscriptions = (extendedParams = {}) => (dispatch) => 
     ...propsToSnakeCase(extendedParams),
   };
 
-  return api
-    .get(`/organizations/${orgId()}/upstream_subscriptions`, {}, params)
-    .then(({ data }) => {
-      dispatch({
-        type: UPSTREAM_SUBSCRIPTIONS_SUCCESS,
-        response: data,
-        search: extendedParams.search,
-      });
-    })
-    .catch(result => dispatch(apiError(UPSTREAM_SUBSCRIPTIONS_FAILURE, result)));
+  try {
+    const { data } = await api.get(`/organizations/${orgId()}/upstream_subscriptions`, {}, params);
+    return dispatch({
+      type: UPSTREAM_SUBSCRIPTIONS_SUCCESS,
+      response: data,
+      search: extendedParams.search,
+    });
+  } catch (error) {
+    return dispatch(apiError(UPSTREAM_SUBSCRIPTIONS_FAILURE, error));
+  }
 };
 
-export const saveUpstreamSubscriptions = upstreamSubscriptions => (dispatch) => {
+export const saveUpstreamSubscriptions = upstreamSubscriptions => async (dispatch) => {
   dispatch({ type: SAVE_UPSTREAM_SUBSCRIPTIONS_REQUEST });
 
   const params = {
     ...propsToSnakeCase(upstreamSubscriptions),
   };
 
-  return api
-    .post(`/organizations/${orgId()}/upstream_subscriptions`, params)
-    .then(({ data }) => {
-      dispatch({
-        type: SAVE_UPSTREAM_SUBSCRIPTIONS_SUCCESS,
-        response: data,
-      });
-    })
-    .catch(result => dispatch(apiError(SAVE_UPSTREAM_SUBSCRIPTIONS_FAILURE, result)));
+  try {
+    const { data } = await api.post(`/organizations/${orgId()}/upstream_subscriptions`, params);
+    return dispatch({
+      type: SAVE_UPSTREAM_SUBSCRIPTIONS_SUCCESS,
+      response: data,
+    });
+  } catch (error) {
+    return dispatch(apiError(SAVE_UPSTREAM_SUBSCRIPTIONS_FAILURE, error));
+  }
 };
 
 export default loadUpstreamSubscriptions;

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/UpstreamSubscriptionsPage.js
@@ -78,7 +78,6 @@ class UpstreamSubscriptionsPage extends Component {
     );
   }
 
-
   quantityValidationInput = (pool) => {
     if (!pool || pool.updatedQuantity === undefined) return null;
     if (this.quantityValidation(pool)[0]) {
@@ -91,7 +90,7 @@ class UpstreamSubscriptionsPage extends Component {
     this.state.selectedRows.length &&
     this.state.selectedRows.every(pool => this.quantityValidation(pool)[0]);
 
-  saveUpstreamSubscriptions = () => {
+  saveUpstreamSubscriptions = async () => {
     const updatedPools = _.map(
       this.state.selectedRows,
       pool => ({ ...pool, quantity: parseInt(pool.updatedQuantity, 10) }),
@@ -99,24 +98,23 @@ class UpstreamSubscriptionsPage extends Component {
 
     const updatedSubscriptions = { pools: updatedPools };
 
-    this.props.saveUpstreamSubscriptions(updatedSubscriptions).then(() => {
-      const { task } = this.props.upstreamSubscriptions;
+    await this.props.saveUpstreamSubscriptions(updatedSubscriptions);
+    const { task } = this.props.upstreamSubscriptions;
 
-      // TODO: could probably factor this out into a task response component
-      if (task) {
-        const message = (
-          <span>
-            <span>{__('Subscriptions have been saved and are being updated. ')}</span>
-            <a href={urlBuilder('foreman_tasks/tasks', '', task.id)}>
-              {__('Click here to go to the tasks page for the task.')}
-            </a>
-          </span>
-        );
+    // TODO: could probably factor this out into a task response component
+    if (task) {
+      const message = (
+        <span>
+          <span>{__('Subscriptions have been saved and are being updated. ')}</span>
+          <a href={urlBuilder('foreman_tasks/tasks', '', task.id)}>
+            {__('Click here to go to the tasks page for the task.')}
+          </a>
+        </span>
+      );
 
-        window.tfm.toastNotifications.notify({ message, type: 'success' });
-        this.props.history.push('/subscriptions');
-      }
-    });
+      window.tfm.toastNotifications.notify({ message, type: 'success' });
+      this.props.history.push('/subscriptions');
+    }
   };
 
   loadData() {

--- a/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/UpstreamSubscriptionsActions.test.js
+++ b/webpack/scenes/Subscriptions/UpstreamSubscriptions/__tests__/UpstreamSubscriptionsActions.test.js
@@ -25,21 +25,20 @@ describe('upstream subscription actions', () => {
   const url = '/katello/api/v2/organizations/1/upstream_subscriptions';
 
   describe('creates UPSTREAM_SUBSCRIPTIONS_REQUEST', () => {
-    it('and then fails with 422', () => {
+    it('and then fails with 422', async () => {
       mockErrorRequest({
         url,
         status: 422,
       });
-
-      return store.dispatch(loadUpstreamSubscriptions())
-        .then(() => expect(store.getActions()).toEqual(getFailureActions));
+      await store.dispatch(loadUpstreamSubscriptions());
+      expect(store.getActions()).toEqual(getFailureActions);
     });
 
-    it('and ends with success', () => {
+    it('and ends with success', async () => {
       mockApi.onGet(url).reply(200, requestSuccessResponse);
 
-      return store.dispatch(loadUpstreamSubscriptions())
-        .then(() => expect(store.getActions()).toEqual(getSuccessActions));
+      await store.dispatch(loadUpstreamSubscriptions());
+      expect(store.getActions()).toEqual(getSuccessActions);
     });
   });
 
@@ -48,22 +47,22 @@ describe('upstream subscription actions', () => {
       pools: [{ id: 'abcde', quantity: 100 }],
     };
 
-    it('and then fails with 422', () => {
+    it('and then fails with 422', async () => {
       mockErrorRequest({
         url,
         status: 422,
         method: 'POST',
       });
 
-      return store.dispatch(saveUpstreamSubscriptions(subscriptionData))
-        .then(() => expect(store.getActions()).toEqual(saveFailureActions));
+      await store.dispatch(saveUpstreamSubscriptions(subscriptionData));
+      expect(store.getActions()).toEqual(saveFailureActions);
     });
 
-    it('and ends with success', () => {
+    it('and ends with success', async () => {
       mockApi.onPost(url).reply(200, getTaskSuccessResponse);
 
-      return store.dispatch(saveUpstreamSubscriptions(subscriptionData))
-        .then(() => expect(store.getActions()).toEqual(saveSuccessActions));
+      await store.dispatch(saveUpstreamSubscriptions(subscriptionData));
+      expect(store.getActions()).toEqual(saveSuccessActions);
     });
   });
 });

--- a/webpack/scenes/Subscriptions/__tests__/SubscriptionsActions.test.js
+++ b/webpack/scenes/Subscriptions/__tests__/SubscriptionsActions.test.js
@@ -45,37 +45,35 @@ describe('subscription actions', () => {
   describe('loadSubscriptions', () => {
     it(
       'creates SUBSCRIPTIONS_REQUEST and then fails with 422',
-      () => {
+      async () => {
         mockErrorRequest({
           url: '/katello/api/v2/subscriptions',
           status: 422,
         });
-        return store.dispatch(loadSubscriptions())
-          .then(() => expect(store.getActions()).toEqual(failureActions));
+        await store.dispatch(loadSubscriptions());
+        expect(store.getActions()).toEqual(failureActions);
       },
     );
     it(
       'creates SUBSCRIPTIONS_REQUEST and ends with success',
-      () => {
+      async () => {
         mockRequest({
           url: '/katello/api/v2/subscriptions',
           response: requestSuccessResponse,
         });
-        return store.dispatch(loadSubscriptions())
-          .then(() => expect(store.getActions()).toEqual(successActions));
+        await store.dispatch(loadSubscriptions());
+        expect(store.getActions()).toEqual(successActions);
       },
     );
     it(
       'creates SUBSCRIPTIONS_REQUEST and triggers loadAvailableQuantities when there is some RH subscription',
-      () => {
+      async () => {
         mockRequest({
           url: '/katello/api/v2/subscriptions',
           response: requestSuccessResponseWithRHSubscriptions,
         });
-        return store.dispatch(loadSubscriptions())
-          .then(() =>
-            expect(store.getActions())
-              .toEqual(successActionsWithQuantityLoad));
+        await store.dispatch(loadSubscriptions());
+        expect(store.getActions()).toEqual(successActionsWithQuantityLoad);
       },
     );
   });
@@ -83,28 +81,28 @@ describe('subscription actions', () => {
   describe('updateQuantity', () => {
     it(
       'creates UPDATE_QUANTITY_REQUEST and then fails with 422',
-      () => {
+      async () => {
         mockErrorRequest({
           method: 'PUT',
           url: '/katello/api/v2/organizations/1/upstream_subscriptions',
           data: { pools: poolsUpdate },
           status: 422,
         });
-        return store.dispatch(updateQuantity(poolsUpdate))
-          .then(() => expect(store.getActions()).toEqual(updateQuantityFailureActions));
+        await store.dispatch(updateQuantity(poolsUpdate));
+        expect(store.getActions()).toEqual(updateQuantityFailureActions);
       },
     );
     it(
       'creates UPDATE_QUANTITY_REQUEST and ends with success',
-      () => {
+      async () => {
         mockRequest({
           method: 'PUT',
           url: '/katello/api/v2/organizations/1/upstream_subscriptions',
           data: { pools: poolsUpdate },
           response: requestSuccessResponse,
         });
-        return store.dispatch(updateQuantity(poolsUpdate))
-          .then(() => expect(store.getActions()).toEqual(updateQuantitySuccessActions));
+        await store.dispatch(updateQuantity(poolsUpdate));
+        expect(store.getActions()).toEqual(updateQuantitySuccessActions);
       },
     );
   });
@@ -114,28 +112,28 @@ describe('subscription actions', () => {
 
     it(
       'creates SUBSCRIPTIONS_QUANTITIES_REQUEST and then fails with 500',
-      () => {
+      async () => {
         mockErrorRequest({
           method: 'GET',
           url: '/katello/api/v2/organizations/1/upstream_subscriptions',
           data,
           status: 500,
         });
-        return store.dispatch(loadAvailableQuantities())
-          .then(() => expect(store.getActions()).toEqual(loadQuantitiesFailureActions));
+        await store.dispatch(loadAvailableQuantities());
+        expect(store.getActions()).toEqual(loadQuantitiesFailureActions);
       },
     );
     it(
       'creates SUBSCRIPTIONS_QUANTITIES_REQUEST and ends with success',
-      () => {
+      async () => {
         mockRequest({
           method: 'GET',
           url: '/katello/api/v2/organizations/1/upstream_subscriptions',
           data,
           response: quantitiesRequestSuccessResponse,
         });
-        return store.dispatch(loadAvailableQuantities())
-          .then(() => expect(store.getActions()).toEqual(loadQuantitiesSuccessActions));
+        await store.dispatch(loadAvailableQuantities());
+        expect(store.getActions()).toEqual(loadQuantitiesSuccessActions);
       },
     );
   });

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/components/Dialogs/UpdateDialog.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/components/Dialogs/UpdateDialog.js
@@ -17,20 +17,20 @@ const UpdateDialog = ({
   enableEditing,
 }) => {
   const quantityLength = Object.keys(updatedQuantity).length;
-  const confirmEdit = () => {
+  const confirmEdit = async () => {
     showUpdateConfirm(false);
     if (quantityLength > 0) {
-      updateQuantity(buildPools(updatedQuantity))
-        .then(() =>
-          bulkSearch({
-            action: `organization '${organization.owner_details.displayName}'`,
-            result: 'pending',
-            label: BLOCKING_FOREMAN_TASK_TYPES.join(' or '),
-          }))
-        .then(() => renderTaskStartedToast(task));
+      await updateQuantity(buildPools(updatedQuantity));
+      await bulkSearch({
+        action: `organization '${organization.owner_details.displayName}'`,
+        result: 'pending',
+        label: BLOCKING_FOREMAN_TASK_TYPES.join(' or '),
+      });
+      renderTaskStartedToast(task);
     }
     enableEditing(false);
   };
+
   return (
     <MessageDialog
       show={show}

--- a/webpack/scenes/Tasks/__tests__/TaskActions.test.js
+++ b/webpack/scenes/Tasks/__tests__/TaskActions.test.js
@@ -49,18 +49,18 @@ describe('task actions', () => {
   describe('creates TASK_BULK_SEARCH_REQUEST', () => {
     const url = '/foreman_tasks/api/tasks';
 
-    it('and then fails with 422', () => {
+    it('and then fails with 422', async () => {
       mockApi.onGet(url).reply(422);
 
-      return store.dispatch(bulkSearch())
-        .then(() => expect(store.getActions()).toEqual(buildBulkSearchFailureActions()));
+      await store.dispatch(bulkSearch());
+      expect(store.getActions()).toEqual(buildBulkSearchFailureActions());
     });
 
-    it('and ends with success', () => {
+    it('and ends with success', async () => {
       mockApi.onGet(url).reply(200, bulkSearchSuccessResponse);
 
-      return store.dispatch(bulkSearch())
-        .then(() => expect(store.getActions()).toEqual(bulkSearchSuccessActions));
+      await store.dispatch(bulkSearch());
+      expect(store.getActions()).toEqual(bulkSearchSuccessActions);
     });
   });
 
@@ -68,18 +68,18 @@ describe('task actions', () => {
     const taskId = 'eb1b6271-8a69-4d98-84fc-bea06ddcc166';
     const url = `/foreman_tasks/api/tasks/${taskId}`;
 
-    it('and then fails with 422', () => {
+    it('and then fails with 422', async () => {
       mockApi.onGet(url).reply(422);
 
-      return store.dispatch(loadTask(taskId))
-        .then(() => expect(store.getActions()).toEqual(buildTaskFailureActions()));
+      await store.dispatch(loadTask(taskId));
+      expect(store.getActions()).toEqual(buildTaskFailureActions());
     });
 
-    it('and ends with success', () => {
+    it('and ends with success', async () => {
       mockApi.onGet(url).reply(200, getTaskSuccessResponse);
 
-      return store.dispatch(loadTask(taskId))
-        .then(() => expect(store.getActions()).toEqual(getTaskSuccessActions));
+      await store.dispatch(loadTask(taskId));
+      expect(store.getActions()).toEqual(getTaskSuccessActions);
     });
   });
 
@@ -87,18 +87,15 @@ describe('task actions', () => {
     const taskId = 'eb1b6271-8a69-4d98-84fc-bea06ddcc166';
     const url = `/foreman_tasks/api/tasks/${taskId}`;
 
-    it("doesn't start polling when the task has finished", () => {
+    it("doesn't start polling when the task has finished", async () => {
       mockApi.onGet(url).replyOnce(200, getTaskSuccessResponse);
 
-      return store
-        .dispatch(pollTaskUntilDone(taskId, {}, 1, 1))
-        .then(() => {
-          expect(store.getActions()).toEqual(getTaskSuccessActions);
-          expect(setTimeoutSpy).toHaveBeenCalledTimes(0);
-        });
+      await store.dispatch(pollTaskUntilDone(taskId, {}, 1, 1));
+      expect(store.getActions()).toEqual(getTaskSuccessActions);
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(0);
     });
 
-    it('polls until a task is done', () => {
+    it('polls until a task is done', async () => {
       mockApi
         .onGet(url)
         .replyOnce(200, getTaskPendingResponse)
@@ -111,15 +108,12 @@ describe('task actions', () => {
         .concat(getTaskPendingActions)
         .concat(getTaskSuccessActions);
 
-      return store
-        .dispatch(pollTaskUntilDone(taskId, {}, 1, 1))
-        .then(() => {
-          expect(store.getActions()).toEqual(expectedActions);
-          expect(setTimeoutSpy).toHaveBeenCalledTimes(2);
-        });
+      await store.dispatch(pollTaskUntilDone(taskId, {}, 1, 1));
+      expect(store.getActions()).toEqual(expectedActions);
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(2);
     });
 
-    it('stops polling on unauthorized response', () => {
+    it('stops polling on unauthorized response', async () => {
       mockApi
         .onGet(url).replyOnce(200, getTaskPendingResponse)
         .onGet(url).replyOnce(401);
@@ -127,41 +121,35 @@ describe('task actions', () => {
       const expectedActions = getTaskPendingActions
         .concat(buildTaskFailureActions(401));
 
-      return store
-        .dispatch(pollTaskUntilDone(taskId, {}, 1, 1))
-        .catch(() => {
-          expect(store.getActions()).toEqual(expectedActions);
-          expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
-        });
+      try {
+        await store.dispatch(pollTaskUntilDone(taskId, {}, 1, 1));
+      } catch (e) {
+        expect(store.getActions()).toEqual(expectedActions);
+        expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+      }
     });
   });
 
   describe('pollBulkSearch', () => {
     const url = '/foreman_tasks/api/tasks';
 
-    it('polls', () => {
+    it('polls', async () => {
       mockApi
         .onGet(url)
         .replyOnce(200, bulkSearchSuccessResponse);
 
-      return store
-        .dispatch(pollBulkSearch({}, 1, 1))
-        .then(() => {
-          expect(store.getActions()).toEqual(bulkSearchSuccessActions);
-          expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
-        });
+      await store.dispatch(pollBulkSearch({}, 1, 1));
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+      expect(store.getActions()).toEqual(bulkSearchSuccessActions);
     });
 
-    it('stops polling on unauthorized response', () => {
+    it('stops polling on unauthorized response', async () => {
       mockApi
         .onGet(url).replyOnce(401);
 
-      return store
-        .dispatch(pollBulkSearch({}, 1, 1))
-        .then(() => {
-          expect(store.getActions()).toEqual(buildBulkSearchFailureActions(401));
-          expect(setTimeoutSpy).toHaveBeenCalledTimes(0);
-        });
+      await store.dispatch(pollBulkSearch({}, 1, 1));
+      expect(store.getActions()).toEqual(buildBulkSearchFailureActions(401));
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(0);
     });
   });
 });


### PR DESCRIPTION
note: Functions in `TaskActions.js` require more time to refactor. So we will leave the eslint rule disabled for those lines for now, and address them later.