### PR TITLE
Fixes #27617 - purge orphaned repo versions

### DIFF
--- a/app/lib/actions/katello/capsule_content/remove_orphans.rb
+++ b/app/lib/actions/katello/capsule_content/remove_orphans.rb
@@ -8,6 +8,11 @@ module Actions
         def plan(proxy)
           sequence do
             plan_action(Actions::Katello::CapsuleContent::RemoveUnneededRepos, proxy) unless proxy.pulp_master?
+
+            if proxy.pulp3_enabled? && proxy == SmartProxy.pulp_master
+              plan_action(Actions::Pulp3::Orchestration::Repository::RemoveOrphans, proxy)
+            end
+
             plan_self(:capsule_id => proxy.id)
           end
         end

--- a/app/lib/actions/pulp3/orchestration/repository/remove_orphans.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/remove_orphans.rb
@@ -1,0 +1,13 @@
+module Actions
+  module Pulp3
+    module Orchestration
+      module Repository
+        class RemoveOrphans < Pulp3::Abstract
+          def plan(smart_proxy)
+            plan_action(Actions::Pulp3::Repository::DeleteOrphanRepositoryVersions, SmartProxy.pulp_master) if smart_proxy.pulp3_enabled?
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/repository/delete_orphan_repository_versions.rb
+++ b/app/lib/actions/pulp3/repository/delete_orphan_repository_versions.rb
@@ -1,0 +1,16 @@
+module Actions
+  module Pulp3
+    module Repository
+      class DeleteOrphanRepositoryVersions < Pulp3::AbstractAsyncTask
+        def plan(smart_proxy)
+          plan_self(:smart_proxy_id => smart_proxy.id)
+        end
+
+        def run
+          smart_proxy = SmartProxy.find(input[:smart_proxy_id])
+          output[:pulp_tasks] = ::Katello::Pulp3::Repository.delete_orphan_repository_versions(smart_proxy)
+        end
+      end
+    end
+  end
+end

--- a/test/actions/pulp3/orchestration/remove_orphans_test.rb
+++ b/test/actions/pulp3/orchestration/remove_orphans_test.rb
@@ -1,0 +1,58 @@
+require 'katello_test_helper'
+
+module ::Actions::Pulp3
+  class RemoveOrphansTest < ActiveSupport::TestCase
+    include Katello::Pulp3Support
+
+    def sync_and_reload_repo(repo, smart_proxy)
+      ForemanTasks.sync_task(
+                ::Actions::Pulp3::Orchestration::Repository::Update,
+                repo,
+                smart_proxy)
+
+      sync_args = {:smart_proxy_id => smart_proxy.id, :repo_id => repo.id}
+      ForemanTasks.sync_task(
+        ::Actions::Pulp3::Orchestration::Repository::Sync,
+        repo, smart_proxy, sync_args)
+    end
+
+    def repo_reference(repo)
+      repository_reference = Katello::Pulp3::RepositoryReference.find_by(
+          :root_repository_id => repo.root.id,
+          :content_view_id => repo.content_view.id)
+      assert repository_reference
+      repository_reference
+    end
+
+    def setup
+      @master = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+      @repo = katello_repositories(:pulp3_file_1)
+      @repo.root.update_attributes(:url => 'https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/file2/')
+      ensure_creatable(@repo, @master)
+      create_repo(@repo, @master)
+
+      sync_and_reload_repo(@repo, @master)
+
+      @repo.root.update_attributes(
+        url: "https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/file/")
+
+      sync_and_reload_repo(@repo, @master)
+
+      ForemanTasks.sync_task(
+        ::Actions::Pulp3::Orchestration::Repository::RemoveOrphans, @master)
+    end
+
+    def teardown
+      ForemanTasks.sync_task(
+          ::Actions::Pulp3::Orchestration::Repository::Delete, @repo, @master)
+      @repo.reload
+    end
+
+    def test_orphans_are_removed
+      repository_reference = repo_reference(@repo)
+      versions = ::Katello::Pulp3::Repository.new(@repo, @master).repository_versions_api.list(repository_reference.repository_href, {}).results.collect(&:_href)
+      refute_includes versions, repository_reference.repository_href + "versions/1/"
+      assert_includes versions, repository_reference.repository_href + "versions/2/"
+    end
+  end
+end

