### PR TITLE
Fixes #27473 - pulp 3 docker content view publishing without filters

### DIFF
--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -114,7 +114,8 @@ module Katello
           manifest = Katello::DockerManifestList.where(digest: params[:tag]).first || Katello::DockerManifest.where(digest: params[:tag]).first
           return item_not_found(params[:tag]) unless manifest
         else
-          tag = DockerMetaTag.where(repository_id: @repository.id, name: params[:tag]).first
+          tag = ::Katello::DockerMetaTag.where(id: ::Katello::RepositoryDockerMetaTag.
+                                    where(repository_id: @repository.id).select(:docker_meta_tag_id), name: params[:tag]).first
           return item_not_found(params[:tag]) unless tag
         end
       end

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -294,11 +294,11 @@ module Katello
     end
 
     def docker_tag_count
-      ::Katello::DockerMetaTag.where(:repository_id => repositories.archived.docker_type).count
+      docker_tags.count
     end
 
     def docker_tags
-      ::Katello::DockerMetaTag.where(:repository_id => repositories.docker_type)
+      ::Katello::DockerMetaTag.where(:id => RepositoryDockerMetaTag.where(:repository_id => repositories.docker_type).select(:docker_meta_tag_id))
     end
 
     def debs

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -66,9 +66,11 @@ module Katello
 
     has_many :yum_metadata_files, :dependent => :destroy, :class_name => "Katello::YumMetadataFile"
 
-    has_many :docker_tags, :dependent => :destroy, :class_name => "Katello::DockerTag"
+    has_many :repository_docker_tags, :class_name => "Katello::RepositoryDockerTag", :dependent => :delete_all
+    has_many :docker_tags, :through => :repository_docker_tags
 
-    has_many :docker_meta_tags, :dependent => :destroy, :class_name => "Katello::DockerMetaTag"
+    has_many :repository_docker_meta_tags, :class_name => "Katello::RepositoryDockerMetaTag", :dependent => :delete_all
+    has_many :docker_meta_tags, :through => :repository_docker_meta_tags
 
     has_many :repository_ostree_branches, :class_name => "Katello::RepositoryOstreeBranch", :dependent => :delete_all
     has_many :ostree_branches, :through => :repository_ostree_branches

--- a/app/models/katello/repository_docker_meta_tag.rb
+++ b/app/models/katello/repository_docker_meta_tag.rb
@@ -1,0 +1,7 @@
+module Katello
+  class RepositoryDockerMetaTag < Katello::Model
+    # Do not use active record callbacks in this join model.  Direct INSERTs and DELETEs are done
+    belongs_to :repository, :inverse_of => :repository_docker_meta_tags, :class_name => 'Katello::Repository'
+    belongs_to :docker_meta_tag, :inverse_of => :repository_docker_meta_tags, :class_name => 'Katello::DockerMetaTag'
+  end
+end

--- a/app/models/katello/repository_docker_tag.rb
+++ b/app/models/katello/repository_docker_tag.rb
@@ -1,0 +1,7 @@
+module Katello
+  class RepositoryDockerTag < Katello::Model
+    # Do not use active record callbacks in this join model.  Direct INSERTs and DELETEs are done
+    belongs_to :repository, :inverse_of => :repository_docker_tags, :class_name => 'Katello::Repository'
+    belongs_to :docker_tag, :inverse_of => :repository_docker_tags, :class_name => 'Katello::DockerTag'
+  end
+end

--- a/app/services/katello/pulp/docker_tag.rb
+++ b/app/services/katello/pulp/docker_tag.rb
@@ -6,7 +6,6 @@ module Katello
       def update_model(model)
         taggable_class = backend_data['manifest_type'] == "list" ? ::Katello::DockerManifestList : ::Katello::DockerManifest
         model.docker_taggable = taggable_class.find_by(:digest => backend_data['manifest_digest'])
-        model.repository_id = ::Katello::Repository.find_by(:pulp_id => backend_data['repo_id']).try(:id)
         model.name = backend_data['name']
         model.save!
       end

