### PR TITLE
Fixes #27739 - Reg. broken when DMI UUID changed after unregister

### DIFF
--- a/app/services/katello/registration_manager.rb
+++ b/app/services/katello/registration_manager.rb
@@ -76,7 +76,7 @@ module Katello
           host = hosts.first
 
           if host.name == host_name
-            unless host.build || host_uuid_overridden
+            unless host.subscription_facet.nil? || host.build || host_uuid_overridden
               found_uuid = host.fact_values.where(fact_name_id: dmi_uuid_fact_id).first
               if found_uuid && found_uuid.value != host_uuid
                 registration_error("This host is reporting a DMI UUID that differs from the existing registration.")


### PR DESCRIPTION
If a host is unregistered and its DMI UUID has changed by the next time it attempts to register (but the hostname is the same) it will not work. It should work so long as the DMI UUID is unique and the host record on the server is not already registered.

**To test**

- register content host to your env
- unregister it (subscription-manager unregister for example)
- change the content host's DMI UUID:

```
echo '{"dmi.system.uuid": "this-is-made-up"}' > /etc/rhsm/facts/uuid.facts
```
- attempt to register and see that it fails stating that the DMI UUID matches another host

- apply this PR and see that the registration succeeds