--- a/test/fixtures/vcr_cassettes/actions/pulp3/remove_orphans/orphans_are_removed.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/remove_orphans/orphans_are_removed.yml
@@ -1,0 +1,2342 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:24 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:24 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:25 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com:8443/candlepin/owners//uebercert
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Authorization:
+      - OAuth oauth_consumer_key="dNZ8tEDWtwokaUEpig4TxxkzbrEKMeY4", oauth_nonce="Op1eDEr1iK3X41MbHwAvUWhGrHAVhB75yAyuOAG4",
+        oauth_signature="pnowoZ3lZfszM7pkoLPk0pm1Jqg%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1568033005", oauth_version="1.0"
+      Cp-User:
+      - foreman_admin
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - a6447e98-ed25-428b-9f1f-4000d9e88753
+      X-Version:
+      - 2.7.1-1
+      - 2.7.1-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 09 Sep 2019 12:43:25 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJkaXNwbGF5TWVzc2FnZSI6IlJ1bnRpbWUgRXJyb3IgUkVTVEVBU1kwMDMy
+        MTA6IENvdWxkIG5vdCBmaW5kIHJlc291cmNlIGZvciBmdWxsIHBhdGg6IGh0
+        dHBzOi8vY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUu
+        Y29tOjg0NDMvY2FuZGxlcGluL293bmVycy8vdWViZXJjZXJ0IGF0IG9yZy5q
+        Ym9zcy5yZXN0ZWFzeS5jb3JlLnJlZ2lzdHJ5LlNlZ21lbnROb2RlLm1hdGNo
+        OjEzOSIsInJlcXVlc3RVdWlkIjoiYTY0NDdlOTgtZWQyNS00MjhiLTlmMWYt
+        NDAwMGQ5ZTg4NzUzIn0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:25 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com:8443/candlepin/owners//uebercert
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Authorization:
+      - OAuth oauth_consumer_key="dNZ8tEDWtwokaUEpig4TxxkzbrEKMeY4", oauth_nonce="IwtbiggTdnkKz5c8xU1IgTidUGAACOMq6dLePc4nU",
+        oauth_signature="MoHs0hx8sUt13RcEuKjm6d1pMsA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1568033005", oauth_version="1.0"
+      Cp-User:
+      - foreman_admin
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 7a83b20d-2789-415b-8d42-6969b8de2ae7
+      X-Version:
+      - 2.7.1-1
+      - 2.7.1-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 09 Sep 2019 12:43:25 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJkaXNwbGF5TWVzc2FnZSI6IlJ1bnRpbWUgRXJyb3IgUkVTVEVBU1kwMDMy
+        MTA6IENvdWxkIG5vdCBmaW5kIHJlc291cmNlIGZvciBmdWxsIHBhdGg6IGh0
+        dHBzOi8vY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUu
+        Y29tOjg0NDMvY2FuZGxlcGluL293bmVycy8vdWViZXJjZXJ0IGF0IG9yZy5q
+        Ym9zcy5yZXN0ZWFzeS5jb3JlLnJlZ2lzdHJ5LlNlZ21lbnROb2RlLm1hdGNo
+        OjEzOSIsInJlcXVlc3RVdWlkIjoiN2E4M2IyMGQtMjc4OS00MTViLThkNDIt
+        Njk2OWI4ZGUyYWU3In0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:25 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com:8443/candlepin/owners//uebercert
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="dNZ8tEDWtwokaUEpig4TxxkzbrEKMeY4",
+        oauth_nonce="rcwZWlb0Hinj47IHkahrSKaoycbM1jZV9UO55MtPFY", oauth_signature="MwQVIbCvuTJPoQjabXWGuuh3JsE%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1568033005", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '2'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 53dacec6-a101-45f3-82fd-ea1bab1685ab
+      X-Version:
+      - 2.7.1-1
+      - 2.7.1-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 09 Sep 2019 12:43:25 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJkaXNwbGF5TWVzc2FnZSI6IlJ1bnRpbWUgRXJyb3IgUkVTVEVBU1kwMDMy
+        MTA6IENvdWxkIG5vdCBmaW5kIHJlc291cmNlIGZvciBmdWxsIHBhdGg6IGh0
+        dHBzOi8vY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUu
+        Y29tOjg0NDMvY2FuZGxlcGluL293bmVycy8vdWViZXJjZXJ0IGF0IG9yZy5q
+        Ym9zcy5yZXN0ZWFzeS5jb3JlLnJlZ2lzdHJ5LlNlZ21lbnROb2RlLm1hdGNo
+        OjEzOSIsInJlcXVlc3RVdWlkIjoiNTNkYWNlYzYtYTEwMS00NWYzLTgyZmQt
+        ZWExYmFiMTY4NWFiIn0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:25 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com:8443/candlepin/owners//uebercert
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="dNZ8tEDWtwokaUEpig4TxxkzbrEKMeY4",
+        oauth_nonce="FMO8pxzsqhRrJaWEZrTgdbiwlh2OM6apaB4KS47EdfY", oauth_signature="gNOPdbU9VIk7%2BY%2BqUxIYWmidRjA%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1568033005", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '2'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 7c2c6248-24a8-42f3-97b7-dab6c89120fd
+      X-Version:
+      - 2.7.1-1
+      - 2.7.1-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Mon, 09 Sep 2019 12:43:25 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJkaXNwbGF5TWVzc2FnZSI6IlJ1bnRpbWUgRXJyb3IgUkVTVEVBU1kwMDMy
+        MTA6IENvdWxkIG5vdCBmaW5kIHJlc291cmNlIGZvciBmdWxsIHBhdGg6IGh0
+        dHBzOi8vY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUu
+        Y29tOjg0NDMvY2FuZGxlcGluL293bmVycy8vdWViZXJjZXJ0IGF0IG9yZy5q
+        Ym9zcy5yZXN0ZWFzeS5jb3JlLnJlZ2lzdHJ5LlNlZ21lbnROb2RlLm1hdGNo
+        OjEzOSIsInJlcXVlc3RVdWlkIjoiN2MyYzYyNDgtMjRhOC00MmYzLTk3Yjct
+        ZGFiNmM4OTEyMGZkIn0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:25 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:25 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:25 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:26 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:26 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:26 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:26 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:26 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:26 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:26 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/b698d83f-60db-42a9-b5b9-b7b8f2366a02/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '306'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYjY5OGQ4M2Yt
+        NjBkYi00MmE5LWI1YjktYjdiOGYyMzY2YTAyLyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wOS0wOVQxMjo0MzoyNi44OTAxMDhaIiwiX3ZlcnNpb25zX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2I2OThkODNmLTYwZGItNDJhOS1i
+        NWI5LWI3YjhmMjM2NmEwMi92ZXJzaW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25f
+        aHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfRmlsZV8xIiwiZGVzY3JpcHRpb24iOm51bGx9
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:26 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEiLCJ1cmwiOiJodHRwczovL3JlcG9zLmZlZG9yYXBlb3BsZS5vcmcv
+        cmVwb3MvcHVscC9wdWxwL2ZpeHR1cmVzL2ZpbGUyLy9QVUxQX01BTklGRVNU
+        Iiwic3NsX3ZhbGlkYXRpb24iOnRydWUsInBvbGljeSI6ImltbWVkaWF0ZSJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:27 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/file/file/bfca9403-0ec2-4a3b-b410-6c2936442735/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '487'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS9iZmNh
+        OTQwMy0wZWMyLTRhM2ItYjQxMC02YzI5MzY0NDI3MzUvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTA5VDEyOjQzOjI3LjA4MjMzOFoiLCJfdHlwZSI6ImZpbGUu
+        ZmlsZSIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1
+        bHAzX0ZpbGVfMSIsInVybCI6Imh0dHBzOi8vcmVwb3MuZmVkb3JhcGVvcGxl
+        Lm9yZy9yZXBvcy9wdWxwL3B1bHAvZml4dHVyZXMvZmlsZTIvL1BVTFBfTUFO
+        SUZFU1QiLCJzc2xfY2FfY2VydGlmaWNhdGUiOm51bGwsInNzbF9jbGllbnRf
+        Y2VydGlmaWNhdGUiOm51bGwsInNzbF9jbGllbnRfa2V5IjpudWxsLCJzc2xf
+        dmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJfbGFzdF91cGRh
+        dGVkIjoiMjAxOS0wOS0wOVQxMjo0MzoyNy4wODIzNjVaIiwiZG93bmxvYWRf
+        Y29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJpbW1lZGlhdGUifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:27 GMT
+- request:
+    method: put
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/b698d83f-60db-42a9-b5b9-b7b8f2366a02/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:27 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY2ZWQ2NDk0LWZlNTEtNGMx
+        MS04Njc2LWM4NjNjZDU1OTFkMy8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:27 GMT
+- request:
+    method: patch
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/bfca9403-0ec2-4a3b-b410-6c2936442735/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzc2xfdmFsaWRhdGlvbiI6dHJ1ZSwibmFtZSI6IkRlZmF1bHRfT3JnYW5p
+        emF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwidXJsIjoiaHR0cHM6Ly9y
+        ZXBvcy5mZWRvcmFwZW9wbGUub3JnL3JlcG9zL3B1bHAvcHVscC9maXh0dXJl
+        cy9maWxlMi8vUFVMUF9NQU5JRkVTVCIsInByb3h5X3VybCI6bnVsbCwic3Ns
+        X2NsaWVudF9jZXJ0aWZpY2F0ZSI6bnVsbCwic3NsX2NsaWVudF9rZXkiOm51
+        bGwsInNzbF9jYV9jZXJ0aWZpY2F0ZSI6bnVsbH0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:27 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UyNmVhOWI1LWUzNDAtNDM4
+        Yy04NGE3LWY5NjAxODk2MmNhYy8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:27 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/bfca9403-0ec2-4a3b-b410-6c2936442735/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4
+        ZDgzZi02MGRiLTQyYTktYjViOS1iN2I4ZjIzNjZhMDIvIiwibWlycm9yIjp0
+        cnVlfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FmZjM5MjE4LTFmNjYtNDU1
+        OS04Zjc2LWZiM2NhODVjMmE5NS8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:28 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/aff39218-1f66-4559-8f76-fb3ca85c2a95/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '504'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hZmYzOTIxOC0xZjY2LTQ1
+        NTktOGY3Ni1mYjNjYTg1YzJhOTUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjQzOjI4LjA2NDE1NFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wOS0wOVQxMjo0MzoyOC4xNjMyODda
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjQzOjI4LjM2NDEzMloi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzL2FmODUzYzcyLTE0NjQtNGY3Yy1hMDM1
+        LTQ3MTY2NTNjZWUzOS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgTWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5n
+        IEFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
+        bmcgQ29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRv
+        bmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRp
+        bmcgQ29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2luZyBN
+        ZXRhZGF0YSBMaW5lcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMs
+        ImRvbmUiOjMsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2I2OThkODNmLTYwZGItNDJh
+        OS1iNWI5LWI3YjhmMjM2NmEwMi92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUv
+        ZmlsZS9iZmNhOTQwMy0wZWMyLTRhM2ItYjQxMC02YzI5MzY0NDI3MzUvIiwi
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4ZDgzZi02MGRiLTQyYTkt
+        YjViOS1iN2I4ZjIzNjZhMDIvIl19
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:28 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/b698d83f-60db-42a9-b5b9-b7b8f2366a02/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '236'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYjY5OGQ4M2Yt
+        NjBkYi00MmE5LWI1YjktYjdiOGYyMzY2YTAyL3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA5VDEyOjQzOjI4LjE4OTIzNloiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9h
+        ZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2I2OThkODNmLTYwZGIt
+        NDJhOS1iNWI5LWI3YjhmMjM2NmEwMi92ZXJzaW9ucy8xLyJ9fSwicmVtb3Zl
+        ZCI6e30sInByZXNlbnQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYjY5OGQ4M2Yt
+        NjBkYi00MmE5LWI1YjktYjdiOGYyMzY2YTAyL3ZlcnNpb25zLzEvIn19fX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:28 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/publications/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2I2OThkODNmLTYwZGItNDJhOS1iNWI5LWI3YjhmMjM2NmEwMi92ZXJz
+        aW9ucy8xLyIsIm1hbmlmZXN0IjoiUFVMUF9NQU5JRkVTVCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NlYjRiM2Y0LTE4N2UtNDI5
+        Zi1hYjFkLWM3MGVhZTNhNmRkYy8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:28 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/ceb4b3f4-187e-429f-ab1d-c70eae3a6ddc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '372'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jZWI0YjNmNC0xODdlLTQy
+        OWYtYWIxZC1jNzBlYWUzYTZkZGMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjQzOjI4LjgwNjgzMloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnB1Ymxpc2hpbmcucHVibGlzaCIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjQzOjI4LjkyNDUxNFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6NDM6MjguOTgwNTc2WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
+        N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUvZmlsZS9hY2VkMzM0YS1hODAz
+        LTRjNDItYTk4NC1lNzJkZjMzMGFiZDEvIl0sInJlc2VydmVkX3Jlc291cmNl
+        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4ZDgz
+        Zi02MGRiLTQyYTktYjViOS1iN2I4ZjIzNjZhMDIvIl19
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:28 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0ZpbGVfMSIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
+        bmV0LXB1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3Yz
+        L3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvYWNlZDMzNGEtYTgwMy00YzQyLWE5
+        ODQtZTcyZGYzMzBhYmQxLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VkZGNhYTkyLWE5NzAtNDE5
+        MC04ZDY1LTYyZWIyNGViOTBlMC8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/eddcaa92-a970-4190-8d65-62eb24eb90e0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '344'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lZGRjYWE5Mi1hOTcwLTQx
+        OTAtOGQ2NS02MmViMjRlYjkwZTAvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjQzOjI5LjE4MzM2N1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjQzOjI5LjI5MDg5OVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6NDM6MjkuNTYwMjM1WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
+        N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxlL2ZpbGUvMGEyZGQwNDAtZTdk
+        OC00YTlkLWI0YTQtYmQyODIxNDdjMWVmLyJdLCJyZXNlcnZlZF9yZXNvdXJj
+        ZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iXX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/0a2dd040-e7d8-4a9d-b4a4-bd282147c1ef/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '283'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2ZpbGUvZmls
+        ZS8wYTJkZDA0MC1lN2Q4LTRhOWQtYjRhNC1iZDI4MjE0N2MxZWYvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA5VDEyOjQzOjI5LjU0ODIzMFoiLCJiYXNlX3Bh
+        dGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVf
+        MSIsImJhc2VfdXJsIjoiY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJz
+        LmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09yZ2FuaXphdGlv
+        bi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsImNvbnRlbnRfZ3VhcmQiOm51bGws
+        Im5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0Zp
+        bGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9u
+        cy9maWxlL2ZpbGUvYWNlZDMzNGEtYTgwMy00YzQyLWE5ODQtZTcyZGYzMzBh
+        YmQxLyJ9
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:29 GMT
+- request:
+    method: put
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/b698d83f-60db-42a9-b5b9-b7b8f2366a02/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:30 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MyNDQ2OWU4LThjNGYtNGYw
+        Zi05MDM4LWNlNmRiZjRkMjVkNy8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:30 GMT
+- request:
+    method: patch
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/bfca9403-0ec2-4a3b-b410-6c2936442735/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzc2xfdmFsaWRhdGlvbiI6dHJ1ZSwibmFtZSI6IkRlZmF1bHRfT3JnYW5p
+        emF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwidXJsIjoiaHR0cHM6Ly9y
+        ZXBvcy5mZWRvcmFwZW9wbGUub3JnL3JlcG9zL3B1bHAvcHVscC9maXh0dXJl
+        cy9maWxlLy9QVUxQX01BTklGRVNUIiwicHJveHlfdXJsIjpudWxsLCJzc2xf
+        Y2xpZW50X2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVs
+        bCwic3NsX2NhX2NlcnRpZmljYXRlIjpudWxsfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:30 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JlY2M4OGU2LTE0ZWUtNDVj
+        Yy1hYzI3LTlhZTVhNDQ5YzRiNS8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:30 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/bfca9403-0ec2-4a3b-b410-6c2936442735/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4
+        ZDgzZi02MGRiLTQyYTktYjViOS1iN2I4ZjIzNjZhMDIvIiwibWlycm9yIjp0
+        cnVlfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:30 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk1YjJmYWU4LTRiYjMtNDBm
+        MC05MTE4LTZhODI3MmI2M2I3NS8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:30 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/95b2fae8-4bb3-40f0-9118-6a8272b63b75/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:31 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '503'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85NWIyZmFlOC00YmIzLTQw
+        ZjAtOTExOC02YTgyNzJiNjNiNzUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjQzOjMwLjk3NDkwOVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wOS0wOVQxMjo0MzozMS4wODA4MzVa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjQzOjMxLjMyMjE0MVoi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzL2FmODUzYzcyLTE0NjQtNGY3Yy1hMDM1
+        LTQ3MTY2NTNjZWUzOS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgTWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5n
+        IEFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
+        bmcgQ29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRv
+        bmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRp
+        bmcgQ29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRv
+        bmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2luZyBNZXRh
+        ZGF0YSBMaW5lcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRv
+        bmUiOjMsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2I2OThkODNmLTYwZGItNDJhOS1i
+        NWI5LWI3YjhmMjM2NmEwMi92ZXJzaW9ucy8yLyJdLCJyZXNlcnZlZF9yZXNv
+        dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUvZmls
+        ZS9iZmNhOTQwMy0wZWMyLTRhM2ItYjQxMC02YzI5MzY0NDI3MzUvIiwiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4ZDgzZi02MGRiLTQyYTktYjVi
+        OS1iN2I4ZjIzNjZhMDIvIl19
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:31 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/b698d83f-60db-42a9-b5b9-b7b8f2366a02/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:31 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '239'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYjY5OGQ4M2Yt
+        NjBkYi00MmE5LWI1YjktYjdiOGYyMzY2YTAyL3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA5VDEyOjQzOjMxLjEyNjIzMVoiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9h
+        ZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2I2OThkODNmLTYwZGIt
+        NDJhOS1iNWI5LWI3YjhmMjM2NmEwMi92ZXJzaW9ucy8yLyJ9fSwicmVtb3Zl
+        ZCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fcmVt
+        b3ZlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2I2OThkODNmLTYwZGIt
+        NDJhOS1iNWI5LWI3YjhmMjM2NmEwMi92ZXJzaW9ucy8yLyJ9fSwicHJlc2Vu
+        dCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4ZDgzZi02MGRiLTQyYTktYjVi
+        OS1iN2I4ZjIzNjZhMDIvdmVyc2lvbnMvMi8ifX19fQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:31 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/publications/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2I2OThkODNmLTYwZGItNDJhOS1iNWI5LWI3YjhmMjM2NmEwMi92ZXJz
+        aW9ucy8yLyIsIm1hbmlmZXN0IjoiUFVMUF9NQU5JRkVTVCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:31 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I5MzM0ZDlmLWJlYTMtNGFl
+        My04YWNkLTE5NTE1ZDAxNzkxZi8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:31 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/b9334d9f-bea3-4ae3-8acd-19515d01791f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:32 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '374'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9iOTMzNGQ5Zi1iZWEzLTRh
+        ZTMtOGFjZC0xOTUxNWQwMTc5MWYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjQzOjMxLjg5NTEzMFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnB1Ymxpc2hpbmcucHVibGlzaCIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjQzOjMxLjk4NTgwNloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6NDM6MzIuMDQzNzAyWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
+        N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUvZmlsZS8xNzEwYzQ4Zi0zOGQz
+        LTQwZDItOTZiZi05NzE5NmEzODRlYmYvIl0sInJlc2VydmVkX3Jlc291cmNl
+        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4ZDgz
+        Zi02MGRiLTQyYTktYjViOS1iN2I4ZjIzNjZhMDIvIl19
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:32 GMT
+- request:
+    method: patch
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/0a2dd040-e7d8-4a9d-b4a4-bd282147c1ef/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmls
+        ZS9maWxlLzE3MTBjNDhmLTM4ZDMtNDBkMi05NmJmLTk3MTk2YTM4NGViZi8i
+        fQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:32 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QyNjQ4YWQ0LWVhNzgtNDFj
+        Yi1hNTFjLTUzYWViMjliZjg2OS8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:32 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/d2648ad4-ea78-41cb-a51c-53aeb29bf869/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:32 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '314'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kMjY0OGFkNC1lYTc4LTQx
+        Y2ItYTUxYy01M2FlYjI5YmY4NjkvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjQzOjMyLjI2MjEyN1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjQzOjMyLjM2MDA2NVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6NDM6MzIuNDU1NjI5WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
+        N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJl
+        c2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRp
+        b25zLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:32 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:32 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '349'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4
+        ZDgzZi02MGRiLTQyYTktYjViOS1iN2I4ZjIzNjZhMDIvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTA5VDEyOjQzOjI2Ljg5MDEwOFoiLCJfdmVyc2lvbnNfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYjY5OGQ4M2YtNjBkYi00
+        MmE5LWI1YjktYjdiOGYyMzY2YTAyL3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVy
+        c2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4ZDgz
+        Zi02MGRiLTQyYTktYjViOS1iN2I4ZjIzNjZhMDIvdmVyc2lvbnMvMi8iLCJu
+        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxl
+        XzEiLCJkZXNjcmlwdGlvbiI6bnVsbH0seyJfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvOTU5Y2YwOWItNzExMy00M2YxLWEwMGEtNGY3ZjRj
+        M2QwNDhiLyIsIl9jcmVhdGVkIjoiMjAxOS0wOS0wNlQxNzo0Mjo0MC40NTUz
+        NTBaIiwiX3ZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzk1OWNmMDliLTcxMTMtNDNmMS1hMDBhLTRmN2Y0YzNkMDQ4Yi92ZXJz
+        aW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25faHJlZiI6bnVsbCwibmFtZSI6IkRl
+        ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRG9ja2VyXzEiLCJk
+        ZXNjcmlwdGlvbiI6bnVsbH0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvYmQ1MDRmOTAtM2UyZC00ZTU1LWEzMjYtNjQ1YTViNTNkYjU2
+        LyIsIl9jcmVhdGVkIjoiMjAxOS0wOS0wNlQxNzo0NDowMy42NTM3NjNaIiwi
+        X3ZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2Jk
+        NTA0ZjkwLTNlMmQtNGU1NS1hMzI2LTY0NWE1YjUzZGI1Ni92ZXJzaW9ucy8i
+        LCJfbGF0ZXN0X3ZlcnNpb25faHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRf
+        T3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMiLCJkZXNjcmlwdGlvbiI6
+        bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:32 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/b698d83f-60db-42a9-b5b9-b7b8f2366a02/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:33 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '294'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4
+        ZDgzZi02MGRiLTQyYTktYjViOS1iN2I4ZjIzNjZhMDIvdmVyc2lvbnMvMi8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDktMDlUMTI6NDM6MzEuMTI2MjMxWiIsIm51
+        bWJlciI6MiwiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250ZW50X3N1bW1hcnki
+        OnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJz
+        aW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYjY5OGQ4M2Yt
+        NjBkYi00MmE5LWI1YjktYjdiOGYyMzY2YTAyL3ZlcnNpb25zLzIvIn19LCJy
+        ZW1vdmVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
+        bl9yZW1vdmVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYjY5OGQ4M2Yt
+        NjBkYi00MmE5LWI1YjktYjdiOGYyMzY2YTAyL3ZlcnNpb25zLzIvIn19LCJw
+        cmVzZW50Ijp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
+        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2I2OThkODNmLTYwZGItNDJh
+        OS1iNWI5LWI3YjhmMjM2NmEwMi92ZXJzaW9ucy8yLyJ9fX19LHsiX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2I2OThkODNmLTYwZGItNDJh
+        OS1iNWI5LWI3YjhmMjM2NmEwMi92ZXJzaW9ucy8xLyIsIl9jcmVhdGVkIjoi
+        MjAxOS0wOS0wOVQxMjo0MzoyOC4xODkyMzZaIiwibnVtYmVyIjoxLCJiYXNl
+        X3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJm
+        aWxlLmZpbGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4ZDgzZi02MGRiLTQyYTktYjVi
+        OS1iN2I4ZjIzNjZhMDIvdmVyc2lvbnMvMS8ifX0sInJlbW92ZWQiOnt9LCJw
+        cmVzZW50Ijp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
+        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2I2OThkODNmLTYwZGItNDJh
+        OS1iNWI5LWI3YjhmMjM2NmEwMi92ZXJzaW9ucy8xLyJ9fX19XX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:33 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/959cf09b-7113-43f1-a00a-4f7f4c3d048b/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:33 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:33 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/bd504f90-3e2d-4e55-a326-645a5b53db56/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:33 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:33 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/b698d83f-60db-42a9-b5b9-b7b8f2366a02/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:33 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYwYWViZTVhLTZmNzQtNGU5
+        Ni04ZTIxLTIyNzI2ZDBjZDM0ZC8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:33 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/b698d83f-60db-42a9-b5b9-b7b8f2366a02/versions/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:33 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '264'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4
+        ZDgzZi02MGRiLTQyYTktYjViOS1iN2I4ZjIzNjZhMDIvdmVyc2lvbnMvMi8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDktMDlUMTI6NDM6MzEuMTI2MjMxWiIsIm51
+        bWJlciI6MiwiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250ZW50X3N1bW1hcnki
+        OnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJz
+        aW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYjY5OGQ4M2Yt
+        NjBkYi00MmE5LWI1YjktYjdiOGYyMzY2YTAyL3ZlcnNpb25zLzIvIn19LCJy
+        ZW1vdmVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
+        bl9yZW1vdmVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYjY5OGQ4M2Yt
+        NjBkYi00MmE5LWI1YjktYjdiOGYyMzY2YTAyL3ZlcnNpb25zLzIvIn19LCJw
+        cmVzZW50Ijp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
+        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2I2OThkODNmLTYwZGItNDJh
+        OS1iNWI5LWI3YjhmMjM2NmEwMi92ZXJzaW9ucy8yLyJ9fX19XX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:33 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/bfca9403-0ec2-4a3b-b410-6c2936442735/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:34 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M5MGU1MTM3LWFiM2UtNDUx
+        MS1iMDBlLTdlZGNhY2I4OTMzNC8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:34 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/c90e5137-ab3e-4511-b00e-7edcacb89334/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:34 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '336'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jOTBlNTEzNy1hYjNlLTQ1
+        MTEtYjAwZS03ZWRjYWNiODkzMzQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjQzOjM0LjA1MTYxMVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjQzOjM0LjEzODczNloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6NDM6MzQuMTg1NDgyWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvYWY4NTNjNzItMTQ2NC00ZjdjLWEwMzUtNDcxNjY1
+        M2NlZTM5LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJl
+        c2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90
+        ZXMvZmlsZS9maWxlL2JmY2E5NDAzLTBlYzItNGEzYi1iNDEwLTZjMjkzNjQ0
+        MjczNS8iXX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:34 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:34 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '315'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmls
+        ZS9maWxlLzBhMmRkMDQwLWU3ZDgtNGE5ZC1iNGE0LWJkMjgyMTQ3YzFlZi8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDktMDlUMTI6NDM6MjkuNTQ4MjMwWiIsImJh
+        c2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNf
+        RmlsZV8xIiwiYmFzZV91cmwiOiJjZW50b3M3LWthdGVsbG8tZGV2ZWwuampl
+        ZmZlcnMuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3JnYW5p
+        emF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVs
+        cDNfRmlsZV8xIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGlj
+        YXRpb25zL2ZpbGUvZmlsZS8xNzEwYzQ4Zi0zOGQzLTQwZDItOTZiZi05NzE5
+        NmEzODRlYmYvIn1dfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:34 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/0a2dd040-e7d8-4a9d-b4a4-bd282147c1ef/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:34 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QwZTdkZDM2LWE5ZDAtNDBi
+        ZS05ODlmLTJiOTlhMmM4MzJkMC8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:34 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/b698d83f-60db-42a9-b5b9-b7b8f2366a02/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:34 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EyMjc0OWVhLTljZDctNGEy
+        NC1hMGM5LWIyZmMxNjllZGMyMy8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:34 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/a22749ea-9cd7-4a24-a0c9-b2fc169edc23/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:43:34 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '332'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hMjI3NDllYS05Y2Q3LTRh
+        MjQtYTBjOS1iMmZjMTY5ZWRjMjMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjQzOjM0Ljc3NjgxM1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5kZWxldGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wOS0wOVQxMjo0MzozNC44ODk5MjNaIiwiZmluaXNo
+        ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjQzOjM0Ljk2MTk0N1oiLCJub25fZmF0
+        YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2Fw
+        aS92My93b3JrZXJzL2FmODUzYzcyLTE0NjQtNGY3Yy1hMDM1LTQ3MTY2NTNj
+        ZWUzOS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9n
+        cmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNl
+        cnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvYjY5OGQ4M2YtNjBkYi00MmE5LWI1YjktYjdiOGYyMzY2YTAyLyJd
+        fQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:43:34 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository_list/list_with_pagination.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository_list/list_with_pagination.yml
@@ -1,0 +1,2418 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:42 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '235'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9jYzQz
+        ZmE5NS1kM2IyLTQ5NTktYWE3Ny1kZmRkNzUyYTA4MTYvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTA5VDEyOjMyOjE5LjU5MzI3OVoiLCJfdmVyc2lvbnNfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvY2M0M2ZhOTUtZDNiMi00
+        OTU5LWFhNzctZGZkZDc1MmEwODE2L3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVy
+        c2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9jYzQzZmE5
+        NS1kM2IyLTQ5NTktYWE3Ny1kZmRkNzUyYTA4MTYvdmVyc2lvbnMvMS8iLCJu
+        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxl
+        XzEiLCJkZXNjcmlwdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:42 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/cc43fa95-d3b2-4959-aa77-dfdd752a0816/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:42 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y5Y2FhN2VlLWQwZjgtNGYx
+        OC1iMmY2LTQ3MzMxMjhmZTdiNC8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:42 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:42 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '360'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlbW90ZXMvZmlsZS9maWxl
+        L2QxMTc5MmM2LTNmZjYtNDRiNS05MWM5LWExMzZhZWM4NzI0MC8iLCJfY3Jl
+        YXRlZCI6IjIwMTktMDktMDlUMTI6MzI6MTkuNzU0ODkyWiIsIl90eXBlIjoi
+        ZmlsZS5maWxlIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfRmlsZV8xIiwidXJsIjoiaHR0cHM6Ly9yZXBvcy5mZWRvcmFw
+        ZW9wbGUub3JnL3B1bHAvcHVscC9kZW1vX3JlcG9zL3Rlc3RfZmlsZV9yZXBv
+        Ly9QVUxQX01BTklGRVNUIiwic3NsX2NhX2NlcnRpZmljYXRlIjpudWxsLCJz
+        c2xfY2xpZW50X2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2tleSI6
+        bnVsbCwic3NsX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwi
+        X2xhc3RfdXBkYXRlZCI6IjIwMTktMDktMDlUMTI6MzI6MjAuMzYyMjYzWiIs
+        ImRvd25sb2FkX2NvbmN1cnJlbmN5IjoyMCwicG9saWN5IjoiaW1tZWRpYXRl
+        In1dfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:42 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/d11792c6-3ff6-44b5-91c9-a136aec87240/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:42 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzE4NjY4M2IwLWE2YTgtNGYz
+        NS1iZmVlLTc1YmYzNDVlOWVlOC8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:42 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:43 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '283'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmls
+        ZS9maWxlLzE2ODNkZTUzLTcyYjItNDViYS05YTQ5LTdkNWYwMDJmYzdmYy8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDktMDlUMTI6MzI6MjIuMjM1NDg2WiIsImJh
+        c2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNf
+        RmlsZV8xIiwiYmFzZV91cmwiOiJjZW50b3M3LWthdGVsbG8tZGV2ZWwuampl
+        ZmZlcnMuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3JnYW5p
+        emF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVs
+        cDNfRmlsZV8xIiwicHVibGljYXRpb24iOm51bGx9XX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:43 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/1683de53-72b2-45ba-9a49-7d5f002fc7fc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:43 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI5Y2YwMTg2LTU5ZTItNDI5
+        MS05MGFiLTIwMzc3OTFmZmE2Ny8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:43 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:43 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:43 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:43 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:43 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:43 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:43 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:43 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:43 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:44 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:44 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:44 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/7217425c-4377-4524-a0a5-f8ffd3bf8248/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '306'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNzIxNzQyNWMt
+        NDM3Ny00NTI0LWEwYTUtZjhmZmQzYmY4MjQ4LyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wOS0wOVQxMjozNTo0NC40MzczOTlaIiwiX3ZlcnNpb25zX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzcyMTc0MjVjLTQzNzctNDUyNC1h
+        MGE1LWY4ZmZkM2JmODI0OC92ZXJzaW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25f
+        aHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfRmlsZV8xIiwiZGVzY3JpcHRpb24iOm51bGx9
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:44 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEiLCJ1cmwiOiJodHRwczovL3JlcG9zLmZlZG9yYXBlb3BsZS5vcmcv
+        cmVwb3MvcHVscC9wdWxwL2ZpeHR1cmVzL2ZpbGUtbWFueS8vUFVMUF9NQU5J
+        RkVTVCIsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJwb2xpY3kiOiJpbW1lZGlh
+        dGUifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:44 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/file/file/68d3e1a9-c604-406c-af9d-130dd026343e/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '491'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS82OGQz
+        ZTFhOS1jNjA0LTQwNmMtYWY5ZC0xMzBkZDAyNjM0M2UvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTA5VDEyOjM1OjQ0LjY1MjQ1M1oiLCJfdHlwZSI6ImZpbGUu
+        ZmlsZSIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1
+        bHAzX0ZpbGVfMSIsInVybCI6Imh0dHBzOi8vcmVwb3MuZmVkb3JhcGVvcGxl
+        Lm9yZy9yZXBvcy9wdWxwL3B1bHAvZml4dHVyZXMvZmlsZS1tYW55Ly9QVUxQ
+        X01BTklGRVNUIiwic3NsX2NhX2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xp
+        ZW50X2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwi
+        c3NsX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwiX2xhc3Rf
+        dXBkYXRlZCI6IjIwMTktMDktMDlUMTI6MzU6NDQuNjUyNDY4WiIsImRvd25s
+        b2FkX2NvbmN1cnJlbmN5IjoyMCwicG9saWN5IjoiaW1tZWRpYXRlIn0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:44 GMT
+- request:
+    method: put
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/7217425c-4377-4524-a0a5-f8ffd3bf8248/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y4MjEwNDQ3LWI3MzQtNDlh
+        Mi1iNjI1LWUxMWJiZTIzZTI3OC8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:45 GMT
+- request:
+    method: patch
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/68d3e1a9-c604-406c-af9d-130dd026343e/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzc2xfdmFsaWRhdGlvbiI6dHJ1ZSwibmFtZSI6IkRlZmF1bHRfT3JnYW5p
+        emF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwidXJsIjoiaHR0cHM6Ly9y
+        ZXBvcy5mZWRvcmFwZW9wbGUub3JnL3JlcG9zL3B1bHAvcHVscC9maXh0dXJl
+        cy9maWxlLW1hbnkvL1BVTFBfTUFOSUZFU1QiLCJwcm94eV91cmwiOm51bGws
+        InNzbF9jbGllbnRfY2VydGlmaWNhdGUiOm51bGwsInNzbF9jbGllbnRfa2V5
+        IjpudWxsLCJzc2xfY2FfY2VydGlmaWNhdGUiOm51bGx9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JlNjY0OWQwLTQwMTctNGFl
+        YS04Y2E5LWVjYjUxNGI1Y2Q2ZC8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:45 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/68d3e1a9-c604-406c-af9d-130dd026343e/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy83MjE3
+        NDI1Yy00Mzc3LTQ1MjQtYTBhNS1mOGZmZDNiZjgyNDgvIiwibWlycm9yIjp0
+        cnVlfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RkNzliMDY1LWUyZjMtNGVm
+        YS04NTg1LWEwODBlYzEwZjJkYi8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:45 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/dd79b065-e2f3-4efa-8585-a080ec10f2db/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '509'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kZDc5YjA2NS1lMmYzLTRl
+        ZmEtODU4NS1hMDgwZWMxMGYyZGIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM1OjQ1LjcyMTYzOFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wOS0wOVQxMjozNTo0NS44Mzc4NjNa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM1OjQ2Ljc3ODAxOFoi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzL2NiNTE1YjkxLWUzNzktNGQ5OS1iYTBh
+        LTQxYTQxYzdhOTJiZC8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgTWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5n
+        IEFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
+        bmcgQ29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjI1MCwi
+        ZG9uZSI6MjUwLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29j
+        aWF0aW5nIENvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpu
+        dWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBhcnNp
+        bmcgTWV0YWRhdGEgTGluZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
+        IjoyNTAsImRvbmUiOjI1MCwic3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVz
+        b3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNzIxNzQyNWMt
+        NDM3Ny00NTI0LWEwYTUtZjhmZmQzYmY4MjQ4L3ZlcnNpb25zLzEvIl0sInJl
+        c2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy83MjE3NDI1Yy00Mzc3LTQ1MjQtYTBhNS1mOGZmZDNiZjgyNDgv
+        IiwiL3B1bHAvYXBpL3YzL3JlbW90ZXMvZmlsZS9maWxlLzY4ZDNlMWE5LWM2
+        MDQtNDA2Yy1hZjlkLTEzMGRkMDI2MzQzZS8iXX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:46 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/7217425c-4377-4524-a0a5-f8ffd3bf8248/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '238'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNzIxNzQyNWMt
+        NDM3Ny00NTI0LWEwYTUtZjhmZmQzYmY4MjQ4L3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA5VDEyOjM1OjQ1Ljg1NjUxMVoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MjUwLCJocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9u
+        X2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNzIxNzQyNWMtNDM3
+        Ny00NTI0LWEwYTUtZjhmZmQzYmY4MjQ4L3ZlcnNpb25zLzEvIn19LCJyZW1v
+        dmVkIjp7fSwicHJlc2VudCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjI1MCwi
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9z
+        aXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzcyMTc0
+        MjVjLTQzNzctNDUyNC1hMGE1LWY4ZmZkM2JmODI0OC92ZXJzaW9ucy8xLyJ9
+        fX19
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:47 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/publications/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzcyMTc0MjVjLTQzNzctNDUyNC1hMGE1LWY4ZmZkM2JmODI0OC92ZXJz
+        aW9ucy8xLyIsIm1hbmlmZXN0IjoiUFVMUF9NQU5JRkVTVCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNmN2U1ZDY4LTA3ZGQtNDgw
+        Mi04MjI1LWE4MWQ0NmY1NmVjNS8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:47 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/3f7e5d68-07dd-4802-8225-a81d46f56ec5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:48 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '374'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zZjdlNWQ2OC0wN2RkLTQ4
+        MDItODIyNS1hODFkNDZmNTZlYzUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM1OjQ3LjM5MTM3OVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnB1Ymxpc2hpbmcucHVibGlzaCIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM1OjQ3LjUxNjk4N1oiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6MzU6NDguMDM1Njg1WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
+        N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUvZmlsZS8xODkwY2Y3OS1lMDdi
+        LTRhODQtYjUwZC1kYzc4MDk2MjE3ZTUvIl0sInJlc2VydmVkX3Jlc291cmNl
+        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy83MjE3NDI1
+        Yy00Mzc3LTQ1MjQtYTBhNS1mOGZmZDNiZjgyNDgvIl19
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:48 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0ZpbGVfMSIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
+        bmV0LXB1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3Yz
+        L3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMTg5MGNmNzktZTA3Yi00YTg0LWI1
+        MGQtZGM3ODA5NjIxN2U1LyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:48 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxZDViMWZhLTRjM2EtNGJk
+        Ni1hYTZlLTZkZTEwZWQ1YjRjYy8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:48 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/01d5b1fa-4c3a-4bd6-aa6e-6de10ed5b4cc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:48 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '344'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8wMWQ1YjFmYS00YzNhLTRi
+        ZDYtYWE2ZS02ZGUxMGVkNWI0Y2MvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM1OjQ4LjM5MzM4M1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM1OjQ4LjUxNTQ5NFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6MzU6NDguNzM2OTI4WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
+        N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxlL2ZpbGUvMmQyMTNkYTItOGU1
+        My00NjNmLTkwOTMtZTc0MDdkODdhYWM0LyJdLCJyZXNlcnZlZF9yZXNvdXJj
+        ZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iXX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:48 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/2d213da2-8e53-463f-9093-e7407d87aac4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:49 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '286'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2ZpbGUvZmls
+        ZS8yZDIxM2RhMi04ZTUzLTQ2M2YtOTA5My1lNzQwN2Q4N2FhYzQvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA5VDEyOjM1OjQ4LjcyNTQyOFoiLCJiYXNlX3Bh
+        dGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVf
+        MSIsImJhc2VfdXJsIjoiY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJz
+        LmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09yZ2FuaXphdGlv
+        bi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsImNvbnRlbnRfZ3VhcmQiOm51bGws
+        Im5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0Zp
+        bGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9u
+        cy9maWxlL2ZpbGUvMTg5MGNmNzktZTA3Yi00YTg0LWI1MGQtZGM3ODA5NjIx
+        N2U1LyJ9
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:49 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:49 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '234'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy83MjE3
+        NDI1Yy00Mzc3LTQ1MjQtYTBhNS1mOGZmZDNiZjgyNDgvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTA5VDEyOjM1OjQ0LjQzNzM5OVoiLCJfdmVyc2lvbnNfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNzIxNzQyNWMtNDM3Ny00
+        NTI0LWEwYTUtZjhmZmQzYmY4MjQ4L3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVy
+        c2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy83MjE3NDI1
+        Yy00Mzc3LTQ1MjQtYTBhNS1mOGZmZDNiZjgyNDgvdmVyc2lvbnMvMS8iLCJu
+        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxl
+        XzEiLCJkZXNjcmlwdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:49 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/7217425c-4377-4524-a0a5-f8ffd3bf8248/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:49 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU2ZjhlMzMzLTExNTMtNDg5
+        My04YmY3LTc4Y2Q3NmE2OWUwZi8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:49 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:49 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '362'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlbW90ZXMvZmlsZS9maWxl
+        LzY4ZDNlMWE5LWM2MDQtNDA2Yy1hZjlkLTEzMGRkMDI2MzQzZS8iLCJfY3Jl
+        YXRlZCI6IjIwMTktMDktMDlUMTI6MzU6NDQuNjUyNDUzWiIsIl90eXBlIjoi
+        ZmlsZS5maWxlIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfRmlsZV8xIiwidXJsIjoiaHR0cHM6Ly9yZXBvcy5mZWRvcmFw
+        ZW9wbGUub3JnL3JlcG9zL3B1bHAvcHVscC9maXh0dXJlcy9maWxlLW1hbnkv
+        L1BVTFBfTUFOSUZFU1QiLCJzc2xfY2FfY2VydGlmaWNhdGUiOm51bGwsInNz
+        bF9jbGllbnRfY2VydGlmaWNhdGUiOm51bGwsInNzbF9jbGllbnRfa2V5Ijpu
+        dWxsLCJzc2xfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJf
+        bGFzdF91cGRhdGVkIjoiMjAxOS0wOS0wOVQxMjozNTo0NS4zOTA3NzhaIiwi
+        ZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJpbW1lZGlhdGUi
+        fV19
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:49 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/68d3e1a9-c604-406c-af9d-130dd026343e/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:49 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IyM2NmYjBiLTE3NmItNGY3
+        Yy05NWYwLTIyMWMyNjQxZjA0Ny8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:49 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:49 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '283'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmls
+        ZS9maWxlLzJkMjEzZGEyLThlNTMtNDYzZi05MDkzLWU3NDA3ZDg3YWFjNC8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDktMDlUMTI6MzU6NDguNzI1NDI4WiIsImJh
+        c2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNf
+        RmlsZV8xIiwiYmFzZV91cmwiOiJjZW50b3M3LWthdGVsbG8tZGV2ZWwuampl
+        ZmZlcnMuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3JnYW5p
+        emF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVs
+        cDNfRmlsZV8xIiwicHVibGljYXRpb24iOm51bGx9XX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:49 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/2d213da2-8e53-463f-9093-e7407d87aac4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:50 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcyMzQzYzdiLWFlODItNDBh
+        OC04MTJlLTUwZDE3NzQ2YmUxYS8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:50 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:50 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:50 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:50 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:50 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:50 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:50 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:50 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:50 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:50 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:50 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:51 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/9f9ef3ff-96b3-45c5-b8f8-ceb8aaff4ae4/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '306'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOWY5ZWYzZmYt
+        OTZiMy00NWM1LWI4ZjgtY2ViOGFhZmY0YWU0LyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wOS0wOVQxMjozNTo1MS4xOTQ3OTVaIiwiX3ZlcnNpb25zX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzlmOWVmM2ZmLTk2YjMtNDVjNS1i
+        OGY4LWNlYjhhYWZmNGFlNC92ZXJzaW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25f
+        aHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfRmlsZV8xIiwiZGVzY3JpcHRpb24iOm51bGx9
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:51 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEiLCJ1cmwiOiJodHRwczovL3JlcG9zLmZlZG9yYXBlb3BsZS5vcmcv
+        cHVscC9wdWxwL2RlbW9fcmVwb3MvdGVzdF9maWxlX3JlcG8vL1BVTFBfTUFO
+        SUZFU1QiLCJzc2xfdmFsaWRhdGlvbiI6dHJ1ZSwicG9saWN5IjoiaW1tZWRp
+        YXRlIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:51 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/file/file/a587fd97-e8cf-4e4b-8df0-c49584675513/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '492'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS9hNTg3
+        ZmQ5Ny1lOGNmLTRlNGItOGRmMC1jNDk1ODQ2NzU1MTMvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTA5VDEyOjM1OjUxLjM2Nzk3N1oiLCJfdHlwZSI6ImZpbGUu
+        ZmlsZSIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1
+        bHAzX0ZpbGVfMSIsInVybCI6Imh0dHBzOi8vcmVwb3MuZmVkb3JhcGVvcGxl
+        Lm9yZy9wdWxwL3B1bHAvZGVtb19yZXBvcy90ZXN0X2ZpbGVfcmVwby8vUFVM
+        UF9NQU5JRkVTVCIsInNzbF9jYV9jZXJ0aWZpY2F0ZSI6bnVsbCwic3NsX2Ns
+        aWVudF9jZXJ0aWZpY2F0ZSI6bnVsbCwic3NsX2NsaWVudF9rZXkiOm51bGws
+        InNzbF92YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsIl9sYXN0
+        X3VwZGF0ZWQiOiIyMDE5LTA5LTA5VDEyOjM1OjUxLjM2Nzk5M1oiLCJkb3du
+        bG9hZF9jb25jdXJyZW5jeSI6MjAsInBvbGljeSI6ImltbWVkaWF0ZSJ9
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:51 GMT
+- request:
+    method: put
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/9f9ef3ff-96b3-45c5-b8f8-ceb8aaff4ae4/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:51 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdhOGQ1MGM0LWZkMmEtNGUz
+        Ny04NTdlLTk1ODA1MjNmYzdkNi8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:51 GMT
+- request:
+    method: patch
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/a587fd97-e8cf-4e4b-8df0-c49584675513/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzc2xfdmFsaWRhdGlvbiI6dHJ1ZSwibmFtZSI6IkRlZmF1bHRfT3JnYW5p
+        emF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwidXJsIjoiaHR0cHM6Ly9y
+        ZXBvcy5mZWRvcmFwZW9wbGUub3JnL3B1bHAvcHVscC9kZW1vX3JlcG9zL3Rl
+        c3RfZmlsZV9yZXBvLy9QVUxQX01BTklGRVNUIiwicHJveHlfdXJsIjpudWxs
+        LCJzc2xfY2xpZW50X2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2tl
+        eSI6bnVsbCwic3NsX2NhX2NlcnRpZmljYXRlIjpudWxsfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:51 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk5MWIzNjAyLWEwYjItNDM4
+        MC04YmZkLTEyYmJmNjg5OGUxNC8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:51 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/a587fd97-e8cf-4e4b-8df0-c49584675513/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85Zjll
+        ZjNmZi05NmIzLTQ1YzUtYjhmOC1jZWI4YWFmZjRhZTQvIiwibWlycm9yIjp0
+        cnVlfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU1ZDFjYmEzLWJiYmYtNGZk
+        Ni1iZGUxLTE5ZTZkOWUxMWJhMi8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:52 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/55d1cba3-bbbf-4fd6-bde1-19e6d9e11ba2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '505'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy81NWQxY2JhMy1iYmJmLTRm
+        ZDYtYmRlMS0xOWU2ZDllMTFiYTIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM1OjUyLjQyNTM1MloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wOS0wOVQxMjozNTo1Mi41MzEzNzJa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM1OjUyLjc4ODQyN1oi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzL2FmODUzYzcyLTE0NjQtNGY3Yy1hMDM1
+        LTQ3MTY2NTNjZWUzOS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgTWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5n
+        IEFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
+        bmcgQ29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRv
+        bmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRp
+        bmcgQ29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2luZyBN
+        ZXRhZGF0YSBMaW5lcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMs
+        ImRvbmUiOjMsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzlmOWVmM2ZmLTk2YjMtNDVj
+        NS1iOGY4LWNlYjhhYWZmNGFlNC92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        OWY5ZWYzZmYtOTZiMy00NWM1LWI4ZjgtY2ViOGFhZmY0YWU0LyIsIi9wdWxw
+        L2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS9hNTg3ZmQ5Ny1lOGNmLTRlNGIt
+        OGRmMC1jNDk1ODQ2NzU1MTMvIl19
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:52 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/9f9ef3ff-96b3-45c5-b8f8-ceb8aaff4ae4/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '236'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOWY5ZWYzZmYt
+        OTZiMy00NWM1LWI4ZjgtY2ViOGFhZmY0YWU0L3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA5VDEyOjM1OjUyLjU3NzMxNVoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9h
+        ZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzlmOWVmM2ZmLTk2YjMt
+        NDVjNS1iOGY4LWNlYjhhYWZmNGFlNC92ZXJzaW9ucy8xLyJ9fSwicmVtb3Zl
+        ZCI6e30sInByZXNlbnQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOWY5ZWYzZmYt
+        OTZiMy00NWM1LWI4ZjgtY2ViOGFhZmY0YWU0L3ZlcnNpb25zLzEvIn19fX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:53 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/publications/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzlmOWVmM2ZmLTk2YjMtNDVjNS1iOGY4LWNlYjhhYWZmNGFlNC92ZXJz
+        aW9ucy8xLyIsIm1hbmlmZXN0IjoiUFVMUF9NQU5JRkVTVCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U0MmVjNjg5LWM4ZjItNDcw
+        Ny04YjU1LTE0ZjRiNDI5M2I4Ny8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:53 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/e42ec689-c8f2-4707-8b55-14f4b4293b87/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '370'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lNDJlYzY4OS1jOGYyLTQ3
+        MDctOGI1NS0xNGY0YjQyOTNiODcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM1OjUzLjE5MzYwOFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnB1Ymxpc2hpbmcucHVibGlzaCIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM1OjUzLjMxNjMyOFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6MzU6NTMuMzk1ODM4WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvYWY4NTNjNzItMTQ2NC00ZjdjLWEwMzUtNDcxNjY1
+        M2NlZTM5LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUvZmlsZS84MmM3ZGNkMS02ZjI0
+        LTQ1NTktOWRjNi1iYzQ0ZjMwNTg0YzIvIl0sInJlc2VydmVkX3Jlc291cmNl
+        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85ZjllZjNm
+        Zi05NmIzLTQ1YzUtYjhmOC1jZWI4YWFmZjRhZTQvIl19
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:53 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0ZpbGVfMSIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
+        bmV0LXB1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3Yz
+        L3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvODJjN2RjZDEtNmYyNC00NTU5LTlk
+        YzYtYmM0NGYzMDU4NGMyLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFjZWVhNGJkLTg5YTQtNGIw
+        ZC1iNjI4LTUxMzczZTA0OGU1Mi8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:53 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/1ceea4bd-89a4-4b0d-b628-51373e048e52/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:54 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '346'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8xY2VlYTRiZC04OWE0LTRi
+        MGQtYjYyOC01MTM3M2UwNDhlNTIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM1OjUzLjc2ODQ4NFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM1OjUzLjg3NTQ1M1oiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6MzU6NTQuMDgzMjY2WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvYWY4NTNjNzItMTQ2NC00ZjdjLWEwMzUtNDcxNjY1
+        M2NlZTM5LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxlL2ZpbGUvMTRjZGRjODQtODFm
+        MC00ZmNjLThlZTctYzA5MTA2YTY0ZjQzLyJdLCJyZXNlcnZlZF9yZXNvdXJj
+        ZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iXX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:54 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/14cddc84-81f0-4fcc-8ee7-c09106a64f43/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:54 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '285'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2ZpbGUvZmls
+        ZS8xNGNkZGM4NC04MWYwLTRmY2MtOGVlNy1jMDkxMDZhNjRmNDMvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA5VDEyOjM1OjU0LjA3MDkyOVoiLCJiYXNlX3Bh
+        dGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVf
+        MSIsImJhc2VfdXJsIjoiY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJz
+        LmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09yZ2FuaXphdGlv
+        bi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsImNvbnRlbnRfZ3VhcmQiOm51bGws
+        Im5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0Zp
+        bGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9u
+        cy9maWxlL2ZpbGUvODJjN2RjZDEtNmYyNC00NTU5LTlkYzYtYmM0NGYzMDU4
+        NGMyLyJ9
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:54 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:35:54 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '354'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85NTlj
+        ZjA5Yi03MTEzLTQzZjEtYTAwYS00ZjdmNGMzZDA0OGIvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTA2VDE3OjQyOjQwLjQ1NTM1MFoiLCJfdmVyc2lvbnNfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOTU5Y2YwOWItNzExMy00
+        M2YxLWEwMGEtNGY3ZjRjM2QwNDhiL3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVy
+        c2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85NTljZjA5
+        Yi03MTEzLTQzZjEtYTAwYS00ZjdmNGMzZDA0OGIvdmVyc2lvbnMvMi8iLCJu
+        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2Nr
+        ZXJfMSIsImRlc2NyaXB0aW9uIjpudWxsfSx7Il9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3JlcG9zaXRvcmllcy9iZDUwNGY5MC0zZTJkLTRlNTUtYTMyNi02NDVh
+        NWI1M2RiNTYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA2VDE3OjQ0OjAzLjY1
+        Mzc2M1oiLCJfdmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvYmQ1MDRmOTAtM2UyZC00ZTU1LWEzMjYtNjQ1YTViNTNkYjU2L3Zl
+        cnNpb25zLyIsIl9sYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L3JlcG9zaXRvcmllcy9iZDUwNGY5MC0zZTJkLTRlNTUtYTMyNi02NDVhNWI1
+        M2RiNTYvdmVyc2lvbnMvMi8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        b24tQ2FiaW5ldC1NeV9GaWxlcyIsImRlc2NyaXB0aW9uIjpudWxsfSx7Il9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85ZjllZjNmZi05NmIz
+        LTQ1YzUtYjhmOC1jZWI4YWFmZjRhZTQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5
+        LTA5VDEyOjM1OjUxLjE5NDc5NVoiLCJfdmVyc2lvbnNfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvOWY5ZWYzZmYtOTZiMy00NWM1LWI4Zjgt
+        Y2ViOGFhZmY0YWU0L3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVyc2lvbl9ocmVm
+        IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85ZjllZjNmZi05NmIzLTQ1
+        YzUtYjhmOC1jZWI4YWFmZjRhZTQvdmVyc2lvbnMvMS8iLCJuYW1lIjoiRGVm
+        YXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJkZXNj
+        cmlwdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:35:54 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository_list/repository_hrefs_are_correct.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository_list/repository_hrefs_are_correct.yml
@@ -1,0 +1,2348 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '235'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy84ZjIy
+        ZWEzNS0yODE0LTQ1OTAtYTgxYy05M2E4NzY3NTJlMjcvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTA2VDE0OjU5OjE3Ljk4NDg3OFoiLCJfdmVyc2lvbnNfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOGYyMmVhMzUtMjgxNC00
+        NTkwLWE4MWMtOTNhODc2NzUyZTI3L3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVy
+        c2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy84ZjIyZWEz
+        NS0yODE0LTQ1OTAtYTgxYy05M2E4NzY3NTJlMjcvdmVyc2lvbnMvMS8iLCJu
+        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxl
+        XzEiLCJkZXNjcmlwdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:04 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/8f22ea35-2814-4590-a81c-93a876752e27/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M3MTBiNDljLWFlMGYtNDY2
+        NC1hNzQzLTU4YWI3MzllZWQ1MS8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:04 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '359'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlbW90ZXMvZmlsZS9maWxl
+        Lzc0MTFjNDBmLTgzYzAtNDRkMy1hMDgzLWY1NjY4MTdkZmExZC8iLCJfY3Jl
+        YXRlZCI6IjIwMTktMDktMDZUMTQ6NTk6MTguMTc1MjQ5WiIsIl90eXBlIjoi
+        ZmlsZS5maWxlIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfRmlsZV8xIiwidXJsIjoiaHR0cHM6Ly9yZXBvcy5mZWRvcmFw
+        ZW9wbGUub3JnL3B1bHAvcHVscC9kZW1vX3JlcG9zL3Rlc3RfZmlsZV9yZXBv
+        Ly9QVUxQX01BTklGRVNUIiwic3NsX2NhX2NlcnRpZmljYXRlIjpudWxsLCJz
+        c2xfY2xpZW50X2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2tleSI6
+        bnVsbCwic3NsX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwi
+        X2xhc3RfdXBkYXRlZCI6IjIwMTktMDktMDZUMTQ6NTk6MTguOTc1MzcxWiIs
+        ImRvd25sb2FkX2NvbmN1cnJlbmN5IjoyMCwicG9saWN5IjoiaW1tZWRpYXRl
+        In1dfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:04 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/7411c40f-83c0-44d3-a083-f566817dfa1d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:04 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZjNjg4N2QzLTVkYjYtNGQ2
+        My04ZDA3LTEyNmIwOTYwNGU1Mi8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:04 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:05 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '282'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmls
+        ZS9maWxlL2U0NGIzYmM0LWY4NzUtNGZlYi04YmFkLTBkYjgzZDZjNzJlOC8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDktMDZUMTQ6NTk6MjEuMDY0MjAxWiIsImJh
+        c2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNf
+        RmlsZV8xIiwiYmFzZV91cmwiOiJjZW50b3M3LWthdGVsbG8tZGV2ZWwuampl
+        ZmZlcnMuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3JnYW5p
+        emF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVs
+        cDNfRmlsZV8xIiwicHVibGljYXRpb24iOm51bGx9XX0=
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:05 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/e44b3bc4-f875-4feb-8bad-0db83d6c72e8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:05 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E5ZjU3NmJiLWI2M2EtNDI2
+        MS1hNjg2LTNkMzdjZGNkMTVjNS8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:05 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:05 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:05 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:05 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:05 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:05 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:05 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:06 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:06 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:06 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:06 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:06 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/482d02e8-0f89-453a-9262-0c760ae88b9f/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '306'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNDgyZDAyZTgt
+        MGY4OS00NTNhLTkyNjItMGM3NjBhZTg4YjlmLyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wOS0wNlQxNTowMjowNi41MTEzNTVaIiwiX3ZlcnNpb25zX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzQ4MmQwMmU4LTBmODktNDUzYS05
+        MjYyLTBjNzYwYWU4OGI5Zi92ZXJzaW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25f
+        aHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfRmlsZV8xIiwiZGVzY3JpcHRpb24iOm51bGx9
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:06 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEiLCJ1cmwiOiJodHRwczovL3JlcG9zLmZlZG9yYXBlb3BsZS5vcmcv
+        cmVwb3MvcHVscC9wdWxwL2ZpeHR1cmVzL2ZpbGUtbWFueS8vUFVMUF9NQU5J
+        RkVTVCIsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJwb2xpY3kiOiJpbW1lZGlh
+        dGUifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:06 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/file/file/caef2548-5f53-4e99-92e6-0101c452366d/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '491'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS9jYWVm
+        MjU0OC01ZjUzLTRlOTktOTJlNi0wMTAxYzQ1MjM2NmQvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTA2VDE1OjAyOjA2LjcyMTE4M1oiLCJfdHlwZSI6ImZpbGUu
+        ZmlsZSIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1
+        bHAzX0ZpbGVfMSIsInVybCI6Imh0dHBzOi8vcmVwb3MuZmVkb3JhcGVvcGxl
+        Lm9yZy9yZXBvcy9wdWxwL3B1bHAvZml4dHVyZXMvZmlsZS1tYW55Ly9QVUxQ
+        X01BTklGRVNUIiwic3NsX2NhX2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xp
+        ZW50X2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwi
+        c3NsX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwiX2xhc3Rf
+        dXBkYXRlZCI6IjIwMTktMDktMDZUMTU6MDI6MDYuNzIxMjA1WiIsImRvd25s
+        b2FkX2NvbmN1cnJlbmN5IjoyMCwicG9saWN5IjoiaW1tZWRpYXRlIn0=
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:06 GMT
+- request:
+    method: put
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/482d02e8-0f89-453a-9262-0c760ae88b9f/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:07 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYwNDIyMjM3LTQ3NzEtNGRi
+        Yy1hNzQ4LTNlNWQ4MTg0NzAzMC8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:07 GMT
+- request:
+    method: patch
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/caef2548-5f53-4e99-92e6-0101c452366d/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzc2xfdmFsaWRhdGlvbiI6dHJ1ZSwibmFtZSI6IkRlZmF1bHRfT3JnYW5p
+        emF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwidXJsIjoiaHR0cHM6Ly9y
+        ZXBvcy5mZWRvcmFwZW9wbGUub3JnL3JlcG9zL3B1bHAvcHVscC9maXh0dXJl
+        cy9maWxlLW1hbnkvL1BVTFBfTUFOSUZFU1QiLCJwcm94eV91cmwiOm51bGws
+        InNzbF9jbGllbnRfY2VydGlmaWNhdGUiOm51bGwsInNzbF9jbGllbnRfa2V5
+        IjpudWxsLCJzc2xfY2FfY2VydGlmaWNhdGUiOm51bGx9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:07 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBhMzhhMmU4LTJjNTktNDUw
+        NC1hMTg0LWU1ZTIxMTA0NzU5OS8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:07 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/caef2548-5f53-4e99-92e6-0101c452366d/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy80ODJk
+        MDJlOC0wZjg5LTQ1M2EtOTI2Mi0wYzc2MGFlODhiOWYvIiwibWlycm9yIjp0
+        cnVlfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:07 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkyNWU1YjdjLWI0ZWItNDNl
+        Yy1hM2RiLWZjNDBhN2QzZjA3YS8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:07 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/925e5b7c-b4eb-43ec-a3db-fc40a7d3f07a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:09 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '505'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85MjVlNWI3Yy1iNGViLTQz
+        ZWMtYTNkYi1mYzQwYTdkM2YwN2EvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA2
+        VDE1OjAyOjA3LjgwNDExN1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wOS0wNlQxNTowMjowNy45NDE0NTFa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA5LTA2VDE1OjAyOjA4Ljk4MzQ3MVoi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzL2FmODUzYzcyLTE0NjQtNGY3Yy1hMDM1
+        LTQ3MTY2NTNjZWUzOS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiUGFyc2luZyBN
+        ZXRhZGF0YSBMaW5lcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjI1
+        MCwiZG9uZSI6MjUwLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25s
+        b2FkaW5nIE1ldGFkYXRhIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6
+        MSwiZG9uZSI6MSwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9h
+        ZGluZyBBcnRpZmFjdHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpu
+        dWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkFzc29j
+        aWF0aW5nIENvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoy
+        NTAsImRvbmUiOjI1MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1B
+        c3NvY2lhdGluZyBDb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3Rh
+        bCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVz
+        b3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNDgyZDAyZTgt
+        MGY4OS00NTNhLTkyNjItMGM3NjBhZTg4YjlmL3ZlcnNpb25zLzEvIl0sInJl
+        c2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9z
+        aXRvcmllcy80ODJkMDJlOC0wZjg5LTQ1M2EtOTI2Mi0wYzc2MGFlODhiOWYv
+        IiwiL3B1bHAvYXBpL3YzL3JlbW90ZXMvZmlsZS9maWxlL2NhZWYyNTQ4LTVm
+        NTMtNGU5OS05MmU2LTAxMDFjNDUyMzY2ZC8iXX0=
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:09 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/482d02e8-0f89-453a-9262-0c760ae88b9f/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:09 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '239'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNDgyZDAyZTgt
+        MGY4OS00NTNhLTkyNjItMGM3NjBhZTg4YjlmL3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA2VDE1OjAyOjA3Ljk2Mzc0OFoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MjUwLCJocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9u
+        X2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNDgyZDAyZTgtMGY4
+        OS00NTNhLTkyNjItMGM3NjBhZTg4YjlmL3ZlcnNpb25zLzEvIn19LCJyZW1v
+        dmVkIjp7fSwicHJlc2VudCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjI1MCwi
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9z
+        aXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzQ4MmQw
+        MmU4LTBmODktNDUzYS05MjYyLTBjNzYwYWU4OGI5Zi92ZXJzaW9ucy8xLyJ9
+        fX19
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:09 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/publications/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzQ4MmQwMmU4LTBmODktNDUzYS05MjYyLTBjNzYwYWU4OGI5Zi92ZXJz
+        aW9ucy8xLyIsIm1hbmlmZXN0IjoiUFVMUF9NQU5JRkVTVCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:09 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFiNmFkOTVhLTdjZGItNDI1
+        ZC04ZGE3LTY4YmY5MjZkZmEyNC8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:09 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/1b6ad95a-7cdb-425d-8da7-68bf926dfa24/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:10 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '376'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8xYjZhZDk1YS03Y2RiLTQy
+        NWQtOGRhNy02OGJmOTI2ZGZhMjQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA2
+        VDE1OjAyOjA5LjUzNTcyM1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnB1Ymxpc2hpbmcucHVibGlzaCIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA2VDE1OjAyOjA5LjYzNDY2OFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDZUMTU6MDI6MTAuMTkzNTQyWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
+        N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUvZmlsZS9lMGI2YWViNC0zZTdk
+        LTRjY2YtYjBmMi05NmEzMzcyNzY5MTIvIl0sInJlc2VydmVkX3Jlc291cmNl
+        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy80ODJkMDJl
+        OC0wZjg5LTQ1M2EtOTI2Mi0wYzc2MGFlODhiOWYvIl19
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:10 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0ZpbGVfMSIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
+        bmV0LXB1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3Yz
+        L3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvZTBiNmFlYjQtM2U3ZC00Y2NmLWIw
+        ZjItOTZhMzM3Mjc2OTEyLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:10 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJjMzY3ZTA2LWE1MzMtNGY5
+        Zi1hZWI0LTQxM2ZkMjQzOWU5YS8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:10 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/2c367e06-a533-4f9f-aeb4-413fd2439e9a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:10 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '346'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yYzM2N2UwNi1hNTMzLTRm
+        OWYtYWViNC00MTNmZDI0MzllOWEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA2
+        VDE1OjAyOjEwLjQ5MDEyOVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA2VDE1OjAyOjEwLjU4ODQyMloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDZUMTU6MDI6MTAuODIwMjMzWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvYWY4NTNjNzItMTQ2NC00ZjdjLWEwMzUtNDcxNjY1
+        M2NlZTM5LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxlL2ZpbGUvMDQ3YjQyOWEtNDVi
+        Ny00MmE0LWJkMTktOTM5ZWIwZjU5YjRhLyJdLCJyZXNlcnZlZF9yZXNvdXJj
+        ZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iXX0=
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:10 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/047b429a-45b7-42a4-bd19-939eb0f59b4a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:11 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '284'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2ZpbGUvZmls
+        ZS8wNDdiNDI5YS00NWI3LTQyYTQtYmQxOS05MzllYjBmNTliNGEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA2VDE1OjAyOjEwLjgwODI2NloiLCJiYXNlX3Bh
+        dGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVf
+        MSIsImJhc2VfdXJsIjoiY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJz
+        LmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09yZ2FuaXphdGlv
+        bi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsImNvbnRlbnRfZ3VhcmQiOm51bGws
+        Im5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0Zp
+        bGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9u
+        cy9maWxlL2ZpbGUvZTBiNmFlYjQtM2U3ZC00Y2NmLWIwZjItOTZhMzM3Mjc2
+        OTEyLyJ9
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:11 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:11 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '235'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy80ODJk
+        MDJlOC0wZjg5LTQ1M2EtOTI2Mi0wYzc2MGFlODhiOWYvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTA2VDE1OjAyOjA2LjUxMTM1NVoiLCJfdmVyc2lvbnNfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNDgyZDAyZTgtMGY4OS00
+        NTNhLTkyNjItMGM3NjBhZTg4YjlmL3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVy
+        c2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy80ODJkMDJl
+        OC0wZjg5LTQ1M2EtOTI2Mi0wYzc2MGFlODhiOWYvdmVyc2lvbnMvMS8iLCJu
+        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxl
+        XzEiLCJkZXNjcmlwdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:11 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/482d02e8-0f89-453a-9262-0c760ae88b9f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:11 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA3ZjFiZjYyLWVkOGEtNDc1
+        NS05OTE0LWNmOTIxYjQxYzFkZC8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:11 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:11 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '363'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlbW90ZXMvZmlsZS9maWxl
+        L2NhZWYyNTQ4LTVmNTMtNGU5OS05MmU2LTAxMDFjNDUyMzY2ZC8iLCJfY3Jl
+        YXRlZCI6IjIwMTktMDktMDZUMTU6MDI6MDYuNzIxMTgzWiIsIl90eXBlIjoi
+        ZmlsZS5maWxlIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfRmlsZV8xIiwidXJsIjoiaHR0cHM6Ly9yZXBvcy5mZWRvcmFw
+        ZW9wbGUub3JnL3JlcG9zL3B1bHAvcHVscC9maXh0dXJlcy9maWxlLW1hbnkv
+        L1BVTFBfTUFOSUZFU1QiLCJzc2xfY2FfY2VydGlmaWNhdGUiOm51bGwsInNz
+        bF9jbGllbnRfY2VydGlmaWNhdGUiOm51bGwsInNzbF9jbGllbnRfa2V5Ijpu
+        dWxsLCJzc2xfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJf
+        bGFzdF91cGRhdGVkIjoiMjAxOS0wOS0wNlQxNTowMjowNy40NjE4NDhaIiwi
+        ZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJpbW1lZGlhdGUi
+        fV19
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:11 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/caef2548-5f53-4e99-92e6-0101c452366d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:11 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2IwNThkNGU2LWJjNjItNGJj
+        MC1iMzM1LTU1YjZlMjgzMWY3YS8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:11 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:11 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '283'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmls
+        ZS9maWxlLzA0N2I0MjlhLTQ1YjctNDJhNC1iZDE5LTkzOWViMGY1OWI0YS8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDktMDZUMTU6MDI6MTAuODA4MjY2WiIsImJh
+        c2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNf
+        RmlsZV8xIiwiYmFzZV91cmwiOiJjZW50b3M3LWthdGVsbG8tZGV2ZWwuampl
+        ZmZlcnMuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3JnYW5p
+        emF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVs
+        cDNfRmlsZV8xIiwicHVibGljYXRpb24iOm51bGx9XX0=
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:11 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/047b429a-45b7-42a4-bd19-939eb0f59b4a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U4YWNmY2JkLWJhZTctNDM4
+        MS04MGQ2LTA5ZGUwY2ExNzI4NS8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:12 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:12 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:12 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:12 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:12 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:12 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:12 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:13 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/a0ea0379-c981-427e-a8a1-5099c1a35a25/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '306'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYTBlYTAzNzkt
+        Yzk4MS00MjdlLWE4YTEtNTA5OWMxYTM1YTI1LyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wOS0wNlQxNTowMjoxMy4yNTkxOThaIiwiX3ZlcnNpb25zX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2EwZWEwMzc5LWM5ODEtNDI3ZS1h
+        OGExLTUwOTljMWEzNWEyNS92ZXJzaW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25f
+        aHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfRmlsZV8xIiwiZGVzY3JpcHRpb24iOm51bGx9
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:13 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEiLCJ1cmwiOiJodHRwczovL3JlcG9zLmZlZG9yYXBlb3BsZS5vcmcv
+        cHVscC9wdWxwL2RlbW9fcmVwb3MvdGVzdF9maWxlX3JlcG8vL1BVTFBfTUFO
+        SUZFU1QiLCJzc2xfdmFsaWRhdGlvbiI6dHJ1ZSwicG9saWN5IjoiaW1tZWRp
+        YXRlIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:13 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/file/file/b4b14cf2-3adc-40d2-b312-0616d9da237f/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '492'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS9iNGIx
+        NGNmMi0zYWRjLTQwZDItYjMxMi0wNjE2ZDlkYTIzN2YvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTA2VDE1OjAyOjEzLjQzMzY1MVoiLCJfdHlwZSI6ImZpbGUu
+        ZmlsZSIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1
+        bHAzX0ZpbGVfMSIsInVybCI6Imh0dHBzOi8vcmVwb3MuZmVkb3JhcGVvcGxl
+        Lm9yZy9wdWxwL3B1bHAvZGVtb19yZXBvcy90ZXN0X2ZpbGVfcmVwby8vUFVM
+        UF9NQU5JRkVTVCIsInNzbF9jYV9jZXJ0aWZpY2F0ZSI6bnVsbCwic3NsX2Ns
+        aWVudF9jZXJ0aWZpY2F0ZSI6bnVsbCwic3NsX2NsaWVudF9rZXkiOm51bGws
+        InNzbF92YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsIl9sYXN0
+        X3VwZGF0ZWQiOiIyMDE5LTA5LTA2VDE1OjAyOjEzLjQzMzY2N1oiLCJkb3du
+        bG9hZF9jb25jdXJyZW5jeSI6MjAsInBvbGljeSI6ImltbWVkaWF0ZSJ9
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:13 GMT
+- request:
+    method: put
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/a0ea0379-c981-427e-a8a1-5099c1a35a25/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:13 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlhNmEyYTQ4LWY4ZDMtNGRh
+        OS04ZTAwLTJhMjA1OTMwOGZhOC8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:13 GMT
+- request:
+    method: patch
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/b4b14cf2-3adc-40d2-b312-0616d9da237f/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzc2xfdmFsaWRhdGlvbiI6dHJ1ZSwibmFtZSI6IkRlZmF1bHRfT3JnYW5p
+        emF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwidXJsIjoiaHR0cHM6Ly9y
+        ZXBvcy5mZWRvcmFwZW9wbGUub3JnL3B1bHAvcHVscC9kZW1vX3JlcG9zL3Rl
+        c3RfZmlsZV9yZXBvLy9QVUxQX01BTklGRVNUIiwicHJveHlfdXJsIjpudWxs
+        LCJzc2xfY2xpZW50X2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2tl
+        eSI6bnVsbCwic3NsX2NhX2NlcnRpZmljYXRlIjpudWxsfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:14 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EwODk0MWU4LWQ2ZTMtNDY3
+        Mi1iNmUyLTEyZGQ0YTI5NjQ0OS8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:14 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/b4b14cf2-3adc-40d2-b312-0616d9da237f/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9hMGVh
+        MDM3OS1jOTgxLTQyN2UtYThhMS01MDk5YzFhMzVhMjUvIiwibWlycm9yIjp0
+        cnVlfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:14 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZiYTY2OGJjLThmMDgtNDhh
+        OS1iNDFhLTVjOWNmZmQ0MTk5OS8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:14 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/fba668bc-8f08-48a9-b41a-5c9cffd41999/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:14 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '506'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9mYmE2NjhiYy04ZjA4LTQ4
+        YTktYjQxYS01YzljZmZkNDE5OTkvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA2
+        VDE1OjAyOjE0LjU1MTU5MVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wOS0wNlQxNTowMjoxNC42NjA5OTha
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA5LTA2VDE1OjAyOjE0Ljg4MzI2NFoi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzL2FmODUzYzcyLTE0NjQtNGY3Yy1hMDM1
+        LTQ3MTY2NTNjZWUzOS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgTWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5n
+        IEFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
+        bmcgQ29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRv
+        bmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRp
+        bmcgQ29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2luZyBN
+        ZXRhZGF0YSBMaW5lcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMs
+        ImRvbmUiOjMsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2EwZWEwMzc5LWM5ODEtNDI3
+        ZS1hOGExLTUwOTljMWEzNWEyNS92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        YTBlYTAzNzktYzk4MS00MjdlLWE4YTEtNTA5OWMxYTM1YTI1LyIsIi9wdWxw
+        L2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS9iNGIxNGNmMi0zYWRjLTQwZDIt
+        YjMxMi0wNjE2ZDlkYTIzN2YvIl19
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:14 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/a0ea0379-c981-427e-a8a1-5099c1a35a25/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '237'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYTBlYTAzNzkt
+        Yzk4MS00MjdlLWE4YTEtNTA5OWMxYTM1YTI1L3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA2VDE1OjAyOjE0LjY5NDg5OFoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9h
+        ZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2EwZWEwMzc5LWM5ODEt
+        NDI3ZS1hOGExLTUwOTljMWEzNWEyNS92ZXJzaW9ucy8xLyJ9fSwicmVtb3Zl
+        ZCI6e30sInByZXNlbnQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYTBlYTAzNzkt
+        Yzk4MS00MjdlLWE4YTEtNTA5OWMxYTM1YTI1L3ZlcnNpb25zLzEvIn19fX0=
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:15 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/publications/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2EwZWEwMzc5LWM5ODEtNDI3ZS1hOGExLTUwOTljMWEzNWEyNS92ZXJz
+        aW9ucy8xLyIsIm1hbmlmZXN0IjoiUFVMUF9NQU5JRkVTVCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNlNDMzOTNhLWJkMDEtNDEw
+        OS1hNzIzLThjYWRiYWQ5NzVlZi8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:15 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/3e43393a-bd01-4109-a723-8cadbad975ef/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '372'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zZTQzMzkzYS1iZDAxLTQx
+        MDktYTcyMy04Y2FkYmFkOTc1ZWYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA2
+        VDE1OjAyOjE1LjMyNjkyN1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnB1Ymxpc2hpbmcucHVibGlzaCIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA2VDE1OjAyOjE1LjQzODkzNFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDZUMTU6MDI6MTUuNTA4MjE4WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvYWY4NTNjNzItMTQ2NC00ZjdjLWEwMzUtNDcxNjY1
+        M2NlZTM5LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUvZmlsZS80NWM5NDJlMi0zZDVj
+        LTRlOWEtODdhMS0xMmE5OTgyZmVhMjkvIl0sInJlc2VydmVkX3Jlc291cmNl
+        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9hMGVhMDM3
+        OS1jOTgxLTQyN2UtYThhMS01MDk5YzFhMzVhMjUvIl19
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:15 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0ZpbGVfMSIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
+        bmV0LXB1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3Yz
+        L3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNDVjOTQyZTItM2Q1Yy00ZTlhLTg3
+        YTEtMTJhOTk4MmZlYTI5LyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:15 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQwMzJjNTVmLTYxYWItNDQ4
+        ZS1hNDlhLTQyZTljZTIwMTY4MS8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:15 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/4032c55f-61ab-448e-a49a-42e9ce201681/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:16 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '347'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy80MDMyYzU1Zi02MWFiLTQ0
+        OGUtYTQ5YS00MmU5Y2UyMDE2ODEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA2
+        VDE1OjAyOjE1LjkwMjU0N1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA2VDE1OjAyOjE2LjAyMzQ3NVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDZUMTU6MDI6MTYuMjQ3NzU5WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
+        N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxlL2ZpbGUvNmViNDc5NjYtYjZh
+        Zi00N2E0LTkyMjEtZDIxZDIyOThmZTY4LyJdLCJyZXNlcnZlZF9yZXNvdXJj
+        ZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iXX0=
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:16 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/6eb47966-b6af-47a4-9221-d21d2298fe68/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:16 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '285'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2ZpbGUvZmls
+        ZS82ZWI0Nzk2Ni1iNmFmLTQ3YTQtOTIyMS1kMjFkMjI5OGZlNjgvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA2VDE1OjAyOjE2LjIzNDU1OFoiLCJiYXNlX3Bh
+        dGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVf
+        MSIsImJhc2VfdXJsIjoiY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJz
+        LmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09yZ2FuaXphdGlv
+        bi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsImNvbnRlbnRfZ3VhcmQiOm51bGws
+        Im5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0Zp
+        bGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9u
+        cy9maWxlL2ZpbGUvNDVjOTQyZTItM2Q1Yy00ZTlhLTg3YTEtMTJhOTk4MmZl
+        YTI5LyJ9
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:16 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository_list/repository_list_size.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository_list/repository_list_size.yml
@@ -1,0 +1,2348 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '233'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9hMGVh
+        MDM3OS1jOTgxLTQyN2UtYThhMS01MDk5YzFhMzVhMjUvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTA2VDE1OjAyOjEzLjI1OTE5OFoiLCJfdmVyc2lvbnNfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYTBlYTAzNzktYzk4MS00
+        MjdlLWE4YTEtNTA5OWMxYTM1YTI1L3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVy
+        c2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9hMGVhMDM3
+        OS1jOTgxLTQyN2UtYThhMS01MDk5YzFhMzVhMjUvdmVyc2lvbnMvMS8iLCJu
+        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxl
+        XzEiLCJkZXNjcmlwdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:17 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/a0ea0379-c981-427e-a8a1-5099c1a35a25/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUzZDM2MWQ4LTRhYWYtNDNh
+        Yi05NDk3LTE3MzRmMTQ1MjdkYy8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:17 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '358'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlbW90ZXMvZmlsZS9maWxl
+        L2I0YjE0Y2YyLTNhZGMtNDBkMi1iMzEyLTA2MTZkOWRhMjM3Zi8iLCJfY3Jl
+        YXRlZCI6IjIwMTktMDktMDZUMTU6MDI6MTMuNDMzNjUxWiIsIl90eXBlIjoi
+        ZmlsZS5maWxlIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfRmlsZV8xIiwidXJsIjoiaHR0cHM6Ly9yZXBvcy5mZWRvcmFw
+        ZW9wbGUub3JnL3B1bHAvcHVscC9kZW1vX3JlcG9zL3Rlc3RfZmlsZV9yZXBv
+        Ly9QVUxQX01BTklGRVNUIiwic3NsX2NhX2NlcnRpZmljYXRlIjpudWxsLCJz
+        c2xfY2xpZW50X2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2tleSI6
+        bnVsbCwic3NsX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwi
+        X2xhc3RfdXBkYXRlZCI6IjIwMTktMDktMDZUMTU6MDI6MTQuMjMxMDI0WiIs
+        ImRvd25sb2FkX2NvbmN1cnJlbmN5IjoyMCwicG9saWN5IjoiaW1tZWRpYXRl
+        In1dfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:17 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/b4b14cf2-3adc-40d2-b312-0616d9da237f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:18 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ1YjA2MDYwLTEwY2ItNGU1
+        Ny1iYTgxLWNlNjhjY2UzZDFkMi8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:18 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:18 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '283'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmls
+        ZS9maWxlLzZlYjQ3OTY2LWI2YWYtNDdhNC05MjIxLWQyMWQyMjk4ZmU2OC8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDktMDZUMTU6MDI6MTYuMjM0NTU4WiIsImJh
+        c2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNf
+        RmlsZV8xIiwiYmFzZV91cmwiOiJjZW50b3M3LWthdGVsbG8tZGV2ZWwuampl
+        ZmZlcnMuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3JnYW5p
+        emF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVs
+        cDNfRmlsZV8xIiwicHVibGljYXRpb24iOm51bGx9XX0=
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:18 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/6eb47966-b6af-47a4-9221-d21d2298fe68/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:18 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JmNDk5NTE3LThjZjAtNDAx
+        MS05YmVhLWIwMGE3MDM5ZWY1ZC8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:18 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:18 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:18 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:18 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:18 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:18 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:18 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:19 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:19 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:19 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:19 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:19 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/f8548791-91a6-47d2-b176-f2e9e3e99c79/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '306'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZjg1NDg3OTEt
+        OTFhNi00N2QyLWIxNzYtZjJlOWUzZTk5Yzc5LyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wOS0wNlQxNTowMjoxOS41Mzc2MjZaIiwiX3ZlcnNpb25zX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2Y4NTQ4NzkxLTkxYTYtNDdkMi1i
+        MTc2LWYyZTllM2U5OWM3OS92ZXJzaW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25f
+        aHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfRmlsZV8xIiwiZGVzY3JpcHRpb24iOm51bGx9
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:19 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEiLCJ1cmwiOiJodHRwczovL3JlcG9zLmZlZG9yYXBlb3BsZS5vcmcv
+        cmVwb3MvcHVscC9wdWxwL2ZpeHR1cmVzL2ZpbGUtbWFueS8vUFVMUF9NQU5J
+        RkVTVCIsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJwb2xpY3kiOiJpbW1lZGlh
+        dGUifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:19 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/file/file/d51231e4-a154-447d-8d50-dde4674f2fee/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '491'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS9kNTEy
+        MzFlNC1hMTU0LTQ0N2QtOGQ1MC1kZGU0Njc0ZjJmZWUvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTA2VDE1OjAyOjE5LjcwOTQ1NFoiLCJfdHlwZSI6ImZpbGUu
+        ZmlsZSIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1
+        bHAzX0ZpbGVfMSIsInVybCI6Imh0dHBzOi8vcmVwb3MuZmVkb3JhcGVvcGxl
+        Lm9yZy9yZXBvcy9wdWxwL3B1bHAvZml4dHVyZXMvZmlsZS1tYW55Ly9QVUxQ
+        X01BTklGRVNUIiwic3NsX2NhX2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xp
+        ZW50X2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwi
+        c3NsX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwiX2xhc3Rf
+        dXBkYXRlZCI6IjIwMTktMDktMDZUMTU6MDI6MTkuNzA5NDg2WiIsImRvd25s
+        b2FkX2NvbmN1cnJlbmN5IjoyMCwicG9saWN5IjoiaW1tZWRpYXRlIn0=
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:19 GMT
+- request:
+    method: put
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/f8548791-91a6-47d2-b176-f2e9e3e99c79/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:20 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q5ZjljNGE4LTI0ZTktNDUx
+        Yy1hYjkyLWY2MjM1MjRlNjFhMC8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:20 GMT
+- request:
+    method: patch
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/d51231e4-a154-447d-8d50-dde4674f2fee/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzc2xfdmFsaWRhdGlvbiI6dHJ1ZSwibmFtZSI6IkRlZmF1bHRfT3JnYW5p
+        emF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwidXJsIjoiaHR0cHM6Ly9y
+        ZXBvcy5mZWRvcmFwZW9wbGUub3JnL3JlcG9zL3B1bHAvcHVscC9maXh0dXJl
+        cy9maWxlLW1hbnkvL1BVTFBfTUFOSUZFU1QiLCJwcm94eV91cmwiOm51bGws
+        InNzbF9jbGllbnRfY2VydGlmaWNhdGUiOm51bGwsInNzbF9jbGllbnRfa2V5
+        IjpudWxsLCJzc2xfY2FfY2VydGlmaWNhdGUiOm51bGx9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:20 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZkMzllMDllLThiNTQtNDQ2
+        ZS1hMDdjLTlhNmYwNzhkZGU0YS8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:20 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/d51231e4-a154-447d-8d50-dde4674f2fee/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9mODU0
+        ODc5MS05MWE2LTQ3ZDItYjE3Ni1mMmU5ZTNlOTljNzkvIiwibWlycm9yIjp0
+        cnVlfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:20 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QwMTc4NDE2LTcxYTEtNDNi
+        Mi1iZjA4LTY4M2NiMjhiODY3YS8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:20 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/d0178416-71a1-43b2-bf08-683cb28b867a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:21 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '510'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kMDE3ODQxNi03MWExLTQz
+        YjItYmYwOC02ODNjYjI4Yjg2N2EvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA2
+        VDE1OjAyOjIwLjc4NzUwNFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wOS0wNlQxNTowMjoyMC45MDg4Mzda
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA5LTA2VDE1OjAyOjIxLjc0MDA3N1oi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzL2FmODUzYzcyLTE0NjQtNGY3Yy1hMDM1
+        LTQ3MTY2NTNjZWUzOS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgTWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5n
+        IEFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
+        bmcgQ29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjI1MCwi
+        ZG9uZSI6MjUwLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVuLUFzc29j
+        aWF0aW5nIENvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpu
+        dWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBhcnNp
+        bmcgTWV0YWRhdGEgTGluZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
+        IjoyNTAsImRvbmUiOjI1MCwic3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVz
+        b3VyY2VzIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZjg1NDg3OTEt
+        OTFhNi00N2QyLWIxNzYtZjJlOWUzZTk5Yzc5L3ZlcnNpb25zLzEvIl0sInJl
+        c2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90
+        ZXMvZmlsZS9maWxlL2Q1MTIzMWU0LWExNTQtNDQ3ZC04ZDUwLWRkZTQ2NzRm
+        MmZlZS8iLCIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2Y4NTQ4NzkxLTkx
+        YTYtNDdkMi1iMTc2LWYyZTllM2U5OWM3OS8iXX0=
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:21 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/f8548791-91a6-47d2-b176-f2e9e3e99c79/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '238'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZjg1NDg3OTEt
+        OTFhNi00N2QyLWIxNzYtZjJlOWUzZTk5Yzc5L3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA2VDE1OjAyOjIwLjkzNDk1MFoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MjUwLCJocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJzaW9u
+        X2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZjg1NDg3OTEtOTFh
+        Ni00N2QyLWIxNzYtZjJlOWUzZTk5Yzc5L3ZlcnNpb25zLzEvIn19LCJyZW1v
+        dmVkIjp7fSwicHJlc2VudCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjI1MCwi
+        aHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9z
+        aXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2Y4NTQ4
+        NzkxLTkxYTYtNDdkMi1iMTc2LWYyZTllM2U5OWM3OS92ZXJzaW9ucy8xLyJ9
+        fX19
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:22 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/publications/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2Y4NTQ4NzkxLTkxYTYtNDdkMi1iMTc2LWYyZTllM2U5OWM3OS92ZXJz
+        aW9ucy8xLyIsIm1hbmlmZXN0IjoiUFVMUF9NQU5JRkVTVCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:22 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJiNGYxYjcyLTg5YjEtNDVl
+        NC04YzFhLTE3YzQ0NzAzNzI3YS8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:22 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/2b4f1b72-89b1-45e4-8c1a-17c44703727a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '373'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yYjRmMWI3Mi04OWIxLTQ1
+        ZTQtOGMxYS0xN2M0NDcwMzcyN2EvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA2
+        VDE1OjAyOjIyLjMxNTU2N1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnB1Ymxpc2hpbmcucHVibGlzaCIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA2VDE1OjAyOjIyLjQxMzEyOFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDZUMTU6MDI6MjIuOTI5ODY4WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvYWY4NTNjNzItMTQ2NC00ZjdjLWEwMzUtNDcxNjY1
+        M2NlZTM5LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUvZmlsZS8wMzBiNmRmMS00MjRk
+        LTQ4NzgtOTYyMC0wNmFlN2ZmNTlhNDgvIl0sInJlc2VydmVkX3Jlc291cmNl
+        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9mODU0ODc5
+        MS05MWE2LTQ3ZDItYjE3Ni1mMmU5ZTNlOTljNzkvIl19
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:23 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0ZpbGVfMSIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
+        bmV0LXB1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3Yz
+        L3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDMwYjZkZjEtNDI0ZC00ODc4LTk2
+        MjAtMDZhZTdmZjU5YTQ4LyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ5MzA5NWE0LWFjNjUtNDQ3
+        YS05NDg2LWUwMTdlMzQ2MjlhNS8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:23 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/493095a4-ac65-447a-9486-e017e34629a5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '349'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy80OTMwOTVhNC1hYzY1LTQ0
+        N2EtOTQ4Ni1lMDE3ZTM0NjI5YTUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA2
+        VDE1OjAyOjIzLjI5MzM0MFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA2VDE1OjAyOjIzLjM5OTc1OFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDZUMTU6MDI6MjMuNjYyMjY5WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
+        N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxlL2ZpbGUvNTA3YTI2MmItODEy
+        NS00ZTg5LWExY2ItN2RkOTQ5OGJmMjM0LyJdLCJyZXNlcnZlZF9yZXNvdXJj
+        ZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iXX0=
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:23 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/507a262b-8125-4e89-a1cb-7dd9498bf234/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:23 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '286'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2ZpbGUvZmls
+        ZS81MDdhMjYyYi04MTI1LTRlODktYTFjYi03ZGQ5NDk4YmYyMzQvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA2VDE1OjAyOjIzLjY0NjA2NVoiLCJiYXNlX3Bh
+        dGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVf
+        MSIsImJhc2VfdXJsIjoiY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJz
+        LmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09yZ2FuaXphdGlv
+        bi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsImNvbnRlbnRfZ3VhcmQiOm51bGws
+        Im5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0Zp
+        bGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9u
+        cy9maWxlL2ZpbGUvMDMwYjZkZjEtNDI0ZC00ODc4LTk2MjAtMDZhZTdmZjU5
+        YTQ4LyJ9
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:23 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '236'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9mODU0
+        ODc5MS05MWE2LTQ3ZDItYjE3Ni1mMmU5ZTNlOTljNzkvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTA2VDE1OjAyOjE5LjUzNzYyNloiLCJfdmVyc2lvbnNfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZjg1NDg3OTEtOTFhNi00
+        N2QyLWIxNzYtZjJlOWUzZTk5Yzc5L3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVy
+        c2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9mODU0ODc5
+        MS05MWE2LTQ3ZDItYjE3Ni1mMmU5ZTNlOTljNzkvdmVyc2lvbnMvMS8iLCJu
+        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxl
+        XzEiLCJkZXNjcmlwdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:24 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/f8548791-91a6-47d2-b176-f2e9e3e99c79/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzljZTExYmY3LWUxYjgtNDk4
+        Yi04NDIyLTY2NjNhMmRiN2U2ZC8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:24 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '363'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlbW90ZXMvZmlsZS9maWxl
+        L2Q1MTIzMWU0LWExNTQtNDQ3ZC04ZDUwLWRkZTQ2NzRmMmZlZS8iLCJfY3Jl
+        YXRlZCI6IjIwMTktMDktMDZUMTU6MDI6MTkuNzA5NDU0WiIsIl90eXBlIjoi
+        ZmlsZS5maWxlIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfRmlsZV8xIiwidXJsIjoiaHR0cHM6Ly9yZXBvcy5mZWRvcmFw
+        ZW9wbGUub3JnL3JlcG9zL3B1bHAvcHVscC9maXh0dXJlcy9maWxlLW1hbnkv
+        L1BVTFBfTUFOSUZFU1QiLCJzc2xfY2FfY2VydGlmaWNhdGUiOm51bGwsInNz
+        bF9jbGllbnRfY2VydGlmaWNhdGUiOm51bGwsInNzbF9jbGllbnRfa2V5Ijpu
+        dWxsLCJzc2xfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJf
+        bGFzdF91cGRhdGVkIjoiMjAxOS0wOS0wNlQxNTowMjoyMC40MzY2MjdaIiwi
+        ZG93bmxvYWRfY29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJpbW1lZGlhdGUi
+        fV19
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:24 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/d51231e4-a154-447d-8d50-dde4674f2fee/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UyMWVlNGM4LWJhZDItNGQy
+        Ny1iYjE3LTNlMTcwZjBmMmZkZi8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:24 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:24 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '283'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmls
+        ZS9maWxlLzUwN2EyNjJiLTgxMjUtNGU4OS1hMWNiLTdkZDk0OThiZjIzNC8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDktMDZUMTU6MDI6MjMuNjQ2MDY1WiIsImJh
+        c2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNf
+        RmlsZV8xIiwiYmFzZV91cmwiOiJjZW50b3M3LWthdGVsbG8tZGV2ZWwuampl
+        ZmZlcnMuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3JnYW5p
+        emF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVs
+        cDNfRmlsZV8xIiwicHVibGljYXRpb24iOm51bGx9XX0=
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:24 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/507a262b-8125-4e89-a1cb-7dd9498bf234/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFhYzYwMGEyLTY1MjctNGNh
+        Zi1hYjQxLTBlYWQ0MGZkMjMzYy8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:25 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:25 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:25 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:25 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:25 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:25 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:25 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:26 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/1f7df861-cd5c-4865-951b-f4ea6ad1ba66/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '306'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvMWY3ZGY4NjEt
+        Y2Q1Yy00ODY1LTk1MWItZjRlYTZhZDFiYTY2LyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wOS0wNlQxNTowMjoyNi4yMjA5MzlaIiwiX3ZlcnNpb25zX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzFmN2RmODYxLWNkNWMtNDg2NS05
+        NTFiLWY0ZWE2YWQxYmE2Ni92ZXJzaW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25f
+        aHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfRmlsZV8xIiwiZGVzY3JpcHRpb24iOm51bGx9
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:26 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEiLCJ1cmwiOiJodHRwczovL3JlcG9zLmZlZG9yYXBlb3BsZS5vcmcv
+        cHVscC9wdWxwL2RlbW9fcmVwb3MvdGVzdF9maWxlX3JlcG8vL1BVTFBfTUFO
+        SUZFU1QiLCJzc2xfdmFsaWRhdGlvbiI6dHJ1ZSwicG9saWN5IjoiaW1tZWRp
+        YXRlIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:26 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/file/file/3c3b63a9-2d27-422a-ae08-b630b55a7b31/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '492'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS8zYzNi
+        NjNhOS0yZDI3LTQyMmEtYWUwOC1iNjMwYjU1YTdiMzEvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTA2VDE1OjAyOjI2LjQwMTMwNloiLCJfdHlwZSI6ImZpbGUu
+        ZmlsZSIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1
+        bHAzX0ZpbGVfMSIsInVybCI6Imh0dHBzOi8vcmVwb3MuZmVkb3JhcGVvcGxl
+        Lm9yZy9wdWxwL3B1bHAvZGVtb19yZXBvcy90ZXN0X2ZpbGVfcmVwby8vUFVM
+        UF9NQU5JRkVTVCIsInNzbF9jYV9jZXJ0aWZpY2F0ZSI6bnVsbCwic3NsX2Ns
+        aWVudF9jZXJ0aWZpY2F0ZSI6bnVsbCwic3NsX2NsaWVudF9rZXkiOm51bGws
+        InNzbF92YWxpZGF0aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsIl9sYXN0
+        X3VwZGF0ZWQiOiIyMDE5LTA5LTA2VDE1OjAyOjI2LjQwMTMyMloiLCJkb3du
+        bG9hZF9jb25jdXJyZW5jeSI6MjAsInBvbGljeSI6ImltbWVkaWF0ZSJ9
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:26 GMT
+- request:
+    method: put
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/1f7df861-cd5c-4865-951b-f4ea6ad1ba66/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:26 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzkwNDVjZTQzLTNjNmQtNDQ1
+        Ni1iNDJhLTM1YzBmNjhlMDcwNS8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:26 GMT
+- request:
+    method: patch
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/3c3b63a9-2d27-422a-ae08-b630b55a7b31/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzc2xfdmFsaWRhdGlvbiI6dHJ1ZSwibmFtZSI6IkRlZmF1bHRfT3JnYW5p
+        emF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwidXJsIjoiaHR0cHM6Ly9y
+        ZXBvcy5mZWRvcmFwZW9wbGUub3JnL3B1bHAvcHVscC9kZW1vX3JlcG9zL3Rl
+        c3RfZmlsZV9yZXBvLy9QVUxQX01BTklGRVNUIiwicHJveHlfdXJsIjpudWxs
+        LCJzc2xfY2xpZW50X2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2tl
+        eSI6bnVsbCwic3NsX2NhX2NlcnRpZmljYXRlIjpudWxsfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:26 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ExODUyMDU0LTA1YjItNDZm
+        YS05YmJmLWIwNThkYjA5N2Q0Yy8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:27 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/3c3b63a9-2d27-422a-ae08-b630b55a7b31/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy8xZjdk
+        Zjg2MS1jZDVjLTQ4NjUtOTUxYi1mNGVhNmFkMWJhNjYvIiwibWlycm9yIjp0
+        cnVlfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:27 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M2NTA2NWRkLTA4NzMtNDhh
+        YS05YTUzLTdiNzdhNTg2YjFiYi8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:27 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/c65065dd-0873-48aa-9a53-7b77a586b1bb/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:27 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '504'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jNjUwNjVkZC0wODczLTQ4
+        YWEtOWE1My03Yjc3YTU4NmIxYmIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA2
+        VDE1OjAyOjI3LjU2MzY0MFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wOS0wNlQxNTowMjoyNy42ODA5MjVa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA5LTA2VDE1OjAyOjI3LjkxNzA2NVoi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzL2NiNTE1YjkxLWUzNzktNGQ5OS1iYTBh
+        LTQxYTQxYzdhOTJiZC8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgTWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5n
+        IEFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
+        bmcgQ29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRv
+        bmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRp
+        bmcgQ29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2luZyBN
+        ZXRhZGF0YSBMaW5lcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMs
+        ImRvbmUiOjMsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzFmN2RmODYxLWNkNWMtNDg2
+        NS05NTFiLWY0ZWE2YWQxYmE2Ni92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        MWY3ZGY4NjEtY2Q1Yy00ODY1LTk1MWItZjRlYTZhZDFiYTY2LyIsIi9wdWxw
+        L2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS8zYzNiNjNhOS0yZDI3LTQyMmEt
+        YWUwOC1iNjMwYjU1YTdiMzEvIl19
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:27 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/1f7df861-cd5c-4865-951b-f4ea6ad1ba66/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '237'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvMWY3ZGY4NjEt
+        Y2Q1Yy00ODY1LTk1MWItZjRlYTZhZDFiYTY2L3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA2VDE1OjAyOjI3LjcxMTIyOFoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9h
+        ZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzFmN2RmODYxLWNkNWMt
+        NDg2NS05NTFiLWY0ZWE2YWQxYmE2Ni92ZXJzaW9ucy8xLyJ9fSwicmVtb3Zl
+        ZCI6e30sInByZXNlbnQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvMWY3ZGY4NjEt
+        Y2Q1Yy00ODY1LTk1MWItZjRlYTZhZDFiYTY2L3ZlcnNpb25zLzEvIn19fX0=
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:28 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/publications/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzFmN2RmODYxLWNkNWMtNDg2NS05NTFiLWY0ZWE2YWQxYmE2Ni92ZXJz
+        aW9ucy8xLyIsIm1hbmlmZXN0IjoiUFVMUF9NQU5JRkVTVCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RmZjQ5OGE5LWMxYjctNGU0
+        MC04NzIyLWE1NWUxNjA4ZDI4Ni8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:28 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/dff498a9-c1b7-4e40-8722-a55e1608d286/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '375'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kZmY0OThhOS1jMWI3LTRl
+        NDAtODcyMi1hNTVlMTYwOGQyODYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA2
+        VDE1OjAyOjI4LjQwMzMyNVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnB1Ymxpc2hpbmcucHVibGlzaCIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA2VDE1OjAyOjI4LjUzMDIzOVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDZUMTU6MDI6MjguNTkzMzAzWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvYWY4NTNjNzItMTQ2NC00ZjdjLWEwMzUtNDcxNjY1
+        M2NlZTM5LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUvZmlsZS81YzI3OGY5MS02NTU2
+        LTQ5ZTYtOWY0ZS1hMTQ1OTNhOThmMWQvIl0sInJlc2VydmVkX3Jlc291cmNl
+        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy8xZjdkZjg2
+        MS1jZDVjLTQ4NjUtOTUxYi1mNGVhNmFkMWJhNjYvIl19
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:28 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0ZpbGVfMSIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
+        bmV0LXB1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3Yz
+        L3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvNWMyNzhmOTEtNjU1Ni00OWU2LTlm
+        NGUtYTE0NTkzYTk4ZjFkLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M3MjViMmQ0LTI0MzctNDk4
+        Ni05YTEyLTA0YjQxNDM4ZDY1Mi8ifQ==
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:28 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/c725b2d4-2437-4986-9a12-04b41438d652/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '348'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jNzI1YjJkNC0yNDM3LTQ5
+        ODYtOWExMi0wNGI0MTQzOGQ2NTIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA2
+        VDE1OjAyOjI4LjgwOTc4M1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA2VDE1OjAyOjI4Ljk0Mzc1MFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDZUMTU6MDI6MjkuMTkzNDQ4WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
+        N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxlL2ZpbGUvNTJlYjEyYTUtNjE5
+        OC00YjEwLWIxY2YtYWFkNmI1ZWM0ZTkyLyJdLCJyZXNlcnZlZF9yZXNvdXJj
+        ZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iXX0=
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/52eb12a5-6198-4b10-b1cf-aad6b5ec4e92/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 06 Sep 2019 15:02:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '284'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2ZpbGUvZmls
+        ZS81MmViMTJhNS02MTk4LTRiMTAtYjFjZi1hYWQ2YjVlYzRlOTIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA2VDE1OjAyOjI5LjE4MTI0MVoiLCJiYXNlX3Bh
+        dGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVf
+        MSIsImJhc2VfdXJsIjoiY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJz
+        LmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09yZ2FuaXphdGlv
+        bi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsImNvbnRlbnRfZ3VhcmQiOm51bGws
+        Im5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0Zp
+        bGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9u
+        cy9maWxlL2ZpbGUvNWMyNzhmOTEtNjU1Ni00OWU2LTlmNGUtYTE0NTkzYTk4
+        ZjFkLyJ9
+    http_version: 
+  recorded_at: Fri, 06 Sep 2019 15:02:29 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository_orphan/delete_orphan_repository_versions.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository_orphan/delete_orphan_repository_versions.yml
@@ -1,0 +1,3090 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:26 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '234'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85Zjll
+        ZjNmZi05NmIzLTQ1YzUtYjhmOC1jZWI4YWFmZjRhZTQvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTA5VDEyOjM1OjUxLjE5NDc5NVoiLCJfdmVyc2lvbnNfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOWY5ZWYzZmYtOTZiMy00
+        NWM1LWI4ZjgtY2ViOGFhZmY0YWU0L3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVy
+        c2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85ZjllZjNm
+        Zi05NmIzLTQ1YzUtYjhmOC1jZWI4YWFmZjRhZTQvdmVyc2lvbnMvMS8iLCJu
+        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxl
+        XzEiLCJkZXNjcmlwdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:26 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/9f9ef3ff-96b3-45c5-b8f8-ceb8aaff4ae4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:26 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI5NDEyMWVjLTViNDctNDEx
+        Ni1hNjQxLWMyNjU2YmI5MzZlMS8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:26 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:26 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '361'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlbW90ZXMvZmlsZS9maWxl
+        L2E1ODdmZDk3LWU4Y2YtNGU0Yi04ZGYwLWM0OTU4NDY3NTUxMy8iLCJfY3Jl
+        YXRlZCI6IjIwMTktMDktMDlUMTI6MzU6NTEuMzY3OTc3WiIsIl90eXBlIjoi
+        ZmlsZS5maWxlIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfRmlsZV8xIiwidXJsIjoiaHR0cHM6Ly9yZXBvcy5mZWRvcmFw
+        ZW9wbGUub3JnL3B1bHAvcHVscC9kZW1vX3JlcG9zL3Rlc3RfZmlsZV9yZXBv
+        Ly9QVUxQX01BTklGRVNUIiwic3NsX2NhX2NlcnRpZmljYXRlIjpudWxsLCJz
+        c2xfY2xpZW50X2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2tleSI6
+        bnVsbCwic3NsX3ZhbGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwi
+        X2xhc3RfdXBkYXRlZCI6IjIwMTktMDktMDlUMTI6MzU6NTIuMTA5NDEwWiIs
+        ImRvd25sb2FkX2NvbmN1cnJlbmN5IjoyMCwicG9saWN5IjoiaW1tZWRpYXRl
+        In1dfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:26 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/a587fd97-e8cf-4e4b-8df0-c49584675513/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:26 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzZjOTQ4MTM4LTY3M2QtNGQ5
+        YS1iNzJjLTc3YmI1YTA2NTVhMy8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:26 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:27 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '282'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmls
+        ZS9maWxlLzE0Y2RkYzg0LTgxZjAtNGZjYy04ZWU3LWMwOTEwNmE2NGY0My8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDktMDlUMTI6MzU6NTQuMDcwOTI5WiIsImJh
+        c2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNf
+        RmlsZV8xIiwiYmFzZV91cmwiOiJjZW50b3M3LWthdGVsbG8tZGV2ZWwuampl
+        ZmZlcnMuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3JnYW5p
+        emF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVs
+        cDNfRmlsZV8xIiwicHVibGljYXRpb24iOm51bGx9XX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:27 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/14cddc84-81f0-4fcc-8ee7-c09106a64f43/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:27 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdmZjg4YjYwLTYwOWYtNGZk
+        Yi05OGM5LTJlYzgwYzQ4NTlkYi8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:27 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:27 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:27 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:27 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:27 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:27 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:27 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:27 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:27 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:28 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/82cccb8e-6eaa-49f2-9400-74083b6a32d6/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '306'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvODJjY2NiOGUt
+        NmVhYS00OWYyLTk0MDAtNzQwODNiNmEzMmQ2LyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wOS0wOVQxMjozNzoyOC4zMjkyNDNaIiwiX3ZlcnNpb25zX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzgyY2NjYjhlLTZlYWEtNDlmMi05
+        NDAwLTc0MDgzYjZhMzJkNi92ZXJzaW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25f
+        aHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfRmlsZV8xIiwiZGVzY3JpcHRpb24iOm51bGx9
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:28 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEiLCJ1cmwiOiJodHRwczovL3JlcG9zLmZlZG9yYXBlb3BsZS5vcmcv
+        cmVwb3MvcHVscC9wdWxwL2ZpeHR1cmVzL2ZpbGUyLy9QVUxQX01BTklGRVNU
+        Iiwic3NsX3ZhbGlkYXRpb24iOnRydWUsInBvbGljeSI6ImltbWVkaWF0ZSJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:28 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/file/file/48d585b9-51bf-45d8-98d5-e3e3942963d2/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '487'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS80OGQ1
+        ODViOS01MWJmLTQ1ZDgtOThkNS1lM2UzOTQyOTYzZDIvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTA5VDEyOjM3OjI4LjYxNjM4M1oiLCJfdHlwZSI6ImZpbGUu
+        ZmlsZSIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1
+        bHAzX0ZpbGVfMSIsInVybCI6Imh0dHBzOi8vcmVwb3MuZmVkb3JhcGVvcGxl
+        Lm9yZy9yZXBvcy9wdWxwL3B1bHAvZml4dHVyZXMvZmlsZTIvL1BVTFBfTUFO
+        SUZFU1QiLCJzc2xfY2FfY2VydGlmaWNhdGUiOm51bGwsInNzbF9jbGllbnRf
+        Y2VydGlmaWNhdGUiOm51bGwsInNzbF9jbGllbnRfa2V5IjpudWxsLCJzc2xf
+        dmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJfbGFzdF91cGRh
+        dGVkIjoiMjAxOS0wOS0wOVQxMjozNzoyOC42MTY0MDhaIiwiZG93bmxvYWRf
+        Y29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJpbW1lZGlhdGUifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:28 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/82cccb8e-6eaa-49f2-9400-74083b6a32d6/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA1ZDYxZjdlLTgyYjAtNDM2
+        Yy04ZDQ4LWIzNmU5YzhiYzI1YS8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/05d61f7e-82b0-436c-8d48-b36e9c8bc25a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '353'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8wNWQ2MWY3ZS04MmIwLTQz
+        NmMtOGQ0OC1iMzZlOWM4YmMyNWEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM3OjI5LjAzNjQ4NloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM3OjI5LjEzMjM4NVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDktMDlUMTI6Mzc6MjkuMTc5NjAyWiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEt
+        NDFhNDFjN2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzgyY2NjYjhlLTZlYWEtNDlm
+        Mi05NDAwLTc0MDgzYjZhMzJkNi92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        ODJjY2NiOGUtNmVhYS00OWYyLTk0MDAtNzQwODNiNmEzMmQ2LyJdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/82cccb8e-6eaa-49f2-9400-74083b6a32d6/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '184'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvODJjY2NiOGUt
+        NmVhYS00OWYyLTk0MDAtNzQwODNiNmEzMmQ2L3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA5VDEyOjM3OjI5LjE1ODIwMFoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:29 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/publications/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzgyY2NjYjhlLTZlYWEtNDlmMi05NDAwLTc0MDgzYjZhMzJkNi92ZXJz
+        aW9ucy8xLyIsIm1hbmlmZXN0IjoiUFVMUF9NQU5JRkVTVCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzViNGNlNTgzLTgyYWEtNGUw
+        YS05OTM2LTA1ZTEyZDNkODhlNC8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/5b4ce583-82aa-4e0a-9936-05e12d3d88e4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '371'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy81YjRjZTU4My04MmFhLTRl
+        MGEtOTkzNi0wNWUxMmQzZDg4ZTQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM3OjI5LjUyOTA1NVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnB1Ymxpc2hpbmcucHVibGlzaCIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM3OjI5LjYzNTI2N1oiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6Mzc6MjkuNjc2MDQ1WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvYWY4NTNjNzItMTQ2NC00ZjdjLWEwMzUtNDcxNjY1
+        M2NlZTM5LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUvZmlsZS9iNTc3MTFiMS02MGJj
+        LTQ4MGItYmIwYS1mYmM1NDNjN2U5NGQvIl0sInJlc2VydmVkX3Jlc291cmNl
+        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy84MmNjY2I4
+        ZS02ZWFhLTQ5ZjItOTQwMC03NDA4M2I2YTMyZDYvIl19
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:29 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0ZpbGVfMSIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
+        bmV0LXB1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3Yz
+        L3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvYjU3NzExYjEtNjBiYy00ODBiLWJi
+        MGEtZmJjNTQzYzdlOTRkLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:29 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q1ZWJhYWNiLTBjYjItNGQ1
+        Mi1iNDA1LTAzNGUxZDY4ZDA5NC8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/d5ebaacb-0cb2-4d52-b405-034e1d68d094/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:30 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '345'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kNWViYWFjYi0wY2IyLTRk
+        NTItYjQwNS0wMzRlMWQ2OGQwOTQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM3OjI5Ljg5Mzk3MFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM3OjI5Ljk5MDE3NVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6Mzc6MzAuMjI3MTkxWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
+        N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxlL2ZpbGUvMjM3MWQ2OGEtOGJh
+        Mi00NDA4LTkyOGMtMmE5Y2U4NzcwNmNhLyJdLCJyZXNlcnZlZF9yZXNvdXJj
+        ZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iXX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:30 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/2371d68a-8ba2-4408-928c-2a9ce87706ca/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:30 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '285'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2ZpbGUvZmls
+        ZS8yMzcxZDY4YS04YmEyLTQ0MDgtOTI4Yy0yYTljZTg3NzA2Y2EvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA5VDEyOjM3OjMwLjIxNzE4MVoiLCJiYXNlX3Bh
+        dGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVf
+        MSIsImJhc2VfdXJsIjoiY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJz
+        LmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09yZ2FuaXphdGlv
+        bi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsImNvbnRlbnRfZ3VhcmQiOm51bGws
+        Im5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0Zp
+        bGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9u
+        cy9maWxlL2ZpbGUvYjU3NzExYjEtNjBiYy00ODBiLWJiMGEtZmJjNTQzYzdl
+        OTRkLyJ9
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:30 GMT
+- request:
+    method: put
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/82cccb8e-6eaa-49f2-9400-74083b6a32d6/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:30 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzg1MjJhYjE1LWFhNGItNGVk
+        NS1iOTFlLTE5NDczMjFmODcwMC8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:30 GMT
+- request:
+    method: patch
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/48d585b9-51bf-45d8-98d5-e3e3942963d2/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzc2xfdmFsaWRhdGlvbiI6dHJ1ZSwibmFtZSI6IkRlZmF1bHRfT3JnYW5p
+        emF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwidXJsIjoiaHR0cHM6Ly9y
+        ZXBvcy5mZWRvcmFwZW9wbGUub3JnL3JlcG9zL3B1bHAvcHVscC9maXh0dXJl
+        cy9maWxlMi8vUFVMUF9NQU5JRkVTVCIsInByb3h5X3VybCI6bnVsbCwic3Ns
+        X2NsaWVudF9jZXJ0aWZpY2F0ZSI6bnVsbCwic3NsX2NsaWVudF9rZXkiOm51
+        bGwsInNzbF9jYV9jZXJ0aWZpY2F0ZSI6bnVsbH0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:30 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M1ODNmMDY3LWM5ZjctNDE1
+        OC1hN2U3LWFiYTkwNTcyYjM1MS8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:30 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/48d585b9-51bf-45d8-98d5-e3e3942963d2/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy84MmNj
+        Y2I4ZS02ZWFhLTQ5ZjItOTQwMC03NDA4M2I2YTMyZDYvIiwibWlycm9yIjp0
+        cnVlfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:31 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQwNWZhNDM5LThiNjMtNGU0
+        Yy1hZTFjLTM4Njc2MzlhYjNiOC8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:31 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/405fa439-8b63-4e4c-ae1c-3867639ab3b8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:31 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '502'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy80MDVmYTQzOS04YjYzLTRl
+        NGMtYWUxYy0zODY3NjM5YWIzYjgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM3OjMxLjQ1MzM5OVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wOS0wOVQxMjozNzozMS41NjE4MjZa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM3OjMxLjg3NjU1OVoi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzL2NiNTE1YjkxLWUzNzktNGQ5OS1iYTBh
+        LTQxYTQxYzdhOTJiZC8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgQXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6Mywi
+        ZG9uZSI6Mywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGlu
+        ZyBDb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MywiZG9u
+        ZSI6Mywic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGlu
+        ZyBDb250ZW50Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwi
+        ZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGlu
+        ZyBNZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjEsImRv
+        bmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2luZyBNZXRh
+        ZGF0YSBMaW5lcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRv
+        bmUiOjMsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzgyY2NjYjhlLTZlYWEtNDlmMi05
+        NDAwLTc0MDgzYjZhMzJkNi92ZXJzaW9ucy8yLyJdLCJyZXNlcnZlZF9yZXNv
+        dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvODJj
+        Y2NiOGUtNmVhYS00OWYyLTk0MDAtNzQwODNiNmEzMmQ2LyIsIi9wdWxwL2Fw
+        aS92My9yZW1vdGVzL2ZpbGUvZmlsZS80OGQ1ODViOS01MWJmLTQ1ZDgtOThk
+        NS1lM2UzOTQyOTYzZDIvIl19
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:31 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/82cccb8e-6eaa-49f2-9400-74083b6a32d6/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:32 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '237'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvODJjY2NiOGUt
+        NmVhYS00OWYyLTk0MDAtNzQwODNiNmEzMmQ2L3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA5VDEyOjM3OjMxLjU4Mzk1MVoiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9h
+        ZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzgyY2NjYjhlLTZlYWEt
+        NDlmMi05NDAwLTc0MDgzYjZhMzJkNi92ZXJzaW9ucy8yLyJ9fSwicmVtb3Zl
+        ZCI6e30sInByZXNlbnQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvODJjY2NiOGUt
+        NmVhYS00OWYyLTk0MDAtNzQwODNiNmEzMmQ2L3ZlcnNpb25zLzIvIn19fX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:32 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/publications/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzgyY2NjYjhlLTZlYWEtNDlmMi05NDAwLTc0MDgzYjZhMzJkNi92ZXJz
+        aW9ucy8yLyIsIm1hbmlmZXN0IjoiUFVMUF9NQU5JRkVTVCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:32 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzVmYzlkZTZkLTcwZWUtNDc1
+        OS05MzM4LTBhZjI2NTRhMTQ2Zi8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:32 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/5fc9de6d-70ee-4759-9338-0af2654a146f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:32 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '372'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy81ZmM5ZGU2ZC03MGVlLTQ3
+        NTktOTMzOC0wYWYyNjU0YTE0NmYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM3OjMyLjMyMDcxMFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnB1Ymxpc2hpbmcucHVibGlzaCIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM3OjMyLjQxODUxOFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6Mzc6MzIuNDcyMzYzWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvYWY4NTNjNzItMTQ2NC00ZjdjLWEwMzUtNDcxNjY1
+        M2NlZTM5LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUvZmlsZS9jOWIwNDI4OS02ZDUw
+        LTRkNTItOTI1Zi0yZDJhNWEzNGVmZDIvIl0sInJlc2VydmVkX3Jlc291cmNl
+        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy84MmNjY2I4
+        ZS02ZWFhLTQ5ZjItOTQwMC03NDA4M2I2YTMyZDYvIl19
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:32 GMT
+- request:
+    method: patch
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/2371d68a-8ba2-4408-928c-2a9ce87706ca/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmls
+        ZS9maWxlL2M5YjA0Mjg5LTZkNTAtNGQ1Mi05MjVmLTJkMmE1YTM0ZWZkMi8i
+        fQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:32 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUxZjc5N2UwLTRmMzItNDhl
+        ZS1hMjM2LWFhZmRlYTNkY2Q0Ny8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:32 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/51f797e0-4f32-48ee-a236-aafdea3dcd47/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:33 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '314'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy81MWY3OTdlMC00ZjMyLTQ4
+        ZWUtYTIzNi1hYWZkZWEzZGNkNDcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM3OjMyLjY4MDc3OFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM3OjMyLjc3NDUxOVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6Mzc6MzIuODU2NDcyWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
+        N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJl
+        c2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRp
+        b25zLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:33 GMT
+- request:
+    method: put
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/82cccb8e-6eaa-49f2-9400-74083b6a32d6/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:33 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhlNjIwYTY0LTA4NTQtNDE1
+        My05ZjY1LWY0ZDkyODYxYWRiMi8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:33 GMT
+- request:
+    method: patch
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/48d585b9-51bf-45d8-98d5-e3e3942963d2/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzc2xfdmFsaWRhdGlvbiI6dHJ1ZSwibmFtZSI6IkRlZmF1bHRfT3JnYW5p
+        emF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwidXJsIjoiaHR0cHM6Ly9y
+        ZXBvcy5mZWRvcmFwZW9wbGUub3JnL3JlcG9zL3B1bHAvcHVscC9maXh0dXJl
+        cy9maWxlLy9QVUxQX01BTklGRVNUIiwicHJveHlfdXJsIjpudWxsLCJzc2xf
+        Y2xpZW50X2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVs
+        bCwic3NsX2NhX2NlcnRpZmljYXRlIjpudWxsfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:33 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FmZTIyYjg4LWM4NDYtNGU4
+        Ni04NWIxLTdlOTdmNzM1ZDkwMi8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:33 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/48d585b9-51bf-45d8-98d5-e3e3942963d2/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy84MmNj
+        Y2I4ZS02ZWFhLTQ5ZjItOTQwMC03NDA4M2I2YTMyZDYvIiwibWlycm9yIjp0
+        cnVlfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:34 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzhiN2MwNWYwLWUwYjYtNGZi
+        MC1hNWEwLTUwM2IwYjU0OTg5MS8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:34 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/8b7c05f0-e0b6-4fb0-a5a0-503b0b549891/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:34 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '495'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy84YjdjMDVmMC1lMGI2LTRm
+        YjAtYTVhMC01MDNiMGI1NDk4OTEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM3OjM0LjAyMzk4MFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wOS0wOVQxMjozNzozNC4xMjYzODZa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM3OjM0LjQyNzQyNFoi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzL2NiNTE1YjkxLWUzNzktNGQ5OS1iYTBh
+        LTQxYTQxYzdhOTJiZC8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgTWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5n
+        IEFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRv
+        bmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRpbmcg
+        Q29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRvbmUi
+        OjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcg
+        Q29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRvbmUi
+        OjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2luZyBNZXRhZGF0
+        YSBMaW5lcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRvbmUi
+        OjMsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzLzgyY2NjYjhlLTZlYWEtNDlmMi05NDAw
+        LTc0MDgzYjZhMzJkNi92ZXJzaW9ucy8zLyJdLCJyZXNlcnZlZF9yZXNvdXJj
+        ZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvODJjY2Ni
+        OGUtNmVhYS00OWYyLTk0MDAtNzQwODNiNmEzMmQ2LyIsIi9wdWxwL2FwaS92
+        My9yZW1vdGVzL2ZpbGUvZmlsZS80OGQ1ODViOS01MWJmLTQ1ZDgtOThkNS1l
+        M2UzOTQyOTYzZDIvIl19
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:34 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/82cccb8e-6eaa-49f2-9400-74083b6a32d6/versions/3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:34 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '238'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvODJjY2NiOGUt
+        NmVhYS00OWYyLTk0MDAtNzQwODNiNmEzMmQ2L3ZlcnNpb25zLzMvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA5VDEyOjM3OjM0LjE0ODUyOFoiLCJudW1iZXIi
+        OjMsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9h
+        ZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzgyY2NjYjhlLTZlYWEt
+        NDlmMi05NDAwLTc0MDgzYjZhMzJkNi92ZXJzaW9ucy8zLyJ9fSwicmVtb3Zl
+        ZCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fcmVt
+        b3ZlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzgyY2NjYjhlLTZlYWEt
+        NDlmMi05NDAwLTc0MDgzYjZhMzJkNi92ZXJzaW9ucy8zLyJ9fSwicHJlc2Vu
+        dCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy84MmNjY2I4ZS02ZWFhLTQ5ZjItOTQw
+        MC03NDA4M2I2YTMyZDYvdmVyc2lvbnMvMy8ifX19fQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:34 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/publications/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzgyY2NjYjhlLTZlYWEtNDlmMi05NDAwLTc0MDgzYjZhMzJkNi92ZXJz
+        aW9ucy8zLyIsIm1hbmlmZXN0IjoiUFVMUF9NQU5JRkVTVCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:34 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MwMDZkZDQ0LTQyNWMtNGQw
+        ZS1iYmMyLWRlOGFlZjg1YjkxNC8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:34 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/c006dd44-425c-4d0e-bbc2-de8aef85b914/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:35 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '373'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jMDA2ZGQ0NC00MjVjLTRk
+        MGUtYmJjMi1kZThhZWY4NWI5MTQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM3OjM0Ljg4MzQwNVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnB1Ymxpc2hpbmcucHVibGlzaCIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM3OjM0Ljk5NzkxOVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6Mzc6MzUuMDcyMjczWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
+        N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUvZmlsZS85YjZmNDU3MS0wZjI2
+        LTRjMzMtYjE4MC03ZjAzNTgzYmQ1NjQvIl0sInJlc2VydmVkX3Jlc291cmNl
+        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy84MmNjY2I4
+        ZS02ZWFhLTQ5ZjItOTQwMC03NDA4M2I2YTMyZDYvIl19
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:35 GMT
+- request:
+    method: patch
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/2371d68a-8ba2-4408-928c-2a9ce87706ca/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmls
+        ZS9maWxlLzliNmY0NTcxLTBmMjYtNGMzMy1iMTgwLTdmMDM1ODNiZDU2NC8i
+        fQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:35 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2U1OGJlMDllLWJiNDItNDk4
+        OC05NDI1LTc3YTc2NDdmOTlhNy8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:35 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/e58be09e-bb42-4988-9425-77a7647f99a7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:35 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '314'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lNThiZTA5ZS1iYjQyLTQ5
+        ODgtOTQyNS03N2E3NjQ3Zjk5YTcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM3OjM1LjQzMzM5OVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM3OjM1LjUyMjg0OVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6Mzc6MzUuNjA1Njg1WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
+        N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJl
+        c2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRp
+        b25zLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:35 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:36 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '353'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85NTlj
+        ZjA5Yi03MTEzLTQzZjEtYTAwYS00ZjdmNGMzZDA0OGIvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTA2VDE3OjQyOjQwLjQ1NTM1MFoiLCJfdmVyc2lvbnNfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOTU5Y2YwOWItNzExMy00
+        M2YxLWEwMGEtNGY3ZjRjM2QwNDhiL3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVy
+        c2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85NTljZjA5
+        Yi03MTEzLTQzZjEtYTAwYS00ZjdmNGMzZDA0OGIvdmVyc2lvbnMvMi8iLCJu
+        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19Eb2Nr
+        ZXJfMSIsImRlc2NyaXB0aW9uIjpudWxsfSx7Il9ocmVmIjoiL3B1bHAvYXBp
+        L3YzL3JlcG9zaXRvcmllcy9iZDUwNGY5MC0zZTJkLTRlNTUtYTMyNi02NDVh
+        NWI1M2RiNTYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA2VDE3OjQ0OjAzLjY1
+        Mzc2M1oiLCJfdmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvYmQ1MDRmOTAtM2UyZC00ZTU1LWEzMjYtNjQ1YTViNTNkYjU2L3Zl
+        cnNpb25zLyIsIl9sYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3Yz
+        L3JlcG9zaXRvcmllcy9iZDUwNGY5MC0zZTJkLTRlNTUtYTMyNi02NDVhNWI1
+        M2RiNTYvdmVyc2lvbnMvMi8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRp
+        b24tQ2FiaW5ldC1NeV9GaWxlcyIsImRlc2NyaXB0aW9uIjpudWxsfSx7Il9o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy84MmNjY2I4ZS02ZWFh
+        LTQ5ZjItOTQwMC03NDA4M2I2YTMyZDYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5
+        LTA5VDEyOjM3OjI4LjMyOTI0M1oiLCJfdmVyc2lvbnNfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvODJjY2NiOGUtNmVhYS00OWYyLTk0MDAt
+        NzQwODNiNmEzMmQ2L3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVyc2lvbl9ocmVm
+        IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy84MmNjY2I4ZS02ZWFhLTQ5
+        ZjItOTQwMC03NDA4M2I2YTMyZDYvdmVyc2lvbnMvMy8iLCJuYW1lIjoiRGVm
+        YXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJkZXNj
+        cmlwdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:36 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/959cf09b-7113-43f1-a00a-4f7f4c3d048b/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:36 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '328'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85NTlj
+        ZjA5Yi03MTEzLTQzZjEtYTAwYS00ZjdmNGMzZDA0OGIvdmVyc2lvbnMvMi8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDktMDZUMTc6NDI6NDIuNjY0MjY0WiIsIm51
+        bWJlciI6MiwiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250ZW50X3N1bW1hcnki
+        OnsiYWRkZWQiOnsiZG9ja2VyLmJsb2IiOnsiY291bnQiOjQsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9kb2NrZXIvYmxvYnMvP3JlcG9zaXRvcnlf
+        dmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzk1OWNm
+        MDliLTcxMTMtNDNmMS1hMDBhLTRmN2Y0YzNkMDQ4Yi92ZXJzaW9ucy8yLyJ9
+        LCJkb2NrZXIubWFuaWZlc3QiOnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9h
+        cGkvdjMvY29udGVudC9kb2NrZXIvbWFuaWZlc3RzLz9yZXBvc2l0b3J5X3Zl
+        cnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85NTljZjA5
+        Yi03MTEzLTQzZjEtYTAwYS00ZjdmNGMzZDA0OGIvdmVyc2lvbnMvMi8ifSwi
+        ZG9ja2VyLnRhZyI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9j
+        b250ZW50L2RvY2tlci90YWdzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9
+        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85NTljZjA5Yi03MTEzLTQzZjEt
+        YTAwYS00ZjdmNGMzZDA0OGIvdmVyc2lvbnMvMi8ifX0sInJlbW92ZWQiOnt9
+        LCJwcmVzZW50Ijp7ImRvY2tlci5ibG9iIjp7ImNvdW50Ijo0LCJocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZG9ja2VyL2Jsb2JzLz9yZXBvc2l0b3J5
+        X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85NTljZjA5Yi03
+        MTEzLTQzZjEtYTAwYS00ZjdmNGMzZDA0OGIvdmVyc2lvbnMvMi8ifSwiZG9j
+        a2VyLm1hbmlmZXN0Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvZG9ja2VyL21hbmlmZXN0cy8/cmVwb3NpdG9yeV92ZXJzaW9u
+        PS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOTU5Y2YwOWItNzExMy00M2Yx
+        LWEwMGEtNGY3ZjRjM2QwNDhiL3ZlcnNpb25zLzIvIn0sImRvY2tlci50YWci
+        OnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kb2Nr
+        ZXIvdGFncy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvOTU5Y2YwOWItNzExMy00M2YxLWEwMGEtNGY3ZjRjM2QwNDhi
+        L3ZlcnNpb25zLzIvIn19fX0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvOTU5Y2YwOWItNzExMy00M2YxLWEwMGEtNGY3ZjRjM2QwNDhi
+        L3ZlcnNpb25zLzEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA2VDE3OjQyOjQx
+        LjEzODU2OFoiLCJudW1iZXIiOjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29u
+        dGVudF9zdW1tYXJ5Ijp7ImFkZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNl
+        bnQiOnt9fX1dfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:36 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/bd504f90-3e2d-4e55-a326-645a5b53db56/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:36 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '286'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iZDUw
+        NGY5MC0zZTJkLTRlNTUtYTMyNi02NDVhNWI1M2RiNTYvdmVyc2lvbnMvMi8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDktMDZUMTc6NDQ6MDYuMzg4MDc1WiIsIm51
+        bWJlciI6MiwiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250ZW50X3N1bW1hcnki
+        OnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJz
+        aW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYmQ1MDRmOTAt
+        M2UyZC00ZTU1LWEzMjYtNjQ1YTViNTNkYjU2L3ZlcnNpb25zLzIvIn19LCJy
+        ZW1vdmVkIjp7fSwicHJlc2VudCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjMs
+        ImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBv
+        c2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iZDUw
+        NGY5MC0zZTJkLTRlNTUtYTMyNi02NDVhNWI1M2RiNTYvdmVyc2lvbnMvMi8i
+        fX19fSx7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iZDUw
+        NGY5MC0zZTJkLTRlNTUtYTMyNi02NDVhNWI1M2RiNTYvdmVyc2lvbnMvMS8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDktMDZUMTc6NDQ6MDQuNDE5NDYxWiIsIm51
+        bWJlciI6MSwiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250ZW50X3N1bW1hcnki
+        OnsiYWRkZWQiOnt9LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6e319fV19
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:36 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/82cccb8e-6eaa-49f2-9400-74083b6a32d6/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:36 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '314'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy84MmNj
+        Y2I4ZS02ZWFhLTQ5ZjItOTQwMC03NDA4M2I2YTMyZDYvdmVyc2lvbnMvMy8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDktMDlUMTI6Mzc6MzQuMTQ4NTI4WiIsIm51
+        bWJlciI6MywiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250ZW50X3N1bW1hcnki
+        OnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJz
+        aW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvODJjY2NiOGUt
+        NmVhYS00OWYyLTk0MDAtNzQwODNiNmEzMmQ2L3ZlcnNpb25zLzMvIn19LCJy
+        ZW1vdmVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
+        bl9yZW1vdmVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvODJjY2NiOGUt
+        NmVhYS00OWYyLTk0MDAtNzQwODNiNmEzMmQ2L3ZlcnNpb25zLzMvIn19LCJw
+        cmVzZW50Ijp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
+        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzgyY2NjYjhlLTZlYWEtNDlm
+        Mi05NDAwLTc0MDgzYjZhMzJkNi92ZXJzaW9ucy8zLyJ9fX19LHsiX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzgyY2NjYjhlLTZlYWEtNDlm
+        Mi05NDAwLTc0MDgzYjZhMzJkNi92ZXJzaW9ucy8yLyIsIl9jcmVhdGVkIjoi
+        MjAxOS0wOS0wOVQxMjozNzozMS41ODM5NTFaIiwibnVtYmVyIjoyLCJiYXNl
+        X3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJm
+        aWxlLmZpbGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy84MmNjY2I4ZS02ZWFhLTQ5ZjItOTQw
+        MC03NDA4M2I2YTMyZDYvdmVyc2lvbnMvMi8ifX0sInJlbW92ZWQiOnt9LCJw
+        cmVzZW50Ijp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
+        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzgyY2NjYjhlLTZlYWEtNDlm
+        Mi05NDAwLTc0MDgzYjZhMzJkNi92ZXJzaW9ucy8yLyJ9fX19LHsiX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzgyY2NjYjhlLTZlYWEtNDlm
+        Mi05NDAwLTc0MDgzYjZhMzJkNi92ZXJzaW9ucy8xLyIsIl9jcmVhdGVkIjoi
+        MjAxOS0wOS0wOVQxMjozNzoyOS4xNTgyMDBaIiwibnVtYmVyIjoxLCJiYXNl
+        X3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30s
+        InJlbW92ZWQiOnt9LCJwcmVzZW50Ijp7fX19XX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:36 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/959cf09b-7113-43f1-a00a-4f7f4c3d048b/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:36 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk2M2IxYjc2LWVjMGEtNDE4
+        My1iNjBiLTBlNDg2ZDc3Mjk0ZC8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:36 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/959cf09b-7113-43f1-a00a-4f7f4c3d048b/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:36 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzBmZTYxN2MxLTFlMDctNGNl
+        Mi04NGUxLTBhZGQ1MjFiOWQ3OS8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:36 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/bd504f90-3e2d-4e55-a326-645a5b53db56/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:36 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q4ZTQyOTczLTZkY2UtNDYy
+        OS04ZjMyLTJkZDliMGY4ODc0My8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:36 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/bd504f90-3e2d-4e55-a326-645a5b53db56/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:37 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2YwOWUwMWFkLWJmMmYtNDYw
+        Ni1iN2MzLTllNGYwZTNkYzU2ZC8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:37 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/82cccb8e-6eaa-49f2-9400-74083b6a32d6/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:37 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y2Y2Q3ODNjLWQ2NTQtNGVi
+        OS05OWFhLTNiZmE4MDBjZjA5Zi8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:37 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/82cccb8e-6eaa-49f2-9400-74083b6a32d6/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:37 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQyOThjOTUwLTU2N2QtNDUx
+        ZS1hNTVkLTRiYTU2MGQxZTE4YS8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:37 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:37 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '350'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85NTlj
+        ZjA5Yi03MTEzLTQzZjEtYTAwYS00ZjdmNGMzZDA0OGIvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTA2VDE3OjQyOjQwLjQ1NTM1MFoiLCJfdmVyc2lvbnNfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOTU5Y2YwOWItNzExMy00
+        M2YxLWEwMGEtNGY3ZjRjM2QwNDhiL3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVy
+        c2lvbl9ocmVmIjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24t
+        Q2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsImRlc2NyaXB0aW9uIjpudWxsfSx7
+        Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iZDUwNGY5MC0z
+        ZTJkLTRlNTUtYTMyNi02NDVhNWI1M2RiNTYvIiwiX2NyZWF0ZWQiOiIyMDE5
+        LTA5LTA2VDE3OjQ0OjAzLjY1Mzc2M1oiLCJfdmVyc2lvbnNfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYmQ1MDRmOTAtM2UyZC00ZTU1LWEz
+        MjYtNjQ1YTViNTNkYjU2L3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVyc2lvbl9o
+        cmVmIjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5l
+        dC1NeV9GaWxlcyIsImRlc2NyaXB0aW9uIjpudWxsfSx7Il9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy84MmNjY2I4ZS02ZWFhLTQ5ZjItOTQw
+        MC03NDA4M2I2YTMyZDYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5VDEyOjM3
+        OjI4LjMyOTI0M1oiLCJfdmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvODJjY2NiOGUtNmVhYS00OWYyLTk0MDAtNzQwODNiNmEz
+        MmQ2L3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL3JlcG9zaXRvcmllcy84MmNjY2I4ZS02ZWFhLTQ5ZjItOTQwMC03
+        NDA4M2I2YTMyZDYvdmVyc2lvbnMvMy8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdh
+        bml6YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJkZXNjcmlwdGlvbiI6
+        bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:37 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/959cf09b-7113-43f1-a00a-4f7f4c3d048b/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:37 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:37 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/bd504f90-3e2d-4e55-a326-645a5b53db56/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:38 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:38 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/82cccb8e-6eaa-49f2-9400-74083b6a32d6/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:38 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '265'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy84MmNj
+        Y2I4ZS02ZWFhLTQ5ZjItOTQwMC03NDA4M2I2YTMyZDYvdmVyc2lvbnMvMy8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDktMDlUMTI6Mzc6MzQuMTQ4NTI4WiIsIm51
+        bWJlciI6MywiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250ZW50X3N1bW1hcnki
+        OnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJz
+        aW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvODJjY2NiOGUt
+        NmVhYS00OWYyLTk0MDAtNzQwODNiNmEzMmQ2L3ZlcnNpb25zLzMvIn19LCJy
+        ZW1vdmVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
+        bl9yZW1vdmVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvODJjY2NiOGUt
+        NmVhYS00OWYyLTk0MDAtNzQwODNiNmEzMmQ2L3ZlcnNpb25zLzMvIn19LCJw
+        cmVzZW50Ijp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
+        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzgyY2NjYjhlLTZlYWEtNDlm
+        Mi05NDAwLTc0MDgzYjZhMzJkNi92ZXJzaW9ucy8zLyJ9fX19XX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:38 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/48d585b9-51bf-45d8-98d5-e3e3942963d2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:38 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzEyNWMxMjQwLTA4YzktNGQx
+        ZC1hY2I0LTU5NGVhZjFmNGYxNS8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:38 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/125c1240-08c9-4d1d-acb4-594eaf1f4f15/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:38 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '337'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8xMjVjMTI0MC0wOGM5LTRk
+        MWQtYWNiNC01OTRlYWYxZjRmMTUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM3OjM4LjQ5OTQ3MVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM3OjM4LjYzNDgxOFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6Mzc6MzguNjYzNjY5WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
+        N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJl
+        c2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90
+        ZXMvZmlsZS9maWxlLzQ4ZDU4NWI5LTUxYmYtNDVkOC05OGQ1LWUzZTM5NDI5
+        NjNkMi8iXX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:38 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:38 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '316'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmls
+        ZS9maWxlLzIzNzFkNjhhLThiYTItNDQwOC05MjhjLTJhOWNlODc3MDZjYS8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDktMDlUMTI6Mzc6MzAuMjE3MTgxWiIsImJh
+        c2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNf
+        RmlsZV8xIiwiYmFzZV91cmwiOiJjZW50b3M3LWthdGVsbG8tZGV2ZWwuampl
+        ZmZlcnMuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3JnYW5p
+        emF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVs
+        cDNfRmlsZV8xIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGlj
+        YXRpb25zL2ZpbGUvZmlsZS85YjZmNDU3MS0wZjI2LTRjMzMtYjE4MC03ZjAz
+        NTgzYmQ1NjQvIn1dfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:38 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/2371d68a-8ba2-4408-928c-2a9ce87706ca/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:39 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzU0NzgzZDM1LTg1Y2QtNDM5
+        Yi1iZTAwLWJkZDE5MzRkOWNjMC8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:39 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/82cccb8e-6eaa-49f2-9400-74083b6a32d6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:39 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y5YzFlNzU2LTg0ODUtNGM4
+        ZC1hN2Y4LTU3NmUxMGI1YjlmYy8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:39 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/f9c1e756-8485-4c8d-a7f8-576e10b5b9fc/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:39 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '333'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9mOWMxZTc1Ni04NDg1LTRj
+        OGQtYTdmOC01NzZlMTBiNWI5ZmMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM3OjM5LjI1NzQ3MloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5kZWxldGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wOS0wOVQxMjozNzozOS4zOTEzMDRaIiwiZmluaXNo
+        ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM3OjM5LjQzMTIyM1oiLCJub25fZmF0
+        YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2Fw
+        aS92My93b3JrZXJzL2NiNTE1YjkxLWUzNzktNGQ5OS1iYTBhLTQxYTQxYzdh
+        OTJiZC8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9n
+        cmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNl
+        cnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvODJjY2NiOGUtNmVhYS00OWYyLTk0MDAtNzQwODNiNmEzMmQ2LyJd
+        fQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:39 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository_orphan/orphan_repository_versions.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository_orphan/orphan_repository_versions.yml
@@ -1,0 +1,2390 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:40 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:40 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:40 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:40 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:40 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:40 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:40 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:40 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:41 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:41 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:41 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:41 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:41 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:41 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:41 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:41 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:41 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/bafa2d36-36d2-4bcb-ac48-d3d0c0d02386/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '306'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYmFmYTJkMzYt
+        MzZkMi00YmNiLWFjNDgtZDNkMGMwZDAyMzg2LyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wOS0wOVQxMjozNzo0MS44NTExMjlaIiwiX3ZlcnNpb25zX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2JhZmEyZDM2LTM2ZDItNGJjYi1h
+        YzQ4LWQzZDBjMGQwMjM4Ni92ZXJzaW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25f
+        aHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
+        ZXQtcHVscDNfRmlsZV8xIiwiZGVzY3JpcHRpb24iOm51bGx9
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:41 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEiLCJ1cmwiOiJodHRwczovL3JlcG9zLmZlZG9yYXBlb3BsZS5vcmcv
+        cmVwb3MvcHVscC9wdWxwL2ZpeHR1cmVzL2ZpbGUyLy9QVUxQX01BTklGRVNU
+        Iiwic3NsX3ZhbGlkYXRpb24iOnRydWUsInBvbGljeSI6ImltbWVkaWF0ZSJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:42 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/file/file/2ae79218-59a2-486c-b04f-d8a011b8ad8d/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '487'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS8yYWU3
+        OTIxOC01OWEyLTQ4NmMtYjA0Zi1kOGEwMTFiOGFkOGQvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTA5VDEyOjM3OjQyLjAyMzg5NVoiLCJfdHlwZSI6ImZpbGUu
+        ZmlsZSIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1
+        bHAzX0ZpbGVfMSIsInVybCI6Imh0dHBzOi8vcmVwb3MuZmVkb3JhcGVvcGxl
+        Lm9yZy9yZXBvcy9wdWxwL3B1bHAvZml4dHVyZXMvZmlsZTIvL1BVTFBfTUFO
+        SUZFU1QiLCJzc2xfY2FfY2VydGlmaWNhdGUiOm51bGwsInNzbF9jbGllbnRf
+        Y2VydGlmaWNhdGUiOm51bGwsInNzbF9jbGllbnRfa2V5IjpudWxsLCJzc2xf
+        dmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJfbGFzdF91cGRh
+        dGVkIjoiMjAxOS0wOS0wOVQxMjozNzo0Mi4wMjM5MDhaIiwiZG93bmxvYWRf
+        Y29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJpbW1lZGlhdGUifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:42 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/bafa2d36-36d2-4bcb-ac48-d3d0c0d02386/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:42 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RjNzJjMjQ3LWE0MjktNDJi
+        My1hYmVmLTJlZjNkMWE2MjVlNC8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:42 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/dc72c247-a429-42b3-abef-2ef3d1a625e4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:42 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '351'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kYzcyYzI0Ny1hNDI5LTQy
+        YjMtYWJlZi0yZWYzZDFhNjI1ZTQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM3OjQyLjQxMzYyNFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM3OjQyLjU0ODYwNFoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMDktMDlUMTI6Mzc6NDIuNjAxODk2WiIs
+        Im5vbl9mYXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoi
+        L3B1bHAvYXBpL3YzL3dvcmtlcnMvYWY4NTNjNzItMTQ2NC00ZjdjLWEwMzUt
+        NDcxNjY1M2NlZTM5LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6
+        W10sInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2JhZmEyZDM2LTM2ZDItNGJj
+        Yi1hYzQ4LWQzZDBjMGQwMjM4Ni92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        YmFmYTJkMzYtMzZkMi00YmNiLWFjNDgtZDNkMGMwZDAyMzg2LyJdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:42 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/bafa2d36-36d2-4bcb-ac48-d3d0c0d02386/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:42 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '184'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYmFmYTJkMzYt
+        MzZkMi00YmNiLWFjNDgtZDNkMGMwZDAyMzg2L3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA5VDEyOjM3OjQyLjU3MzcyOVoiLCJudW1iZXIi
+        OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnt9fX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:42 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/publications/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2JhZmEyZDM2LTM2ZDItNGJjYi1hYzQ4LWQzZDBjMGQwMjM4Ni92ZXJz
+        aW9ucy8xLyIsIm1hbmlmZXN0IjoiUFVMUF9NQU5JRkVTVCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:43 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdlMWRmMGUxLTY1MTktNGE2
+        NC1iNjkyLWIzMTJiYTMxYjM3MC8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:43 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/7e1df0e1-6519-4a64-b692-b312ba31b370/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:43 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '368'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy83ZTFkZjBlMS02NTE5LTRh
+        NjQtYjY5Mi1iMzEyYmEzMWIzNzAvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM3OjQzLjAzODg0MFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnB1Ymxpc2hpbmcucHVibGlzaCIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM3OjQzLjE1NzU2MVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6Mzc6NDMuMjIzODQwWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvYWY4NTNjNzItMTQ2NC00ZjdjLWEwMzUtNDcxNjY1
+        M2NlZTM5LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUvZmlsZS84NTMyZmEzMi1jMTZk
+        LTQ2NzYtYWMzMS1hNTI3NTFmZWJhN2YvIl0sInJlc2VydmVkX3Jlc291cmNl
+        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iYWZhMmQz
+        Ni0zNmQyLTRiY2ItYWM0OC1kM2QwYzBkMDIzODYvIl19
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:43 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0ZpbGVfMSIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
+        bmV0LXB1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3Yz
+        L3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvODUzMmZhMzItYzE2ZC00Njc2LWFj
+        MzEtYTUyNzUxZmViYTdmLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:43 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcyNTI4NTY4LTZmMzItNDdi
+        Mi1hYzQxLWE2MmUxNmIzZWY5Ny8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:43 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/72528568-6f32-47b2-ac41-a62e16b3ef97/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:43 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '344'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy83MjUyODU2OC02ZjMyLTQ3
+        YjItYWM0MS1hNjJlMTZiM2VmOTcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM3OjQzLjUxMzI0M1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM3OjQzLjYwOTg4NloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6Mzc6NDMuODE0NzU2WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvYWY4NTNjNzItMTQ2NC00ZjdjLWEwMzUtNDcxNjY1
+        M2NlZTM5LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxlL2ZpbGUvMjhlYzM3ZWYtZDY3
+        Ni00ZDRmLThjYjMtOTMxNjA2MjRiN2IzLyJdLCJyZXNlcnZlZF9yZXNvdXJj
+        ZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iXX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:43 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/28ec37ef-d676-4d4f-8cb3-93160624b7b3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:44 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '284'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2ZpbGUvZmls
+        ZS8yOGVjMzdlZi1kNjc2LTRkNGYtOGNiMy05MzE2MDYyNGI3YjMvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA5VDEyOjM3OjQzLjgwMjMyMVoiLCJiYXNlX3Bh
+        dGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVf
+        MSIsImJhc2VfdXJsIjoiY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJz
+        LmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09yZ2FuaXphdGlv
+        bi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsImNvbnRlbnRfZ3VhcmQiOm51bGws
+        Im5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0Zp
+        bGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9u
+        cy9maWxlL2ZpbGUvODUzMmZhMzItYzE2ZC00Njc2LWFjMzEtYTUyNzUxZmVi
+        YTdmLyJ9
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:44 GMT
+- request:
+    method: put
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/bafa2d36-36d2-4bcb-ac48-d3d0c0d02386/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:44 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQzNWFhMDllLWQzNTUtNDQ5
+        OS04YTQ2LTRjMjBhZGVhY2Q5Mi8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:44 GMT
+- request:
+    method: patch
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/2ae79218-59a2-486c-b04f-d8a011b8ad8d/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzc2xfdmFsaWRhdGlvbiI6dHJ1ZSwibmFtZSI6IkRlZmF1bHRfT3JnYW5p
+        emF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwidXJsIjoiaHR0cHM6Ly9y
+        ZXBvcy5mZWRvcmFwZW9wbGUub3JnL3JlcG9zL3B1bHAvcHVscC9maXh0dXJl
+        cy9maWxlMi8vUFVMUF9NQU5JRkVTVCIsInByb3h5X3VybCI6bnVsbCwic3Ns
+        X2NsaWVudF9jZXJ0aWZpY2F0ZSI6bnVsbCwic3NsX2NsaWVudF9rZXkiOm51
+        bGwsInNzbF9jYV9jZXJ0aWZpY2F0ZSI6bnVsbH0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:44 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Y0YTQ3ZGEwLTE1NjYtNGUw
+        Mi1iMzkwLWU1MTIxZDEzZjgzNi8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:44 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/2ae79218-59a2-486c-b04f-d8a011b8ad8d/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iYWZh
+        MmQzNi0zNmQyLTRiY2ItYWM0OC1kM2QwYzBkMDIzODYvIiwibWlycm9yIjp0
+        cnVlfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzNkODllZWQzLWFlOGYtNDcx
+        YS05Y2I1LTA3YjhjM2ZhMzY4YS8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:45 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/3d89eed3-ae8f-471a-9cb5-07b8c3fa368a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '503'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zZDg5ZWVkMy1hZThmLTQ3
+        MWEtOWNiNS0wN2I4YzNmYTM2OGEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM3OjQ1LjA4MjU4NFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wOS0wOVQxMjozNzo0NS4xODA5NzZa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM3OjQ1LjM2OTk1Nloi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzL2FmODUzYzcyLTE0NjQtNGY3Yy1hMDM1
+        LTQ3MTY2NTNjZWUzOS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgTWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5n
+        IEFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
+        bmcgQ29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRv
+        bmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRp
+        bmcgQ29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2luZyBN
+        ZXRhZGF0YSBMaW5lcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMs
+        ImRvbmUiOjMsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2JhZmEyZDM2LTM2ZDItNGJj
+        Yi1hYzQ4LWQzZDBjMGQwMjM4Ni92ZXJzaW9ucy8yLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        YmFmYTJkMzYtMzZkMi00YmNiLWFjNDgtZDNkMGMwZDAyMzg2LyIsIi9wdWxw
+        L2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS8yYWU3OTIxOC01OWEyLTQ4NmMt
+        YjA0Zi1kOGEwMTFiOGFkOGQvIl19
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:45 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/bafa2d36-36d2-4bcb-ac48-d3d0c0d02386/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '237'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYmFmYTJkMzYt
+        MzZkMi00YmNiLWFjNDgtZDNkMGMwZDAyMzg2L3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA5VDEyOjM3OjQ1LjIwNDc4NVoiLCJudW1iZXIi
+        OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9h
+        ZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2JhZmEyZDM2LTM2ZDIt
+        NGJjYi1hYzQ4LWQzZDBjMGQwMjM4Ni92ZXJzaW9ucy8yLyJ9fSwicmVtb3Zl
+        ZCI6e30sInByZXNlbnQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9y
+        eV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYmFmYTJkMzYt
+        MzZkMi00YmNiLWFjNDgtZDNkMGMwZDAyMzg2L3ZlcnNpb25zLzIvIn19fX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:45 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/publications/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2JhZmEyZDM2LTM2ZDItNGJjYi1hYzQ4LWQzZDBjMGQwMjM4Ni92ZXJz
+        aW9ucy8yLyIsIm1hbmlmZXN0IjoiUFVMUF9NQU5JRkVTVCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIyZGI0M2QwLTAxN2UtNGJk
+        Ny1iOGY3LWI5MGI4YTI2NjY1My8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:45 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/22db43d0-017e-4bd7-b8f7-b90b8a266653/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '373'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yMmRiNDNkMC0wMTdlLTRi
+        ZDctYjhmNy1iOTBiOGEyNjY2NTMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM3OjQ1Ljc2NzYxOFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnB1Ymxpc2hpbmcucHVibGlzaCIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM3OjQ1Ljg3MTA3NVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6Mzc6NDUuOTM4ODM3WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvYWY4NTNjNzItMTQ2NC00ZjdjLWEwMzUtNDcxNjY1
+        M2NlZTM5LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUvZmlsZS8zMGQ4ZjUxOC0xNjE1
+        LTQyOTEtOTVlMi0yNWYyOWU4ZTU1NjgvIl0sInJlc2VydmVkX3Jlc291cmNl
+        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iYWZhMmQz
+        Ni0zNmQyLTRiY2ItYWM0OC1kM2QwYzBkMDIzODYvIl19
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:45 GMT
+- request:
+    method: patch
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/28ec37ef-d676-4d4f-8cb3-93160624b7b3/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmls
+        ZS9maWxlLzMwZDhmNTE4LTE2MTUtNDI5MS05NWUyLTI1ZjI5ZThlNTU2OC8i
+        fQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZmMDRjNmM4LTk1OTEtNGI3
+        YS04OGViLTVlMzY1MDMzNDEzOC8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:46 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/ff04c6c8-9591-4b7a-88eb-5e3650334138/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '315'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9mZjA0YzZjOC05NTkxLTRi
+        N2EtODhlYi01ZTM2NTAzMzQxMzgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM3OjQ2LjE5OTEyNloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM3OjQ2LjMyMjE5NVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6Mzc6NDYuNDI5MDkyWiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
+        N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJl
+        c2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRp
+        b25zLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:46 GMT
+- request:
+    method: put
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/bafa2d36-36d2-4bcb-ac48-d3d0c0d02386/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY5ZmI3ZjYyLTg3ZmEtNDRi
+        ZS1iYWNhLTQwMWMzNDE0MDNmZS8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:46 GMT
+- request:
+    method: patch
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/2ae79218-59a2-486c-b04f-d8a011b8ad8d/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzc2xfdmFsaWRhdGlvbiI6dHJ1ZSwibmFtZSI6IkRlZmF1bHRfT3JnYW5p
+        emF0aW9uLUNhYmluZXQtcHVscDNfRmlsZV8xIiwidXJsIjoiaHR0cHM6Ly9y
+        ZXBvcy5mZWRvcmFwZW9wbGUub3JnL3JlcG9zL3B1bHAvcHVscC9maXh0dXJl
+        cy9maWxlLy9QVUxQX01BTklGRVNUIiwicHJveHlfdXJsIjpudWxsLCJzc2xf
+        Y2xpZW50X2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVs
+        bCwic3NsX2NhX2NlcnRpZmljYXRlIjpudWxsfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZhOWFlMzE3LWU5MDgtNGE5
+        NS04M2FkLTYxMzgxNjRiY2NlYy8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:47 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/2ae79218-59a2-486c-b04f-d8a011b8ad8d/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iYWZh
+        MmQzNi0zNmQyLTRiY2ItYWM0OC1kM2QwYzBkMDIzODYvIiwibWlycm9yIjp0
+        cnVlfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJjODg4NmI1LWNmOWQtNDMx
+        ZS05MGZkLTFiY2Y4ZWQzMmE5Yy8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:47 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/2c8886b5-cf9d-431e-90fd-1bcf8ed32a9c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:48 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '503'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yYzg4ODZiNS1jZjlkLTQz
+        MWUtOTBmZC0xYmNmOGVkMzJhOWMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM3OjQ3LjY4NDQzNloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wOS0wOVQxMjozNzo0Ny44MTkxNDda
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM3OjQ4LjA1ODM4MFoi
+        LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzL2NiNTE1YjkxLWUzNzktNGQ5OS1iYTBh
+        LTQxYTQxYzdhOTJiZC8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
+        OltdLCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiRG93bmxvYWRp
+        bmcgTWV0YWRhdGEiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjoxLCJk
+        b25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IkRvd25sb2FkaW5n
+        IEFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
+        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
+        bmcgQ29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRv
+        bmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRp
+        bmcgQ29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRv
+        bmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2luZyBNZXRh
+        ZGF0YSBMaW5lcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRv
+        bmUiOjMsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2JhZmEyZDM2LTM2ZDItNGJjYi1h
+        YzQ4LWQzZDBjMGQwMjM4Ni92ZXJzaW9ucy8zLyJdLCJyZXNlcnZlZF9yZXNv
+        dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYmFm
+        YTJkMzYtMzZkMi00YmNiLWFjNDgtZDNkMGMwZDAyMzg2LyIsIi9wdWxwL2Fw
+        aS92My9yZW1vdGVzL2ZpbGUvZmlsZS8yYWU3OTIxOC01OWEyLTQ4NmMtYjA0
+        Zi1kOGEwMTFiOGFkOGQvIl19
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:48 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/bafa2d36-36d2-4bcb-ac48-d3d0c0d02386/versions/3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:48 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '238'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYmFmYTJkMzYt
+        MzZkMi00YmNiLWFjNDgtZDNkMGMwZDAyMzg2L3ZlcnNpb25zLzMvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTA5VDEyOjM3OjQ3Ljg0Njg0MloiLCJudW1iZXIi
+        OjMsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2Fw
+        aS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9h
+        ZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2JhZmEyZDM2LTM2ZDIt
+        NGJjYi1hYzQ4LWQzZDBjMGQwMjM4Ni92ZXJzaW9ucy8zLyJ9fSwicmVtb3Zl
+        ZCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fcmVt
+        b3ZlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2JhZmEyZDM2LTM2ZDIt
+        NGJjYi1hYzQ4LWQzZDBjMGQwMjM4Ni92ZXJzaW9ucy8zLyJ9fSwicHJlc2Vu
+        dCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iYWZhMmQzNi0zNmQyLTRiY2ItYWM0
+        OC1kM2QwYzBkMDIzODYvdmVyc2lvbnMvMy8ifX19fQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:48 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/publications/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2JhZmEyZDM2LTM2ZDItNGJjYi1hYzQ4LWQzZDBjMGQwMjM4Ni92ZXJz
+        aW9ucy8zLyIsIm1hbmlmZXN0IjoiUFVMUF9NQU5JRkVTVCJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:48 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MxYzU3YWQzLTQ4YTYtNDY5
+        Yy1hMTM4LWIxNzQ0NTYzZTBkYi8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:48 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/c1c57ad3-48a6-469c-a138-b1744563e0db/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:48 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '374'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jMWM1N2FkMy00OGE2LTQ2
+        OWMtYTEzOC1iMTc0NDU2M2UwZGIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM3OjQ4LjU1ODMwN1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnB1Ymxpc2hpbmcucHVibGlzaCIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM3OjQ4LjY2NTM0MFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6Mzc6NDguNzE4Mjk2WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
+        N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
+        cC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUvZmlsZS9lZWI3MjU5MS1mZmI4
+        LTQ3NWQtOTE4Ni1lOTRmM2I1ZTkyZDAvIl0sInJlc2VydmVkX3Jlc291cmNl
+        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iYWZhMmQz
+        Ni0zNmQyLTRiY2ItYWM0OC1kM2QwYzBkMDIzODYvIl19
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:48 GMT
+- request:
+    method: patch
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/28ec37ef-d676-4d4f-8cb3-93160624b7b3/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmls
+        ZS9maWxlL2VlYjcyNTkxLWZmYjgtNDc1ZC05MTg2LWU5NGYzYjVlOTJkMC8i
+        fQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:48 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJkZmQ0OTYyLWM1ZWEtNDQy
+        Yy04YTAzLWMwNWFmMmZkZTQ2Ny8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:48 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/2dfd4962-c5ea-442c-8a03-c05af2fde467/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:49 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '317'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yZGZkNDk2Mi1jNWVhLTQ0
+        MmMtOGEwMy1jMDVhZjJmZGU0NjcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM3OjQ4Ljk1OTMwOFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM3OjQ5LjA4NTc3MFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6Mzc6NDkuMTg1MzY1WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
+        N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJl
+        c2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRp
+        b25zLyJdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:49 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:49 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '350'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy85NTlj
+        ZjA5Yi03MTEzLTQzZjEtYTAwYS00ZjdmNGMzZDA0OGIvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTA2VDE3OjQyOjQwLjQ1NTM1MFoiLCJfdmVyc2lvbnNfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOTU5Y2YwOWItNzExMy00
+        M2YxLWEwMGEtNGY3ZjRjM2QwNDhiL3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVy
+        c2lvbl9ocmVmIjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24t
+        Q2FiaW5ldC1wdWxwM19Eb2NrZXJfMSIsImRlc2NyaXB0aW9uIjpudWxsfSx7
+        Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iZDUwNGY5MC0z
+        ZTJkLTRlNTUtYTMyNi02NDVhNWI1M2RiNTYvIiwiX2NyZWF0ZWQiOiIyMDE5
+        LTA5LTA2VDE3OjQ0OjAzLjY1Mzc2M1oiLCJfdmVyc2lvbnNfaHJlZiI6Ii9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYmQ1MDRmOTAtM2UyZC00ZTU1LWEz
+        MjYtNjQ1YTViNTNkYjU2L3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVyc2lvbl9o
+        cmVmIjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5l
+        dC1NeV9GaWxlcyIsImRlc2NyaXB0aW9uIjpudWxsfSx7Il9ocmVmIjoiL3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iYWZhMmQzNi0zNmQyLTRiY2ItYWM0
+        OC1kM2QwYzBkMDIzODYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5VDEyOjM3
+        OjQxLjg1MTEyOVoiLCJfdmVyc2lvbnNfaHJlZiI6Ii9wdWxwL2FwaS92My9y
+        ZXBvc2l0b3JpZXMvYmFmYTJkMzYtMzZkMi00YmNiLWFjNDgtZDNkMGMwZDAy
+        Mzg2L3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAv
+        YXBpL3YzL3JlcG9zaXRvcmllcy9iYWZhMmQzNi0zNmQyLTRiY2ItYWM0OC1k
+        M2QwYzBkMDIzODYvdmVyc2lvbnMvMy8iLCJuYW1lIjoiRGVmYXVsdF9Pcmdh
+        bml6YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJkZXNjcmlwdGlvbiI6
+        bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:49 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/959cf09b-7113-43f1-a00a-4f7f4c3d048b/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:49 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:49 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/bd504f90-3e2d-4e55-a326-645a5b53db56/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:49 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:49 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/bafa2d36-36d2-4bcb-ac48-d3d0c0d02386/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:49 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '315'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iYWZh
+        MmQzNi0zNmQyLTRiY2ItYWM0OC1kM2QwYzBkMDIzODYvdmVyc2lvbnMvMy8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDktMDlUMTI6Mzc6NDcuODQ2ODQyWiIsIm51
+        bWJlciI6MywiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250ZW50X3N1bW1hcnki
+        OnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJz
+        aW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYmFmYTJkMzYt
+        MzZkMi00YmNiLWFjNDgtZDNkMGMwZDAyMzg2L3ZlcnNpb25zLzMvIn19LCJy
+        ZW1vdmVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
+        bl9yZW1vdmVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYmFmYTJkMzYt
+        MzZkMi00YmNiLWFjNDgtZDNkMGMwZDAyMzg2L3ZlcnNpb25zLzMvIn19LCJw
+        cmVzZW50Ijp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
+        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2JhZmEyZDM2LTM2ZDItNGJj
+        Yi1hYzQ4LWQzZDBjMGQwMjM4Ni92ZXJzaW9ucy8zLyJ9fX19LHsiX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2JhZmEyZDM2LTM2ZDItNGJj
+        Yi1hYzQ4LWQzZDBjMGQwMjM4Ni92ZXJzaW9ucy8yLyIsIl9jcmVhdGVkIjoi
+        MjAxOS0wOS0wOVQxMjozNzo0NS4yMDQ3ODVaIiwibnVtYmVyIjoyLCJiYXNl
+        X3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJm
+        aWxlLmZpbGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkvdjMvY29u
+        dGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iYWZhMmQzNi0zNmQyLTRiY2ItYWM0
+        OC1kM2QwYzBkMDIzODYvdmVyc2lvbnMvMi8ifX0sInJlbW92ZWQiOnt9LCJw
+        cmVzZW50Ijp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxw
+        L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
+        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2JhZmEyZDM2LTM2ZDItNGJj
+        Yi1hYzQ4LWQzZDBjMGQwMjM4Ni92ZXJzaW9ucy8yLyJ9fX19LHsiX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2JhZmEyZDM2LTM2ZDItNGJj
+        Yi1hYzQ4LWQzZDBjMGQwMjM4Ni92ZXJzaW9ucy8xLyIsIl9jcmVhdGVkIjoi
+        MjAxOS0wOS0wOVQxMjozNzo0Mi41NzM3MjlaIiwibnVtYmVyIjoxLCJiYXNl
+        X3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6e30s
+        InJlbW92ZWQiOnt9LCJwcmVzZW50Ijp7fX19XX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:49 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/2ae79218-59a2-486c-b04f-d8a011b8ad8d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:50 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzI5MGU2NDk0LTc2OGMtNGI2
+        ZC1hMmZhLThiYjI5NzM2YjM2MS8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:50 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/290e6494-768c-4b6d-a2fa-8bb29736b361/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:50 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '338'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yOTBlNjQ5NC03NjhjLTRi
+        NmQtYTJmYS04YmIyOTczNmIzNjEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM3OjUwLjE4Njc3MloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsInN0
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM3OjUwLjI4MjExNloiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6Mzc6NTAuMzE0NjQ0WiIsIm5vbl9m
+        YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvYWY4NTNjNzItMTQ2NC00ZjdjLWEwMzUtNDcxNjY1
+        M2NlZTM5LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJl
+        c2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90
+        ZXMvZmlsZS9maWxlLzJhZTc5MjE4LTU5YTItNDg2Yy1iMDRmLWQ4YTAxMWI4
+        YWQ4ZC8iXX0=
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:50 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:50 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '315'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmls
+        ZS9maWxlLzI4ZWMzN2VmLWQ2NzYtNGQ0Zi04Y2IzLTkzMTYwNjI0YjdiMy8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDktMDlUMTI6Mzc6NDMuODAyMzIxWiIsImJh
+        c2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNf
+        RmlsZV8xIiwiYmFzZV91cmwiOiJjZW50b3M3LWthdGVsbG8tZGV2ZWwuampl
+        ZmZlcnMuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3JnYW5p
+        emF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xIiwiY29udGVudF9ndWFyZCI6
+        bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVs
+        cDNfRmlsZV8xIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGlj
+        YXRpb25zL2ZpbGUvZmlsZS9lZWI3MjU5MS1mZmI4LTQ3NWQtOTE4Ni1lOTRm
+        M2I1ZTkyZDAvIn1dfQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:50 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/28ec37ef-d676-4d4f-8cb3-93160624b7b3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01567190410/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:50 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQzYTBlY2IwLTlhNWItNGVi
+        NC05Yjc1LTgzODI5NzRmNzU1OS8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:50 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/bafa2d36-36d2-4bcb-ac48-d3d0c0d02386/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:50 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM0MzViYzc3LTI4ZTMtNDM4
+        ZS05MWQ3LWQyODc0MDgzOTNhZi8ifQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:50 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/3435bc77-28e3-438e-91d7-d287408393af/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 09 Sep 2019 12:37:51 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '333'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8zNDM1YmM3Ny0yOGUzLTQz
+        OGUtOTFkNy1kMjg3NDA4MzkzYWYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
+        VDEyOjM3OjUwLjgzOTIyN1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5kZWxldGUiLCJzdGFy
+        dGVkX2F0IjoiMjAxOS0wOS0wOVQxMjozNzo1MC45NDUwMDhaIiwiZmluaXNo
+        ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjM3OjUxLjAwOTcyNFoiLCJub25fZmF0
+        YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2Fw
+        aS92My93b3JrZXJzL2FmODUzYzcyLTE0NjQtNGY3Yy1hMDM1LTQ3MTY2NTNj
+        ZWUzOS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9n
+        cmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNl
+        cnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvYmFmYTJkMzYtMzZkMi00YmNiLWFjNDgtZDNkMGMwZDAyMzg2LyJd
+        fQ==
+    http_version: 
+  recorded_at: Mon, 09 Sep 2019 12:37:51 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository_orphan_content_view/orphan_repository_versions.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository_orphan_content_view/orphan_repository_versions.yml
@@ -1,0 +1,815 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com:8443/candlepin/owners/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJrZXkiOiJvcmcxIiwiZGlzcGxheU5hbWUiOiJPcmdhbml6YXRpb24xIiwi
+        Y29udGVudFByZWZpeCI6Ii9vcmcxLyRlbnYifQ==
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="dNZ8tEDWtwokaUEpig4TxxkzbrEKMeY4",
+        oauth_nonce="ZjQNRq8qwiJ5gRbbynfHyIVbpKcH4gl5w8jbuiONos", oauth_signature="TW9QbeV%2BCRhMOuTmL4bPsLfmfEI%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1567098641", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '73'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - efbc22e9-07f5-4b38-b578-b4ab0dd17c83
+      X-Version:
+      - 2.7.1-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Thu, 29 Aug 2019 17:10:41 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wOC0yOVQxNzoxMDo0MSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDgtMjlUMTc6MTA6NDErMDAwMCIsImlkIjoiNDAyOGY5YmI2
+        Y2RkYTQ4ZjAxNmNkZTViOWQ0ODAwMDUiLCJrZXkiOiJvcmcxIiwiZGlzcGxh
+        eU5hbWUiOiJPcmdhbml6YXRpb24xIiwicGFyZW50T3duZXIiOm51bGwsImNv
+        bnRlbnRQcmVmaXgiOiIvb3JnMS8kZW52IiwiZGVmYXVsdFNlcnZpY2VMZXZl
+        bCI6bnVsbCwidXBzdHJlYW1Db25zdW1lciI6bnVsbCwibG9nTGV2ZWwiOm51
+        bGwsImF1dG9iaW5kRGlzYWJsZWQiOmZhbHNlLCJjb250ZW50QWNjZXNzTW9k
+        ZSI6ImVudGl0bGVtZW50IiwiY29udGVudEFjY2Vzc01vZGVMaXN0IjoiZW50
+        aXRsZW1lbnQiLCJsYXN0UmVmcmVzaGVkIjpudWxsLCJocmVmIjoiL293bmVy
+        cy9vcmcxIn0=
+    http_version: 
+  recorded_at: Thu, 29 Aug 2019 17:10:41 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com:8443/candlepin/owners/org1/environments
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6ImE4OWFlYTEzOGZjZGZlMGI1MDFmNzkwNGMyNWUzZDIyIiwibmFt
+        ZSI6IkxpYnJhcnkiLCJkZXNjcmlwdGlvbiI6bnVsbH0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="dNZ8tEDWtwokaUEpig4TxxkzbrEKMeY4",
+        oauth_nonce="DdmmOBXLNSZOSreZkxXHCtFqvuPYwtsBbF6tvW6bc", oauth_signature="kBtTSiRmUVf4A1FUuV%2BA82L%2Fh1c%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1567098641", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '77'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 256f7e68-767e-4943-a748-e7d22375faf5
+      X-Version:
+      - 2.7.1-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Thu, 29 Aug 2019 17:10:41 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wOC0yOVQxNzoxMDo0MSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDgtMjlUMTc6MTA6NDErMDAwMCIsImlkIjoiYTg5YWVhMTM4
+        ZmNkZmUwYjUwMWY3OTA0YzI1ZTNkMjIiLCJuYW1lIjoiTGlicmFyeSIsImRl
+        c2NyaXB0aW9uIjpudWxsLCJvd25lciI6eyJpZCI6IjQwMjhmOWJiNmNkZGE0
+        OGYwMTZjZGU1YjlkNDgwMDA1Iiwia2V5Ijoib3JnMSIsImRpc3BsYXlOYW1l
+        IjoiT3JnYW5pemF0aW9uMSIsImhyZWYiOiIvb3duZXJzL29yZzEifSwiZW52
+        aXJvbm1lbnRDb250ZW50IjpbXX0=
+    http_version: 
+  recorded_at: Thu, 29 Aug 2019 17:10:41 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com:8443/candlepin/owners/org1/uebercert
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Authorization:
+      - OAuth oauth_consumer_key="dNZ8tEDWtwokaUEpig4TxxkzbrEKMeY4", oauth_nonce="LsQ3dJe3wm2K8oPBwlAhZbu0YEHABimfmfMowLkY8",
+        oauth_signature="0seC422fF79guOz0Y%2B6GD0VzJDM%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1567098641", oauth_version="1.0"
+      Cp-User:
+      - foreman_admin
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - e51fd4e9-1967-405a-8584-961258beeeeb
+      X-Version:
+      - 2.7.1-1
+      - 2.7.1-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Thu, 29 Aug 2019 17:10:41 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJkaXNwbGF5TWVzc2FnZSI6InViZXIgY2VydGlmaWNhdGUgZm9yIG93bmVy
+        IG9yZzEgd2FzIG5vdCBmb3VuZC4gUGxlYXNlIGdlbmVyYXRlIG9uZS4iLCJy
+        ZXF1ZXN0VXVpZCI6ImU1MWZkNGU5LTE5NjctNDA1YS04NTg0LTk2MTI1OGJl
+        ZWVlYiJ9
+    http_version: 
+  recorded_at: Thu, 29 Aug 2019 17:10:41 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com:8443/candlepin/owners/org1/uebercert
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="dNZ8tEDWtwokaUEpig4TxxkzbrEKMeY4",
+        oauth_nonce="jlFNZXJuH3UR19oIvUBREjPQQPTD86sx3iYn2kPeuA", oauth_signature="lqm8qLZA33m7ZqwkDWvxYgTtVkc%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1567098641", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '2'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 0fcd8bbd-5cc4-4382-9f88-09502995fc2c
+      X-Version:
+      - 2.7.1-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Thu, 29 Aug 2019 17:10:45 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wOC0yOVQxNzoxMDo0MSswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDgtMjlUMTc6MTA6NDUrMDAwMCIsImlkIjoiNDAyOGY5YmI2
+        Y2RkYTQ4ZjAxNmNkZTViYWI4ZTAwMDciLCJrZXkiOiItLS0tLUJFR0lOIFJT
+        QSBQUklWQVRFIEtFWS0tLS0tXG5NSUlKS2dJQkFBS0NBZ0VBb2kzeTRtREJv
+        UGJEMTA4WmRBeUdVa21vYktGbWZrMXE5bTdBb3VJZzBzb0RVN0MwXG43dE9O
+        clJ1SkF4bjRTOUtha281Njk1K0NaTStJT3RBTlNJZjU2eVUrcE1DcnkzRUVv
+        VjZNRkd0L25tUkxtQWovXG52a0xJcVI0VVlmV3UxZHJRVWQzZzBtcERVaURV
+        Skt3S0l3RWhYMlJYb3RNWDBKbkZWeDhzN2ZZRjZSOGdUQ3htXG40Skc4ZlVv
+        bWw0d3llaGpOMkpHbjYyRWZqTHNkSFZIV0k4dHlhVis2NlBjaFF1UTVtWnZR
+        UnIzc2x1Z3RiN2diXG5FaGNnc3pOMzUxckRHbENUWjRLUEFXaWJGK2x5ZFo1
+        cW9PM1YxVGxyZGRpZjZKcmRqZzlQbmpmMkwrTlBRU3FDXG5ZWlo5R29QYWNx
+        OGlIRXpGY29UMWZjbG5UYlFTTG1tTXk4Mk8yenFMZDJsMWsvSk8zaTU3Zlho
+        ZEdmVFFYcFJyXG5XL2RnVGhrejFjY1dUTU9FNSthVkFISWFPdHlLVm9qMVht
+        MDQvMG13UUpqR2ltd1kyUTRkNEpWYU5jSFFQZG5hXG5Qc2tLV1F4RWRDeFdR
+        cng3bXJnNlpFYXlXRHJhY29GelFUM3RDTzREekRtejREeGxWLzRpOStOZVJi
+        RWV5VHhsXG5RUlc0ekpCQXh3RkRjM3YybW0rVDRHc3N3Y2MvQWZmODJZTysr
+        M0dzMkIwcTg5cGxjZGFHbTFLRC90SjBSbngyXG44NXJLZ3FpcEF1d2JsdWNt
+        YytQK2FMSUlaemg2VitWNHBtS2I0L3FGcHVvUDdvUXdNVDhVbXdXMXUzaXE1
+        TDIzXG5QWC9sQnFXQ3BOSTFVUDhxSWlDVjZ2SHVwMjJodFlCQ2h6VFZ2aXJt
+        QnByMEhEOThpWEhCeUh4L3ozc0NBd0VBXG5BUUtDQWdBWkEzVStyU1d3S2Q4
+        eXlpUm0zYmVwNFdwMHRzQVVJdVNvZFpTSWlzLzlNdU1vZVV5dXVUcFV4TFp4
+        XG5JQVJIellmQnF2QVVXU25IV3Fyc1IwS0ZPVk8yak53SWxSN3FGZGhjK3pR
+        bndoekExVDlEaDcvS0hJck9hckZDXG5HcDZJcFdNVC9XQzdrMkFtdnFGNXRu
+        OHB2dmJpdTVzNHBjNDZnajBKbnVsVEdtcjI5YklKalorZ2ExbmpDUmpDXG5y
+        d0RxREFGVHNjTndibDVyV2tDM1VQUHlPV0xBRmQvQ0pydWVrWXpBd0dOelJi
+        L0Qxck9MVTUzNVFFL3UwN1ZlXG5uWVVSL2ZOK040ak84czlZOU15T2o0eHFu
+        Y1FwU3Qza0l6RW1zeHdRMlJPeWwzY0ZFODRaZ3ZEeEZFRGZZZzdEXG5PWGZO
+        WFpubWU5TlJQMHNMbFFabzJpYTVHRTg4Q1FoREhIeHhxY2dvUUpGOG1hRnZR
+        YzJ2NTFaVFh2VkpqRE5lXG5Ga0o2Qmgyd2ttalJxZVJIV1VuM1c4emdBei92
+        bkUyT1pydXZJN3NGNzY3T0hCMzlhNWl1VTBRYzQ1Y1RjL1VpXG5qeDJCWVhh
+        dzI3dUhrN0R2alpxekIwZ2FlWWdSK2xMTVIzU1p3T21BdC9VeFpycUxvWi9W
+        bkZCRUlhekJRaGVOXG50WTJzM1ZldnVlbTgzcFVyUEtzeG9OZzV6N0FYUFZ4
+        WnFtRnd6Vk02U2dBTXcwYWJwdGV3Q2NDOXlBV0h3SWJHXG5oNnhlM0tCNnBL
+        SzZFQ2N2aXlrbHRZVnBieko0QzFqcTBBY1JDcHF5K0p0SDlsU1QzdnRNVEdu
+        ckdQbXpZaVRzXG51akRoZWF6dEhpZUNyaCtWcUV0Ri9lS0VGRDFYRkRWM3lE
+        eEpGd0trYXI1cHhLQXFBUUtDQVFFQTh6WGJFeitlXG5LUHc1d1A1OS82Ym53
+        OVVLbTExUVYwQ1N5YnVjSEsyRFFWQ3NyRjYybER6QUJaaExwaGVKeTlsVFFw
+        ODE5aFNnXG5rZ3hFdWZOU2RPUFVacTRuaXlzYVJiUE5UZGFaUU9ITlFEOTVZ
+        Y1lOWXlJamNHcGdRTzFMRHpkL3gwSjBlRnJJXG5Bb01VaXg0QVdBbzg5b09U
+        ZEFBUDJCSXh1b3Y5TTJnUER4cUFFOGk4blFVczFHeGo3VlY0blJoV0lZZDUr
+        aTByXG5XS1BqTUE0Tkk5RmtuOU5JSFpQRjl6dVVFWWU4dGFMQW9McFFWMC9s
+        aEFhVjd6YWpjUC96WHlXbldVejhTblBkXG4zalhoaXQ0TGpobWc0OWpIOEpt
+        cFM4eW81SDZEaVRzcHcxMGJ0SmVRRWNHbU9YdE44YU9QOG4yaitPWnU5aWw3
+        XG5wR1dPbnZzR21MMjRPd0tDQVFFQXFyVTlaT2xSZzJBcWIrQWxsYndtajNu
+        cXlwbXRldE9qWFZOS3ZzSHQzTWRjXG5XaGFUOURSZWJ5eklsbC9wZndoR0c1
+        b2tLRU8vSFpDOXk3QTd5dHM5OWNZbmJlMEpYdDVyMjJOQmIxcURGaDNoXG4y
+        OTFQVDRyYkxBb2tPL3lMM3dTckJ6cStIbE1XUTFMNXcwNTdDcEhmU2w5MWdC
+        M2NtZXNEYVdPL3BUKzVwZnQ3XG5FTEJURzJZK2ZQRkJQcE9vYk5WR0RIdm9X
+        WjRyMFdHN1M0cFF0UEdrU3FlMVN1a1EyVVNVUmxNOThlcHdJaXZ0XG43alJl
+        MXRvMjhCa0llS1cwbm5aYmUyanZTUElMOGlxWUo3OEJTMU5QZVdOTlZZUzRm
+        OEFlcFBKVUtidjF1MGpBXG5DWndSTDFiemJkN3RESWdGWDBnYy9oMnVNUmsx
+        Q1dzdDhwMjNMUFFSd1FLQ0FRRUF4Ni96Vk1XS0pWcWFUTVJuXG5UVzJMbzNX
+        YkJOOUQ1Sy9IRmMxdEt2cW41d3ZIQ3F1bE91YjZQbDNCMXZoQ2tsVzRqOTNL
+        MzJZbVJHUEFWZkRiXG5SYy8rQitSNzRUOGRqaGRIdk40eTdGdTVPMFFpZEUy
+        NWxpaGtjcHRVdGxwZW8zck05aHl4SmxSYkhmemo5Q2xJXG4zUUJpOTRBbXBE
+        cWN4NnFBbkFydWRMTytrWWNQbTY3WWRnL1dzLzdldVBIUld5S3RMVkJmclRK
+        REFiOWwvSUc4XG45aWlwZHJSeDVKNzlEcllqSjVXTU1wSVRtS1FBN1A5VGtl
+        Z2FXTk5DdExmaDZjQXZ2Qm1DbDlxMFV3dG9TSzF4XG5UVlhyak1manViOWdp
+        alRhZ3VrQk5MNlgxcWp1NDRNQnJpS1NTV1hkSkVaSUhUQmRYakpNN3Q0MmYw
+        OUhIMjg2XG5CbFRYR3dLQ0FRRUFnajdrUitFbzIxYjlLZnpZVUdXTStqMW9J
+        Z3FjN1RFYTNQTFcvYktUWExjVFJIMGpoOWlKXG5FTVFYaTN4RWVETUU0cng1
+        eCtyZ241czI1SGxqTllTUHdyemNpcWVuVmFYWW56d2N5ZXhDUmhhb3BBczRI
+        eFZ2XG40aXNldUZJWkdpRENxVEp0cWs5MGxndHlHMHorM2ZLc2JsOWxGRW8w
+        Ylk5OU8rVHFiUmV3K3U1a1dEaGdRSENEXG5UdXIzLzluRFVMNXN3c3VyWE8w
+        c3U0V1kxS3NFcHZvVGd3NXdhV1puLzQydW4vV1ZOc1hMcHBiajQ3STdoaXhh
+        XG5iRmg5T1NnZEppWmg2RWdKQWh3RGQxSitZeHo5ek00VXZpWkE4L1hlbTBJ
+        blgyeXhRR0p6dStCbS9TNEJncUFSXG4vWXR3Uy9aZ092R1hoVjk1NzJZdkxD
+        K0ZrQzQ3ZTJZQlFRS0NBUUVBdldpaTVJYlFHY3lSaXhaMFo3aHpSMVl2XG5o
+        TWloRjlDaVJDckZJSmV6dHEvRGdYMU9aaEpicWREVjJuaEVyWTIzOHlva1V6
+        am5ZMWh5WXh1MEx4a0lzNXFQXG5YYmhtQlM1Q1hhV1dRSldzVFNNdWplYkNz
+        UGJlRHVKMm5na2hRSnNsYjdLK3VjYU53QzJCd0pBQk8vQTlmWjgvXG5HUk5Q
+        VFNsYXBVRXdBcFdxTFNKTzgzN0NXVUQzMFdmcVVnVlBYNFY4M0MrOU11aVlG
+        ZHg1QkoxamJGZjJlOGh4XG5ucjg4cTZLdytEQ2pjVXVLUHBybGo1T3VvOEx5
+        U1VKWXlnd0cyR05QMFlIK3NEeTVYVUNRbWJvNkk2KzhwSkVWXG5XVHE5U29w
+        dkE4RGRLVDNzSGo3QU1hN21Za0NVaEJnK3NRRkM5UVRBam9saG1abHhuRzB4
+        NVVhMmxGVkFGQT09XG4tLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLVxu
+        IiwiY2VydCI6Ii0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLVxuTUlJSFRq
+        Q0NCamFnQXdJQkFnSUlaVHR5Uk56Wjl3Z3dEUVlKS29aSWh2Y05BUUVMQlFB
+        d2daVXhDekFKQmdOVlxuQkFZVEFsVlRNUmN3RlFZRFZRUUlEQTVPYjNKMGFD
+        QkRZWEp2YkdsdVlURVFNQTRHQTFVRUJ3d0hVbUZzWldsblxuYURFUU1BNEdB
+        MVVFQ2d3SFMyRjBaV3hzYnpFVU1CSUdBMVVFQ3d3TFUyOXRaVTl5WjFWdWFY
+        UXhNekF4QmdOVlxuQkFNTUttTmxiblJ2Y3pjdGEyRjBaV3hzYnkxa1pYWmxi
+        QzVxYW1WbVptVnljeTVsZUdGdGNHeGxMbU52YlRBZVxuRncweE9UQTRNamt4
+        TnpFd05ERmFGdzAwT1RFeU1ERXhNekF3TURCYU1BOHhEVEFMQmdOVkJBb01C
+        Rzl5WnpFd1xuZ2dJaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQ0R3QXdnZ0lL
+        QW9JQ0FRQ2lMZkxpWU1HZzlzUFhUeGwwRElaU1xuU2Foc29XWitUV3IyYnND
+        aTRpRFN5Z05Uc0xUdTA0MnRHNGtER2ZoTDBwcVNqbnIzbjRKa3o0ZzYwQTFJ
+        aC9uclxuSlQ2a3dLdkxjUVNoWG93VWEzK2VaRXVZQ1ArK1FzaXBIaFJoOWE3
+        VjJ0QlIzZURTYWtOU0lOUWtyQW9qQVNGZlxuWkZlaTB4ZlFtY1ZYSHl6dDln
+        WHBIeUJNTEdiZ2tieDlTaWFYakRKNkdNM1lrYWZyWVIrTXV4MGRVZFlqeTNK
+        cFxuWDdybzl5RkM1RG1abTlCR3ZleVc2QzF2dUJzU0Z5Q3pNM2ZuV3NNYVVK
+        Tm5nbzhCYUpzWDZYSjFubXFnN2RYVlxuT1d0MTJKL29tdDJPRDArZU4vWXY0
+        MDlCS29KaGxuMGFnOXB5cnlJY1RNVnloUFY5eVdkTnRCSXVhWXpMelk3Ylxu
+        T290M2FYV1Q4azdlTG50OWVGMFo5TkJlbEd0YjkyQk9HVFBWeHhaTXc0VG41
+        cFVBY2hvNjNJcFdpUFZlYlRqL1xuU2JCQW1NYUtiQmpaRGgzZ2xWbzF3ZEE5
+        MmRvK3lRcFpERVIwTEZaQ3ZIdWF1RHBrUnJKWU90cHlnWE5CUGUwSVxuN2dQ
+        TU9iUGdQR1ZYL2lMMzQxNUZzUjdKUEdWQkZiak1rRURIQVVOemUvYWFiNVBn
+        YXl6Qnh6OEI5L3paZzc3N1xuY2F6WUhTcnoybVZ4MW9hYlVvUCswblJHZkhi
+        em1zcUNxS2tDN0J1VzV5Wno0LzVvc2dobk9IcFg1WGltWXB2alxuK29XbTZn
+        L3VoREF4UHhTYkJiVzdlS3JrdmJjOWYrVUdwWUtrMGpWUS95b2lJSlhxOGU2
+        bmJhRzFnRUtITk5XK1xuS3VZR212UWNQM3lKY2NISWZIL1Bld0lEQVFBQm80
+        SURKVENDQXlFd0RnWURWUjBQQVFIL0JBUURBZ1N3TUJNR1xuQTFVZEpRUU1N
+        QW9HQ0NzR0FRVUZCd01DTUFrR0ExVWRFd1FDTUFBd0VRWUpZSVpJQVliNFFn
+        RUJCQVFEQWdXZ1xuTUIwR0ExVWREZ1FXQkJSN3J6ampQc2RCdnM2c0hSL0tP
+        QjNZKzBweUFqQWZCZ05WSFNNRUdEQVdnQlJMMFZ0T1xucmFQVS9EVStTZ0lv
+        OW5tWXdlcWd2akFvQmhBckJnRUVBWklJQ1FHdHpmTHV2RUlCQkJRTUVtOXla
+        ekZmZFdWaVxuWlhKZmNISnZaSFZqZERBV0JoQXJCZ0VFQVpJSUNRR3R6Zkx1
+        dkVJREJBSU1BREFXQmhBckJnRUVBWklJQ1FHdFxuemZMdXZFSUNCQUlNQURB
+        V0JoQXJCZ0VFQVpJSUNRR3R6Zkx1dkVJRkJBSU1BREFaQmhBckJnRUVBWklJ
+        Q1FLdFxuemZMdXZFUUJCQVVNQTNsMWJUQWtCaEVyQmdFRUFaSUlDUUt0emZM
+        dXZFUUJBUVFQREExMVpXSmxjbDlqYjI1MFxuWlc1ME1ESUdFU3NHQVFRQmtn
+        Z0pBcTNOOHU2OFJBRUNCQjBNR3pFMU5qY3dPVGcyTkRFNU9EWmZkV1ZpWlhK
+        ZlxuWTI5dWRHVnVkREFkQmhFckJnRUVBWklJQ1FLdHpmTHV2RVFCQlFRSURB
+        WkRkWE4wYjIwd0hBWVJLd1lCQkFHU1xuQ0FrQ3JjM3k3cnhFQVFZRUJ3d0ZM
+        Mjl5WnpFd0Z3WVJLd1lCQkFHU0NBa0NyYzN5N3J4RUFRY0VBZ3dBTUJnR1xu
+        RVNzR0FRUUJrZ2dKQXEzTjh1NjhSQUVJQkFNTUFURXdJZ1lLS3dZQkJBR1ND
+        QWtFQVFRVURCSnZjbWN4WDNWbFxuWW1WeVgzQnliMlIxWTNRd0VBWUtLd1lC
+        QkFHU0NBa0VBZ1FDREFBd0hRWUtLd1lCQkFHU0NBa0VBd1FQREEweFxuTlRZ
+        M01EazROalF4T1RnMk1CRUdDaXNHQVFRQmtnZ0pCQVVFQXd3Qk1UQWtCZ29y
+        QmdFRUFaSUlDUVFHQkJZTVxuRkRJd01Ua3RNRGd0TWpsVU1UYzZNVEE2TkRG
+        YU1DUUdDaXNHQVFRQmtnZ0pCQWNFRmd3VU1qQTBPUzB4TWkwd1xuTVZReE16
+        b3dNRG93TUZvd0VRWUtLd1lCQkFHU0NBa0VEQVFEREFFd01CQUdDaXNHQVFR
+        QmtnZ0pCQW9FQWd3QVxuTUJBR0Npc0dBUVFCa2dnSkJBMEVBZ3dBTUJFR0Np
+        c0dBUVFCa2dnSkJBNEVBd3dCTURBUkJnb3JCZ0VFQVpJSVxuQ1FRTEJBTU1B
+        VEV3TkFZS0t3WUJCQUdTQ0FrRkFRUW1EQ1JoTkRobE1HUmhaQzFsT0RKa0xU
+        UmhaRFl0T0RreVxuWVMwMU4yWTRNbVl3WXpBeFpUY3dEUVlKS29aSWh2Y05B
+        UUVMQlFBRGdnRUJBRXh0RUpieEhUZFFUS00rOVFuN1xueTl1OHdsSDB6RXow
+        NFdEbVNYVnFYU2FMRHBIKzVlNkRIa2RGaE84Y3BCL0NyQWs0ekg5UmIzMTd3
+        SkYrSHUxeFxuWDJXbW1ON2hyNXpucmhwa1Bod2RpTm9DNmNFWjdNOUlzazBM
+        b2VEanhQT1Y2a3NVam5HeGhNZjRDV3MvYVR2QlxuK291MGJTb2c2bFhTYVpT
+        Snk4dmRoVUMyaUFEbjJWbFl4Z2tQTHNSNnZlRy9WaGYrUWt2YUNvaER3ZDhi
+        QTV2cVxuTHdTaDN0SWh0bUZCS25WdldaM0Z5Y0EvYi9ZVE5ETFR3U1ZVQlBI
+        OHVIWmtTdXpuY2lTMzRsS3JQNHQ2U3dKM1xuWUhEeW82MVpJZXJmZFQvallh
+        U2FPZVI1cHpyajh4dHkzbm5RK1dzbTh2Rkg3SGpxT2Z0c2JvbGZHbVpSeURj
+        MlxuMWhVPVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLVxuIiwic2VyaWFs
+        Ijp7ImNyZWF0ZWQiOiIyMDE5LTA4LTI5VDE3OjEwOjQxKzAwMDAiLCJ1cGRh
+        dGVkIjoiMjAxOS0wOC0yOVQxNzoxMDo0MSswMDAwIiwiaWQiOjcyOTQ1NDk2
+        NjE1NDUyNjQ5MDQsInNlcmlhbCI6NzI5NDU0OTY2MTU0NTI2NDkwNCwiZXhw
+        aXJhdGlvbiI6IjIwNDktMTItMDFUMTM6MDA6MDArMDAwMCIsImNvbGxlY3Rl
+        ZCI6ZmFsc2UsInJldm9rZWQiOmZhbHNlfSwib3duZXIiOnsiaWQiOiI0MDI4
+        ZjliYjZjZGRhNDhmMDE2Y2RlNWI5ZDQ4MDAwNSIsImtleSI6Im9yZzEiLCJk
+        aXNwbGF5TmFtZSI6Ik9yZ2FuaXphdGlvbjEiLCJocmVmIjoiL293bmVycy9v
+        cmcxIn19
+    http_version: 
+  recorded_at: Thu, 29 Aug 2019 17:10:45 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=pulp-1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Aug 2019 17:10:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 29 Aug 2019 17:10:45 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=pulp-1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Aug 2019 17:10:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 29 Aug 2019 17:10:45 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=pulp-1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Aug 2019 17:10:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 29 Aug 2019 17:10:46 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=ACME_Corporation/DEV/Repo1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Aug 2019 17:10:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 29 Aug 2019 17:10:46 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=pulp-1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Aug 2019 17:10:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 29 Aug 2019 17:10:46 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=pulp-1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Aug 2019 17:10:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 29 Aug 2019 17:10:46 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=pulp-1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Aug 2019 17:10:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 29 Aug 2019 17:10:46 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=ACME_Corporation/DEV/Repo1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01566325827/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Aug 2019 17:10:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 29 Aug 2019 17:10:46 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJuYW1lIjoicHVscC0xIn0=
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 29 Aug 2019 17:10:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/9ad1a8f7-1647-49e3-94a6-f51b6c1ddcf6/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '271'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvOWFkMWE4Zjct
+        MTY0Ny00OWUzLTk0YTYtZjUxYjZjMWRkY2Y2LyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wOC0yOVQxNzoxMDo0Ny4wNjY1MjlaIiwiX3ZlcnNpb25zX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzlhZDFhOGY3LTE2NDctNDllMy05
+        NGE2LWY1MWI2YzFkZGNmNi92ZXJzaW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25f
+        aHJlZiI6bnVsbCwibmFtZSI6InB1bHAtMSIsImRlc2NyaXB0aW9uIjpudWxs
+        fQ==
+    http_version: 
+  recorded_at: Thu, 29 Aug 2019 17:10:47 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/9ad1a8f7-1647-49e3-94a6-f51b6c1ddcf6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01566405557/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 29 Aug 2019 17:10:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E3M2MxZDM1LTk0MWMtNDIw
+        Zi05YmVmLWIxMmY1Y2M0ZTM3OS8ifQ==
+    http_version: 
+  recorded_at: Thu, 29 Aug 2019 17:10:47 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository_orphancontent_view/delete_orphan_repository_versions.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository_orphancontent_view/delete_orphan_repository_versions.yml
@@ -1,0 +1,815 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com:8443/candlepin/owners/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJrZXkiOiJvcmcyIiwiZGlzcGxheU5hbWUiOiJPcmdhbml6YXRpb24yIiwi
+        Y29udGVudFByZWZpeCI6Ii9vcmcyLyRlbnYifQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="R8nEUmjt96croPKUVLGWtXwqRH22Cfaq",
+        oauth_nonce="Yl1ilXMCoQ1FIgFO5KMojZgVWOSajJ2MTXSYrsptg", oauth_signature="9Mzs5jmrSalQVDIAW5maIVb8g0w%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1566492134", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '73'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 4d724ed3-0e4c-4e8a-8bff-527e08dbeee5
+      X-Version:
+      - 2.7.1-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Thu, 22 Aug 2019 16:42:14 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wOC0yMlQxNjo0MjoxNCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDgtMjJUMTY6NDI6MTQrMDAwMCIsImlkIjoiNDAyOGY5NDQ2
+        Y2JhMmVjNTAxNmNiYTM1MGMwNzAwMGMiLCJrZXkiOiJvcmcyIiwiZGlzcGxh
+        eU5hbWUiOiJPcmdhbml6YXRpb24yIiwicGFyZW50T3duZXIiOm51bGwsImNv
+        bnRlbnRQcmVmaXgiOiIvb3JnMi8kZW52IiwiZGVmYXVsdFNlcnZpY2VMZXZl
+        bCI6bnVsbCwidXBzdHJlYW1Db25zdW1lciI6bnVsbCwibG9nTGV2ZWwiOm51
+        bGwsImF1dG9iaW5kRGlzYWJsZWQiOmZhbHNlLCJjb250ZW50QWNjZXNzTW9k
+        ZSI6ImVudGl0bGVtZW50IiwiY29udGVudEFjY2Vzc01vZGVMaXN0IjoiZW50
+        aXRsZW1lbnQiLCJsYXN0UmVmcmVzaGVkIjpudWxsLCJocmVmIjoiL293bmVy
+        cy9vcmcyIn0=
+    http_version: 
+  recorded_at: Thu, 22 Aug 2019 16:42:14 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com:8443/candlepin/owners/org2/environments
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6Ijk4MzA3N2ZiMTQxOGJkMzdiMTc4ZjM5MjVjNTJhYTYxIiwibmFt
+        ZSI6IkxpYnJhcnkiLCJkZXNjcmlwdGlvbiI6bnVsbH0=
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="R8nEUmjt96croPKUVLGWtXwqRH22Cfaq",
+        oauth_nonce="d7sWRTCqbc8xrXye5qOy32GzIEPSUxJBExx37Ukj28", oauth_signature="m%2FdTbhCOHrZ5Ko6pp8lzzBroqb8%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1566492134", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '77'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 202e322b-fb18-4f4c-971f-4d7402578d9d
+      X-Version:
+      - 2.7.1-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Thu, 22 Aug 2019 16:42:14 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wOC0yMlQxNjo0MjoxNCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDgtMjJUMTY6NDI6MTQrMDAwMCIsImlkIjoiOTgzMDc3ZmIx
+        NDE4YmQzN2IxNzhmMzkyNWM1MmFhNjEiLCJuYW1lIjoiTGlicmFyeSIsImRl
+        c2NyaXB0aW9uIjpudWxsLCJvd25lciI6eyJpZCI6IjQwMjhmOTQ0NmNiYTJl
+        YzUwMTZjYmEzNTBjMDcwMDBjIiwia2V5Ijoib3JnMiIsImRpc3BsYXlOYW1l
+        IjoiT3JnYW5pemF0aW9uMiIsImhyZWYiOiIvb3duZXJzL29yZzIifSwiZW52
+        aXJvbm1lbnRDb250ZW50IjpbXX0=
+    http_version: 
+  recorded_at: Thu, 22 Aug 2019 16:42:14 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com:8443/candlepin/owners/org2/uebercert
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      Authorization:
+      - OAuth oauth_consumer_key="R8nEUmjt96croPKUVLGWtXwqRH22Cfaq", oauth_nonce="lqiB3msvZYvEztfoqwxhwNeRZsgKssSylEkxc7k3I",
+        oauth_signature="I8qu%2BfuNcOqDFLjJAb0E2LwzfrA%3D", oauth_signature_method="HMAC-SHA1",
+        oauth_timestamp="1566492134", oauth_version="1.0"
+      Cp-User:
+      - foreman_admin
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - 8b57cc91-b83f-44d3-9b57-a13a23616a0b
+      X-Version:
+      - 2.7.1-1
+      - 2.7.1-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Thu, 22 Aug 2019 16:42:14 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJkaXNwbGF5TWVzc2FnZSI6InViZXIgY2VydGlmaWNhdGUgZm9yIG93bmVy
+        IG9yZzIgd2FzIG5vdCBmb3VuZC4gUGxlYXNlIGdlbmVyYXRlIG9uZS4iLCJy
+        ZXF1ZXN0VXVpZCI6IjhiNTdjYzkxLWI4M2YtNDRkMy05YjU3LWExM2EyMzYx
+        NmEwYiJ9
+    http_version: 
+  recorded_at: Thu, 22 Aug 2019 16:42:14 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com:8443/candlepin/owners/org2/uebercert
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="R8nEUmjt96croPKUVLGWtXwqRH22Cfaq",
+        oauth_nonce="GS1c06VQCrmQ6zyBVCKsmotqNjhtFjlpitrmY0HUk", oauth_signature="xZvaifBGQTgKeRG5Vl7awAwxj1s%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1566492134", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '2'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - a755f062-33bb-468b-b4f4-ef36b7f34f0e
+      X-Version:
+      - 2.7.1-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Thu, 22 Aug 2019 16:42:16 GMT
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcmVhdGVkIjoiMjAxOS0wOC0yMlQxNjo0MjoxNCswMDAwIiwidXBkYXRl
+        ZCI6IjIwMTktMDgtMjJUMTY6NDI6MTYrMDAwMCIsImlkIjoiNDAyOGY5NDQ2
+        Y2JhMmVjNTAxNmNiYTM1MTMwMDAwMGUiLCJrZXkiOiItLS0tLUJFR0lOIFJT
+        QSBQUklWQVRFIEtFWS0tLS0tXG5NSUlKS0FJQkFBS0NBZ0VBam1nQ21BRW9X
+        OFVxdGpleHFGTXgwMUgrd3BtUExlR2RlMy9aZjdjYTBqQm1ES1Q2XG4zbTlG
+        Ty8wMzdtMCtSTE1PdXRkOFMvR1NIR3BvUHdOeVM4L05za3JjdG5pZi9DQ09k
+        REdiU0p6VjhwTHJvODFmXG4reU04b0tIVWp6WnIvOXowTmgrbTVnTTFXSFpj
+        NWkvQWhXWlNPOEY1Y3lHSDF3VTl3UDZBMlBXaFBNYmVvOGJFXG5ydlBPazlS
+        akgzZE5RRXU1cENOamp2Tjk5WXd4N3M3bSt1SUt1SW1iZldFSytRT2QyeWRm
+        U1ZUUW1sODlENlN6XG5nK0VoVkNNcDQwWVJkOEpTdEhZZ3lPUlpXSU9ZWDhu
+        QytoVU0wZ2t0OWIyMkE2WURRR3c5ckRGT0ZTemQ0ZFFHXG5lNzRGNStoT3lB
+        MHlneDRXNVZsOXN0KzNUc3M1OWVXYkR4ajhlUzRrdXdMWk5RcWt4c0VoR1RE
+        WGMyS082OEl0XG55OGVhZW5HNnFBQ08xTVpUZFpmV05NUjJ4YllYa0drV2s5
+        NHdwalRQS1Y1MXF4NE96MXZNNGNoNW43K2JzTzJOXG56dUkvVTlYK0VBYWpD
+        eDZmd29BUHZOSGQrK3lXWVJMOVplaDJ3OXM3RlZud2xVMVlHRzNFSVcrMkRi
+        M2VXcnNhXG5KRGtCTnBMaVk4bzMxT3IwQ0tZVm90NmFoSGNRSnR4cms3UFdz
+        NmpzdGhPU0F0WU9ySVVQZVQ5NWF0MjZrR3NDXG5PeGwzd1d2RnQ3a3pCZlk1
+        TTE5eEhtNmhIWDFiV0NUSnhXOXBVWm1yU21TVnllRk1TcTdHQm15Ymtrb2k0
+        bDlVXG5iMDNJZXk0STFOU0lqTVROYWpuWXBjVjdQbk5QcHVab0hjYktyNkx4
+        dzJuanRrZmlwdHBSVTZKMUZoY0NBd0VBXG5BUUtDQWdCSTVpdTF2cG4zYUpa
+        MTAwcnAzVFRiZGRVUnIyUmhXMmF2eXdIL1pDK2h1ODd4MkI3b2NWT2k0dnlY
+        XG4zR3FNNXBDNnl3YkJKYmZqUGdHQmlIVWhKQTZybjdFZTQ5OGFSVnhIVlFH
+        bUNVdG9zeGRYc2hIWlVPOS9WM2lsXG5tM2xyOEtNL2RiS05lc1Q3TlJSWGJj
+        aURRWjhGSWdUWEVDb213M01hY2U1cG9reFkvWUVKbS80aGhZT1JuNTdpXG5n
+        OE1URC9ESGVxcERpcGhIYys0M3pzamxVNE9qZGlZWDUrNmpETnZwVFYxMC82
+        c042NFVwbGVtanNFTE1mSGU3XG45YW1KZ2Z1dWorNDJpTmJIL2cycHMzSlJi
+        U2N6K2lrQjdJelpqMG1JMkNBMkhzTlhDYkhJSWk3emQ1STBabksxXG43RE9Z
+        ZFhYSkVLZk5Rc0xtM2hnY3JkNVR1em02MWsyWW9XRExMSnNGQlJtRStDWEZi
+        UGRyNHhKZGwwWjZkZ2ZzXG5MS1FhVkxFcGdWL0JQVHl2YzBrVFpRQnFSQXhX
+        VHA2OXBZbkNGUldlMmF3b3dmMWRQWVcrTzRxYWxodlVXZ1lnXG5lakkyYTln
+        Vk0yUTMxZkRJMWF2YjVRaFUxRDhNdnRLZzdjT05Ba1ZPby9oV3lrRWx5R2Ev
+        U0I3VXBPMmZXaVBoXG5Tb2ZPUnNyZ01YcnBndXhLOTNNMGJFQ2NtRHl4b0g0
+        bWEwQkpaR3FpdFBtVVJOaHBIcnVkQWZDYzFlQUxXRGluXG4yanVSVk9YMWc3
+        a0lwREZIbWpzKzZRVmZjTUZSaFJkZ0tldmh0d255QXJXcXhnVXdaTXJPc3oz
+        d2h2WGtTVmlWXG5ESXlRcnV4c1RBdFNtT1hYeHcwR2JnNXByci85ekphcWpS
+        aE00bjhwRDJWZkI5dExhUUtDQVFFQTFjTDlXOWJsXG51MG8yYWIxc1FwdWhM
+        QXdSNmVIVXpRRTV0UjFJcnhSOXZ0MTV4amFSeXArcm1CTjdXSW5sN2x4L2ta
+        WWI1OVdlXG45ejhXYU9BSytZcHJvSDllZ3VyZndUU2gxbEZveE5Na2lXNVlz
+        ckRJZEFxbjE1TjVmMkdMWHV6ZVN0V2lyek02XG5vb0p1cWZrVUFOaklsSGNz
+        MUwxeHVTV0hkS2NVMCtzdnFGOW1MVmpWb3Zycnk4VWdzaUtzczI1UDB6ZzVO
+        ZGl5XG5pWTl1MVBxWWgvbU9qbFBlSnQ3MFBXNE9pZUtRT09UWjdCWnN6R1p3
+        Vmc3R3p4RGcrenkyRWN1UXEveTJBeTJQXG43OCszbzVjZHN3Z0hCaDFNR1pz
+        Z00rbFdKemNLdVI2d0l5WTJTUU1EOW5HTzA2UHh1a0NyMmZGUWFJN0ZqVHJn
+        XG5CT3d1ZE5yR0plL1B1d0tDQVFFQXFvdU1yOU9vMkVEZjFodHJxU1hlL3dt
+        aHczNWora0UyY21HTDhCbnZUcndkXG5ndmtDYjJmcklydzhGa3YrRjlMcGZH
+        MnA2M0I5R0FDc1p1VTRidmg5QXBwTVFhZFNHN0NGU011THd1NnZneGpSXG54
+        Z2poR3dlbFVIVFBjUllMUXhZQ3F4SHlwUmJlN2k0ZU9xQUlabU1lWnMxOFRq
+        cTRTUW1rSmFXWmpsYkYyb05PXG5QQUVvTFE3Y0F1b09GUkJRbElRZTUrZmhk
+        eHdDemUxMDg2bnlxeDROS3dGTmNqRUpXbGsvRS9HNmJnalFIQjU0XG5CdkJ0
+        aS9oaWMzUEcwUURHWm8rb1lwMVJNcnJ3QU12WFMyK0RrV3FuNnpyenJiT2FZ
+        TU8vc0tmSm1FYkdRVFZ6XG5qN2I1bFFxc1FIVU5yK25TY1p2NnVIcXk3bFZN
+        QnRGYnVVd3JQWVVIVlFLQ0FRQnhyZ29aWGxhOFhNSkZSNlNjXG5ZN0c2QUEx
+        Q3lZUG5KbUN2TGd5cWQ0Wk1DL0tuOC90aXU3bUEzZE42Q1pRTFNJdmJPKzVK
+        UTdVUG5qQm53OFp5XG5ZU2ZOcWc3MEpyNnFQRGhaQnVCbDFEZ1pFbUwvWEw2
+        dDM4RFZCNnZVajJhVUsvb242Q2RsYnlRZXFxajVvZW4rXG5iVXQya1U1NU1P
+        cWE0UmVCZFIzQmVkRFZoUzZNclRLb1F6TkZJZWU2ZEhCTjJEdUJnK1FBKytZ
+        dSsrV2dSRWo3XG4vejdOK0ZJcmIrU0tDczZXaTdQUlhmdDY3NDRhd2R1NkdJ
+        K29MVHpJdjhlLy9QZEtUOUhvTE1IZ2NpSWlVTXBOXG5uTlpIYlNzOGJ1QVlX
+        MTRpNnNXOEgxTGl6bjZPSTVsbTVZdGtpRXFVbDdJTTdLV3JoVW9RU3FBNlhm
+        UnkxcW9NXG5JTlhqQW9JQkFBZXdrU0JnYjgySVowOVZIeTZhU1lyQVdXM2lK
+        Z25qcE52VmNDVGNWb0Q3VkcxU1l2eTQ5ODR5XG5KSmR3eDcwMVFsZmM3ZnR5
+        c0FGRURvSDVOZWt6QlJmMzh4Wkd3Qm9GaEl6NnVJdUtqWmxncGh6Q3k3dVhS
+        YW55XG5DbVJ6OVFBS1h3WnRvYjQxNE1sbWhQQnB4TmN4QXU3cHR3QWovNmt6
+        YVJaVmVDNEYxWmY3c2F4YzlQM0xITHA0XG42VGVqNjY0Mm90b2NCM3VDWk5I
+        Nk1mckduKzE5Um1TNUEwL3h6QlVwendGTU5mYStLUHdMbDZmZ2NXQU5UQXNl
+        XG5ua2xRT3FIbk9sVnYrSGhNRzRROXJMQjNEN3lmellCNndRQUZDQ0h5MFpM
+        YWplbHl6MytqTkZtM2kxdGdCdEpGXG5OTi9Jc0RkMUxBSGpibXYycHAzc0ZM
+        R3ZNSWZ1bHAwQ2dnRUJBTXNvUnRzQ0FVQy9Ib05sWUNQRVdxN21LQkhFXG45
+        R0dnaUFGU29jNkNPYjFhMHN4WTg0aXV0NGhiU1E1RnBoUlVtOGFsK0NCR3VE
+        dk9TWGkzWFkyVVhmZmZVeEZWXG5kWGNhVXk1azdoMFhJL0xCZS9zKzFHRmlR
+        eThHVEt5c1pTUnc0b0NodGpNVFJrOEh5Nkxwc1BaWjZQdTVZNHlVXG5qR0VT
+        b0R6SXJDNytGYUVmVDZ1VHVaRmppQkFTaFB6WFJJOFBZRFFXeDFha3AwM0NR
+        dTd6L2VGUVAyRzlaRTd0XG5WL2F2c2lsRm5OTGJHRDBrV3UrQm9Qdnp1NDM4
+        bzRIKzhmNkMvZGtQOXBVbEJZQUV5YzBlL0lkSXFJSi9aVWhXXG44ZnN6dG1z
+        Yi9PSzlGT0FvYktDeVlpYzdLcmZQWS9CMk9FT2hOeTdwOWVkMENEU29QeWxT
+        aCtiV292OD1cbi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tXG4iLCJj
+        ZXJ0IjoiLS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tXG5NSUlIVGpDQ0Jq
+        YWdBd0lCQWdJSUs4VkF1SWhXTmNBd0RRWUpLb1pJaHZjTkFRRUxCUUF3Z1pV
+        eEN6QUpCZ05WXG5CQVlUQWxWVE1SY3dGUVlEVlFRSURBNU9iM0owYUNCRFlY
+        SnZiR2x1WVRFUU1BNEdBMVVFQnd3SFVtRnNaV2xuXG5hREVRTUE0R0ExVUVD
+        Z3dIUzJGMFpXeHNiekVVTUJJR0ExVUVDd3dMVTI5dFpVOXlaMVZ1YVhReE16
+        QXhCZ05WXG5CQU1NS21ObGJuUnZjemN0YTJGMFpXeHNieTFrWlhabGJDNXFh
+        bVZtWm1WeWN5NWxlR0Z0Y0d4bExtTnZiVEFlXG5GdzB4T1RBNE1qSXhOalF5
+        TVRSYUZ3MDBPVEV5TURFeE16QXdNREJhTUE4eERUQUxCZ05WQkFvTUJHOXla
+        ekl3XG5nZ0lpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElDRHdBd2dnSUtBb0lD
+        QVFDT2FBS1lBU2hieFNxMk43R29VekhUXG5VZjdDbVk4dDRaMTdmOWwvdHhy
+        U01HWU1wUHJlYjBVNy9UZnViVDVFc3c2NjEzeEw4WkljYW1nL0EzSkx6ODJ5
+        XG5TdHkyZUovOElJNTBNWnRJbk5YeWt1dWp6Vi83SXp5Z29kU1BObXYvM1BR
+        Mkg2Ym1BelZZZGx6bUw4Q0ZabEk3XG53WGx6SVlmWEJUM0Evb0RZOWFFOHh0
+        Nmp4c1N1ODg2VDFHTWZkMDFBUzdta0kyT084MzMxakRIdXp1YjY0Z3E0XG5p
+        WnQ5WVFyNUE1M2JKMTlKVk5DYVh6MFBwTE9ENFNGVUl5bmpSaEYzd2xLMGRp
+        REk1RmxZZzVoZnljTDZGUXpTXG5DUzMxdmJZRHBnTkFiRDJzTVU0VkxOM2gx
+        QVo3dmdYbjZFN0lEVEtESGhibFdYMnkzN2RPeXpuMTVac1BHUHg1XG5MaVM3
+        QXRrMUNxVEd3U0VaTU5kellvN3J3aTNMeDVwNmNicW9BSTdVeGxOMWw5WTB4
+        SGJGdGhlUWFSYVQzakNtXG5OTThwWG5XckhnN1BXOHpoeUhtZnY1dXc3WTNP
+        NGo5VDFmNFFCcU1MSHAvQ2dBKzgwZDM3N0paaEV2MWw2SGJEXG4yenNWV2ZD
+        VlRWZ1liY1FoYjdZTnZkNWF1eG9rT1FFMmt1Smp5amZVNnZRSXBoV2kzcHFF
+        ZHhBbTNHdVRzOWF6XG5xT3kyRTVJQzFnNnNoUTk1UDNscTNicVFhd0k3R1hm
+        QmE4VzN1VE1GOWprelgzRWVicUVkZlZ0WUpNbkZiMmxSXG5tYXRLWkpYSjRV
+        eEtyc1lHYkp1U1NpTGlYMVJ2VGNoN0xnalUxSWlNeE0xcU9kaWx4WHMrYzAr
+        bTVtZ2R4c3F2XG5vdkhEYWVPMlIrS20ybEZUb25VV0Z3SURBUUFCbzRJREpU
+        Q0NBeUV3RGdZRFZSMFBBUUgvQkFRREFnU3dNQk1HXG5BMVVkSlFRTU1Bb0dD
+        Q3NHQVFVRkJ3TUNNQWtHQTFVZEV3UUNNQUF3RVFZSllJWklBWWI0UWdFQkJB
+        UURBZ1dnXG5NQjBHQTFVZERnUVdCQlRqMUR6RE1QVzZGa1pzQ1lWUjlOSC91
+        ejBtaERBZkJnTlZIU01FR0RBV2dCVDltWk9lXG4rS3MrdFRHaGR2cS9VTEFX
+        WmlETmZ6QW9CaEFyQmdFRUFaSUlDUUd0eTlIVW1Yd0JCQlFNRW05eVp6SmZk
+        V1ZpXG5aWEpmY0hKdlpIVmpkREFXQmhBckJnRUVBWklJQ1FHdHk5SFVtWHdE
+        QkFJTUFEQVdCaEFyQmdFRUFaSUlDUUd0XG55OUhVbVh3Q0JBSU1BREFXQmhB
+        ckJnRUVBWklJQ1FHdHk5SFVtWHdGQkFJTUFEQVpCaEFyQmdFRUFaSUlDUUt0
+        XG55OUhVbVgwQkJBVU1BM2wxYlRBa0JoRXJCZ0VFQVpJSUNRS3R5OUhVbVgw
+        QkFRUVBEQTExWldKbGNsOWpiMjUwXG5aVzUwTURJR0VTc0dBUVFCa2dnSkFx
+        M0wwZFNaZlFFQ0JCME1HekUxTmpZME9USXhNelEyTlRKZmRXVmlaWEpmXG5Z
+        Mjl1ZEdWdWREQWRCaEVyQmdFRUFaSUlDUUt0eTlIVW1YMEJCUVFJREFaRGRY
+        TjBiMjB3SEFZUkt3WUJCQUdTXG5DQWtDcmN2UjFKbDlBUVlFQnd3RkwyOXla
+        ekl3RndZUkt3WUJCQUdTQ0FrQ3JjdlIxSmw5QVFjRUFnd0FNQmdHXG5FU3NH
+        QVFRQmtnZ0pBcTNMMGRTWmZRRUlCQU1NQVRFd0lnWUtLd1lCQkFHU0NBa0VB
+        UVFVREJKdmNtY3lYM1ZsXG5ZbVZ5WDNCeWIyUjFZM1F3RUFZS0t3WUJCQUdT
+        Q0FrRUFnUUNEQUF3SFFZS0t3WUJCQUdTQ0FrRUF3UVBEQTB4XG5OVFkyTkRr
+        eU1UTTBOalV5TUJFR0Npc0dBUVFCa2dnSkJBVUVBd3dCTVRBa0Jnb3JCZ0VF
+        QVpJSUNRUUdCQllNXG5GREl3TVRrdE1EZ3RNakpVTVRZNk5ESTZNVFJhTUNR
+        R0Npc0dBUVFCa2dnSkJBY0VGZ3dVTWpBME9TMHhNaTB3XG5NVlF4TXpvd01E
+        b3dNRm93RVFZS0t3WUJCQUdTQ0FrRURBUUREQUV3TUJBR0Npc0dBUVFCa2dn
+        SkJBb0VBZ3dBXG5NQkFHQ2lzR0FRUUJrZ2dKQkEwRUFnd0FNQkVHQ2lzR0FR
+        UUJrZ2dKQkE0RUF3d0JNREFSQmdvckJnRUVBWklJXG5DUVFMQkFNTUFURXdO
+        QVlLS3dZQkJBR1NDQWtGQVFRbURDUm1OamhpWVdFNFlpMDBZMk15TFRRd04y
+        SXRPV0ZsXG5OUzA0TlRCaVpESTRPVEEwTkRRd0RRWUpLb1pJaHZjTkFRRUxC
+        UUFEZ2dFQkFIYlpuS1ZNV2lKcHhGZFdNTlFlXG5MZjdOLytwSHpYQXJqQity
+        em9jVVhETEtDWWY0UXhNK3puVnpVemlzTG9NMWx6Z2VDUEJqVlExcVIyaWhk
+        eE5HXG5Mc2lNd3YvekpIVUdBR0dpdC8yS0dQYStidUphaC94UHgvRXhBVXFn
+        VTVYMTFsRGJPdC9ycERVT0Y4Yk10NmNCXG5VRVFBUFMzbFFTNlZnbGovQ09F
+        cGpvajBnWHp1YnlJR1dVTjlQZmNxMEJxRHc5dm92ek1DeGZUYnRrZ09VTFA1
+        XG5PV2lUZ1pybGFNYmEzNmpBQWUycTdGQzJGdlRHOTB6NE5aWXhYUEVZRTha
+        Z280dW5PZ1hHem5WSis4aENvNkFIXG50MFVCREpXaHVlNjJCeUYyK21BQjRm
+        VDF6UkFuaGpTK2srWU1CZE1yenVVOGZVN3h5bk45VXZoN0J5cFdNWFc2XG4z
+        YVE9XG4tLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tXG4iLCJzZXJpYWwiOnsi
+        Y3JlYXRlZCI6IjIwMTktMDgtMjJUMTY6NDI6MTQrMDAwMCIsInVwZGF0ZWQi
+        OiIyMDE5LTA4LTIyVDE2OjQyOjE0KzAwMDAiLCJpZCI6MzE1Mzk5ODI3NTM0
+        ODQxMTg0MCwic2VyaWFsIjozMTUzOTk4Mjc1MzQ4NDExODQwLCJleHBpcmF0
+        aW9uIjoiMjA0OS0xMi0wMVQxMzowMDowMCswMDAwIiwiY29sbGVjdGVkIjpm
+        YWxzZSwicmV2b2tlZCI6ZmFsc2V9LCJvd25lciI6eyJpZCI6IjQwMjhmOTQ0
+        NmNiYTJlYzUwMTZjYmEzNTBjMDcwMDBjIiwia2V5Ijoib3JnMiIsImRpc3Bs
+        YXlOYW1lIjoiT3JnYW5pemF0aW9uMiIsImhyZWYiOiIvb3duZXJzL29yZzIi
+        fX0=
+    http_version: 
+  recorded_at: Thu, 22 Aug 2019 16:42:16 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=pulp-1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01565959455/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 22 Aug 2019 16:42:16 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 22 Aug 2019 16:42:16 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=pulp-1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01565980160/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 22 Aug 2019 16:42:16 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 22 Aug 2019 16:42:16 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=pulp-1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01565980160/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 22 Aug 2019 16:42:16 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 22 Aug 2019 16:42:16 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=ACME_Corporation/DEV/Repo1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01565980160/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 22 Aug 2019 16:42:16 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 22 Aug 2019 16:42:16 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=pulp-1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01565959455/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 22 Aug 2019 16:42:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 22 Aug 2019 16:42:17 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=pulp-1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01565980160/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 22 Aug 2019 16:42:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 22 Aug 2019 16:42:17 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=pulp-1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01565980160/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 22 Aug 2019 16:42:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 22 Aug 2019 16:42:17 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=ACME_Corporation/DEV/Repo1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b2.dev01565980160/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 22 Aug 2019 16:42:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 22 Aug 2019 16:42:17 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJuYW1lIjoicHVscC0xIn0=
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01565959455/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 22 Aug 2019 16:42:17 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/3683e4fa-7d91-46f7-90da-260337a11740/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '271'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvMzY4M2U0ZmEt
+        N2Q5MS00NmY3LTkwZGEtMjYwMzM3YTExNzQwLyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wOC0yMlQxNjo0MjoxNy44MDY1MTJaIiwiX3ZlcnNpb25zX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzM2ODNlNGZhLTdkOTEtNDZmNy05
+        MGRhLTI2MDMzN2ExMTc0MC92ZXJzaW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25f
+        aHJlZiI6bnVsbCwibmFtZSI6InB1bHAtMSIsImRlc2NyaXB0aW9uIjpudWxs
+        fQ==
+    http_version: 
+  recorded_at: Thu, 22 Aug 2019 16:42:17 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/3683e4fa-7d91-46f7-90da-260337a11740/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01565959455/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 22 Aug 2019 16:42:18 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgzOGRiZDc4LTViYWUtNDE4
+        Ni05NjU2LWFhM2IwYTVmYzg1Ny8ifQ==
+    http_version: 
+  recorded_at: Thu, 22 Aug 2019 16:42:18 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository_orphancontent_view/orphan_repository_versions.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository_orphancontent_view/orphan_repository_versions.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com:8443/candlepin/owners/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJrZXkiOiJvcmcxIiwiZGlzcGxheU5hbWUiOiJPcmdhbml6YXRpb24xIiwi
+        Y29udGVudFByZWZpeCI6Ii9vcmcxLyRlbnYifQ==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      Authorization:
+      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="R8nEUmjt96croPKUVLGWtXwqRH22Cfaq",
+        oauth_nonce="qhMLHdmBsZZfUN1XX6RxoFyHgpEGdV6AG7fQGRJP5Q", oauth_signature="tv7CnKKGZskdtYLNIUpNFwr7atg%3D",
+        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1566495005", oauth_version="1.0"
+      Accept-Language:
+      - en
+      Content-Type:
+      - application/json
+      Cp-User:
+      - foreman_admin
+      Content-Length:
+      - '73'
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Candlepin-Request-Uuid:
+      - d331ae2f-eb82-419c-b830-99f2844b7bcc
+      X-Version:
+      - 2.7.1-1
+      - 2.7.1-1
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Thu, 22 Aug 2019 17:30:05 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJkaXNwbGF5TWVzc2FnZSI6IkNvdWxkIG5vdCBjcmVhdGUgdGhlIE93bmVy
+        OiBPd25lciBbaWQ6IDQwMjhmOTQ0NmNiYTJlYzUwMTZjYmE2MGRjMzUwMDEx
+        LCBrZXk6IG9yZzFdIiwicmVxdWVzdFV1aWQiOiJkMzMxYWUyZi1lYjgyLTQx
+        OWMtYjgzMC05OWYyODQ0YjdiY2MifQ==
+    http_version: 
+  recorded_at: Thu, 22 Aug 2019 17:30:05 GMT
+recorded_with: VCR 3.0.3