--- a/db/migrate/20190730183518_add_docker_tag_join_table.rb
+++ b/db/migrate/20190730183518_add_docker_tag_join_table.rb
@@ -1,0 +1,25 @@
+class AddDockerTagJoinTable < ActiveRecord::Migration[5.2]
+  def up
+    create_table :katello_repository_docker_tags do |t|
+      t.integer :docker_tag_id, null: false
+      t.integer :repository_id
+      t.timestamps null: true
+    end
+
+    ::Katello::Repository.all.each do |repository|
+      repository.docker_tags = ::Katello::DockerTag.where(:repository_id => repository.id)
+    end
+
+    remove_column :katello_docker_tags, :repository_id
+  end
+
+  def down
+    add_column :katello_docker_tags, :repository_id, :integer
+
+    ::Katello::DockerTag.all.each do |tag|
+      tag.update_attributes(repository_id: tag.repositories.first.id)
+    end
+
+    drop_table :katello_repository_docker_tags
+  end
+end

--- a/db/migrate/20190730203334_add_docker_meta_tag_join_table.rb
+++ b/db/migrate/20190730203334_add_docker_meta_tag_join_table.rb
@@ -1,0 +1,25 @@
+class AddDockerMetaTagJoinTable < ActiveRecord::Migration[5.2]
+  def up
+    create_table :katello_repository_docker_meta_tags do |t|
+      t.integer :docker_meta_tag_id, null: false
+      t.integer :repository_id
+      t.timestamps null: true
+    end
+
+    ::Katello::Repository.all.each do |repository|
+      repository.docker_meta_tags = ::Katello::DockerMetaTag.where(:repository_id => repository.id)
+    end
+
+    remove_column :katello_docker_meta_tags, :repository_id
+  end
+
+  def down
+    add_column :katello_docker_meta_tags, :repository_id, :integer
+
+    ::Katello::DockerMetaTag.all.each do |meta_tag|
+      meta_tag.update_attributes(repository_id: meta_tag.repositories.first.id)
+    end
+
+    drop_table :katello_repository_docker_meta_tags
+  end
+end

--- a/test/controllers/api/registry/registry_proxies_controller_test.rb
+++ b/test/controllers/api/registry/registry_proxies_controller_test.rb
@@ -297,7 +297,9 @@ module Katello
         @controller.stubs(:registry_authorize).returns(true)
         @controller.stubs(:find_readable_repository).returns(@docker_repo)
         Resources::Registry::Proxy.stubs(:get).returns(stubbed: true)
-        DockerMetaTag.stubs(:where).with(repository_id: @docker_repo.id, name: @tag.name).returns([@tag])
+        DockerMetaTag.stubs(:where).with(id: RepositoryDockerMetaTag.
+                                         where(repository_id: @docker_repo.id).
+                                         select(:docker_meta_tag_id), name: @tag.name).returns([@tag])
 
         allowed_perms = [:create_personal_access_tokens]
         denied_perms = []
@@ -311,7 +313,9 @@ module Katello
         @controller.stubs(:registry_authorize).returns(true)
         @controller.stubs(:find_readable_repository).returns(@docker_repo)
         Resources::Registry::Proxy.stubs(:get).returns(manifest)
-        DockerMetaTag.stubs(:where).with(repository_id: @docker_repo.id, name: @tag.name).returns([@tag])
+        DockerMetaTag.stubs(:where).with(id: RepositoryDockerMetaTag.
+                                         where(repository_id: @docker_repo.id).
+                                         select(:docker_meta_tag_id), name: @tag.name).returns([@tag])
 
         get :pull_manifest, params: { repository: @docker_repo.name, tag: @tag.name }
         assert_response 200
@@ -334,7 +338,9 @@ module Katello
         expected_headers['AUTHORIZATION'] = request.env['HTTP_AUTHORIZATION']
 
         Resources::Registry::Proxy.stubs(:get).with('/v2/busybox/manifests/one', expected_headers).returns(manifest)
-        DockerMetaTag.stubs(:where).with(repository_id: @docker_repo.id, name: @tag.name).returns([@tag])
+        DockerMetaTag.stubs(:where).with(id: RepositoryDockerMetaTag.
+                                         where(repository_id: @docker_repo.id).
+                                         select(:docker_meta_tag_id), name: @tag.name).returns([@tag])
 
         get :pull_manifest, params: { repository: @docker_repo.name, tag: @tag.name }
         assert_response 200
@@ -348,7 +354,9 @@ module Katello
         @controller.stubs(:registry_authorize).returns(true)
         @controller.stubs(:find_readable_repository).returns(@docker_repo)
         Resources::Registry::Proxy.stubs(:get).returns(manifest)
-        DockerMetaTag.stubs(:where).with(repository_id: @docker_repo.id, name: @tag.name).returns([@tag])
+        DockerMetaTag.stubs(:where).with(id: RepositoryDockerMetaTag.
+                                         where(repository_id: @docker_repo.id).
+                                         select(:docker_meta_tag_id), name: @tag.name).returns([@tag])
 
         get :pull_manifest, params: { repository: @docker_repo.name, tag: @tag.name }
         assert_response 200
