### PR TITLE
Fixes #27667 - Add register client directive

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-register-client.directive.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content-host-register-client.directive.js
@@ -1,0 +1,6 @@
+angular.module('Bastion.content-hosts').directive('registerClient', function () {
+    return {
+        restrict: 'E',
+        templateUrl: 'content-hosts/views/register-client.html'
+    };
+});

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/register-client.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/register-client.html
@@ -1,0 +1,13 @@
+<li>
+  <p translate>Install client package:</p>
+
+  <p translate>To report package & errata information:</p>
+  <pre><code>yum -y install katello-host-tools</code></pre>
+
+  <p translate>To optionally report tracer information:</p>
+  <pre><code>yum -y install katello-host-tools-tracer</code></pre>
+
+  <p translate>For remote actions and reporting package & errata information:</p>
+  <pre><code>yum -y install katello-agent</code></pre>
+  <p translate>Learn more about these packages in the <a href="https://theforeman.org/plugins/katello/">Documentation</a> </p>
+</li>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/register.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/register.html
@@ -24,19 +24,7 @@
         <p translate>Using a username and password:</p>
         <pre><code>subscription-manager register --org="{{ organization.label }}" --environment="Library"</code></pre>
       </li>
-      <li>
-        <p translate>Install client package:</p>
-
-        <p translate>To report package & errata information:</p>
-        <pre><code>yum -y install katello-host-tools</code></pre>
-
-        <p translate>To optionally report tracer information:</p>
-        <pre><code>yum -y install katello-host-tools-tracer</code></pre>
-
-        <p translate>For remote actions and reporting package & errata information:</p>
-        <pre><code>yum -y install katello-agent</code></pre>
-        <p translate>Learn more about these packages in the <a href="https://theforeman.org/plugins/katello/">Documentation</a> </p>
-      </li>
+      <register-client />
     </ol>
   </div>
 </section>


### PR DESCRIPTION
This extracts the last step for client registration
into a directive, which can be overriden more easily
than a template when modified instructions for client
registration steps are needed.