--- a/test/services/katello/pulp3/orphan_test.rb
+++ b/test/services/katello/pulp3/orphan_test.rb
@@ -1,0 +1,78 @@
+require 'katello_test_helper'
+require 'support/pulp3_support'
+
+module Katello
+  module Service
+    class RepositoryOrphanBaseTest < ActiveSupport::TestCase
+      include Katello::Pulp3Support
+
+      def sync_and_reload_repo(repo, smart_proxy)
+        ForemanTasks.sync_task(
+                  ::Actions::Pulp3::Orchestration::Repository::Update,
+                  repo,
+                  smart_proxy)
+
+        sync_args = {:smart_proxy_id => smart_proxy.id, :repo_id => repo.id}
+        ForemanTasks.sync_task(
+          ::Actions::Pulp3::Orchestration::Repository::Sync,
+          repo, smart_proxy, sync_args)
+      end
+
+      def assert_version(repo, version)
+        repo.reload
+        repository_reference = Katello::Pulp3::RepositoryReference.find_by(
+            :root_repository_id => repo.root.id,
+            :content_view_id => repo.content_view.id)
+        assert repository_reference
+        assert_equal repository_reference.repository_href + version,
+          repo.version_href
+      end
+    end
+
+    class RepositoryOrphanTest < RepositoryOrphanBaseTest
+      def setup
+        User.current = users(:admin)
+        @master = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+        @repo = katello_repositories(:pulp3_file_1)
+        @repo.root.update_attributes(:url => 'https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/file2/')
+        ensure_creatable(@repo, @master)
+        create_repo(@repo, @master)
+
+        ForemanTasks.sync_task(
+          ::Actions::Katello::Repository::MetadataGenerate, @repo,
+          repository_creation: true)
+
+        sync_and_reload_repo(@repo, @master)
+        assert_version(@repo, "versions/2/")
+
+        @repo.root.update_attributes(
+          url: "https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/file/")
+
+        sync_and_reload_repo(@repo, @master)
+        assert_version(@repo, "versions/3/")
+      end
+
+      def teardown
+        ForemanTasks.sync_task(
+            ::Actions::Pulp3::Orchestration::Repository::Delete, @repo, @master)
+        @repo.reload
+      end
+
+      def test_orphan_repository_versions
+        orphans = ::Katello::Pulp3::Repository.orphan_repository_versions(@master)
+
+        repo_reference = Katello::Pulp3::RepositoryReference.find_by(
+            :root_repository_id => @repo.root.id,
+            :content_view_id => @repo.content_view.id)
+        assert_includes orphans, repo_reference.repository_href + 'versions/2/'
+        refute_includes orphans, repo_reference.repository_href + 'versions/3/'
+      end
+
+      def test_delete_orphan_repository_versions
+        ::Katello::Pulp3::Repository.delete_orphan_repository_versions(@master)
+        orphans = ::Katello::Pulp3::Repository.orphan_repository_versions(@master)
+        assert_empty orphans
+      end
+    end
+  end
+end