@@ -362,7 +370,9 @@ module Katello
         @controller.stubs(:registry_authorize).returns(true)
         @controller.stubs(:find_readable_repository).returns(@docker_repo)
         Resources::Registry::Proxy.stubs(:get).returns(manifest)
-        DockerMetaTag.stubs(:where).with(repository_id: @docker_repo.id, name: @tag.name).returns([@tag])
+        DockerMetaTag.stubs(:where).with(id: RepositoryDockerMetaTag.
+                                         where(repository_id: @docker_repo.id).
+                                         select(:docker_meta_tag_id), name: @tag.name).returns([@tag])
 
         get :pull_manifest, params: { repository: @docker_repo.name, tag: @tag.name }
         assert_response 200
@@ -376,7 +386,9 @@ module Katello
         @controller.stubs(:registry_authorize).returns(true)
         @controller.stubs(:find_readable_repository).returns(@docker_repo)
         Resources::Registry::Proxy.stubs(:get).returns(manifest)
-        DockerMetaTag.stubs(:where).with(repository_id: @docker_repo.id, name: @tag.name).returns([@tag])
+        DockerMetaTag.stubs(:where).with(id: RepositoryDockerMetaTag.
+                                         where(repository_id: @docker_repo.id).
+                                         select(:docker_meta_tag_id), name: @tag.name).returns([@tag])
 
         get :pull_manifest, params: { repository: @docker_repo.name, tag: @tag.name }
         assert_response 200

--- a/test/controllers/api/v2/docker_tags_controller_test.rb
+++ b/test/controllers/api/v2/docker_tags_controller_test.rb
@@ -6,7 +6,7 @@ module Katello
       @repo = Repository.find(katello_repositories(:redis).id)
       @manifest = @repo.docker_manifests.create!(:digest => "abc123", :pulp_id => "123xyz")
       @tag = @repo.docker_tags.create!(:name => "wat", :docker_taggable => @manifest)
-      @meta_tag = DockerMetaTag.create!(:name => @tag.name, :schema1 => @tag, :repository => @repo)
+      @meta_tag = DockerMetaTag.create!(:name => @tag.name, :schema1 => @tag, :repositories => [@repo])
     end
 
     def setup

--- a/test/factories/docker_tag_factory.rb
+++ b/test/factories/docker_tag_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :docker_tag, :class => Katello::DockerTag do
     sequence(:name) { |n| "2.#{n}" }
-    repository { :docker_repository }
+    repositories { :docker_repository }
     association :docker_taggable, :factory => :docker_manifest
 
     trait :schema1 do

--- a/test/models/content_view_docker_filter_test.rb
+++ b/test/models/content_view_docker_filter_test.rb
@@ -9,8 +9,8 @@ module Katello
 
     def test_repo_clause
       repo = Repository.find(katello_repositories(:busybox).id)
-      schema2 = create(:docker_tag, :with_uuid, :repository => repo, :name => "latest")
-      schema1 = create(:docker_tag, :with_uuid, :schema1, :repository => repo, :name => "latest")
+      schema2 = create(:docker_tag, :with_uuid, :repositories => [repo], :name => "latest")
+      schema1 = create(:docker_tag, :with_uuid, :schema1, :repositories => [repo], :name => "latest")
 
       repo.docker_tags << schema2
       repo.docker_tags << schema1
@@ -35,8 +35,8 @@ module Katello
 
     def test_repo_clause_with_manifest_lists
       repo = Repository.find(katello_repositories(:busybox).id)
-      schema2 = create(:docker_tag, :with_uuid, :with_manifest_list, :repository => repo, :name => "latest")
-      schema1 = create(:docker_tag, :with_uuid, :with_manifest_list, :schema1, :repository => repo, :name => "latest")
+      schema2 = create(:docker_tag, :with_uuid, :with_manifest_list, :repositories => [repo], :name => "latest")
+      schema1 = create(:docker_tag, :with_uuid, :with_manifest_list, :schema1, :repositories => [repo], :name => "latest")
 
       repo.docker_tags << schema2
       repo.docker_tags << schema1
@@ -67,12 +67,12 @@ module Katello
       repo1.stubs(:container_repository_name).returns('repo1')
       repo1.stubs(:set_container_repository_name).returns('repo1')
       repo1.save!
