### PR TITLE
Fixes #25876 - Return 422 on a locked task

### DIFF
--- a/app/controllers/katello/concerns/api/v2/organizations_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/organizations_controller_extensions.rb
@@ -1,0 +1,14 @@
+module Katello
+  module Concerns
+    module Api::V2::OrganizationsControllerExtensions
+      extend ActiveSupport::Concern
+
+      included do
+        rescue_from ::ForemanTasks::Lock::LockConflict do |error|
+          ::Foreman::Logging.exception("Action failed", error)
+          render_error 'standard_error', :status => :unprocessable_entity, :locals => { :exception => error }
+        end
+      end
+    end
+  end
+end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -192,6 +192,7 @@ module Katello
       ::Api::V2::HostsController.send :include, Katello::Concerns::Api::V2::HostsControllerExtensions
       ::Api::V2::HostgroupsController.send :include, Katello::Concerns::Api::V2::HostgroupsControllerExtensions
       ::Api::V2::SmartProxiesController.send :include, Katello::Concerns::Api::V2::SmartProxiesControllerExtensions
+      ::Api::V2::OrganizationsController.send :include, Katello::Concerns::Api::V2::OrganizationsControllerExtensions
 
       Katello::EventQueue.register_event(Katello::Events::ImportHostApplicability::EVENT_TYPE, Katello::Events::ImportHostApplicability)
       Katello::EventQueue.register_event(Katello::Events::ImportPool::EVENT_TYPE, Katello::Events::ImportPool)


### PR DESCRIPTION
When trying to delete the same org
simultaneously multiple times,
we may hit lock on a task.
In that case, return 422 rather than 500.