--- a/test/services/katello/pulp3/repository_list_test.rb
+++ b/test/services/katello/pulp3/repository_list_test.rb
@@ -1,0 +1,45 @@
+require 'katello_test_helper'
+require 'support/pulp3_support'
+
+module Katello
+  module Service
+    class RepositoryListTest < ActiveSupport::TestCase
+      include Katello::Pulp3Support
+
+      def sync_and_reload_repo(repo, smart_proxy)
+        ForemanTasks.sync_task(
+                  ::Actions::Pulp3::Orchestration::Repository::Update,
+                  repo,
+                  smart_proxy)
+
+        sync_args = {:smart_proxy_id => smart_proxy.id, :repo_id => repo.id}
+        ForemanTasks.sync_task(
+          ::Actions::Pulp3::Orchestration::Repository::Sync,
+          repo, smart_proxy, sync_args)
+      end
+
+      def test_list_with_pagination
+        User.current = users(:admin)
+        @master = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+
+        repo1 = katello_repositories(:pulp3_file_1)
+        repo1.root.update_attributes(:url => 'https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/file-many/')
+        ensure_creatable(repo1, @master)
+        create_repo(repo1, @master)
+        sync_and_reload_repo(repo1, @master)
+
+        repo2 = katello_repositories(:pulp3_file_1)
+        repo2.root.update_attributes(:url => 'https://repos.fedorapeople.org/pulp/pulp/demo_repos/test_file_repo/')
+        ensure_creatable(repo2, @master)
+        create_repo(repo2, @master)
+        sync_and_reload_repo(repo2, @master)
+
+        repository_list = ::Katello::Pulp3::Repository.list(@master, :limit => 1)
+
+        Katello::Pulp3::RepositoryReference.all.each do |repo_reference|
+          assert_includes repository_list.pluck(:_href), repo_reference.repository_href
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces support for deleting orphaned repository versions in Pulp3 servers.

Currently the Katello rake task that deletes orphaned content doesn't handle these orphaned repository version.

An example scenario:
Create a file repository with an upstream URL. Synchronize that repository. Then, change the upstream URL and re-sryncrhonize. The pulp server will now have 2 repository versions, although only the latest version is reflected in the repository reference in Katello. The first version is not referenced and therefore an orphan.

After applying this PR, the rake task `katello:delete_orphaned_content` will identify and delete orphaned repository versions.

(A follow-on PR will introduce functionality to purge pulp3 mirrors of orphaned repositories.)