-      schema1_repo1 = create(:docker_tag, :with_uuid, :repository => repo1, :name => "latest")
-      schema2_repo1 = create(:docker_tag, :with_uuid, :schema1, :repository => repo1, :name => "latest")
+      schema1_repo1 = create(:docker_tag, :with_uuid, :repositories => [repo1], :name => "latest")
+      schema2_repo1 = create(:docker_tag, :with_uuid, :schema1, :repositories => [repo1], :name => "latest")
 
       # Create a docker tag goo that points to the same manifest as schema1_repo1
       # i.e. both latest and goo point ot the same manifest
-      schema_goo_repo1 = create(:docker_tag, :with_uuid, :repository => repo1, :name => "goo")
+      schema_goo_repo1 = create(:docker_tag, :with_uuid, :repositories => [repo1], :name => "goo")
       schema_goo_repo1.docker_taggable = schema1_repo1.docker_manifest
       schema_goo_repo1.save!
 
@@ -93,8 +93,8 @@ module Katello
       repo2.stubs(:container_repository_name).returns('repo2')
       repo2.stubs(:set_container_repository_name).returns('repo2')
       repo2.save!
-      schema1_repo2 = create(:docker_tag, :with_uuid, :repository => repo1, :name => "latest")
-      schema2_repo2 = create(:docker_tag, :with_uuid, :schema1, :repository => repo1, :name => "latest")
+      schema1_repo2 = create(:docker_tag, :with_uuid, :repositories => [repo1], :name => "latest")
+      schema2_repo2 = create(:docker_tag, :with_uuid, :schema1, :repositories => [repo1], :name => "latest")
 
       schema1_repo2.docker_taggable = schema1_repo1.docker_manifest
       schema2_repo2.docker_taggable = schema2_repo1.docker_manifest

--- a/test/models/docker_tag_test.rb
+++ b/test/models/docker_tag_test.rb
@@ -9,7 +9,7 @@ module Katello
     def setup
       @repo = Repository.find(katello_repositories(:busybox).id)
       @manifest = create(:docker_manifest)
-      @tag = create(:docker_tag, :repository => @repo)
+      @tag = create(:docker_tag, :repositories => [@repo])
 
       @repo.clones.each do |repo|
         repo.docker_tags << @tag.dup
@@ -25,13 +25,6 @@ module Katello
       @tag.update_attributes(:pulp_id => 'ksdjfkdjkfjdk')
       tag = DockerTag.with_pulp_id(@tag.pulp_id).first
       refute_nil tag
-    end
-
-    def test_grouped
-      assert_equal 1, DockerTag.grouped.where(:name => @tag.name).count
-
-      create(:docker_tag, :latest, :repository => @repo)
-      assert_equal 2, DockerTag.grouped.where(:name => [@tag.name, "latest"]).count
     end
 
     def test_related_tags

--- a/test/services/katello/pulp3/docker_tag_test.rb
+++ b/test/services/katello/pulp3/docker_tag_test.rb
@@ -23,7 +23,7 @@ module Katello
         ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @master, sync_args)
         @repo.reload
         @repo.index_content
-        assert_equal @repo, ::Katello::Repository.find_by(:id => ::Katello::DockerTag.first.repository_id)
+        assert_equal @repo, ::Katello::Repository.find_by(:id => ::Katello::RepositoryDockerTag.first.repository_id)
         assert_equal ::Katello::DockerManifest.find_by(id: ::Katello::DockerTag.first.docker_taggable_id).digest, "sha256:a6ecbb1553353a08936f50c275b010388ed1bd6d9d84743c7e8e7468e2acd82e"
       end
 
@@ -35,7 +35,7 @@ module Katello
         ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
         @repo.reload
 
-        assert_equal @repo, ::Katello::Repository.find_by(:id => ::Katello::DockerTag.first.repository_id)
+        assert_equal @repo, ::Katello::Repository.find_by(:id => ::Katello::RepositoryDockerTag.first.repository_id)
         assert_equal ::Katello::DockerManifest.find_by(id: ::Katello::DockerTag.first.docker_taggable_id).digest, "sha256:a6ecbb1553353a08936f50c275b010388ed1bd6d9d84743c7e8e7468e2acd82e"
       end
     end


### PR DESCRIPTION
The biggest change in this PR is that Docker Tags are now many-to-many to fit the new Pulp 3 modelling scheme.  This allows content view publishing with docker content to work with Pulp 3.

This PR also fixes https://projects.theforeman.org/issues/27676