### PR TITLE
Fixes #27395 - Missing CentOS env groups in content view versions

### DIFF
--- a/app/services/katello/pulp/repository/yum.rb
+++ b/app/services/katello/pulp/repository/yum.rb
@@ -91,7 +91,8 @@ module Katello
           modular_includes = {filters: {unit: { 'filename' => { '$in' => repo.rpms.modular.pluck(:filename) } }}}
           tasks << smart_proxy.pulp_api.extensions.rpm.copy(repo.pulp_id, destination_repo.pulp_id, modular_includes)
 
-          [:srpm, :errata, :package_group, :yum_repo_metadata_file, :distribution, :module, :module_default].each do |type|
+          [:srpm, :errata, :package_group, :package_environment,
+           :yum_repo_metadata_file, :distribution, :module, :module_default].each do |type|
             tasks << smart_proxy.pulp_api.extensions.send(type).copy(repo.pulp_id, destination_repo.pulp_id)
           end
           tasks

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "apipie-rails", ">= 0.5.14"
 
   # Pulp
-  gem.add_dependency "runcible", ">= 2.11.0", "< 3.0.0"
+  gem.add_dependency "runcible", ">= 2.12.1", "< 3.0.0"
   gem.add_dependency "anemone"
 
   #pulp3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/rpm_with_proxy/create_with_global_http_proxy.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/rpm_with_proxy/create_with_global_http_proxy.yml
@@ -2,26 +2,26 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/debian_9/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/debian_9/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:08 GMT
+      - Fri, 30 Aug 2019 14:34:11 GMT
       Server:
       - Apache
       Content-Length:
@@ -44,29 +44,29 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJkZWJpYW5f
         OSJ9fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:08 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:11 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:08 GMT
+      - Fri, 30 Aug 2019 14:34:11 GMT
       Server:
       - Apache
       Content-Length:
@@ -89,29 +89,29 @@ http_interactions:
         YmFjayI6IG51bGwsICJyZXNvdXJjZXMiOiB7InJlcG9zaXRvcnkiOiAiRmVk
         b3JhXzE3In19
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:08 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:11 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/2_duplicate/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/2_duplicate/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:08 GMT
+      - Fri, 30 Aug 2019 14:34:11 GMT
       Server:
       - Apache
       Content-Length:
@@ -134,29 +134,29 @@ http_interactions:
         LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9y
         eSI6ICIyX2R1cGxpY2F0ZSJ9fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:08 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:11 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/feedless_1/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/feedless_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:08 GMT
+      - Fri, 30 Aug 2019 14:34:12 GMT
       Server:
       - Apache
       Content-Length:
@@ -179,29 +179,29 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         ImZlZWRsZXNzXzEifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:08 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:12 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/9/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/9/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:08 GMT
+      - Fri, 30 Aug 2019 14:34:12 GMT
       Server:
       - Apache
       Content-Length:
@@ -223,29 +223,29 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjkifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:08 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:12 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:09 GMT
+      - Fri, 30 Aug 2019 14:34:12 GMT
       Server:
       - Apache
       Content-Length:
@@ -269,29 +269,29 @@ http_interactions:
         W119LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3Np
         dG9yeSI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCJ9fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:09 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:12 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/1/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:09 GMT
+      - Fri, 30 Aug 2019 14:34:12 GMT
       Server:
       - Apache
       Content-Length:
@@ -313,29 +313,29 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjEifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:09 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:12 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/9_noarch/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/9_noarch/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:09 GMT
+      - Fri, 30 Aug 2019 14:34:12 GMT
       Server:
       - Apache
       Content-Length:
@@ -358,29 +358,29 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICI5X25vYXJj
         aCJ9fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:09 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:12 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/4/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/4/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:09 GMT
+      - Fri, 30 Aug 2019 14:34:13 GMT
       Server:
       - Apache
       Content-Length:
@@ -402,29 +402,29 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjQifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:09 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:13 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/6/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/6/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:09 GMT
+      - Fri, 30 Aug 2019 14:34:13 GMT
       Server:
       - Apache
       Content-Length:
@@ -446,29 +446,29 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjYifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:09 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:13 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/7/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/7/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:09 GMT
+      - Fri, 30 Aug 2019 14:34:13 GMT
       Server:
       - Apache
       Content-Length:
@@ -490,29 +490,29 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjcifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:09 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:13 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/source_rpm/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/source_rpm/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:10 GMT
+      - Fri, 30 Aug 2019 14:34:13 GMT
       Server:
       - Apache
       Content-Length:
@@ -535,29 +535,29 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         InNvdXJjZV9ycG0ifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:10 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:13 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:10 GMT
+      - Fri, 30 Aug 2019 14:34:13 GMT
       Server:
       - Apache
       Content-Length:
@@ -582,29 +582,29 @@ http_interactions:
         Y2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1
         bHRfT3JnYW5pemF0aW9uLVRlc3QtcmVkaXMifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:10 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:13 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:10 GMT
+      - Fri, 30 Aug 2019 14:34:14 GMT
       Server:
       - Apache
       Content-Length:
@@ -630,29 +630,29 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSJ9fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:10 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:14 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox2-dev/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox2-dev/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:10 GMT
+      - Fri, 30 Aug 2019 14:34:14 GMT
       Server:
       - Apache
       Content-Length:
@@ -678,29 +678,29 @@ http_interactions:
         cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1U
         ZXN0LWJ1c3lib3gyLWRldiJ9fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:10 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:14 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/100/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/100/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:10 GMT
+      - Fri, 30 Aug 2019 14:34:14 GMT
       Server:
       - Apache
       Content-Length:
@@ -722,29 +722,29 @@ http_interactions:
         X2Vycm9ycyI6IFtdfSwgInRyYWNlYmFjayI6IG51bGwsICJyZXNvdXJjZXMi
         OiB7InJlcG9zaXRvcnkiOiAiMTAwIn19
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:10 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:14 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:10 GMT
+      - Fri, 30 Aug 2019 14:34:14 GMT
       Server:
       - Apache
       Content-Length:
@@ -770,29 +770,29 @@ http_interactions:
         IjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
         ZXQtTXlfRmlsZXMifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:10 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:14 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_File_1/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_File_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:10 GMT
+      - Fri, 30 Aug 2019 14:34:14 GMT
       Server:
       - Apache
       Content-Length:
@@ -818,29 +818,29 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSJ9fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:10 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:14 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Docker_1/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Docker_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:11 GMT
+      - Fri, 30 Aug 2019 14:34:15 GMT
       Server:
       - Apache
       Content-Length:
@@ -866,10 +866,10 @@ http_interactions:
         ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRl
         ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRG9ja2VyXzEifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:11 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:15 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -901,21 +901,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '1115'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 201
       message: CREATED
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:11 GMT
+      - Fri, 30 Aug 2019 14:34:15 GMT
       Server:
       - Apache
       Content-Length:
@@ -932,41 +932,41 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWQ0ODdmOGJhY2UyM2YwN2E3Zjc0MDQwIn0sICJpZCI6ICJGZWRvcmFfMTci
+        NWQ2OTMzZTc3YWNjZTkwN2UzODFjZWFkIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:11 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:15 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:11 GMT
+      - Fri, 30 Aug 2019 14:34:15 GMT
       Server:
       - Apache
       Etag:
-      - '"1cc671152348786e0fd63fe892dded9a-gzip"'
+      - '"14c80f80b629d901d4359ba07d099132-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2330'
+      - '634'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -975,79 +975,79 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
-        MjAxOS0wOC0wNVQxOToxMjoxMVoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        MjAxOS0wOC0zMFQxNDozNDoxNVoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
         L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
         aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
         c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
         cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
         cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWQ0ODdmOGJhY2UyM2YwN2E3Zjc0MDQ0In0sICJj
+        aWQiOiB7IiRvaWQiOiAiNWQ2OTMzZTc3YWNjZTkwN2UzODFjZWIxIn0sICJj
         b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
         X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
         IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
         b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDgt
-        MDVUMTk6MTI6MTFaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        MzBUMTQ6MzQ6MTVaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
         b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
         IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
         OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
         dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
         Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVkNDg3ZjhiYWNlMjNmMDdhN2Y3NDA0MyJ9LCAiY29uZmlnIjog
+        b2lkIjogIjVkNjkzM2U3N2FjY2U5MDdlMzgxY2ViMCJ9LCAiY29uZmlnIjog
         eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
         ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9LCB7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjEyOjExWiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjE1WiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9kaXN0cmlidXRvcnMvRmVkb3JhXzE3LyIsICJsYXN0X292ZXJyaWRlX2Nv
         bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
         X3R5cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6
         IHRydWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmli
-        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3ZjhiYWNlMjNmMDdhN2Y3
-        NDA0MiJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
+        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVkNjkzM2U3N2FjY2U5MDdlMzgx
+        Y2VhZiJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
         IGZhbHNlLCAiaHR0cHMiOiB0cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVf
         Q29ycG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwifSwgImlkIjog
         IkZlZG9yYV8xNyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3Rl
         cyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3Jl
         bW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25z
         IjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjEyOjExWiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjE1WiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBv
         cnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
         bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGws
-        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y4
-        YmFjZTIzZjA3YTdmNzQwNDEifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJmaWxl
+        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzNl
+        NzdhY2NlOTA3ZTM4MWNlYWUifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJmaWxl
         Oi8vL3Zhci93d3cvdGVzdF9yZXBvcy96b28iLCAicHJveHlfcG9ydCI6IDgw
         LCAiZG93bmxvYWRfcG9saWN5IjogImltbWVkaWF0ZSIsICJyZW1vdmVfbWlz
         c2luZyI6IHRydWUsICJwcm94eV9ob3N0IjogImh0dHA6Ly91cmxfMSIsICJz
         c2xfdmFsaWRhdGlvbiI6IHRydWV9LCAiaWQiOiAieXVtX2ltcG9ydGVyIn1d
         LCAibG9jYWxseV9zdG9yZWRfdW5pdHMiOiAwLCAiX2lkIjogeyIkb2lkIjog
-        IjVkNDg3ZjhiYWNlMjNmMDdhN2Y3NDA0MCJ9LCAidG90YWxfcmVwb3NpdG9y
+        IjVkNjkzM2U3N2FjY2U5MDdlMzgxY2VhZCJ9LCAidG90YWxfcmVwb3NpdG9y
         eV91bml0cyI6IDAsICJpZCI6ICJGZWRvcmFfMTciLCAiX2hyZWYiOiAiL3B1
         bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvIn0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:11 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:15 GMT
 - request:
     method: delete
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:11 GMT
+      - Fri, 30 Aug 2019 14:34:15 GMT
       Server:
       - Apache
       Content-Length:
@@ -1058,41 +1058,41 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzFlMjBlNWYzLWM3ZjMtNDBjMC05NDhmLTA3Y2Y0YjE1YTFkMS8iLCAi
-        dGFza19pZCI6ICIxZTIwZTVmMy1jN2YzLTQwYzAtOTQ4Zi0wN2NmNGIxNWEx
-        ZDEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzg5NTI1ZmU0LWQ2OWMtNGM4ZS05Mzk5LTdmOTAyMGQ5ZWRlOC8iLCAi
+        dGFza19pZCI6ICI4OTUyNWZlNC1kNjljLTRjOGUtOTM5OS03ZjkwMjBkOWVk
+        ZTgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:11 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:15 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/1e20e5f3-c7f3-40c0-948f-07cf4b15a1d1/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/89525fe4-d69c-4c8e-9399-7f9020d9ede8/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:11 GMT
+      - Fri, 30 Aug 2019 14:34:15 GMT
       Server:
       - Apache
       Etag:
-      - '"2ce4709b9de9740aa3d0b882b1406e8a-gzip"'
+      - '"213b09dac02c2ddbe7a19ccd7298e725-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '689'
+      - '372'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1100,20 +1100,21 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xZTIwZTVmMy1jN2YzLTQwYzAtOTQ4Zi0wN2NmNGIxNWEx
-        ZDEvIiwgInRhc2tfaWQiOiAiMWUyMGU1ZjMtYzdmMy00MGMwLTk0OGYtMDdj
-        ZjRiMTVhMWQxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy84OTUyNWZlNC1kNjljLTRjOGUtOTM5OS03ZjkwMjBkOWVk
+        ZTgvIiwgInRhc2tfaWQiOiAiODk1MjVmZTQtZDY5Yy00YzhlLTkzOTktN2Y5
+        MDIwZDllZGU4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE5LTA4LTA1VDE5OjEyOjExWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjExWiIsICJ0cmFjZWJh
+        MDE5LTA4LTMwVDE0OjM0OjE1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjE1WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
-        ImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
-        X3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVk
-        NDg3ZjhiYWIzNmNlM2ZlNTFkZmQxOCJ9LCAiaWQiOiAiNWQ0ODdmOGJhYjM2
-        Y2UzZmU1MWRmZDE4In0=
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        LmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2
+        ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZTczMmRiNjA3
+        N2E3OTY0NTgzIn0sICJpZCI6ICI1ZDY5MzNlNzMyZGI2MDc3YTc5NjQ1ODMi
+        fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:11 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:15 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/rpm_with_proxy/sync_with_global_http_proxy.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/rpm_with_proxy/sync_with_global_http_proxy.yml
@@ -2,26 +2,26 @@
 http_interactions:
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/debian_9/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/debian_9/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:13 GMT
+      - Fri, 30 Aug 2019 14:34:16 GMT
       Server:
       - Apache
       Content-Length:
@@ -44,29 +44,29 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJkZWJpYW5f
         OSJ9fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:13 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:16 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:13 GMT
+      - Fri, 30 Aug 2019 14:34:16 GMT
       Server:
       - Apache
       Content-Length:
@@ -89,29 +89,29 @@ http_interactions:
         YmFjayI6IG51bGwsICJyZXNvdXJjZXMiOiB7InJlcG9zaXRvcnkiOiAiRmVk
         b3JhXzE3In19
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:13 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:16 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/2_duplicate/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/2_duplicate/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:13 GMT
+      - Fri, 30 Aug 2019 14:34:16 GMT
       Server:
       - Apache
       Content-Length:
@@ -134,29 +134,29 @@ http_interactions:
         LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9y
         eSI6ICIyX2R1cGxpY2F0ZSJ9fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:13 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:17 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/feedless_1/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/feedless_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:13 GMT
+      - Fri, 30 Aug 2019 14:34:17 GMT
       Server:
       - Apache
       Content-Length:
@@ -179,29 +179,29 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         ImZlZWRsZXNzXzEifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:13 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:17 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/9/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/9/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:13 GMT
+      - Fri, 30 Aug 2019 14:34:17 GMT
       Server:
       - Apache
       Content-Length:
@@ -223,29 +223,29 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjkifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:13 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:17 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:14 GMT
+      - Fri, 30 Aug 2019 14:34:17 GMT
       Server:
       - Apache
       Content-Length:
@@ -269,29 +269,29 @@ http_interactions:
         W119LCAidHJhY2ViYWNrIjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3Np
         dG9yeSI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCJ9fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:14 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:17 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/1/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:14 GMT
+      - Fri, 30 Aug 2019 14:34:17 GMT
       Server:
       - Apache
       Content-Length:
@@ -313,29 +313,29 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjEifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:14 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:17 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/9_noarch/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/9_noarch/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:14 GMT
+      - Fri, 30 Aug 2019 14:34:17 GMT
       Server:
       - Apache
       Content-Length:
@@ -358,29 +358,29 @@ http_interactions:
         IjogbnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICI5X25vYXJj
         aCJ9fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:14 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:17 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/4/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/4/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:14 GMT
+      - Fri, 30 Aug 2019 14:34:17 GMT
       Server:
       - Apache
       Content-Length:
@@ -402,29 +402,29 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjQifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:14 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:17 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/6/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/6/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:14 GMT
+      - Fri, 30 Aug 2019 14:34:18 GMT
       Server:
       - Apache
       Content-Length:
@@ -446,29 +446,29 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjYifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:14 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:18 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/7/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/7/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:14 GMT
+      - Fri, 30 Aug 2019 14:34:18 GMT
       Server:
       - Apache
       Content-Length:
@@ -490,29 +490,29 @@ http_interactions:
         OiBbXX0sICJ0cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBv
         c2l0b3J5IjogIjcifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:14 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:18 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/source_rpm/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/source_rpm/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:15 GMT
+      - Fri, 30 Aug 2019 14:34:18 GMT
       Server:
       - Apache
       Content-Length:
@@ -535,29 +535,29 @@ http_interactions:
         cmFjZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5Ijog
         InNvdXJjZV9ycG0ifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:15 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:18 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Test-redis/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:15 GMT
+      - Fri, 30 Aug 2019 14:34:18 GMT
       Server:
       - Apache
       Content-Length:
@@ -582,29 +582,29 @@ http_interactions:
         Y2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRlZmF1
         bHRfT3JnYW5pemF0aW9uLVRlc3QtcmVkaXMifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:15 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:18 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox-library/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:15 GMT
+      - Fri, 30 Aug 2019 14:34:18 GMT
       Server:
       - Apache
       Content-Length:
@@ -630,29 +630,29 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1UZXN0LWJ1c3lib3gtbGlicmFyeSJ9fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:15 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:18 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox2-dev/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Test-busybox2-dev/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:15 GMT
+      - Fri, 30 Aug 2019 14:34:18 GMT
       Server:
       - Apache
       Content-Length:
@@ -678,29 +678,29 @@ http_interactions:
         cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1U
         ZXN0LWJ1c3lib3gyLWRldiJ9fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:15 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:18 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/100/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/100/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:15 GMT
+      - Fri, 30 Aug 2019 14:34:19 GMT
       Server:
       - Apache
       Content-Length:
@@ -722,29 +722,29 @@ http_interactions:
         X2Vycm9ycyI6IFtdfSwgInRyYWNlYmFjayI6IG51bGwsICJyZXNvdXJjZXMi
         OiB7InJlcG9zaXRvcnkiOiAiMTAwIn19
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:15 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:19 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:15 GMT
+      - Fri, 30 Aug 2019 14:34:19 GMT
       Server:
       - Apache
       Content-Length:
@@ -770,29 +770,29 @@ http_interactions:
         IjogeyJyZXBvc2l0b3J5IjogIkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
         ZXQtTXlfRmlsZXMifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:15 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:19 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_File_1/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_File_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:16 GMT
+      - Fri, 30 Aug 2019 14:34:19 GMT
       Server:
       - Apache
       Content-Length:
@@ -818,29 +818,29 @@ http_interactions:
         bnVsbCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJEZWZhdWx0X09y
         Z2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSJ9fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:16 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:19 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Docker_1/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-pulp3_Docker_1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:16 GMT
+      - Fri, 30 Aug 2019 14:34:19 GMT
       Server:
       - Apache
       Content-Length:
@@ -866,10 +866,10 @@ http_interactions:
         ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogIkRl
         ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRG9ja2VyXzEifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:16 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:19 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -901,21 +901,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '1115'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 201
       message: CREATED
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:16 GMT
+      - Fri, 30 Aug 2019 14:34:20 GMT
       Server:
       - Apache
       Content-Length:
@@ -932,14 +932,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWQ0ODdmOTBhY2UyM2YwN2E3Zjc0MDQ1In0sICJpZCI6ICJGZWRvcmFfMTci
+        NWQ2OTMzZWM3YWNjZTkwN2U0ZDdmMjlkIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:16 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:20 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -948,21 +948,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '53'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:17 GMT
+      - Fri, 30 Aug 2019 14:34:20 GMT
       Server:
       - Apache
       Content-Length:
@@ -973,41 +973,41 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzY0MzFhMjFlLTAzNmYtNDA4ZS04NzBhLTZjMDRlZTk2NmE0NS8iLCAi
-        dGFza19pZCI6ICI2NDMxYTIxZS0wMzZmLTQwOGUtODcwYS02YzA0ZWU5NjZh
-        NDUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzFmNTgyYjc0LTZmOGMtNGVhYS05YjdhLTY2NWUyZGQ5YmU3MC8iLCAi
+        dGFza19pZCI6ICIxZjU4MmI3NC02ZjhjLTRlYWEtOWI3YS02NjVlMmRkOWJl
+        NzAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:17 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:20 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/6431a21e-036f-408e-870a-6c04ee966a45/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/1f582b74-6f8c-4eaa-9b7a-665e2dd9be70/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:17 GMT
+      - Fri, 30 Aug 2019 14:34:22 GMT
       Server:
       - Apache
       Etag:
-      - '"df437390bec00c85baf9886d4ba33102-gzip"'
+      - '"204aafcb7d7335aa48cc5bc048545392-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
+      - '736'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1015,90 +1015,91 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NDMxYTIxZS0wMzZmLTQwOGUtODcwYS02YzA0ZWU5NjZh
-        NDUvIiwgInRhc2tfaWQiOiAiNjQzMWEyMWUtMDM2Zi00MDhlLTg3MGEtNmMw
-        NGVlOTY2YTQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xZjU4MmI3NC02ZjhjLTRlYWEtOWI3YS02NjVlMmRkOWJl
+        NzAvIiwgInRhc2tfaWQiOiAiMWY1ODJiNzQtNmY4Yy00ZWFhLTliN2EtNjY1
+        ZTJkZDliZTcwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMjoxN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMjoxN1oiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDoyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDoyMFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZWQ5YzViMjgtYTJiYy00ODk1LThjMWMtYTJmM2E4NGU3
-        MDBlLyIsICJ0YXNrX2lkIjogImVkOWM1YjI4LWEyYmMtNDg5NS04YzFjLWEy
-        ZjNhODRlNzAwZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjoxN1oiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjEyOjE3WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y5MWFjZTIzZjBhMTQ5NDQ1YjUiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjkxYWIzNmNlM2ZlNTFkZmUwMSJ9LCAiaWQiOiAiNWQ0ODdm
-        OTFhYjM2Y2UzZmU1MWRmZTAxIn0=
+        cGkvdjIvdGFza3MvN2MyNjM3Y2QtMGU0Zi00Mzc3LThmNjctNmVmYjExNTAx
+        NTA0LyIsICJ0YXNrX2lkIjogIjdjMjYzN2NkLTBlNGYtNDM3Ny04ZjY3LTZl
+        ZmIxMTUwMTUwNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDE4LCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMTgsICJycG1fZG9uZSI6IDE4LCAiZHJwbV90b3Rh
+        bCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiA2NTE1OSwg
+        InNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxv
+        LWRldmVsLTIuY2Fubm9sby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLTIuY2Fubm9sby5leGFt
+        cGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImlt
+        cG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxs
+        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InN0YXJ0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDoyMFoiLCAiX25zIjogInJl
+        cG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4LTMwVDE0
+        OjM0OjIyWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJlbW92ZWRf
+        Y291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDY5MzNl
+        ZTdhY2NlOTBiNjM5ZmM2YTQiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwi
+        OiA2NTE1OSwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAxOCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxz
+        IjogeyJycG1fdG90YWwiOiAxOCwgInJwbV9kb25lIjogMTgsICJkcnBtX3Rv
+        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
+        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1ZDY5MzNlYzMyZGI2MDc3YTc5NjQ2NzUifSwgImlkIjogIjVkNjkz
+        M2VjMzJkYjYwNzdhNzk2NDY3NSJ9
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:17 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:22 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/6431a21e-036f-408e-870a-6c04ee966a45/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/1f582b74-6f8c-4eaa-9b7a-665e2dd9be70/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:17 GMT
+      - Fri, 30 Aug 2019 14:34:22 GMT
       Server:
       - Apache
       Etag:
-      - '"df437390bec00c85baf9886d4ba33102-gzip"'
+      - '"204aafcb7d7335aa48cc5bc048545392-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
+      - '736'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1106,90 +1107,91 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NDMxYTIxZS0wMzZmLTQwOGUtODcwYS02YzA0ZWU5NjZh
-        NDUvIiwgInRhc2tfaWQiOiAiNjQzMWEyMWUtMDM2Zi00MDhlLTg3MGEtNmMw
-        NGVlOTY2YTQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xZjU4MmI3NC02ZjhjLTRlYWEtOWI3YS02NjVlMmRkOWJl
+        NzAvIiwgInRhc2tfaWQiOiAiMWY1ODJiNzQtNmY4Yy00ZWFhLTliN2EtNjY1
+        ZTJkZDliZTcwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMjoxN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMjoxN1oiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDoyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDoyMFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZWQ5YzViMjgtYTJiYy00ODk1LThjMWMtYTJmM2E4NGU3
-        MDBlLyIsICJ0YXNrX2lkIjogImVkOWM1YjI4LWEyYmMtNDg5NS04YzFjLWEy
-        ZjNhODRlNzAwZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjoxN1oiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjEyOjE3WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y5MWFjZTIzZjBhMTQ5NDQ1YjUiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjkxYWIzNmNlM2ZlNTFkZmUwMSJ9LCAiaWQiOiAiNWQ0ODdm
-        OTFhYjM2Y2UzZmU1MWRmZTAxIn0=
+        cGkvdjIvdGFza3MvN2MyNjM3Y2QtMGU0Zi00Mzc3LThmNjctNmVmYjExNTAx
+        NTA0LyIsICJ0YXNrX2lkIjogIjdjMjYzN2NkLTBlNGYtNDM3Ny04ZjY3LTZl
+        ZmIxMTUwMTUwNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDE4LCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMTgsICJycG1fZG9uZSI6IDE4LCAiZHJwbV90b3Rh
+        bCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiA2NTE1OSwg
+        InNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxv
+        LWRldmVsLTIuY2Fubm9sby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLTIuY2Fubm9sby5leGFt
+        cGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImlt
+        cG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxs
+        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InN0YXJ0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDoyMFoiLCAiX25zIjogInJl
+        cG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4LTMwVDE0
+        OjM0OjIyWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJlbW92ZWRf
+        Y291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDY5MzNl
+        ZTdhY2NlOTBiNjM5ZmM2YTQiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwi
+        OiA2NTE1OSwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAxOCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxz
+        IjogeyJycG1fdG90YWwiOiAxOCwgInJwbV9kb25lIjogMTgsICJkcnBtX3Rv
+        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
+        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1ZDY5MzNlYzMyZGI2MDc3YTc5NjQ2NzUifSwgImlkIjogIjVkNjkz
+        M2VjMzJkYjYwNzdhNzk2NDY3NSJ9
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:17 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:22 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/6431a21e-036f-408e-870a-6c04ee966a45/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/1f582b74-6f8c-4eaa-9b7a-665e2dd9be70/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:17 GMT
+      - Fri, 30 Aug 2019 14:34:22 GMT
       Server:
       - Apache
       Etag:
-      - '"df437390bec00c85baf9886d4ba33102-gzip"'
+      - '"204aafcb7d7335aa48cc5bc048545392-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
+      - '736'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1197,90 +1199,91 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NDMxYTIxZS0wMzZmLTQwOGUtODcwYS02YzA0ZWU5NjZh
-        NDUvIiwgInRhc2tfaWQiOiAiNjQzMWEyMWUtMDM2Zi00MDhlLTg3MGEtNmMw
-        NGVlOTY2YTQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xZjU4MmI3NC02ZjhjLTRlYWEtOWI3YS02NjVlMmRkOWJl
+        NzAvIiwgInRhc2tfaWQiOiAiMWY1ODJiNzQtNmY4Yy00ZWFhLTliN2EtNjY1
+        ZTJkZDliZTcwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMjoxN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMjoxN1oiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDoyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDoyMFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZWQ5YzViMjgtYTJiYy00ODk1LThjMWMtYTJmM2E4NGU3
-        MDBlLyIsICJ0YXNrX2lkIjogImVkOWM1YjI4LWEyYmMtNDg5NS04YzFjLWEy
-        ZjNhODRlNzAwZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjoxN1oiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjEyOjE3WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y5MWFjZTIzZjBhMTQ5NDQ1YjUiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjkxYWIzNmNlM2ZlNTFkZmUwMSJ9LCAiaWQiOiAiNWQ0ODdm
-        OTFhYjM2Y2UzZmU1MWRmZTAxIn0=
+        cGkvdjIvdGFza3MvN2MyNjM3Y2QtMGU0Zi00Mzc3LThmNjctNmVmYjExNTAx
+        NTA0LyIsICJ0YXNrX2lkIjogIjdjMjYzN2NkLTBlNGYtNDM3Ny04ZjY3LTZl
+        ZmIxMTUwMTUwNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDE4LCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMTgsICJycG1fZG9uZSI6IDE4LCAiZHJwbV90b3Rh
+        bCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiA2NTE1OSwg
+        InNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxv
+        LWRldmVsLTIuY2Fubm9sby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLTIuY2Fubm9sby5leGFt
+        cGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImlt
+        cG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxs
+        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InN0YXJ0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDoyMFoiLCAiX25zIjogInJl
+        cG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4LTMwVDE0
+        OjM0OjIyWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJlbW92ZWRf
+        Y291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDY5MzNl
+        ZTdhY2NlOTBiNjM5ZmM2YTQiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwi
+        OiA2NTE1OSwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAxOCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxz
+        IjogeyJycG1fdG90YWwiOiAxOCwgInJwbV9kb25lIjogMTgsICJkcnBtX3Rv
+        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
+        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1ZDY5MzNlYzMyZGI2MDc3YTc5NjQ2NzUifSwgImlkIjogIjVkNjkz
+        M2VjMzJkYjYwNzdhNzk2NDY3NSJ9
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:17 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:22 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/6431a21e-036f-408e-870a-6c04ee966a45/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/1f582b74-6f8c-4eaa-9b7a-665e2dd9be70/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:17 GMT
+      - Fri, 30 Aug 2019 14:34:22 GMT
       Server:
       - Apache
       Etag:
-      - '"df437390bec00c85baf9886d4ba33102-gzip"'
+      - '"204aafcb7d7335aa48cc5bc048545392-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
+      - '736'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1288,90 +1291,91 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NDMxYTIxZS0wMzZmLTQwOGUtODcwYS02YzA0ZWU5NjZh
-        NDUvIiwgInRhc2tfaWQiOiAiNjQzMWEyMWUtMDM2Zi00MDhlLTg3MGEtNmMw
-        NGVlOTY2YTQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xZjU4MmI3NC02ZjhjLTRlYWEtOWI3YS02NjVlMmRkOWJl
+        NzAvIiwgInRhc2tfaWQiOiAiMWY1ODJiNzQtNmY4Yy00ZWFhLTliN2EtNjY1
+        ZTJkZDliZTcwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMjoxN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMjoxN1oiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDoyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDoyMFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZWQ5YzViMjgtYTJiYy00ODk1LThjMWMtYTJmM2E4NGU3
-        MDBlLyIsICJ0YXNrX2lkIjogImVkOWM1YjI4LWEyYmMtNDg5NS04YzFjLWEy
-        ZjNhODRlNzAwZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjoxN1oiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjEyOjE3WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y5MWFjZTIzZjBhMTQ5NDQ1YjUiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjkxYWIzNmNlM2ZlNTFkZmUwMSJ9LCAiaWQiOiAiNWQ0ODdm
-        OTFhYjM2Y2UzZmU1MWRmZTAxIn0=
+        cGkvdjIvdGFza3MvN2MyNjM3Y2QtMGU0Zi00Mzc3LThmNjctNmVmYjExNTAx
+        NTA0LyIsICJ0YXNrX2lkIjogIjdjMjYzN2NkLTBlNGYtNDM3Ny04ZjY3LTZl
+        ZmIxMTUwMTUwNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDE4LCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMTgsICJycG1fZG9uZSI6IDE4LCAiZHJwbV90b3Rh
+        bCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiA2NTE1OSwg
+        InNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxv
+        LWRldmVsLTIuY2Fubm9sby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLTIuY2Fubm9sby5leGFt
+        cGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImlt
+        cG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxs
+        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InN0YXJ0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDoyMFoiLCAiX25zIjogInJl
+        cG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4LTMwVDE0
+        OjM0OjIyWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJlbW92ZWRf
+        Y291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDY5MzNl
+        ZTdhY2NlOTBiNjM5ZmM2YTQiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwi
+        OiA2NTE1OSwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAxOCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxz
+        IjogeyJycG1fdG90YWwiOiAxOCwgInJwbV9kb25lIjogMTgsICJkcnBtX3Rv
+        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
+        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1ZDY5MzNlYzMyZGI2MDc3YTc5NjQ2NzUifSwgImlkIjogIjVkNjkz
+        M2VjMzJkYjYwNzdhNzk2NDY3NSJ9
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:17 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:22 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/6431a21e-036f-408e-870a-6c04ee966a45/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/1f582b74-6f8c-4eaa-9b7a-665e2dd9be70/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:17 GMT
+      - Fri, 30 Aug 2019 14:34:22 GMT
       Server:
       - Apache
       Etag:
-      - '"df437390bec00c85baf9886d4ba33102-gzip"'
+      - '"204aafcb7d7335aa48cc5bc048545392-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
+      - '736'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1379,90 +1383,91 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NDMxYTIxZS0wMzZmLTQwOGUtODcwYS02YzA0ZWU5NjZh
-        NDUvIiwgInRhc2tfaWQiOiAiNjQzMWEyMWUtMDM2Zi00MDhlLTg3MGEtNmMw
-        NGVlOTY2YTQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xZjU4MmI3NC02ZjhjLTRlYWEtOWI3YS02NjVlMmRkOWJl
+        NzAvIiwgInRhc2tfaWQiOiAiMWY1ODJiNzQtNmY4Yy00ZWFhLTliN2EtNjY1
+        ZTJkZDliZTcwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMjoxN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMjoxN1oiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDoyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDoyMFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZWQ5YzViMjgtYTJiYy00ODk1LThjMWMtYTJmM2E4NGU3
-        MDBlLyIsICJ0YXNrX2lkIjogImVkOWM1YjI4LWEyYmMtNDg5NS04YzFjLWEy
-        ZjNhODRlNzAwZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjoxN1oiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjEyOjE3WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y5MWFjZTIzZjBhMTQ5NDQ1YjUiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjkxYWIzNmNlM2ZlNTFkZmUwMSJ9LCAiaWQiOiAiNWQ0ODdm
-        OTFhYjM2Y2UzZmU1MWRmZTAxIn0=
+        cGkvdjIvdGFza3MvN2MyNjM3Y2QtMGU0Zi00Mzc3LThmNjctNmVmYjExNTAx
+        NTA0LyIsICJ0YXNrX2lkIjogIjdjMjYzN2NkLTBlNGYtNDM3Ny04ZjY3LTZl
+        ZmIxMTUwMTUwNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDE4LCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMTgsICJycG1fZG9uZSI6IDE4LCAiZHJwbV90b3Rh
+        bCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiA2NTE1OSwg
+        InNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxv
+        LWRldmVsLTIuY2Fubm9sby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLTIuY2Fubm9sby5leGFt
+        cGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImlt
+        cG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxs
+        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InN0YXJ0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDoyMFoiLCAiX25zIjogInJl
+        cG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4LTMwVDE0
+        OjM0OjIyWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJlbW92ZWRf
+        Y291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDY5MzNl
+        ZTdhY2NlOTBiNjM5ZmM2YTQiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwi
+        OiA2NTE1OSwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAxOCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxz
+        IjogeyJycG1fdG90YWwiOiAxOCwgInJwbV9kb25lIjogMTgsICJkcnBtX3Rv
+        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
+        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1ZDY5MzNlYzMyZGI2MDc3YTc5NjQ2NzUifSwgImlkIjogIjVkNjkz
+        M2VjMzJkYjYwNzdhNzk2NDY3NSJ9
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:17 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:22 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/6431a21e-036f-408e-870a-6c04ee966a45/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/1f582b74-6f8c-4eaa-9b7a-665e2dd9be70/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:17 GMT
+      - Fri, 30 Aug 2019 14:34:22 GMT
       Server:
       - Apache
       Etag:
-      - '"df437390bec00c85baf9886d4ba33102-gzip"'
+      - '"204aafcb7d7335aa48cc5bc048545392-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
+      - '736'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1470,363 +1475,91 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NDMxYTIxZS0wMzZmLTQwOGUtODcwYS02YzA0ZWU5NjZh
-        NDUvIiwgInRhc2tfaWQiOiAiNjQzMWEyMWUtMDM2Zi00MDhlLTg3MGEtNmMw
-        NGVlOTY2YTQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8xZjU4MmI3NC02ZjhjLTRlYWEtOWI3YS02NjVlMmRkOWJl
+        NzAvIiwgInRhc2tfaWQiOiAiMWY1ODJiNzQtNmY4Yy00ZWFhLTliN2EtNjY1
+        ZTJkZDliZTcwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMjoxN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMjoxN1oiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDoyMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDoyMFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZWQ5YzViMjgtYTJiYy00ODk1LThjMWMtYTJmM2E4NGU3
-        MDBlLyIsICJ0YXNrX2lkIjogImVkOWM1YjI4LWEyYmMtNDg5NS04YzFjLWEy
-        ZjNhODRlNzAwZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjoxN1oiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjEyOjE3WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y5MWFjZTIzZjBhMTQ5NDQ1YjUiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjkxYWIzNmNlM2ZlNTFkZmUwMSJ9LCAiaWQiOiAiNWQ0ODdm
-        OTFhYjM2Y2UzZmU1MWRmZTAxIn0=
+        cGkvdjIvdGFza3MvN2MyNjM3Y2QtMGU0Zi00Mzc3LThmNjctNmVmYjExNTAx
+        NTA0LyIsICJ0YXNrX2lkIjogIjdjMjYzN2NkLTBlNGYtNDM3Ny04ZjY3LTZl
+        ZmIxMTUwMTUwNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDE4LCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        IHsicnBtX3RvdGFsIjogMTgsICJycG1fZG9uZSI6IDE4LCAiZHJwbV90b3Rh
+        bCI6IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiA2NTE1OSwg
+        InNpemVfbGVmdCI6IDAsICJpdGVtc19sZWZ0IjogMH0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMywgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgIm1vZHVsZXMiOiB7InN0YXRlIjog
+        IkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifX19LCAicXVldWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxv
+        LWRldmVsLTIuY2Fubm9sby5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAi
+        ZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vf
+        d29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLTIuY2Fubm9sby5leGFt
+        cGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNzIiwgImlt
+        cG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24iOiBudWxs
+        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjogbnVsbCwg
+        InN0YXJ0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDoyMFoiLCAiX25zIjogInJl
+        cG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4LTMwVDE0
+        OjM0OjIyWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIs
+        ICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1vZHVsZXMi
+        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0s
+        ICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
+        ZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJlbW92ZWRf
+        Y291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1ZDY5MzNl
+        ZTdhY2NlOTBiNjM5ZmM2YTQiLCAiZGV0YWlscyI6IHsibW9kdWxlcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVfdG90YWwi
+        OiA2NTE1OSwgIml0ZW1zX2xlZnQiOiAwLCAiaXRlbXNfdG90YWwiOiAxOCwg
+        InN0YXRlIjogIkZJTklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxz
+        IjogeyJycG1fdG90YWwiOiAxOCwgInJwbV9kb25lIjogMTgsICJkcnBtX3Rv
+        dGFsIjogMCwgImRycG1fZG9uZSI6IDB9LCAiZXJyb3JfZGV0YWlscyI6IFtd
+        fSwgImNvbXBzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVw
+        bGljYXRlcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImRpc3RyaWJ1dGlv
+        biI6IHsiaXRlbXNfdG90YWwiOiAzLCAic3RhdGUiOiAiRklOSVNIRUQiLCAi
+        ZXJyb3JfZGV0YWlscyI6IFtdLCAiaXRlbXNfbGVmdCI6IDB9LCAiZXJyYXRh
+        IjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7InN0YXRl
+        IjogIkZJTklTSEVEIn19fSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1ZDY5MzNlYzMyZGI2MDc3YTc5NjQ2NzUifSwgImlkIjogIjVkNjkz
+        M2VjMzJkYjYwNzdhNzk2NDY3NSJ9
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:17 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:22 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/6431a21e-036f-408e-870a-6c04ee966a45/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/7c2637cd-0e4f-4377-8f67-6efb11501504/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:18 GMT
+      - Fri, 30 Aug 2019 14:34:22 GMT
       Server:
       - Apache
       Etag:
-      - '"df437390bec00c85baf9886d4ba33102-gzip"'
+      - '"ae4b786e2ab70b10117995a90615329e-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NDMxYTIxZS0wMzZmLTQwOGUtODcwYS02YzA0ZWU5NjZh
-        NDUvIiwgInRhc2tfaWQiOiAiNjQzMWEyMWUtMDM2Zi00MDhlLTg3MGEtNmMw
-        NGVlOTY2YTQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMjoxN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMjoxN1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZWQ5YzViMjgtYTJiYy00ODk1LThjMWMtYTJmM2E4NGU3
-        MDBlLyIsICJ0YXNrX2lkIjogImVkOWM1YjI4LWEyYmMtNDg5NS04YzFjLWEy
-        ZjNhODRlNzAwZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjoxN1oiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjEyOjE3WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y5MWFjZTIzZjBhMTQ5NDQ1YjUiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjkxYWIzNmNlM2ZlNTFkZmUwMSJ9LCAiaWQiOiAiNWQ0ODdm
-        OTFhYjM2Y2UzZmU1MWRmZTAxIn0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:18 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/6431a21e-036f-408e-870a-6c04ee966a45/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:18 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"df437390bec00c85baf9886d4ba33102-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2405'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NDMxYTIxZS0wMzZmLTQwOGUtODcwYS02YzA0ZWU5NjZh
-        NDUvIiwgInRhc2tfaWQiOiAiNjQzMWEyMWUtMDM2Zi00MDhlLTg3MGEtNmMw
-        NGVlOTY2YTQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMjoxN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMjoxN1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZWQ5YzViMjgtYTJiYy00ODk1LThjMWMtYTJmM2E4NGU3
-        MDBlLyIsICJ0YXNrX2lkIjogImVkOWM1YjI4LWEyYmMtNDg5NS04YzFjLWEy
-        ZjNhODRlNzAwZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjoxN1oiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjEyOjE3WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y5MWFjZTIzZjBhMTQ5NDQ1YjUiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjkxYWIzNmNlM2ZlNTFkZmUwMSJ9LCAiaWQiOiAiNWQ0ODdm
-        OTFhYjM2Y2UzZmU1MWRmZTAxIn0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:18 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/6431a21e-036f-408e-870a-6c04ee966a45/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:18 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"df437390bec00c85baf9886d4ba33102-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2405'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NDMxYTIxZS0wMzZmLTQwOGUtODcwYS02YzA0ZWU5NjZh
-        NDUvIiwgInRhc2tfaWQiOiAiNjQzMWEyMWUtMDM2Zi00MDhlLTg3MGEtNmMw
-        NGVlOTY2YTQ1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMjoxN1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMjoxN1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvZWQ5YzViMjgtYTJiYy00ODk1LThjMWMtYTJmM2E4NGU3
-        MDBlLyIsICJ0YXNrX2lkIjogImVkOWM1YjI4LWEyYmMtNDg5NS04YzFjLWEy
-        ZjNhODRlNzAwZSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAz
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjoxN1oiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjEyOjE3WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y5MWFjZTIzZjBhMTQ5NDQ1YjUiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjkxYWIzNmNlM2ZlNTFkZmUwMSJ9LCAiaWQiOiAiNWQ0ODdm
-        OTFhYjM2Y2UzZmU1MWRmZTAxIn0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:18 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/ed9c5b28-a2bc-4895-8c1c-a2f3a84e700e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:18 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"ff91cf4286b04b88eae90b4de29bcea0-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '8529'
+      - '1373'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1834,226 +1567,227 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9lZDljNWIyOC1hMmJjLTQ4OTUtOGMxYy1hMmYz
-        YTg0ZTcwMGUvIiwgInRhc2tfaWQiOiAiZWQ5YzViMjgtYTJiYy00ODk1LThj
-        MWMtYTJmM2E4NGU3MDBlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy83YzI2MzdjZC0wZTRmLTQzNzctOGY2Ny02ZWZi
+        MTE1MDE1MDQvIiwgInRhc2tfaWQiOiAiN2MyNjM3Y2QtMGU0Zi00Mzc3LThm
+        NjctNmVmYjExNTAxNTA0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxOS0wOC0wNVQxOToxMjoxOFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMjoxN1oiLCAi
+        bWUiOiAiMjAxOS0wOC0zMFQxNDozNDoyMloiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDoyMloiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI2ODhlODU2ZC0xMGE0LTQ1MDgtYTNhOC00ZDUwMWJl
-        NGZmYWIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICJmNDY3NWU5MC04OWIyLTQ3YTUtYTM3OS0zYTE2NDQ5
+        ZmNlOWYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiOTBlNDkxNWYtNWM1OC00MTUzLWE3MjYtZTk3ZDJiNjE5NTBkIiwg
+        aWQiOiAiZDM3YjljM2EtOGZmZS00ZWYwLWI3MzMtMmEyZGRkNTEzOTljIiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVz
         Y3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJy
         cG1zIiwgIml0ZW1zX3RvdGFsIjogMTgsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4ZTdmNmNhZi0xNTk3LTQwYTEtOTRi
-        OS1lY2JmNzdiNzRjODEiLCAibnVtX3Byb2Nlc3NlZCI6IDE4fSwgeyJudW1f
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2NWQ1NzE4NC1jMDA2LTQzMzktODI5
+        OC04NjJmZTcwNmRlNjQiLCAibnVtX3Byb2Nlc3NlZCI6IDE4fSwgeyJudW1f
         c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRh
         IFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjog
         MSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        N2E5YWEyN2MtNTM3NS00ZTBkLThlZWQtMDY1ZGI0NTllNGFjIiwgIm51bV9w
+        YmY5ZWNiZjMtOTI5My00MDkzLWEzYmYtNWYzZTA1Y2QwYzU1IiwgIm51bV9w
         cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlv
         biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
         IiwgIml0ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
         cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjcyN2YyNWQ3LTk4Y2MtNDRmMi05NDEzLTM0
-        OWZmODBiMDU3ZSIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
+        cyI6IDAsICJzdGVwX2lkIjogIjI1M2YxZDAwLTI1YmMtNDhlNi1iZGRmLTNi
+        OTE2ZGZhOWM3NyIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
         c3MiOiA5LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwg
         InN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0
         YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjlmNGM2
-        ZTY3LWFkODEtNDE0Zi05Zjk0LTIwNjIwOWJhYjY4ZiIsICJudW1fcHJvY2Vz
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRiNTlh
+        ZGM5LTdmOGEtNDk2ZS1hYjBiLWMwMDkwZWUzMzY4MiIsICJudW1fcHJvY2Vz
         c2VkIjogOX0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAi
         UHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIs
         ICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI3NDJjYTVkNy0zZDY0LTQ2Y2ItODkwOC0zZDA5
-        Y2M4ZTRhMTEiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICJhOTBjNGFjYy1lY2Q1LTQ0M2UtOTU2MC0yMjQ5
+        Mjk0MGRlZmUiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNz
         IjogMiwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwg
         InN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDIsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkZWY5
-        NGM5OC05ZDYyLTQ5ZTYtOGMxMy0xNjc0OTQwZTExNjkiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzYTUz
+        ZTg4ZC05ZTYwLTQ2ZjEtYWZkOS0wMzc0MTVlNWQxNDUiLCAibnVtX3Byb2Nl
         c3NlZCI6IDJ9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2Vf
         cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0NzFkZTE3OS0xOGQz
-        LTRmYjctODUxZS1hNTU3YzdhZDFlNWEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyOTgzNTQ5Zi1lMmI4
+        LTQxZGMtOTUzMC1iZGM5MWQyMDVmM2UiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRp
         bmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxp
         dGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICIwOWVmYjRlNC05OTZmLTQzOGMtOTZmNi0y
-        ZjE5YjBkNjgxM2UiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI5YWIyNWE2Yy02MjFjLTQzZmUtOGVjMi1m
+        MjQzN2IyZGUyNmUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0
         YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVt
         c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICIwMzJjMjE3Yy01MzgwLTQ0MDctOTY1Yy0zYTc0ZDcwMDIx
-        ZjYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICI3MmFkMDA2NS1mY2ZhLTQ2MjQtOGMyNC01ZjRiNGZhZDhl
+        M2YiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVw
         X3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
         OiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwM2NlYWEwOC04
-        YzFjLTQ5MzUtOGYzZi0xNmI5OWZkMzBkOTUiLCAibnVtX3Byb2Nlc3NlZCI6
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyZTE4YzA2Ny1m
+        NGU4LTQ3YTUtYjIzYi0zODM4ODczNDEyZGMiLCAibnVtX3Byb2Nlc3NlZCI6
         IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
         c2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2Rp
         cmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
         RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlMmIzMWI1My01MmIzLTQ2Yzgt
-        ODZmZS1hZWVjYzU5MDU2MDUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxYjZmZmFjNy1kMTcwLTQ3YWIt
+        YWU0My0xNTQzOWNkOTQwNWQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
         bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGlu
         Z3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
         YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImIyMjg2ZmMwLWU5MWItNDIyYi1iYTc2
-        LWQwODEzMDkzOGI0NSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29y
-        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwu
-        bG9jYWxob3N0LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0Ijog
-        InN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVk
-        b3JhXzE3IiwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjoxN1oiLCAi
-        X25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIy
-        MDE5LTA4LTA1VDE5OjEyOjE4WiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlz
-        dHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFy
-        eSI6IHsiZ2VuZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNI
-        RUQiLCAicmVtb3ZlX29sZF9yZXBvZGF0YSI6ICJGSU5JU0hFRCIsICJtb2R1
-        bGVzIjogIkZJTklTSEVEIiwgImNsb3NlX3JlcG9fbWV0YWRhdGEiOiAiRklO
-        SVNIRUQiLCAiZHJwbXMiOiAiU0tJUFBFRCIsICJjb21wcyI6ICJGSU5JU0hF
-        RCIsICJkaXN0cmlidXRpb24iOiAiRklOSVNIRUQiLCAicmVwb3ZpZXciOiAi
-        U0tJUFBFRCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJGSU5JU0hFRCIsICJl
-        cnJhdGEiOiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAiRklOSVNIRUQifSwg
-        ImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiRmVk
-        b3JhXzE3IiwgImlkIjogIjVkNDg3ZjkyYWNlMjNmMGExNDk0NDViNiIsICJk
-        ZXRhaWxzIjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2ODhl
-        ODU2ZC0xMGE0LTQ1MDgtYTNhOC00ZDUwMWJlNGZmYWIiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiOTBlNDkxNWYtNWM1
-        OC00MTUzLWE3MjYtZTk3ZDJiNjE5NTBkIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFs
-        IjogMTgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICI4ZTdmNmNhZi0xNTk3LTQwYTEtOTRiOS1lY2JmNzdiNzRjODEiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDE4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
-        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQ
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiN2E5YWEyN2MtNTM3NS00ZTBk
-        LThlZWQtMDY1ZGI0NTllNGFjIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
-        dW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVy
-        cmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjog
-        NiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjcyN2YyNWQ3LTk4Y2MtNDRmMi05NDEzLTM0OWZmODBiMDU3ZSIsICJudW1f
-        cHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nlc3MiOiA5LCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1
-        bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjlmNGM2ZTY3LWFkODEtNDE0Zi05Zjk0
-        LTIwNjIwOWJhYjY4ZiIsICJudW1fcHJvY2Vzc2VkIjogOX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBm
-        aWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI3
-        NDJjYTVkNy0zZDY0LTQ2Y2ItODkwOC0zZDA5Y2M4ZTRhMTEiLCAibnVtX3By
-        b2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMiwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRh
-        ZGF0YSIsICJpdGVtc190b3RhbCI6IDIsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkZWY5NGM5OC05ZDYyLTQ5ZTYtOGMx
-        My0xNjc0OTQwZTExNjkiLCAibnVtX3Byb2Nlc3NlZCI6IDJ9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRh
-        ZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjgwYjg4ZGIyLWQyM2ItNDYwMS05MGY0
+        LWIyNWU5Y2MyOGE5YyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxs
+        by1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        ImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJl
+        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3Rh
+        cnRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjIyWiIsICJfbnMiOiAicmVwb19w
+        dWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTktMDgtMzBUMTQ6
+        MzQ6MjJaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBl
+        X2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0
+        ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJycG1zIjogIkZJTklTSEVEIiwgImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJyZW1vdmVf
+        b2xkX3JlcG9kYXRhIjogIkZJTklTSEVEIiwgIm1vZHVsZXMiOiAiRklOSVNI
+        RUQiLCAiY2xvc2VfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJkcnBt
+        cyI6ICJTS0lQUEVEIiwgImNvbXBzIjogIkZJTklTSEVEIiwgImRpc3RyaWJ1
+        dGlvbiI6ICJGSU5JU0hFRCIsICJyZXBvdmlldyI6ICJTS0lQUEVEIiwgInB1
+        Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5J
+        U0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2Fn
+        ZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQi
+        OiAiNWQ2OTMzZWU3YWNjZTkwYjYzOWZjNmE1IiwgImRldGFpbHMiOiBbeyJu
+        dW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcg
+        cmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImY0Njc1ZTkwLTg5YjItNDdh
+        NS1hMzc5LTNhMTY0NDlmY2U5ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        aXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlv
+        biIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJkMzdiOWMzYS04ZmZlLTRlZjAtYjczMy0y
+        YTJkZGQ1MTM5OWMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMTgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAi
+        c3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiAxOCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjY1ZDU3MTg0
+        LWMwMDYtNDMzOS04Mjk4LTg2MmZlNzA2ZGU2NCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMTh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAi
+        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI0NzFkZTE3OS0xOGQzLTRmYjctODUxZS1hNTU3Yzdh
-        ZDFlNWEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwg
-        InN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwi
-        OiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICIwOWVmYjRlNC05OTZmLTQzOGMtOTZmNi0yZjE5YjBkNjgxM2UiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0
-        aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAi
-        cmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwMzJjMjE3
-        Yy01MzgwLTQ0MDctOTY1Yy0zYTc0ZDcwMDIxZjYiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdl
-        bmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXci
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICIwM2NlYWEwOC04YzFjLTQ5MzUtOGYzZi0xNmI5
-        OWZkMzBkOTUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2Vi
-        IiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJlMmIzMWI1My01MmIzLTQ2YzgtODZmZS1hZWVjYzU5MDU2MDUi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
-        c2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        LCAic3RlcF9pZCI6ICJiZjllY2JmMy05MjkzLTQwOTMtYTNiZi01ZjNlMDVj
+        ZDBjNTUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        NiwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBf
+        dHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiA2LCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjUzZjFkMDAtMjVi
+        Yy00OGU2LWJkZGYtM2I5MTZkZmE5Yzc3IiwgIm51bV9wcm9jZXNzZWQiOiA2
+        fSwgeyJudW1fc3VjY2VzcyI6IDksICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNf
+        dG90YWwiOiA5LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiNGI1OWFkYzktN2Y4YS00OTZlLWFiMGItYzAwOTBlZTMzNjgy
+        IiwgIm51bV9wcm9jZXNzZWQiOiA5fSwgeyJudW1fc3VjY2VzcyI6IDMsICJk
+        ZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90
+        eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE5MGM0YWNjLWVjZDUt
+        NDQzZS05NTYwLTIyNDkyOTQwZGVmZSIsICJudW1fcHJvY2Vzc2VkIjogM30s
+        IHsibnVtX3N1Y2Nlc3MiOiAyLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjNhNTNlODhkLTllNjAtNDZmMS1hZmQ5LTAzNzQxNWU1ZDE0
+        NSIsICJudW1fcHJvY2Vzc2VkIjogMn0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBf
+        dHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjog
+        MSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjI5ODM1NDlmLWUyYjgtNDFkYy05NTMwLWJkYzkxZDIwNWYzZSIsICJudW1f
+        cHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjog
+        ImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjlhYjI1YTZjLTYy
+        MWMtNDNmZS04ZWMyLWYyNDM3YjJkZTI2ZSIsICJudW1fcHJvY2Vzc2VkIjog
+        MH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zp
+        bmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3Jl
+        cG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjcyYWQwMDY1LWZjZmEtNDYyNC04
+        YzI0LTVmNGI0ZmFkOGUzZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1M
+        IGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImIyMjg2ZmMwLWU5MWItNDIyYi1iYTc2LWQwODEzMDkzOGI0NSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
-        JG9pZCI6ICI1ZDQ4N2Y5MWFiMzZjZTNmZTUxZTAwYjcifSwgImlkIjogIjVk
-        NDg3ZjkxYWIzNmNlM2ZlNTFlMDBiNyJ9
+        IjogIjJlMThjMDY3LWY0ZTgtNDdhNS1iMjNiLTM4Mzg4NzM0MTJkYyIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
+        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjFiNmZm
+        YWM3LWQxNzAtNDdhYi1hZTQzLTE1NDM5Y2Q5NDA1ZCIsICJudW1fcHJvY2Vz
+        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
+        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiODBiODhkYjIt
+        ZDIzYi00NjAxLTkwZjQtYjI1ZTljYzI4YTljIiwgIm51bV9wcm9jZXNzZWQi
+        OiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNjkz
+        M2VlMzJkYjYwNzdhNzk2NTEwOSJ9LCAiaWQiOiAiNWQ2OTMzZWUzMmRiNjA3
+        N2E3OTY1MTA5In0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:18 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:22 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:18 GMT
+      - Fri, 30 Aug 2019 14:34:22 GMT
       Server:
       - Apache
       Etag:
-      - '"e5a0682fd92a1b9591e55e525bfdb3c0-gzip"'
+      - '"742dcee606f4895935a2a303db521454-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2678'
+      - '805'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2062,87 +1796,87 @@ http_interactions:
         eyJzY3JhdGNocGFkIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiJ9LCAi
         ZGlzcGxheV9uYW1lIjogIkZlZG9yYSAxNyB4ODZfNjQiLCAiZGVzY3JpcHRp
         b24iOiBudWxsLCAiZGlzdHJpYnV0b3JzIjogW3sicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDgtMDVUMTk6MTI6MTZa
+        cmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6MjBa
         IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvRmVkb3Jh
         XzE3L2Rpc3RyaWJ1dG9ycy9leHBvcnRfZGlzdHJpYnV0b3IvIiwgImxhc3Rf
         b3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAi
         ZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJleHBvcnRfZGlzdHJpYnV0b3IiLCAi
         YXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFkIjoge30sICJfbnMi
-        OiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3
-        ZjkwYWNlMjNmMDdhN2Y3NDA0OSJ9LCAiY29uZmlnIjogeyJodHRwIjogZmFs
+        OiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVkNjkz
+        M2VjN2FjY2U5MDdlNGQ3ZjJhMSJ9LCAiY29uZmlnIjogeyJodHRwIjogZmFs
         c2UsICJyZWxhdGl2ZV91cmwiOiAiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5
         L2ZlZG9yYV8xN19sYWJlbCIsICJodHRwcyI6IGZhbHNlfSwgImlkIjogImV4
         cG9ydF9kaXN0cmlidXRvciJ9LCB7InJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        Imxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjEyOjE2WiIsICJfaHJl
+        Imxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjIwWiIsICJfaHJl
         ZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy9kaXN0
         cmlidXRvcnMvRmVkb3JhXzE3X2Nsb25lLyIsICJsYXN0X292ZXJyaWRlX2Nv
         bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
         X3R5cGVfaWQiOiAieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVi
         bGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9f
-        ZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y5MGFjZTIz
-        ZjA3YTdmNzQwNDgifSwgImNvbmZpZyI6IHsiZGVzdGluYXRpb25fZGlzdHJp
+        ZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzNlYzdhY2Nl
+        OTA3ZTRkN2YyYTAifSwgImNvbmZpZyI6IHsiZGVzdGluYXRpb25fZGlzdHJp
         YnV0b3JfaWQiOiAiRmVkb3JhXzE3In0sICJpZCI6ICJGZWRvcmFfMTdfY2xv
         bmUifSwgeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQi
-        OiAiMjAxOS0wOC0wNVQxOToxMjoxNloiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
+        OiAiMjAxOS0wOC0zMFQxNDozNDoyMFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
         L3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL0ZlZG9y
         YV8xNy8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVi
-        bGlzaCI6ICIyMDE5LTA4LTA1VDE5OjEyOjE4WiIsICJkaXN0cmlidXRvcl90
+        bGlzaCI6ICIyMDE5LTA4LTMwVDE0OjM0OjIyWiIsICJkaXN0cmlidXRvcl90
         eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0
         cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0
-        b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y5MGFjZTIzZjA3YTdmNzQw
-        NDcifSwgImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBm
+        b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzNlYzdhY2NlOTA3ZTRkN2Yy
+        OWYifSwgImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBm
         YWxzZSwgImh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0Nv
         cnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIn0sICJpZCI6ICJG
-        ZWRvcmFfMTcifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAxOS0wOC0wNVQx
-        OToxMjoxN1oiLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        ZWRvcmFfMTcifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAxOS0wOC0zMFQx
+        NDozNDoyMloiLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7Im1vZHVsZW1kX2RlZmF1bHRzIjogMywgImVycmF0dW0iOiA2
         LCAicGFja2FnZV9ncm91cCI6IDIsICJwYWNrYWdlX2NhdGVnb3J5IjogMSwg
         ImRpc3RyaWJ1dGlvbiI6IDEsICJtb2R1bGVtZCI6IDYsICJycG0iOiAxOCwg
         Inl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiOiAyfSwgIl9ucyI6ICJyZXBvcyIs
         ICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0
-        X3VwZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjoxNloiLCAiX2hyZWYiOiAi
+        X3VwZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDoyMFoiLCAiX2hyZWYiOiAi
         L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvaW1wb3J0ZXJz
         L3l1bV9pbXBvcnRlci8iLCAiX25zIjogInJlcG9faW1wb3J0ZXJzIiwgImlt
         cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImxhc3Rfb3ZlcnJp
-        ZGVfY29uZmlnIjoge30sICJsYXN0X3N5bmMiOiAiMjAxOS0wOC0wNVQxOTox
-        MjoxN1oiLCAic2NyYXRjaHBhZCI6IHsicmVwb21kX3JldmlzaW9uIjogMTU2
+        ZGVfY29uZmlnIjoge30sICJsYXN0X3N5bmMiOiAiMjAxOS0wOC0zMFQxNDoz
+        NDoyMloiLCAic2NyYXRjaHBhZCI6IHsicmVwb21kX3JldmlzaW9uIjogMTU2
         Mjc4MzM0NSwgInJlcG9tZF9jaGVja3N1bSI6ICIyOTFhZjNkN2M2ZGNlZTQ1
         YWM1ODdmYWEwYTIxZjdjNzI2NGMxNTZhYzQ4MDY3YjkxODFmMzk1ZDVlMjVi
-        MTA5In0sICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmOTBhY2UyM2YwN2E3Zjc0
-        MDQ2In0sICJjb25maWciOiB7ImZlZWQiOiAiZmlsZTovLy92YXIvd3d3L3Rl
+        MTA5In0sICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZWM3YWNjZTkwN2U0ZDdm
+        MjllIn0sICJjb25maWciOiB7ImZlZWQiOiAiZmlsZTovLy92YXIvd3d3L3Rl
         c3RfcmVwb3Mvem9vIiwgInByb3h5X3BvcnQiOiA4MCwgImRvd25sb2FkX3Bv
         bGljeSI6ICJpbW1lZGlhdGUiLCAicmVtb3ZlX21pc3NpbmciOiB0cnVlLCAi
         cHJveHlfaG9zdCI6ICJodHRwOi8vdXJsXzEiLCAic3NsX3ZhbGlkYXRpb24i
         OiB0cnVlfSwgImlkIjogInl1bV9pbXBvcnRlciJ9XSwgImxvY2FsbHlfc3Rv
-        cmVkX3VuaXRzIjogMzksICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmOTBhY2Uy
-        M2YwN2E3Zjc0MDQ1In0sICJ0b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMzks
+        cmVkX3VuaXRzIjogMzksICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZWM3YWNj
+        ZTkwN2U0ZDdmMjlkIn0sICJ0b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMzks
         ICJpZCI6ICJGZWRvcmFfMTciLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Jl
         cG9zaXRvcmllcy9GZWRvcmFfMTcvIn0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:18 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:22 GMT
 - request:
     method: delete
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:18 GMT
+      - Fri, 30 Aug 2019 14:34:22 GMT
       Server:
       - Apache
       Content-Length:
@@ -2153,41 +1887,41 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzY3MjFiYmNhLWQzYmQtNDM3NS1hMzRhLTg0ZWE4OGY3YWIxYy8iLCAi
-        dGFza19pZCI6ICI2NzIxYmJjYS1kM2JkLTQzNzUtYTM0YS04NGVhODhmN2Fi
-        MWMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzM2MmExYzJhLWY0ZDktNDUwOS05YTQ4LTkxYzhkMDczN2Q5Yi8iLCAi
+        dGFza19pZCI6ICIzNjJhMWMyYS1mNGQ5LTQ1MDktOWE0OC05MWM4ZDA3Mzdk
+        OWIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:18 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:23 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/6721bbca-d3bd-4375-a34a-84ea88f7ab1c/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/362a1c2a-f4d9-4509-9a48-91c8d0737d9b/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:18 GMT
+      - Fri, 30 Aug 2019 14:34:23 GMT
       Server:
       - Apache
       Etag:
-      - '"7de9bdee3ccd0e0c2958f86fef171fc4-gzip"'
+      - '"fa48d37ba0a57bb688f29fc5ee938c27-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '689'
+      - '372'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2195,20 +1929,21 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy82NzIxYmJjYS1kM2JkLTQzNzUtYTM0YS04NGVhODhmN2Fi
-        MWMvIiwgInRhc2tfaWQiOiAiNjcyMWJiY2EtZDNiZC00Mzc1LWEzNGEtODRl
-        YTg4ZjdhYjFjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zNjJhMWMyYS1mNGQ5LTQ1MDktOWE0OC05MWM4ZDA3Mzdk
+        OWIvIiwgInRhc2tfaWQiOiAiMzYyYTFjMmEtZjRkOS00NTA5LTlhNDgtOTFj
+        OGQwNzM3ZDliIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE5LTA4LTA1VDE5OjEyOjE4WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjE4WiIsICJ0cmFjZWJh
+        MDE5LTA4LTMwVDE0OjM0OjIzWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjIzWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
-        ImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
-        X3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVk
-        NDg3ZjkyYWIzNmNlM2ZlNTFlMDIwYSJ9LCAiaWQiOiAiNWQ0ODdmOTJhYjM2
-        Y2UzZmU1MWUwMjBhIn0=
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        LmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2
+        ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZWUzMmRiNjA3
+        N2E3OTY1MjQ1In0sICJpZCI6ICI1ZDY5MzNlZTMyZGI2MDc3YTc5NjUyNDUi
+        fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:18 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:23 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/create.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/create.yml
@@ -2,26 +2,26 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:19 GMT
+      - Fri, 30 Aug 2019 14:34:06 GMT
       Server:
       - Apache
       Content-Length:
@@ -43,29 +43,29 @@ http_interactions:
         ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogInB1
         bHAtdXVpZC1yaGVsXzZfeDg2XzY0In19
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:19 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:06 GMT
 - request:
     method: delete
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:19 GMT
+      - Fri, 30 Aug 2019 14:34:06 GMT
       Server:
       - Apache
       Content-Length:
@@ -85,10 +85,10 @@ http_interactions:
         ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
         bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:19 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:06 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -120,21 +120,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '1111'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 201
       message: CREATED
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:19 GMT
+      - Fri, 30 Aug 2019 14:34:06 GMT
       Server:
       - Apache
       Content-Length:
@@ -150,42 +150,42 @@ http_interactions:
         Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJsYXN0X3VuaXRfYWRkZWQi
         OiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8ifSwg
         Imxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3Vu
-        dHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0
-        ODdmOTNhY2UyM2YwN2E3Zjc0MDRhIn0sICJpZCI6ICJwdWxwLXV1aWQtcmhl
+        dHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAiNWQ2
+        OTMzZGU3YWNjZTkwN2U0ZDdmMjk4In0sICJpZCI6ICJwdWxwLXV1aWQtcmhl
         bF82X3g4Nl82NCIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
         aWVzL3B1bHAtdXVpZC1yaGVsXzZfeDg2XzY0LyJ9
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:19 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:06 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:19 GMT
+      - Fri, 30 Aug 2019 14:34:06 GMT
       Server:
       - Apache
       Etag:
-      - '"50fc9c53cb3eb75a868374995ae368ca-gzip"'
+      - '"c534fecc0c4cb75c0e9669523988ee1f-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2616'
+      - '671'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -194,37 +194,37 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiUkhFTCA2IHg4
         Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMiOiBb
         eyJyZXBvX2lkIjogInB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgImxhc3Rf
-        dXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjEyOjE5WiIsICJfaHJlZiI6ICIv
+        dXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjA2WiIsICJfaHJlZiI6ICIv
         cHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL3B1bHAtdXVpZC1yaGVsXzZfeDg2
         XzY0L2Rpc3RyaWJ1dG9ycy9wdWxwLXV1aWQtcmhlbF82X3g4Nl82NF9jbG9u
         ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
         aCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9jbG9uZV9k
         aXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hw
         YWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7
-        IiRvaWQiOiAiNWQ0ODdmOTNhY2UyM2YwN2E3Zjc0MDRkIn0sICJjb25maWci
+        IiRvaWQiOiAiNWQ2OTMzZGU3YWNjZTkwN2U0ZDdmMjliIn0sICJjb25maWci
         OiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogInB1bHAtdXVpZC1y
         aGVsXzZfeDg2XzY0In0sICJpZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82
         NF9jbG9uZSJ9LCB7InJlcG9faWQiOiAicHVscC11dWlkLXJoZWxfNl94ODZf
-        NjQiLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDgtMDVUMTk6MTI6MTlaIiwg
+        NjQiLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6MDZaIiwg
         Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvcHVscC11dWlk
         LXJoZWxfNl94ODZfNjQvZGlzdHJpYnV0b3JzL3B1bHAtdXVpZC1yaGVsXzZf
         eDg2XzY0LyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9w
         dWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAieXVtX2Rp
         c3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IHRydWUsICJzY3JhdGNocGFk
         Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVkNDg3ZjkzYWNlMjNmMDdhN2Y3NDA0YyJ9LCAiY29uZmlnIjog
+        b2lkIjogIjVkNjkzM2RlN2FjY2U5MDdlNGQ3ZjI5YSJ9LCAiY29uZmlnIjog
         eyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6IGZhbHNlLCAiaHR0cHMiOiB0
         cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29ycG9yYXRpb24vbGlicmFy
         eS9yaGVsXzZfbGFiZWwifSwgImlkIjogInB1bHAtdXVpZC1yaGVsXzZfeDg2
         XzY0In0sIHsicmVwb19pZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCIs
-        ICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjoxOVoiLCAiX2hy
+        ICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDowNloiLCAiX2hy
         ZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9wdWxwLXV1aWQtcmhl
         bF82X3g4Nl82NC9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3RyaWJ1dG9yLyIs
         ICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjog
         bnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1
         dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9
         LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6
-        ICI1ZDQ4N2Y5M2FjZTIzZjA3YTdmNzQwNGUifSwgImNvbmZpZyI6IHsiaHR0
+        ICI1ZDY5MzNkZTdhY2NlOTA3ZTRkN2YyOWMifSwgImNvbmZpZyI6IHsiaHR0
         cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29ycG9yYXRpb24v
         bGlicmFyeS9yaGVsXzZfbGFiZWwiLCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6
         ICJleHBvcnRfZGlzdHJpYnV0b3IifV0sICJsYXN0X3VuaXRfYWRkZWQiOiBu
@@ -232,48 +232,48 @@ http_interactions:
         c3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9jb3VudHMi
         OiB7fSwgIl9ucyI6ICJyZXBvcyIsICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lk
         IjogInB1bHAtdXVpZC1yaGVsXzZfeDg2XzY0IiwgImxhc3RfdXBkYXRlZCI6
-        ICIyMDE5LTA4LTA1VDE5OjEyOjE5WiIsICJfaHJlZiI6ICIvcHVscC9hcGkv
+        ICIyMDE5LTA4LTMwVDE0OjM0OjA2WiIsICJfaHJlZiI6ICIvcHVscC9hcGkv
         djIvcmVwb3NpdG9yaWVzL3B1bHAtdXVpZC1yaGVsXzZfeDg2XzY0L2ltcG9y
         dGVycy95dW1faW1wb3J0ZXIvIiwgIl9ucyI6ICJyZXBvX2ltcG9ydGVycyIs
         ICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBvcnRlciIsICJsYXN0X292
         ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9zeW5jIjogbnVsbCwgInNjcmF0
-        Y2hwYWQiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3ZjkzYWNlMjNm
-        MDdhN2Y3NDA0YiJ9LCAiY29uZmlnIjogeyJmZWVkIjogImh0dHBzOi8vY2Ru
+        Y2hwYWQiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNjkzM2RlN2FjY2U5
+        MDdlNGQ3ZjI5OSJ9LCAiY29uZmlnIjogeyJmZWVkIjogImh0dHBzOi8vY2Ru
         LnJlZGhhdC5jb20vZm9vL2JhciIsICJzc2xfY2FfY2VydCI6ICJjYV9jZXJ0
         IiwgInNzbF9jbGllbnRfY2VydCI6ICJyZXBvX2NlcnQiLCAicmVtb3ZlX21p
         c3NpbmciOiB0cnVlLCAicHJveHlfaG9zdCI6ICIiLCAic3NsX3ZhbGlkYXRp
         b24iOiB0cnVlLCAic3NsX2NsaWVudF9rZXkiOiAicmVwb19rZXkiLCAiZG93
         bmxvYWRfcG9saWN5IjogIm9uX2RlbWFuZCIsICJ0eXBlX3NraXBfbGlzdCI6
         IFsicnBtIl19LCAiaWQiOiAieXVtX2ltcG9ydGVyIn1dLCAibG9jYWxseV9z
-        dG9yZWRfdW5pdHMiOiAwLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3ZjkzYWNl
-        MjNmMDdhN2Y3NDA0YSJ9LCAidG90YWxfcmVwb3NpdG9yeV91bml0cyI6IDAs
+        dG9yZWRfdW5pdHMiOiAwLCAiX2lkIjogeyIkb2lkIjogIjVkNjkzM2RlN2Fj
+        Y2U5MDdlNGQ3ZjI5OCJ9LCAidG90YWxfcmVwb3NpdG9yeV91bml0cyI6IDAs
         ICJpZCI6ICJwdWxwLXV1aWQtcmhlbF82X3g4Nl82NCIsICJfaHJlZiI6ICIv
         cHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL3B1bHAtdXVpZC1yaGVsXzZfeDg2
         XzY0LyJ9
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:19 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:06 GMT
 - request:
     method: delete
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:19 GMT
+      - Fri, 30 Aug 2019 14:34:06 GMT
       Server:
       - Apache
       Content-Length:
@@ -284,41 +284,41 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzQ3ZDc5MmQ0LTAxNmQtNDE4ZS05MTg3LTQ1YTczOTNhM2I1OC8iLCAi
-        dGFza19pZCI6ICI0N2Q3OTJkNC0wMTZkLTQxOGUtOTE4Ny00NWE3MzkzYTNi
-        NTgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzQxYjM1ODlkLWI5ZmEtNGViMS1hZGQ3LWRiOGJlOTZiZGQ1My8iLCAi
+        dGFza19pZCI6ICI0MWIzNTg5ZC1iOWZhLTRlYjEtYWRkNy1kYjhiZTk2YmRk
+        NTMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:19 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:06 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/47d792d4-016d-418e-9187-45a7393a3b58/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/41b3589d-b9fa-4eb1-add7-db8be96bdd53/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:19 GMT
+      - Fri, 30 Aug 2019 14:34:06 GMT
       Server:
       - Apache
       Etag:
-      - '"cd7c12ec60101400d170c121a1205987-gzip"'
+      - '"b8aef58f05d911f52433aaeacbf17609-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '703'
+      - '381'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -326,20 +326,21 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy80N2Q3OTJkNC0wMTZkLTQxOGUtOTE4Ny00NWE3MzkzYTNi
-        NTgvIiwgInRhc2tfaWQiOiAiNDdkNzkyZDQtMDE2ZC00MThlLTkxODctNDVh
-        NzM5M2EzYjU4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpwdWxwLXV1
+        aS92Mi90YXNrcy80MWIzNTg5ZC1iOWZhLTRlYjEtYWRkNy1kYjhiZTk2YmRk
+        NTMvIiwgInRhc2tfaWQiOiAiNDFiMzU4OWQtYjlmYS00ZWIxLWFkZDctZGI4
+        YmU5NmJkZDUzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpwdWxwLXV1
         aWQtcmhlbF82X3g4Nl82NCIsICJwdWxwOmFjdGlvbjpkZWxldGUiXSwgImZp
-        bmlzaF90aW1lIjogIjIwMTktMDgtMDVUMTk6MTI6MTlaIiwgIl9ucyI6ICJ0
-        YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTktMDgtMDVUMTk6MTI6
-        MTlaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10s
+        bmlzaF90aW1lIjogIjIwMTktMDgtMzBUMTQ6MzQ6MDZaIiwgIl9ucyI6ICJ0
+        YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTktMDgtMzBUMTQ6MzQ6
+        MDZaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tzIjogW10s
         ICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2VydmVkX3Jl
-        c291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxlLmNvbS5k
-        cTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVz
-        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwubG9jYWxob3N0LmV4YW1w
-        bGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGwsICJfaWQi
-        OiB7IiRvaWQiOiAiNWQ0ODdmOTNhYjM2Y2UzZmU1MWUwMjg5In0sICJpZCI6
-        ICI1ZDQ4N2Y5M2FiMzZjZTNmZTUxZTAyODkifQ==
+        c291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5v
+        bG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndv
+        cmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRv
+        czcta2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20iLCAicmVz
+        dWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        ZDY5MzNkZTMyZGI2MDc3YTc5NjQyYzQifSwgImlkIjogIjVkNjkzM2RlMzJk
+        YjYwNzdhNzk2NDJjNCJ9
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:19 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:06 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/create_custom.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/create_custom.yml
@@ -2,26 +2,26 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:21 GMT
+      - Fri, 30 Aug 2019 14:34:09 GMT
       Server:
       - Apache
       Content-Length:
@@ -43,29 +43,29 @@ http_interactions:
         ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogInB1
         bHAtdXVpZC1yaGVsXzZfeDg2XzY0In19
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:21 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:09 GMT
 - request:
     method: delete
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:21 GMT
+      - Fri, 30 Aug 2019 14:34:09 GMT
       Server:
       - Apache
       Content-Length:
@@ -85,10 +85,10 @@ http_interactions:
         ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
         bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:21 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:10 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -119,21 +119,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '1040'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 201
       message: CREATED
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:21 GMT
+      - Fri, 30 Aug 2019 14:34:10 GMT
       Server:
       - Apache
       Content-Length:
@@ -150,41 +150,41 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWQ0ODdmOTVhY2UyM2YwN2E1MDZkZDNmIn0sICJpZCI6ICJGZWRvcmFfMTci
+        NWQ2OTMzZTI3YWNjZTkwN2U1N2E0ZGE5In0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:21 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:10 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:21 GMT
+      - Fri, 30 Aug 2019 14:34:10 GMT
       Server:
       - Apache
       Etag:
-      - '"7d990a9126d2f9aba471245a9fa82b71-gzip"'
+      - '"18d53c58939ae4644cd63ba72457f905-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2378'
+      - '656'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -193,80 +193,80 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
-        MjAxOS0wOC0wNVQxOToxMjoyMVoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        MjAxOS0wOC0zMFQxNDozNDoxMFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
         L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
         aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
         c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
         cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
         cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWQ0ODdmOTVhY2UyM2YwN2E1MDZkZDQzIn0sICJj
+        aWQiOiB7IiRvaWQiOiAiNWQ2OTMzZTI3YWNjZTkwN2U1N2E0ZGFkIn0sICJj
         b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
         X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
         IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
         b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDgt
-        MDVUMTk6MTI6MjFaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        MzBUMTQ6MzQ6MTBaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
         b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
         IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
         OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
         dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
         Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVkNDg3Zjk1YWNlMjNmMDdhNTA2ZGQ0MiJ9LCAiY29uZmlnIjog
+        b2lkIjogIjVkNjkzM2UyN2FjY2U5MDdlNTdhNGRhYyJ9LCAiY29uZmlnIjog
         eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
         ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9LCB7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjEyOjIxWiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjEwWiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9kaXN0cmlidXRvcnMvRmVkb3JhXzE3LyIsICJsYXN0X292ZXJyaWRlX2Nv
         bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
         X3R5cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6
         IHRydWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmli
-        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3Zjk1YWNlMjNmMDdhNTA2
-        ZGQ0MSJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
+        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVkNjkzM2UyN2FjY2U5MDdlNTdh
+        NGRhYiJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
         IGZhbHNlLCAiaHR0cHMiOiB0cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVf
         Q29ycG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwifSwgImlkIjog
         IkZlZG9yYV8xNyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3Rl
         cyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3Jl
         bW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25z
         IjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjEyOjIxWiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjEwWiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBv
         cnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
         bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGws
-        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y5
-        NWFjZTIzZjA3YTUwNmRkNDAifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
+        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzNl
+        MjdhY2NlOTA3ZTU3YTRkYWEifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
         Oi8vbXlyZXBvLmNvbSIsICJiYXNpY19hdXRoX3Bhc3N3b3JkIjogIioqKioq
         IiwgInJlbW92ZV9taXNzaW5nIjogdHJ1ZSwgInByb3h5X2hvc3QiOiAiIiwg
         InNzbF92YWxpZGF0aW9uIjogdHJ1ZSwgImJhc2ljX2F1dGhfdXNlcm5hbWUi
         OiAicm9vdCIsICJkb3dubG9hZF9wb2xpY3kiOiAib25fZGVtYW5kIiwgInR5
         cGVfc2tpcF9saXN0IjogWyJkcnBtIl19LCAiaWQiOiAieXVtX2ltcG9ydGVy
         In1dLCAibG9jYWxseV9zdG9yZWRfdW5pdHMiOiAwLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3Zjk1YWNlMjNmMDdhNTA2ZGQzZiJ9LCAidG90YWxfcmVwb3Np
+        IjogIjVkNjkzM2UyN2FjY2U5MDdlNTdhNGRhOSJ9LCAidG90YWxfcmVwb3Np
         dG9yeV91bml0cyI6IDAsICJpZCI6ICJGZWRvcmFfMTciLCAiX2hyZWYiOiAi
         L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvIn0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:21 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:10 GMT
 - request:
     method: delete
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:21 GMT
+      - Fri, 30 Aug 2019 14:34:10 GMT
       Server:
       - Apache
       Content-Length:
@@ -277,41 +277,41 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2Y0ZjNhYjExLTU4MTMtNGFkNi05ZGM3LTcyNzFiNWI0ZWU1Yy8iLCAi
-        dGFza19pZCI6ICJmNGYzYWIxMS01ODEzLTRhZDYtOWRjNy03MjcxYjViNGVl
-        NWMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2QzYjVjY2ZlLTU2NTUtNDNmYy04NmQ3LWQwZWU5MWQzNGU1NS8iLCAi
+        dGFza19pZCI6ICJkM2I1Y2NmZS01NjU1LTQzZmMtODZkNy1kMGVlOTFkMzRl
+        NTUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:21 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:10 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/f4f3ab11-5813-4ad6-9dc7-7271b5b4ee5c/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/d3b5ccfe-5655-43fc-86d7-d0ee91d34e55/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:21 GMT
+      - Fri, 30 Aug 2019 14:34:10 GMT
       Server:
       - Apache
       Etag:
-      - '"59a87816b062083a78fb3d0e5fea6c38-gzip"'
+      - '"421e9f1ad68607c9d135f07b606874ba-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '689'
+      - '372'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -319,20 +319,21 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNGYzYWIxMS01ODEzLTRhZDYtOWRjNy03MjcxYjViNGVl
-        NWMvIiwgInRhc2tfaWQiOiAiZjRmM2FiMTEtNTgxMy00YWQ2LTlkYzctNzI3
-        MWI1YjRlZTVjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kM2I1Y2NmZS01NjU1LTQzZmMtODZkNy1kMGVlOTFkMzRl
+        NTUvIiwgInRhc2tfaWQiOiAiZDNiNWNjZmUtNTY1NS00M2ZjLTg2ZDctZDBl
+        ZTkxZDM0ZTU1IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE5LTA4LTA1VDE5OjEyOjIxWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjIxWiIsICJ0cmFjZWJh
+        MDE5LTA4LTMwVDE0OjM0OjEwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjEwWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
-        ImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
-        X3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVk
-        NDg3Zjk1YWIzNmNlM2ZlNTFlMDMwMyJ9LCAiaWQiOiAiNWQ0ODdmOTVhYjM2
-        Y2UzZmU1MWUwMzAzIn0=
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        LmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2
+        ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZTIzMmRiNjA3
+        N2E3OTY0NDk5In0sICJpZCI6ICI1ZDY5MzNlMjMyZGI2MDc3YTc5NjQ0OTki
+        fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:21 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:10 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/refresh.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr/refresh.yml
@@ -2,26 +2,26 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/pulp-uuid-rhel_6_x86_64/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:22 GMT
+      - Fri, 30 Aug 2019 14:34:07 GMT
       Server:
       - Apache
       Content-Length:
@@ -43,29 +43,29 @@ http_interactions:
         ZWJhY2siOiBudWxsLCAicmVzb3VyY2VzIjogeyJyZXBvc2l0b3J5IjogInB1
         bHAtdXVpZC1yaGVsXzZfeDg2XzY0In19
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:22 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:07 GMT
 - request:
     method: delete
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:23 GMT
+      - Fri, 30 Aug 2019 14:34:07 GMT
       Server:
       - Apache
       Content-Length:
@@ -85,10 +85,10 @@ http_interactions:
         ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
         bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:23 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:07 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -118,21 +118,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '1030'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 201
       message: CREATED
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:23 GMT
+      - Fri, 30 Aug 2019 14:34:07 GMT
       Server:
       - Apache
       Content-Length:
@@ -149,41 +149,41 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWQ0ODdmOTdhY2UyM2YwN2E2N2UwZTljIn0sICJpZCI6ICJGZWRvcmFfMTci
+        NWQ2OTMzZGY3YWNjZTkwN2UzODFjZWE4In0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:23 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:07 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:23 GMT
+      - Fri, 30 Aug 2019 14:34:07 GMT
       Server:
       - Apache
       Etag:
-      - '"77a28938871d9fffe93d9f27c8609bdb-gzip"'
+      - '"d9cc560f5ab471eaa87859ffcf275a8d-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2287'
+      - '603'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -192,78 +192,78 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
-        MjAxOS0wOC0wNVQxOToxMjoyM1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        MjAxOS0wOC0zMFQxNDozNDowN1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
         L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
         aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
         c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
         cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
         cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWQ0ODdmOTdhY2UyM2YwN2E2N2UwZWEwIn0sICJj
+        aWQiOiB7IiRvaWQiOiAiNWQ2OTMzZGY3YWNjZTkwN2UzODFjZWFjIn0sICJj
         b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
         X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
         IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
         b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDgt
-        MDVUMTk6MTI6MjNaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        MzBUMTQ6MzQ6MDdaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
         b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
         IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
         OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
         dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
         Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVkNDg3Zjk3YWNlMjNmMDdhNjdlMGU5ZiJ9LCAiY29uZmlnIjog
+        b2lkIjogIjVkNjkzM2RmN2FjY2U5MDdlMzgxY2VhYiJ9LCAiY29uZmlnIjog
         eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
         ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9LCB7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjEyOjIzWiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjA3WiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9kaXN0cmlidXRvcnMvRmVkb3JhXzE3LyIsICJsYXN0X292ZXJyaWRlX2Nv
         bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
         X3R5cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6
         IHRydWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmli
-        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3Zjk3YWNlMjNmMDdhNjdl
-        MGU5ZSJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
+        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVkNjkzM2RmN2FjY2U5MDdlMzgx
+        Y2VhYSJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
         IGZhbHNlLCAiaHR0cHMiOiB0cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVf
         Q29ycG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwifSwgImlkIjog
         IkZlZG9yYV8xNyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3Rl
         cyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3Jl
         bW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25z
         IjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjEyOjIzWiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjA3WiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBv
         cnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
         bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGws
-        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y5
-        N2FjZTIzZjA3YTY3ZTBlOWQifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
+        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzNk
+        ZjdhY2NlOTA3ZTM4MWNlYTkifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
         Oi8vbXlyZXBvLmNvbSIsICJzc2xfdmFsaWRhdGlvbiI6IHRydWUsICJyZW1v
         dmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9wb2xpY3kiOiAib25fZGVt
         YW5kIiwgInByb3h5X2hvc3QiOiAiIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIi
         fV0sICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQi
-        OiAiNWQ0ODdmOTdhY2UyM2YwN2E2N2UwZTljIn0sICJ0b3RhbF9yZXBvc2l0
+        OiAiNWQ2OTMzZGY3YWNjZTkwN2UzODFjZWE4In0sICJ0b3RhbF9yZXBvc2l0
         b3J5X3VuaXRzIjogMCwgImlkIjogIkZlZG9yYV8xNyIsICJfaHJlZiI6ICIv
         cHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8ifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:23 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:07 GMT
 - request:
     method: delete
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17//distributors/Fedora_17/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17//distributors/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:23 GMT
+      - Fri, 30 Aug 2019 14:34:07 GMT
       Server:
       - Apache
       Content-Length:
@@ -274,41 +274,41 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2NkZDQwNzcwLTUyNDYtNDFmMi04Y2UwLTdhMGI5Y2U2N2Q1Zi8iLCAi
-        dGFza19pZCI6ICJjZGQ0MDc3MC01MjQ2LTQxZjItOGNlMC03YTBiOWNlNjdk
-        NWYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzRiMWEwZTk2LTYxZjktNGZmNC1hNzAyLTM1YWJhNjYzODAxNy8iLCAi
+        dGFza19pZCI6ICI0YjFhMGU5Ni02MWY5LTRmZjQtYTcwMi0zNWFiYTY2Mzgw
+        MTcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:23 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:08 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/cdd40770-5246-41f2-8ce0-7a0b9ce67d5f/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/4b1a0e96-61f9-4ff4-a702-35aba6638017/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:24 GMT
+      - Fri, 30 Aug 2019 14:34:08 GMT
       Server:
       - Apache
       Etag:
-      - '"db4be909fac4d864cfd2344a9be1e566-gzip"'
+      - '"47ffd47d9d24489cb0cb748c3a8fd0fb-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '754'
+      - '395'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -316,53 +316,54 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGlzdHJpYnV0b3JfZGVsZXRlIiwgIl9ocmVm
-        IjogIi9wdWxwL2FwaS92Mi90YXNrcy9jZGQ0MDc3MC01MjQ2LTQxZjItOGNl
-        MC03YTBiOWNlNjdkNWYvIiwgInRhc2tfaWQiOiAiY2RkNDA3NzAtNTI0Ni00
-        MWYyLThjZTAtN2EwYjljZTY3ZDVmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
+        IjogIi9wdWxwL2FwaS92Mi90YXNrcy80YjFhMGU5Ni02MWY5LTRmZjQtYTcw
+        Mi0zNWFiYTY2MzgwMTcvIiwgInRhc2tfaWQiOiAiNGIxYTBlOTYtNjFmOS00
+        ZmY0LWE3MDItMzVhYmE2NjM4MDE3IiwgInRhZ3MiOiBbInB1bHA6cmVwb3Np
         dG9yeTpGZWRvcmFfMTciLCAicHVscDpyZXBvc2l0b3J5X2Rpc3RyaWJ1dG9y
         OkZlZG9yYV8xNyIsICJwdWxwOmFjdGlvbjpyZW1vdmVfZGlzdHJpYnV0b3Ii
-        XSwgImZpbmlzaF90aW1lIjogIjIwMTktMDgtMDVUMTk6MTI6MjNaIiwgIl9u
-        cyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTktMDgtMDVU
-        MTk6MTI6MjNaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
+        XSwgImZpbmlzaF90aW1lIjogIjIwMTktMDgtMzBUMTQ6MzQ6MDhaIiwgIl9u
+        cyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTktMDgtMzBU
+        MTQ6MzQ6MDhaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVkX3Rhc2tz
         IjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7fSwgInF1ZXVlIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUi
-        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwubG9jYWxob3N0
-        LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJlcnJvciI6IG51bGws
-        ICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmOTdhYjM2Y2UzZmU1MWUwMzgzIn0s
-        ICJpZCI6ICI1ZDQ4N2Y5N2FiMzZjZTNmZTUxZTAzODMifQ==
+        dmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0y
+        LmNhbm5vbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVk
+        IiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0y
+        QGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20i
+        LCAicmVzdWx0IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1ZDY5MzNkZjMyZGI2MDc3YTc5NjQzNDgifSwgImlkIjogIjVkNjkz
+        M2RmMzJkYjYwNzdhNzk2NDM0OCJ9
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:24 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:08 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:24 GMT
+      - Fri, 30 Aug 2019 14:34:08 GMT
       Server:
       - Apache
       Etag:
-      - '"7bbd8ea5f9fc1f5fe33b959436f1a556-gzip"'
+      - '"a8309018bb63eb7fa513a6c3ec7eb130-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1804'
+      - '568'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -371,76 +372,76 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
-        MjAxOS0wOC0wNVQxOToxMjoyM1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        MjAxOS0wOC0zMFQxNDozNDowN1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
         L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
         aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
         c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
         cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
         cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWQ0ODdmOTdhY2UyM2YwN2E2N2UwZWEwIn0sICJj
+        aWQiOiB7IiRvaWQiOiAiNWQ2OTMzZGY3YWNjZTkwN2UzODFjZWFjIn0sICJj
         b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
         X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
         IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
         b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDgt
-        MDVUMTk6MTI6MjNaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        MzBUMTQ6MzQ6MDdaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
         b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
         IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
         OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
         dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
         Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVkNDg3Zjk3YWNlMjNmMDdhNjdlMGU5ZiJ9LCAiY29uZmlnIjog
+        b2lkIjogIjVkNjkzM2RmN2FjY2U5MDdlMzgxY2VhYiJ9LCAiY29uZmlnIjog
         eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
         ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6
         IG51bGwsICJub3RlcyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAi
         bGFzdF91bml0X3JlbW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50
         cyI6IHt9LCAiX25zIjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9f
-        aWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTA1
-        VDE5OjEyOjIzWiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
+        aWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTMw
+        VDE0OjM0OjA3WiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
         aWVzL0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMi
         OiAicmVwb19pbXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
         aW1wb3J0ZXIiLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rf
         c3luYyI6IG51bGwsICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1ZDQ4N2Y5N2FjZTIzZjA3YTY3ZTBlOWQifSwgImNvbmZpZyI6IHsi
+        ZCI6ICI1ZDY5MzNkZjdhY2NlOTA3ZTM4MWNlYTkifSwgImNvbmZpZyI6IHsi
         ZmVlZCI6ICJodHRwOi8vbXlyZXBvLmNvbSIsICJzc2xfdmFsaWRhdGlvbiI6
         IHRydWUsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9wb2xp
         Y3kiOiAib25fZGVtYW5kIiwgInByb3h5X2hvc3QiOiAiIn0sICJpZCI6ICJ5
         dW1faW1wb3J0ZXIifV0sICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDAsICJf
-        aWQiOiB7IiRvaWQiOiAiNWQ0ODdmOTdhY2UyM2YwN2E2N2UwZTljIn0sICJ0
+        aWQiOiB7IiRvaWQiOiAiNWQ2OTMzZGY3YWNjZTkwN2UzODFjZWE4In0sICJ0
         b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMCwgImlkIjogIkZlZG9yYV8xNyIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny8ifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:24 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:08 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:24 GMT
+      - Fri, 30 Aug 2019 14:34:08 GMT
       Server:
       - Apache
       Etag:
-      - '"7bbd8ea5f9fc1f5fe33b959436f1a556-gzip"'
+      - '"a8309018bb63eb7fa513a6c3ec7eb130-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1804'
+      - '568'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -449,49 +450,49 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
-        MjAxOS0wOC0wNVQxOToxMjoyM1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        MjAxOS0wOC0zMFQxNDozNDowN1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
         L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
         aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
         c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
         cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
         cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWQ0ODdmOTdhY2UyM2YwN2E2N2UwZWEwIn0sICJj
+        aWQiOiB7IiRvaWQiOiAiNWQ2OTMzZGY3YWNjZTkwN2UzODFjZWFjIn0sICJj
         b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
         X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
         IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
         b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDgt
-        MDVUMTk6MTI6MjNaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        MzBUMTQ6MzQ6MDdaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
         b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
         IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
         OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
         dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
         Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVkNDg3Zjk3YWNlMjNmMDdhNjdlMGU5ZiJ9LCAiY29uZmlnIjog
+        b2lkIjogIjVkNjkzM2RmN2FjY2U5MDdlMzgxY2VhYiJ9LCAiY29uZmlnIjog
         eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
         ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6
         IG51bGwsICJub3RlcyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAi
         bGFzdF91bml0X3JlbW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50
         cyI6IHt9LCAiX25zIjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9f
-        aWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTA1
-        VDE5OjEyOjIzWiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
+        aWQiOiAiRmVkb3JhXzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTMw
+        VDE0OjM0OjA3WiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
         aWVzL0ZlZG9yYV8xNy9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMi
         OiAicmVwb19pbXBvcnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1f
         aW1wb3J0ZXIiLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rf
         c3luYyI6IG51bGwsICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1ZDQ4N2Y5N2FjZTIzZjA3YTY3ZTBlOWQifSwgImNvbmZpZyI6IHsi
+        ZCI6ICI1ZDY5MzNkZjdhY2NlOTA3ZTM4MWNlYTkifSwgImNvbmZpZyI6IHsi
         ZmVlZCI6ICJodHRwOi8vbXlyZXBvLmNvbSIsICJzc2xfdmFsaWRhdGlvbiI6
         IHRydWUsICJyZW1vdmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9wb2xp
         Y3kiOiAib25fZGVtYW5kIiwgInByb3h5X2hvc3QiOiAiIn0sICJpZCI6ICJ5
         dW1faW1wb3J0ZXIifV0sICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDAsICJf
-        aWQiOiB7IiRvaWQiOiAiNWQ0ODdmOTdhY2UyM2YwN2E2N2UwZTljIn0sICJ0
+        aWQiOiB7IiRvaWQiOiAiNWQ2OTMzZGY3YWNjZTkwN2UzODFjZWE4In0sICJ0
         b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMCwgImlkIjogIkZlZG9yYV8xNyIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny8ifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:24 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:08 GMT
 - request:
     method: put
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer//
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer//
     body:
       encoding: UTF-8
       base64_string: |
@@ -500,21 +501,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '85'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:24 GMT
+      - Fri, 30 Aug 2019 14:34:08 GMT
       Server:
       - Apache
       Content-Length:
@@ -525,14 +526,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2QxOWEyYzE1LTYyZjUtNDhiYi05NjUzLTE4Y2ZlNTg4YmUzNC8iLCAi
-        dGFza19pZCI6ICJkMTlhMmMxNS02MmY1LTQ4YmItOTY1My0xOGNmZTU4OGJl
-        MzQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzgyM2RkNDY4LTE5ODYtNDIzNi1hNWM5LWZkMjAxM2JiMTExYS8iLCAi
+        dGFza19pZCI6ICI4MjNkZDQ2OC0xOTg2LTQyMzYtYTVjOS1mZDIwMTNiYjEx
+        MWEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:24 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:08 GMT
 - request:
     method: put
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer//
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/importers/yum_importer//
     body:
       encoding: UTF-8
       base64_string: |
@@ -546,21 +547,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '278'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:24 GMT
+      - Fri, 30 Aug 2019 14:34:08 GMT
       Server:
       - Apache
       Content-Length:
@@ -571,14 +572,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzE3NzkwNzUwLWI5ZTctNDcyYy1hNDZmLWRmYWMyMjI4MjNhMy8iLCAi
-        dGFza19pZCI6ICIxNzc5MDc1MC1iOWU3LTQ3MmMtYTQ2Zi1kZmFjMjIyODIz
-        YTMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzljNDc4ZTA3LWFjZGMtNGUxOS05Yzc1LWE5MWE4NGRlMDgzOS8iLCAi
+        dGFza19pZCI6ICI5YzQ3OGUwNy1hY2RjLTRlMTktOWM3NS1hOTFhODRkZTA4
+        MzkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:24 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:08 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/distributors/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/distributors/
     body:
       encoding: UTF-8
       base64_string: |
@@ -591,21 +592,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '235'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 201
       message: CREATED
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:24 GMT
+      - Fri, 30 Aug 2019 14:34:08 GMT
       Server:
       - Apache
       Content-Length:
@@ -618,21 +619,21 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAiMjAx
-        OS0wOC0wNVQxOToxMjoyNFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Jl
+        OS0wOC0zMFQxNDozNDowOFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Jl
         cG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL0ZlZG9yYV8xNy8i
         LCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlzaCI6
         IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9kaXN0cmlidXRv
         ciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAi
         X25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1
-        ZDQ4N2Y5OGFjZTIzZjA3YTdmNzQwNGYifSwgImNvbmZpZyI6IHsicHJvdGVj
+        ZDY5MzNlMDdhY2NlOTA3ZTU3YTRkYTgifSwgImNvbmZpZyI6IHsicHJvdGVj
         dGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJB
         Q01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0
         dHBzIjogdHJ1ZX0sICJpZCI6ICJGZWRvcmFfMTcifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:24 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:08 GMT
 - request:
     method: put
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/distributors/Fedora_17_clone//
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/distributors/Fedora_17_clone//
     body:
       encoding: UTF-8
       base64_string: |
@@ -641,21 +642,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '65'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:24 GMT
+      - Fri, 30 Aug 2019 14:34:08 GMT
       Server:
       - Apache
       Content-Length:
@@ -666,14 +667,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzY1MDYxNGNiLTY5YTgtNDYxZS04Y2ViLTkyYmZjNWJmYWJhYy8iLCAi
-        dGFza19pZCI6ICI2NTA2MTRjYi02OWE4LTQ2MWUtOGNlYi05MmJmYzViZmFi
-        YWMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2M1OGExYTQ0LTVkYjYtNGVjZi1iNWE5LTllNWU1ZWJlNmZhMC8iLCAi
+        dGFza19pZCI6ICJjNThhMWE0NC01ZGI2LTRlY2YtYjVhOS05ZTVlNWViZTZm
+        YTAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:24 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:08 GMT
 - request:
     method: put
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/distributors/export_distributor//
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/distributors/export_distributor//
     body:
       encoding: UTF-8
       base64_string: |
@@ -683,21 +684,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '109'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:24 GMT
+      - Fri, 30 Aug 2019 14:34:08 GMT
       Server:
       - Apache
       Content-Length:
@@ -708,41 +709,41 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2ZhYzk3MTRhLWZkMDctNDQwNy1hMTgxLWQ0Y2Q1NjgzMTUzNy8iLCAi
-        dGFza19pZCI6ICJmYWM5NzE0YS1mZDA3LTQ0MDctYTE4MS1kNGNkNTY4MzE1
-        MzcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzY1MTExMzRmLTg3MWItNDcyYS1hOThhLTk4YjBhNzc5MDExZi8iLCAi
+        dGFza19pZCI6ICI2NTExMTM0Zi04NzFiLTQ3MmEtYTk4YS05OGIwYTc3OTAx
+        MWYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:24 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:08 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:24 GMT
+      - Fri, 30 Aug 2019 14:34:08 GMT
       Server:
       - Apache
       Etag:
-      - '"acf31ebcc142b67ebf166dbeca485b72-gzip"'
+      - '"85d0221ee3db6faae3f89a3cb10b3a2c-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2287'
+      - '619'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -751,78 +752,78 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQiOiAi
-        MjAxOS0wOC0wNVQxOToxMjoyM1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
+        MjAxOS0wOC0zMFQxNDozNDowN1oiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3Yy
         L3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL2V4cG9ydF9k
         aXN0cmlidXRvci8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxh
         c3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogImV4
         cG9ydF9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNj
         cmF0Y2hwYWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJf
-        aWQiOiB7IiRvaWQiOiAiNWQ0ODdmOTdhY2UyM2YwN2E2N2UwZWEwIn0sICJj
+        aWQiOiB7IiRvaWQiOiAiNWQ2OTMzZGY3YWNjZTkwN2UzODFjZWFjIn0sICJj
         b25maWciOiB7Imh0dHAiOiBmYWxzZSwgInJlbGF0aXZlX3VybCI6ICJBQ01F
         X0NvcnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIiwgImh0dHBz
         IjogZmFsc2V9LCAiaWQiOiAiZXhwb3J0X2Rpc3RyaWJ1dG9yIn0sIHsicmVw
         b19pZCI6ICJGZWRvcmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDgt
-        MDVUMTk6MTI6MjRaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
+        MzBUMTQ6MzQ6MDdaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0
         b3JpZXMvRmVkb3JhXzE3L2Rpc3RyaWJ1dG9ycy9GZWRvcmFfMTdfY2xvbmUv
         IiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2gi
         OiBudWxsLCAiZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fY2xvbmVfZGlz
         dHJpYnV0b3IiLCAiYXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFk
         Ijoge30sICJfbnMiOiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIk
-        b2lkIjogIjVkNDg3Zjk3YWNlMjNmMDdhNjdlMGU5ZiJ9LCAiY29uZmlnIjog
+        b2lkIjogIjVkNjkzM2RmN2FjY2U5MDdlMzgxY2VhYiJ9LCAiY29uZmlnIjog
         eyJkZXN0aW5hdGlvbl9kaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTcifSwg
         ImlkIjogIkZlZG9yYV8xN19jbG9uZSJ9LCB7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjEyOjI0WiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjA4WiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9kaXN0cmlidXRvcnMvRmVkb3JhXzE3LyIsICJsYXN0X292ZXJyaWRlX2Nv
         bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
         X3R5cGVfaWQiOiAieXVtX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6
         IHRydWUsICJzY3JhdGNocGFkIjoge30sICJfbnMiOiAicmVwb19kaXN0cmli
-        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3Zjk4YWNlMjNmMDdhN2Y3
-        NDA0ZiJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
+        dXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVkNjkzM2UwN2FjY2U5MDdlNTdh
+        NGRhOCJ9LCAiY29uZmlnIjogeyJwcm90ZWN0ZWQiOiB0cnVlLCAiaHR0cCI6
         IGZhbHNlLCAiaHR0cHMiOiB0cnVlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVf
         Q29ycG9yYXRpb24vbGlicmFyeS9mZWRvcmFfMTdfbGFiZWwifSwgImlkIjog
         IkZlZG9yYV8xNyJ9XSwgImxhc3RfdW5pdF9hZGRlZCI6IG51bGwsICJub3Rl
         cyI6IHsiX3JlcG8tdHlwZSI6ICJycG0tcmVwbyJ9LCAibGFzdF91bml0X3Jl
         bW92ZWQiOiBudWxsLCAiY29udGVudF91bml0X2NvdW50cyI6IHt9LCAiX25z
         IjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJlcG9faWQiOiAiRmVkb3Jh
-        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjEyOjI0WiIs
+        XzE3IiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjA4WiIs
         ICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8x
         Ny9pbXBvcnRlcnMveXVtX2ltcG9ydGVyLyIsICJfbnMiOiAicmVwb19pbXBv
         cnRlcnMiLCAiaW1wb3J0ZXJfdHlwZV9pZCI6ICJ5dW1faW1wb3J0ZXIiLCAi
         bGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3Rfc3luYyI6IG51bGws
-        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y5
-        N2FjZTIzZjA3YTY3ZTBlOWQifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
+        ICJzY3JhdGNocGFkIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzNk
+        ZjdhY2NlOTA3ZTM4MWNlYTkifSwgImNvbmZpZyI6IHsiZmVlZCI6ICJodHRw
         Oi8vbXlyZXBvLmNvbSIsICJzc2xfdmFsaWRhdGlvbiI6IHRydWUsICJyZW1v
         dmVfbWlzc2luZyI6IHRydWUsICJkb3dubG9hZF9wb2xpY3kiOiAib25fZGVt
         YW5kIiwgInByb3h5X2hvc3QiOiAiIn0sICJpZCI6ICJ5dW1faW1wb3J0ZXIi
         fV0sICJsb2NhbGx5X3N0b3JlZF91bml0cyI6IDAsICJfaWQiOiB7IiRvaWQi
-        OiAiNWQ0ODdmOTdhY2UyM2YwN2E2N2UwZTljIn0sICJ0b3RhbF9yZXBvc2l0
+        OiAiNWQ2OTMzZGY3YWNjZTkwN2UzODFjZWE4In0sICJ0b3RhbF9yZXBvc2l0
         b3J5X3VuaXRzIjogMCwgImlkIjogIkZlZG9yYV8xNyIsICJfaHJlZiI6ICIv
         cHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy8ifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:24 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:08 GMT
 - request:
     method: delete
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:25 GMT
+      - Fri, 30 Aug 2019 14:34:08 GMT
       Server:
       - Apache
       Content-Length:
@@ -833,41 +834,41 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2UzMWIyOTBlLWY1OTAtNDk5MC05MzE5LTAwNDg3Y2M3NTBjYi8iLCAi
-        dGFza19pZCI6ICJlMzFiMjkwZS1mNTkwLTQ5OTAtOTMxOS0wMDQ4N2NjNzUw
-        Y2IifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzQ3NTVjYmVmLTU0ZjEtNDZkOS05ODRiLWMzNjUzZGI5NjNlMy8iLCAi
+        dGFza19pZCI6ICI0NzU1Y2JlZi01NGYxLTQ2ZDktOTg0Yi1jMzY1M2RiOTYz
+        ZTMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:25 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:08 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/e31b290e-f590-4990-9319-00487cc750cb/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/4755cbef-54f1-46d9-984b-c3653db963e3/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:25 GMT
+      - Fri, 30 Aug 2019 14:34:09 GMT
       Server:
       - Apache
       Etag:
-      - '"0985aafcaa4ef04d76dcb7407b8601b3-gzip"'
+      - '"43f20f57cfdde6862313694f07d93323-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '689'
+      - '376'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -875,20 +876,21 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9lMzFiMjkwZS1mNTkwLTQ5OTAtOTMxOS0wMDQ4N2NjNzUw
-        Y2IvIiwgInRhc2tfaWQiOiAiZTMxYjI5MGUtZjU5MC00OTkwLTkzMTktMDA0
-        ODdjYzc1MGNiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy80NzU1Y2JlZi01NGYxLTQ2ZDktOTg0Yi1jMzY1M2RiOTYz
+        ZTMvIiwgInRhc2tfaWQiOiAiNDc1NWNiZWYtNTRmMS00NmQ5LTk4NGItYzM2
+        NTNkYjk2M2UzIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE5LTA4LTA1VDE5OjEyOjI1WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjI1WiIsICJ0cmFjZWJh
+        MDE5LTA4LTMwVDE0OjM0OjA5WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjA4WiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
-        ImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
-        X3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVk
-        NDg3Zjk5YWIzNmNlM2ZlNTFlMDQ2YiJ9LCAiaWQiOiAiNWQ0ODdmOTlhYjM2
-        Y2UzZmU1MWUwNDZiIn0=
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        LmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2
+        ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZTAzMmRiNjA3
+        N2E3OTY0NDFmIn0sICJpZCI6ICI1ZDY5MzNlMDMyZGI2MDc3YTc5NjQ0MWYi
+        fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:25 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:09 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/copy_no_filters.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/copy_no_filters.yml
@@ -2,26 +2,26 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:46 GMT
+      - Fri, 30 Aug 2019 14:34:26 GMT
       Server:
       - Apache
       Content-Length:
@@ -41,10 +41,10 @@ http_interactions:
         ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
         bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:46 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:26 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -75,21 +75,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '1043'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 201
       message: CREATED
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:46 GMT
+      - Fri, 30 Aug 2019 14:34:26 GMT
       Server:
       - Apache
       Content-Length:
@@ -106,14 +106,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWQ0ODdmNzJhY2UyM2YwN2E2N2UwZTc3In0sICJpZCI6ICJGZWRvcmFfMTci
+        NWQ2OTMzZjI3YWNjZTkwN2U0ZDdmMmEyIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:46 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:26 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -122,21 +122,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '53'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:46 GMT
+      - Fri, 30 Aug 2019 14:34:27 GMT
       Server:
       - Apache
       Content-Length:
@@ -147,41 +147,41 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2E1MDdiNjhmLTlhYzctNDQ3Zi04MTUyLWY0Y2Q3NmJlNTYzZS8iLCAi
-        dGFza19pZCI6ICJhNTA3YjY4Zi05YWM3LTQ0N2YtODE1Mi1mNGNkNzZiZTU2
-        M2UifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzNjNzc0NTAyLWE2ZDYtNDdkOS04NTIzLWJmMzM0ZGIwMjMxYS8iLCAi
+        dGFza19pZCI6ICIzYzc3NDUwMi1hNmQ2LTQ3ZDktODUyMy1iZjMzNGRiMDIz
+        MWEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:46 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:27 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/a507b68f-9ac7-447f-8152-f4cd76be563e/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/3c774502-a6d6-47d9-8523-bf334db0231a/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:47 GMT
+      - Fri, 30 Aug 2019 14:34:28 GMT
       Server:
       - Apache
       Etag:
-      - '"d7981af4a89bfa6ef33c455b5235cff9-gzip"'
+      - '"4e5cf3622d73fe41b3a6cf5891f7d795-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
+      - '726'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -189,16 +189,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hNTA3YjY4Zi05YWM3LTQ0N2YtODE1Mi1mNGNkNzZiZTU2
-        M2UvIiwgInRhc2tfaWQiOiAiYTUwN2I2OGYtOWFjNy00NDdmLTgxNTItZjRj
-        ZDc2YmU1NjNlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zYzc3NDUwMi1hNmQ2LTQ3ZDktODUyMy1iZjMzNGRiMDIz
+        MWEvIiwgInRhc2tfaWQiOiAiM2M3NzQ1MDItYTZkNi00N2Q5LTg1MjMtYmYz
+        MzRkYjAyMzFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo0N1oiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDoyOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDoyN1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMGI1YzZiYmUtM2VkZi00MGYwLWEwZjctMGFmOGQxMTA1
-        ZjIwLyIsICJ0YXNrX2lkIjogIjBiNWM2YmJlLTNlZGYtNDBmMC1hMGY3LTBh
-        ZjhkMTEwNWYyMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvMTE1MGUwMmUtODdmZC00ZWJlLTkyZDEtMTY5MmVmOTRi
+        YzhkLyIsICJ0YXNrX2lkIjogIjExNTBlMDJlLTg3ZmQtNGViZS05MmQxLTE2
+        OTJlZjk0YmM4ZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -210,69 +210,70 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo0N1oiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjExOjQ3WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y3M2FjZTIzZjBhMTQ5NDQ1MzAiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjcyYWIzNmNlM2ZlNTFkZTU0NyJ9LCAiaWQiOiAiNWQ0ODdm
-        NzJhYjM2Y2UzZmU1MWRlNTQ3In0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        Mi5jYW5ub2xvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjI3WiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6Mjha
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
+        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3ZlZF9jb3VudCI6
+        IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVkNjkzM2Y0N2FjY2U5
+        MGI2MzlmYzZjNyIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJp
+        dGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90
+        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
+        X2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZjMz
+        MmRiNjA3N2E3OTY1MmQxIn0sICJpZCI6ICI1ZDY5MzNmMzMyZGI2MDc3YTc5
+        NjUyZDEifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:47 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:28 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/a507b68f-9ac7-447f-8152-f4cd76be563e/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/3c774502-a6d6-47d9-8523-bf334db0231a/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:47 GMT
+      - Fri, 30 Aug 2019 14:34:28 GMT
       Server:
       - Apache
       Etag:
-      - '"d7981af4a89bfa6ef33c455b5235cff9-gzip"'
+      - '"4e5cf3622d73fe41b3a6cf5891f7d795-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
+      - '726'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -280,16 +281,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hNTA3YjY4Zi05YWM3LTQ0N2YtODE1Mi1mNGNkNzZiZTU2
-        M2UvIiwgInRhc2tfaWQiOiAiYTUwN2I2OGYtOWFjNy00NDdmLTgxNTItZjRj
-        ZDc2YmU1NjNlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zYzc3NDUwMi1hNmQ2LTQ3ZDktODUyMy1iZjMzNGRiMDIz
+        MWEvIiwgInRhc2tfaWQiOiAiM2M3NzQ1MDItYTZkNi00N2Q5LTg1MjMtYmYz
+        MzRkYjAyMzFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo0N1oiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDoyOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDoyN1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMGI1YzZiYmUtM2VkZi00MGYwLWEwZjctMGFmOGQxMTA1
-        ZjIwLyIsICJ0YXNrX2lkIjogIjBiNWM2YmJlLTNlZGYtNDBmMC1hMGY3LTBh
-        ZjhkMTEwNWYyMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvMTE1MGUwMmUtODdmZC00ZWJlLTkyZDEtMTY5MmVmOTRi
+        YzhkLyIsICJ0YXNrX2lkIjogIjExNTBlMDJlLTg3ZmQtNGViZS05MmQxLTE2
+        OTJlZjk0YmM4ZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -301,69 +302,70 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo0N1oiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjExOjQ3WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y3M2FjZTIzZjBhMTQ5NDQ1MzAiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjcyYWIzNmNlM2ZlNTFkZTU0NyJ9LCAiaWQiOiAiNWQ0ODdm
-        NzJhYjM2Y2UzZmU1MWRlNTQ3In0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        Mi5jYW5ub2xvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjI3WiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6Mjha
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
+        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3ZlZF9jb3VudCI6
+        IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVkNjkzM2Y0N2FjY2U5
+        MGI2MzlmYzZjNyIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJp
+        dGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90
+        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
+        X2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZjMz
+        MmRiNjA3N2E3OTY1MmQxIn0sICJpZCI6ICI1ZDY5MzNmMzMyZGI2MDc3YTc5
+        NjUyZDEifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:47 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:28 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/a507b68f-9ac7-447f-8152-f4cd76be563e/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/3c774502-a6d6-47d9-8523-bf334db0231a/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:47 GMT
+      - Fri, 30 Aug 2019 14:34:28 GMT
       Server:
       - Apache
       Etag:
-      - '"d7981af4a89bfa6ef33c455b5235cff9-gzip"'
+      - '"4e5cf3622d73fe41b3a6cf5891f7d795-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
+      - '726'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -371,16 +373,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hNTA3YjY4Zi05YWM3LTQ0N2YtODE1Mi1mNGNkNzZiZTU2
-        M2UvIiwgInRhc2tfaWQiOiAiYTUwN2I2OGYtOWFjNy00NDdmLTgxNTItZjRj
-        ZDc2YmU1NjNlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zYzc3NDUwMi1hNmQ2LTQ3ZDktODUyMy1iZjMzNGRiMDIz
+        MWEvIiwgInRhc2tfaWQiOiAiM2M3NzQ1MDItYTZkNi00N2Q5LTg1MjMtYmYz
+        MzRkYjAyMzFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo0N1oiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDoyOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDoyN1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMGI1YzZiYmUtM2VkZi00MGYwLWEwZjctMGFmOGQxMTA1
-        ZjIwLyIsICJ0YXNrX2lkIjogIjBiNWM2YmJlLTNlZGYtNDBmMC1hMGY3LTBh
-        ZjhkMTEwNWYyMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvMTE1MGUwMmUtODdmZC00ZWJlLTkyZDEtMTY5MmVmOTRi
+        YzhkLyIsICJ0YXNrX2lkIjogIjExNTBlMDJlLTg3ZmQtNGViZS05MmQxLTE2
+        OTJlZjk0YmM4ZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -392,69 +394,70 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo0N1oiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjExOjQ3WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y3M2FjZTIzZjBhMTQ5NDQ1MzAiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjcyYWIzNmNlM2ZlNTFkZTU0NyJ9LCAiaWQiOiAiNWQ0ODdm
-        NzJhYjM2Y2UzZmU1MWRlNTQ3In0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        Mi5jYW5ub2xvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjI3WiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6Mjha
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
+        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3ZlZF9jb3VudCI6
+        IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVkNjkzM2Y0N2FjY2U5
+        MGI2MzlmYzZjNyIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJp
+        dGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90
+        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
+        X2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZjMz
+        MmRiNjA3N2E3OTY1MmQxIn0sICJpZCI6ICI1ZDY5MzNmMzMyZGI2MDc3YTc5
+        NjUyZDEifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:47 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:28 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/a507b68f-9ac7-447f-8152-f4cd76be563e/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/3c774502-a6d6-47d9-8523-bf334db0231a/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:47 GMT
+      - Fri, 30 Aug 2019 14:34:28 GMT
       Server:
       - Apache
       Etag:
-      - '"d7981af4a89bfa6ef33c455b5235cff9-gzip"'
+      - '"4e5cf3622d73fe41b3a6cf5891f7d795-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
+      - '726'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -462,16 +465,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hNTA3YjY4Zi05YWM3LTQ0N2YtODE1Mi1mNGNkNzZiZTU2
-        M2UvIiwgInRhc2tfaWQiOiAiYTUwN2I2OGYtOWFjNy00NDdmLTgxNTItZjRj
-        ZDc2YmU1NjNlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zYzc3NDUwMi1hNmQ2LTQ3ZDktODUyMy1iZjMzNGRiMDIz
+        MWEvIiwgInRhc2tfaWQiOiAiM2M3NzQ1MDItYTZkNi00N2Q5LTg1MjMtYmYz
+        MzRkYjAyMzFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo0N1oiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDoyOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDoyN1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMGI1YzZiYmUtM2VkZi00MGYwLWEwZjctMGFmOGQxMTA1
-        ZjIwLyIsICJ0YXNrX2lkIjogIjBiNWM2YmJlLTNlZGYtNDBmMC1hMGY3LTBh
-        ZjhkMTEwNWYyMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvMTE1MGUwMmUtODdmZC00ZWJlLTkyZDEtMTY5MmVmOTRi
+        YzhkLyIsICJ0YXNrX2lkIjogIjExNTBlMDJlLTg3ZmQtNGViZS05MmQxLTE2
+        OTJlZjk0YmM4ZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -483,69 +486,70 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo0N1oiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjExOjQ3WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y3M2FjZTIzZjBhMTQ5NDQ1MzAiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjcyYWIzNmNlM2ZlNTFkZTU0NyJ9LCAiaWQiOiAiNWQ0ODdm
-        NzJhYjM2Y2UzZmU1MWRlNTQ3In0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        Mi5jYW5ub2xvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjI3WiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6Mjha
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
+        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3ZlZF9jb3VudCI6
+        IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVkNjkzM2Y0N2FjY2U5
+        MGI2MzlmYzZjNyIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJp
+        dGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90
+        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
+        X2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZjMz
+        MmRiNjA3N2E3OTY1MmQxIn0sICJpZCI6ICI1ZDY5MzNmMzMyZGI2MDc3YTc5
+        NjUyZDEifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:47 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:28 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/a507b68f-9ac7-447f-8152-f4cd76be563e/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/3c774502-a6d6-47d9-8523-bf334db0231a/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:47 GMT
+      - Fri, 30 Aug 2019 14:34:28 GMT
       Server:
       - Apache
       Etag:
-      - '"d7981af4a89bfa6ef33c455b5235cff9-gzip"'
+      - '"4e5cf3622d73fe41b3a6cf5891f7d795-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
+      - '726'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -553,16 +557,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hNTA3YjY4Zi05YWM3LTQ0N2YtODE1Mi1mNGNkNzZiZTU2
-        M2UvIiwgInRhc2tfaWQiOiAiYTUwN2I2OGYtOWFjNy00NDdmLTgxNTItZjRj
-        ZDc2YmU1NjNlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy8zYzc3NDUwMi1hNmQ2LTQ3ZDktODUyMy1iZjMzNGRiMDIz
+        MWEvIiwgInRhc2tfaWQiOiAiM2M3NzQ1MDItYTZkNi00N2Q5LTg1MjMtYmYz
+        MzRkYjAyMzFhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo0N1oiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDoyOFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDoyN1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMGI1YzZiYmUtM2VkZi00MGYwLWEwZjctMGFmOGQxMTA1
-        ZjIwLyIsICJ0YXNrX2lkIjogIjBiNWM2YmJlLTNlZGYtNDBmMC1hMGY3LTBh
-        ZjhkMTEwNWYyMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvMTE1MGUwMmUtODdmZC00ZWJlLTkyZDEtMTY5MmVmOTRi
+        YzhkLyIsICJ0YXNrX2lkIjogIjExNTBlMDJlLTg3ZmQtNGViZS05MmQxLTE2
+        OTJlZjk0YmM4ZCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -574,433 +578,70 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo0N1oiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjExOjQ3WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y3M2FjZTIzZjBhMTQ5NDQ1MzAiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjcyYWIzNmNlM2ZlNTFkZTU0NyJ9LCAiaWQiOiAiNWQ0ODdm
-        NzJhYjM2Y2UzZmU1MWRlNTQ3In0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        Mi5jYW5ub2xvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjI3WiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6Mjha
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
+        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3ZlZF9jb3VudCI6
+        IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVkNjkzM2Y0N2FjY2U5
+        MGI2MzlmYzZjNyIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJp
+        dGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90
+        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
+        X2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZjMz
+        MmRiNjA3N2E3OTY1MmQxIn0sICJpZCI6ICI1ZDY5MzNmMzMyZGI2MDc3YTc5
+        NjUyZDEifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:47 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:28 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/a507b68f-9ac7-447f-8152-f4cd76be563e/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/1150e02e-87fd-4ebe-92d1-1692ef94bc8d/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:47 GMT
+      - Fri, 30 Aug 2019 14:34:28 GMT
       Server:
       - Apache
       Etag:
-      - '"d7981af4a89bfa6ef33c455b5235cff9-gzip"'
+      - '"c220a990ff359e3cdd251ecdcf1c83e7-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hNTA3YjY4Zi05YWM3LTQ0N2YtODE1Mi1mNGNkNzZiZTU2
-        M2UvIiwgInRhc2tfaWQiOiAiYTUwN2I2OGYtOWFjNy00NDdmLTgxNTItZjRj
-        ZDc2YmU1NjNlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo0N1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMGI1YzZiYmUtM2VkZi00MGYwLWEwZjctMGFmOGQxMTA1
-        ZjIwLyIsICJ0YXNrX2lkIjogIjBiNWM2YmJlLTNlZGYtNDBmMC1hMGY3LTBh
-        ZjhkMTEwNWYyMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo0N1oiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjExOjQ3WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y3M2FjZTIzZjBhMTQ5NDQ1MzAiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjcyYWIzNmNlM2ZlNTFkZTU0NyJ9LCAiaWQiOiAiNWQ0ODdm
-        NzJhYjM2Y2UzZmU1MWRlNTQ3In0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:47 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/a507b68f-9ac7-447f-8152-f4cd76be563e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:11:47 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"d7981af4a89bfa6ef33c455b5235cff9-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2405'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hNTA3YjY4Zi05YWM3LTQ0N2YtODE1Mi1mNGNkNzZiZTU2
-        M2UvIiwgInRhc2tfaWQiOiAiYTUwN2I2OGYtOWFjNy00NDdmLTgxNTItZjRj
-        ZDc2YmU1NjNlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo0N1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMGI1YzZiYmUtM2VkZi00MGYwLWEwZjctMGFmOGQxMTA1
-        ZjIwLyIsICJ0YXNrX2lkIjogIjBiNWM2YmJlLTNlZGYtNDBmMC1hMGY3LTBh
-        ZjhkMTEwNWYyMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo0N1oiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjExOjQ3WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y3M2FjZTIzZjBhMTQ5NDQ1MzAiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjcyYWIzNmNlM2ZlNTFkZTU0NyJ9LCAiaWQiOiAiNWQ0ODdm
-        NzJhYjM2Y2UzZmU1MWRlNTQ3In0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:47 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/a507b68f-9ac7-447f-8152-f4cd76be563e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:11:47 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"d7981af4a89bfa6ef33c455b5235cff9-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2405'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hNTA3YjY4Zi05YWM3LTQ0N2YtODE1Mi1mNGNkNzZiZTU2
-        M2UvIiwgInRhc2tfaWQiOiAiYTUwN2I2OGYtOWFjNy00NDdmLTgxNTItZjRj
-        ZDc2YmU1NjNlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo0N1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMGI1YzZiYmUtM2VkZi00MGYwLWEwZjctMGFmOGQxMTA1
-        ZjIwLyIsICJ0YXNrX2lkIjogIjBiNWM2YmJlLTNlZGYtNDBmMC1hMGY3LTBh
-        ZjhkMTEwNWYyMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo0N1oiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjExOjQ3WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y3M2FjZTIzZjBhMTQ5NDQ1MzAiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjcyYWIzNmNlM2ZlNTFkZTU0NyJ9LCAiaWQiOiAiNWQ0ODdm
-        NzJhYjM2Y2UzZmU1MWRlNTQ3In0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:47 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/a507b68f-9ac7-447f-8152-f4cd76be563e/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:11:47 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"d7981af4a89bfa6ef33c455b5235cff9-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2405'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hNTA3YjY4Zi05YWM3LTQ0N2YtODE1Mi1mNGNkNzZiZTU2
-        M2UvIiwgInRhc2tfaWQiOiAiYTUwN2I2OGYtOWFjNy00NDdmLTgxNTItZjRj
-        ZDc2YmU1NjNlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo0N1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo0N1oiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMGI1YzZiYmUtM2VkZi00MGYwLWEwZjctMGFmOGQxMTA1
-        ZjIwLyIsICJ0YXNrX2lkIjogIjBiNWM2YmJlLTNlZGYtNDBmMC1hMGY3LTBh
-        ZjhkMTEwNWYyMCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo0N1oiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjExOjQ3WiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y3M2FjZTIzZjBhMTQ5NDQ1MzAiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjcyYWIzNmNlM2ZlNTFkZTU0NyJ9LCAiaWQiOiAiNWQ0ODdm
-        NzJhYjM2Y2UzZmU1MWRlNTQ3In0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:48 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/0b5c6bbe-3edf-40f0-a0f7-0af8d1105f20/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:11:48 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"8ef14cea28190b87d1a3db7ecca5cbd9-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '8529'
+      - '1372'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1008,199 +649,200 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8wYjVjNmJiZS0zZWRmLTQwZjAtYTBmNy0wYWY4
-        ZDExMDVmMjAvIiwgInRhc2tfaWQiOiAiMGI1YzZiYmUtM2VkZi00MGYwLWEw
-        ZjctMGFmOGQxMTA1ZjIwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy8xMTUwZTAyZS04N2ZkLTRlYmUtOTJkMS0xNjky
+        ZWY5NGJjOGQvIiwgInRhc2tfaWQiOiAiMTE1MGUwMmUtODdmZC00ZWJlLTky
+        ZDEtMTY5MmVmOTRiYzhkIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxOS0wOC0wNVQxOToxMTo0N1oiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo0N1oiLCAi
+        bWUiOiAiMjAxOS0wOC0zMFQxNDozNDoyOFoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDoyOFoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJlZTk1NWNkNS1mZDg4LTQ3ODgtOGQwZC1kMTc0MWE5
-        NjAxODIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICJkNTg0YmFmNi0zN2RhLTQ2ZTUtYjM2My02YzgyZTQ3
+        NTgzMmIiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMjFhNjQwMjgtNzgxZC00YThkLTk3MTYtNTE3NzAwZjE0N2M4Iiwg
+        aWQiOiAiMDE1ODA0YzgtMWM1ZC00MDVkLTk5Y2YtZWQ1Yzg2ZDg1ZjY4Iiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVz
         Y3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJy
         cG1zIiwgIml0ZW1zX3RvdGFsIjogMTgsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwNmIxYjgwZS05N2Y0LTRkYWQtOWE1
-        NC01MTExNTI3OGEwYTAiLCAibnVtX3Byb2Nlc3NlZCI6IDE4fSwgeyJudW1f
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4NWI0OTM3OC1mNjQxLTRmNjMtYTQz
+        YS1kYzZhOTRkNzQ4NDAiLCAibnVtX3Byb2Nlc3NlZCI6IDE4fSwgeyJudW1f
         c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRh
         IFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjog
         MSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        MzQ3NjhhZjUtOTlhYi00ZWUyLTg1ZDEtNjQxNjczMzU1YzFhIiwgIm51bV9w
+        NTZjZWFhYjItMzMwYS00YmNmLWE5NjMtZDI0NDdlZGNhOGU5IiwgIm51bV9w
         cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlv
         biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
         IiwgIml0ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
         cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogImZhMjI3ZDgxLWY0ZjgtNDQyNy04NDhhLTM3
-        ZDkxMDFlYTdmNiIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
+        cyI6IDAsICJzdGVwX2lkIjogImZmYjQ0MDZhLWExNTctNGFmZC05NjBiLWZh
+        YjliNjBjZjZmOCIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
         c3MiOiA5LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwg
         InN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0
         YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImZlYzQx
-        OWRlLWJkODItNDVjNS1iMjBlLWY5NmYxMWMxZWNlZiIsICJudW1fcHJvY2Vz
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjYyMzg3
+        NGUyLTBmMTAtNGZlZS04YmVlLTUyY2FlMDExNWViMSIsICJudW1fcHJvY2Vz
         c2VkIjogOX0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAi
         UHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIs
         ICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI4ZGI0Y2Q3ZC0yNTY3LTQ5NTMtOThjYS1kNzBh
-        YjJjMjQzOGMiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICIxMzFjNzMzYS0xNmU1LTQ5NzQtYWQ1My01OWQ3
+        NGQ0ODY3YTUiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNz
         IjogMiwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwg
         InN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDIsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlNDEz
-        MzM2OC1lNGM2LTQ3ZTAtYWY0YS1jYTFkYjVjMWY4NTMiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhMGVm
+        Yzk2OC0xMzkxLTRiMzQtYmU0Yi02ZDcxMmNmZTU0NTQiLCAibnVtX3Byb2Nl
         c3NlZCI6IDJ9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2Vf
         cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2YzJlMTJlNi02ZTll
-        LTRkZDQtYTJmOS0wYzUwNzgzNGQ2M2YiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiMTNjMmQyMC1mM2Ji
+        LTRhZTQtOTQyOC04YzUxMGYxOThlZGUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRp
         bmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxp
         dGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI2MTZkYmNhNC0xMDZmLTQzMTgtYjY2YS1h
-        ZTAyYzVmYWU4NjAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI0YTk2MDY4Mi0xOGYxLTQ1ZjAtYTEyNi1l
+        Y2U4ZDJjZTljM2YiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0
         YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVt
         c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICIxNmE4OGIzMC02OGM5LTRmOTAtOTU1MS1iODg0MjU4YzU1
-        MTYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICJlMWRmNTU5YS02ZjRjLTQ4MWQtODVhNS05OGY3MDE5YWM5
+        YmUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVw
         X3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
         OiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4YzNjZDZkMy05
-        MThjLTRiMTAtYTBiYy1lMjQxYTgyZTJiYjYiLCAibnVtX3Byb2Nlc3NlZCI6
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkOTkwM2Y4OC01
+        NDVlLTQ3YzQtYTY3OS03MmI0MTU3MTYyZmEiLCAibnVtX3Byb2Nlc3NlZCI6
         IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
         c2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2Rp
         cmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
         RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiOWZhODIyNy1mNjgzLTRhMjgt
-        YTAxZC00YmI2MjU3OWFhZTAiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkYjIzYmExYy1jMzNlLTQ4MDct
+        YWQ5My04MTBiMTgyZDVkMjkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
         bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGlu
         Z3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
         YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImM5MTVhOGJjLTQ2YjMtNDE2OS05Yzgz
-        LWJjMGNlOTQ4NjZhOSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29y
-        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwu
-        bG9jYWxob3N0LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0Ijog
-        InN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVk
-        b3JhXzE3IiwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo0N1oiLCAi
-        X25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIy
-        MDE5LTA4LTA1VDE5OjExOjQ3WiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlz
-        dHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFy
-        eSI6IHsiZ2VuZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNI
-        RUQiLCAicmVtb3ZlX29sZF9yZXBvZGF0YSI6ICJGSU5JU0hFRCIsICJtb2R1
-        bGVzIjogIkZJTklTSEVEIiwgImNsb3NlX3JlcG9fbWV0YWRhdGEiOiAiRklO
-        SVNIRUQiLCAiZHJwbXMiOiAiU0tJUFBFRCIsICJjb21wcyI6ICJGSU5JU0hF
-        RCIsICJkaXN0cmlidXRpb24iOiAiRklOSVNIRUQiLCAicmVwb3ZpZXciOiAi
-        U0tJUFBFRCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJGSU5JU0hFRCIsICJl
-        cnJhdGEiOiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAiRklOSVNIRUQifSwg
-        ImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiRmVk
-        b3JhXzE3IiwgImlkIjogIjVkNDg3ZjczYWNlMjNmMGExNDk0NDUzMSIsICJk
-        ZXRhaWxzIjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlZTk1
-        NWNkNS1mZDg4LTQ3ODgtOGQwZC1kMTc0MWE5NjAxODIiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMjFhNjQwMjgtNzgx
-        ZC00YThkLTk3MTYtNTE3NzAwZjE0N2M4IiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFs
-        IjogMTgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICIwNmIxYjgwZS05N2Y0LTRkYWQtOWE1NC01MTExNTI3OGEwYTAiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDE4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
-        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQ
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMzQ3NjhhZjUtOTlhYi00ZWUy
-        LTg1ZDEtNjQxNjczMzU1YzFhIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
-        dW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVy
-        cmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjog
-        NiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImZhMjI3ZDgxLWY0ZjgtNDQyNy04NDhhLTM3ZDkxMDFlYTdmNiIsICJudW1f
-        cHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nlc3MiOiA5LCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1
-        bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImZlYzQxOWRlLWJkODItNDVjNS1iMjBl
-        LWY5NmYxMWMxZWNlZiIsICJudW1fcHJvY2Vzc2VkIjogOX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBm
-        aWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4
-        ZGI0Y2Q3ZC0yNTY3LTQ5NTMtOThjYS1kNzBhYjJjMjQzOGMiLCAibnVtX3By
-        b2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMiwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRh
-        ZGF0YSIsICJpdGVtc190b3RhbCI6IDIsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlNDEzMzM2OC1lNGM2LTQ3ZTAtYWY0
-        YS1jYTFkYjVjMWY4NTMiLCAibnVtX3Byb2Nlc3NlZCI6IDJ9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRh
-        ZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        dXJlcyI6IDAsICJzdGVwX2lkIjogImE2NGUyMmNjLTg2N2EtNGE3MS1iYmIz
+        LTkwYTRkODQzMWY2MyIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxs
+        by1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        ImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJl
+        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3Rh
+        cnRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjI4WiIsICJfbnMiOiAicmVwb19w
+        dWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTktMDgtMzBUMTQ6
+        MzQ6MjhaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBl
+        X2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0
+        ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJycG1zIjogIkZJTklTSEVEIiwgImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJyZW1vdmVf
+        b2xkX3JlcG9kYXRhIjogIkZJTklTSEVEIiwgIm1vZHVsZXMiOiAiRklOSVNI
+        RUQiLCAiY2xvc2VfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJkcnBt
+        cyI6ICJTS0lQUEVEIiwgImNvbXBzIjogIkZJTklTSEVEIiwgImRpc3RyaWJ1
+        dGlvbiI6ICJGSU5JU0hFRCIsICJyZXBvdmlldyI6ICJTS0lQUEVEIiwgInB1
+        Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5J
+        U0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2Fn
+        ZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQi
+        OiAiNWQ2OTMzZjQ3YWNjZTkwYjYzOWZjNmM4IiwgImRldGFpbHMiOiBbeyJu
+        dW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcg
+        cmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ1ODRiYWY2LTM3ZGEtNDZl
+        NS1iMzYzLTZjODJlNDc1ODMyYiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        aXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlv
+        biIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIwMTU4MDRjOC0xYzVkLTQwNWQtOTljZi1l
+        ZDVjODZkODVmNjgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMTgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAi
+        c3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiAxOCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjg1YjQ5Mzc4
+        LWY2NDEtNGY2My1hNDNhLWRjNmE5NGQ3NDg0MCIsICJudW1fcHJvY2Vzc2Vk
+        IjogMTh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAi
+        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI2YzJlMTJlNi02ZTllLTRkZDQtYTJmOS0wYzUwNzgz
-        NGQ2M2YiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwg
-        InN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwi
-        OiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI2MTZkYmNhNC0xMDZmLTQzMTgtYjY2YS1hZTAyYzVmYWU4NjAiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0
-        aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAi
-        cmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxNmE4OGIz
-        MC02OGM5LTRmOTAtOTU1MS1iODg0MjU4YzU1MTYiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdl
-        bmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXci
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI4YzNjZDZkMy05MThjLTRiMTAtYTBiYy1lMjQx
-        YTgyZTJiYjYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2Vi
-        IiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICJiOWZhODIyNy1mNjgzLTRhMjgtYTAxZC00YmI2MjU3OWFhZTAi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
-        c2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        LCAic3RlcF9pZCI6ICI1NmNlYWFiMi0zMzBhLTRiY2YtYTk2My1kMjQ0N2Vk
+        Y2E4ZTkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        NiwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBf
+        dHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiA2LCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZmZiNDQwNmEtYTE1
+        Ny00YWZkLTk2MGItZmFiOWI2MGNmNmY4IiwgIm51bV9wcm9jZXNzZWQiOiA2
+        fSwgeyJudW1fc3VjY2VzcyI6IDksICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNf
+        dG90YWwiOiA5LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiNjIzODc0ZTItMGYxMC00ZmVlLThiZWUtNTJjYWUwMTE1ZWIx
+        IiwgIm51bV9wcm9jZXNzZWQiOiA5fSwgeyJudW1fc3VjY2VzcyI6IDMsICJk
+        ZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90
+        eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjEzMWM3MzNhLTE2ZTUt
+        NDk3NC1hZDUzLTU5ZDc0ZDQ4NjdhNSIsICJudW1fcHJvY2Vzc2VkIjogM30s
+        IHsibnVtX3N1Y2Nlc3MiOiAyLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImEwZWZjOTY4LTEzOTEtNGIzNC1iZTRiLTZkNzEyY2ZlNTQ1
+        NCIsICJudW1fcHJvY2Vzc2VkIjogMn0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBf
+        dHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjog
+        MSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        ImIxM2MyZDIwLWYzYmItNGFlNC05NDI4LThjNTEwZjE5OGVkZSIsICJudW1f
+        cHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjog
+        ImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjRhOTYwNjgyLTE4
+        ZjEtNDVmMC1hMTI2LWVjZThkMmNlOWMzZiIsICJudW1fcHJvY2Vzc2VkIjog
+        MH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zp
+        bmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3Jl
+        cG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImUxZGY1NTlhLTZmNGMtNDgxZC04
+        NWE1LTk4ZjcwMTlhYzliZSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1M
+        IGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogImM5MTVhOGJjLTQ2YjMtNDE2OS05YzgzLWJjMGNlOTQ4NjZhOSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
-        JG9pZCI6ICI1ZDQ4N2Y3M2FiMzZjZTNmZTUxZGU3ZWYifSwgImlkIjogIjVk
-        NDg3ZjczYWIzNmNlM2ZlNTFkZTdlZiJ9
+        IjogImQ5OTAzZjg4LTU0NWUtNDdjNC1hNjc5LTcyYjQxNTcxNjJmYSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
+        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImRiMjNi
+        YTFjLWMzM2UtNDgwNy1hZDkzLTgxMGIxODJkNWQyOSIsICJudW1fcHJvY2Vz
+        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
+        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiYTY0ZTIyY2Mt
+        ODY3YS00YTcxLWJiYjMtOTBhNGQ4NDMxZjYzIiwgIm51bV9wcm9jZXNzZWQi
+        OiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNjkz
+        M2Y0MzJkYjYwNzdhNzk2NWQ1OSJ9LCAiaWQiOiAiNWQ2OTMzZjQzMmRiNjA3
+        N2E3OTY1ZDU5In0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:48 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:28 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1225,21 +867,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '790'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 201
       message: CREATED
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:48 GMT
+      - Fri, 30 Aug 2019 14:34:28 GMT
       Server:
       - Apache
       Content-Length:
@@ -1256,14 +898,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWQ0ODdmNzRhY2UyM2YwN2E2N2UwZTdjIn0sICJpZCI6ICIzX3ZpZXcxIiwg
+        NWQ2OTMzZjQ3YWNjZTkwN2UzODFjZWIyIn0sICJpZCI6ICIzX3ZpZXcxIiwg
         Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS8i
         fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:48 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:28 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1275,21 +917,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '184'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:48 GMT
+      - Fri, 30 Aug 2019 14:34:28 GMT
       Server:
       - Apache
       Content-Length:
@@ -1300,14 +942,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzc4M2Y5ZGUxLTQyOTAtNGEwNy1hMGI2LTM1ZWY1ZjRhZTYxZC8iLCAi
-        dGFza19pZCI6ICI3ODNmOWRlMS00MjkwLTRhMDctYTBiNi0zNWVmNWY0YWU2
-        MWQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2M3NjYwNDA1LTZjOGMtNGRkZC1hMzNkLTIxOTliZGIwNzRmYi8iLCAi
+        dGFza19pZCI6ICJjNzY2MDQwNS02YzhjLTRkZGQtYTMzZC0yMTk5YmRiMDc0
+        ZmIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:48 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:28 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1317,21 +959,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '121'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:48 GMT
+      - Fri, 30 Aug 2019 14:34:28 GMT
       Server:
       - Apache
       Content-Length:
@@ -1342,14 +984,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzUyZjZjYTg1LTQ3MTMtNDNiZC04YmI3LWM3YmRmMjE3NjM1Yi8iLCAi
-        dGFza19pZCI6ICI1MmY2Y2E4NS00NzEzLTQzYmQtOGJiNy1jN2JkZjIxNzYz
-        NWIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2ViZTZjNGRhLTRiYjctNGEzZS05ZWYyLTlhOGJkYWM0ZDBkMS8iLCAi
+        dGFza19pZCI6ICJlYmU2YzRkYS00YmI3LTRhM2UtOWVmMi05YThiZGFjNGQw
+        ZDEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:48 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:28 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1358,21 +1000,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '76'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:48 GMT
+      - Fri, 30 Aug 2019 14:34:28 GMT
       Server:
       - Apache
       Content-Length:
@@ -1383,14 +1025,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzI4MTY1NWE2LTdmZmUtNDYyNi05NWE5LWQwODAzYjdkNDZlZC8iLCAi
-        dGFza19pZCI6ICIyODE2NTVhNi03ZmZlLTQ2MjYtOTVhOS1kMDgwM2I3ZDQ2
-        ZWQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2Q4ZjE0MmYyLTVhYTUtNGJjZi04YmFhLTRhYzFjOTM4ZTgyMS8iLCAi
+        dGFza19pZCI6ICJkOGYxNDJmMi01YWE1LTRiY2YtOGJhYS00YWMxYzkzOGU4
+        MjEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:48 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:28 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1399,21 +1041,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '79'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:48 GMT
+      - Fri, 30 Aug 2019 14:34:28 GMT
       Server:
       - Apache
       Content-Length:
@@ -1424,14 +1066,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2MwNjFiZDIwLTFkYzAtNDcwMS1hYzJlLWU4N2YzZGEzM2YxNy8iLCAi
-        dGFza19pZCI6ICJjMDYxYmQyMC0xZGMwLTQ3MDEtYWMyZS1lODdmM2RhMzNm
-        MTcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2I2MzUwOWU1LWIxZDQtNDhhMC1iNDEwLWZiMzY3ZTkwNWYwNS8iLCAi
+        dGFza19pZCI6ICJiNjM1MDllNS1iMWQ0LTQ4YTAtYjQxMC1mYjM2N2U5MDVm
+        MDUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:48 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:28 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1440,21 +1082,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '85'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:48 GMT
+      - Fri, 30 Aug 2019 14:34:28 GMT
       Server:
       - Apache
       Content-Length:
@@ -1465,14 +1107,56 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzI3YzE0MmFhLTk4MGItNDdkNi04YTM2LWUzMGRmODFlMjI4ZC8iLCAi
-        dGFza19pZCI6ICIyN2MxNDJhYS05ODBiLTQ3ZDYtOGEzNi1lMzBkZjgxZTIy
-        OGQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2I3OTdkYWM4LTRjZjUtNGZkNC04NmEzLTQyMjgzNmNjZTcyYi8iLCAi
+        dGFza19pZCI6ICJiNzk3ZGFjOC00Y2Y1LTRmZDQtODZhMy00MjI4MzZjY2U3
+        MmIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:48 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:28 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInBhY2thZ2VfZW52aXJvbm1lbnQiXSwiZmlsdGVycyI6e319
+        fQ==
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '91'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:28 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2U2ZWJhNzQ5LTNkNTYtNGUxMy04ZmRlLTNkNmYxN2YyYzViMi8iLCAi
+        dGFza19pZCI6ICJlNmViYTc0OS0zZDU2LTRlMTMtOGZkZS0zZDZmMTdmMmM1
+        YjIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:28 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1482,21 +1166,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '94'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:48 GMT
+      - Fri, 30 Aug 2019 14:34:28 GMT
       Server:
       - Apache
       Content-Length:
@@ -1507,14 +1191,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzI0ZjY2Mzc1LTg3NjctNDY0OS1hOWZhLWVjMGI5OGM4YTg4Yi8iLCAi
-        dGFza19pZCI6ICIyNGY2NjM3NS04NzY3LTQ2NDktYTlmYS1lYzBiOThjOGE4
-        OGIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzI1MWJlNDBlLTdlYmQtNDM0MS05Njg3LWY0M2NlZTBjNjg0Yi8iLCAi
+        dGFza19pZCI6ICIyNTFiZTQwZS03ZWJkLTQzNDEtOTY4Ny1mNDNjZWUwYzY4
+        NGIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:48 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:28 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1523,21 +1207,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '84'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:48 GMT
+      - Fri, 30 Aug 2019 14:34:28 GMT
       Server:
       - Apache
       Content-Length:
@@ -1548,14 +1232,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2FjYzAyNjk0LTUzNjYtNGM3YS1iNmI5LTRjMmFiOGM5NGU0NS8iLCAi
-        dGFza19pZCI6ICJhY2MwMjY5NC01MzY2LTRjN2EtYjZiOS00YzJhYjhjOTRl
-        NDUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2Q0NmExZjQzLWJlZTktNGJlYS04NzY4LWM0YThlNTJiZDg3OS8iLCAi
+        dGFza19pZCI6ICJkNDZhMWY0My1iZWU5LTRiZWEtODc2OC1jNGE4ZTUyYmQ4
+        NzkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:48 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:28 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1564,21 +1248,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '80'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:48 GMT
+      - Fri, 30 Aug 2019 14:34:28 GMT
       Server:
       - Apache
       Content-Length:
@@ -1589,14 +1273,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2M4MjU5ZDk0LTdjNjEtNGU2Zi1iNzVkLWQ0MmZhMWQ0YmE2NC8iLCAi
-        dGFza19pZCI6ICJjODI1OWQ5NC03YzYxLTRlNmYtYjc1ZC1kNDJmYTFkNGJh
-        NjQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzg2NmNkNmIzLTBhNTgtNDVlNi1hNThmLWFhZDhjYjk3MGUxMi8iLCAi
+        dGFza19pZCI6ICI4NjZjZDZiMy0wYTU4LTQ1ZTYtYTU4Zi1hYWQ4Y2I5NzBl
+        MTIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:48 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:28 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1605,21 +1289,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '89'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:48 GMT
+      - Fri, 30 Aug 2019 14:34:28 GMT
       Server:
       - Apache
       Content-Length:
@@ -1630,41 +1314,41 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2U2ZjM1MGFiLTM3MGMtNDRmZS1iYjExLWQxZWZkMGNlODIzZi8iLCAi
-        dGFza19pZCI6ICJlNmYzNTBhYi0zNzBjLTQ0ZmUtYmIxMS1kMWVmZDBjZTgy
-        M2YifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzZkMjljYzFkLTMwNTgtNGE0NC04Y2E4LWZjNzNjZDc2OTAxOS8iLCAi
+        dGFza19pZCI6ICI2ZDI5Y2MxZC0zMDU4LTRhNDQtOGNhOC1mYzczY2Q3Njkw
+        MTkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:48 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:28 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/783f9de1-4290-4a07-a0b6-35ef5f4ae61d/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/c7660405-6c8c-4ddd-a33d-2199bdb074fb/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:48 GMT
+      - Fri, 30 Aug 2019 14:34:28 GMT
       Server:
       - Apache
       Etag:
-      - '"71774d6ed8d71ac0dd5d1ada1bb3b6ee-gzip"'
+      - '"08a701b8e8d9cfda7a97f9c08aa75e55-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '5245'
+      - '1427'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1672,153 +1356,683 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy83ODNmOWRl
-        MS00MjkwLTRhMDctYTBiNi0zNWVmNWY0YWU2MWQvIiwgInRhc2tfaWQiOiAi
-        NzgzZjlkZTEtNDI5MC00YTA3LWEwYjYtMzVlZjVmNGFlNjFkIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9jNzY2MDQw
+        NS02YzhjLTRkZGQtYTMzZC0yMTk5YmRiMDc0ZmIvIiwgInRhc2tfaWQiOiAi
+        Yzc2NjA0MDUtNmM4Yy00ZGRkLWEzM2QtMjE5OWJkYjA3NGZiIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjQ4WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjQ4
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjI4WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjI4
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJzaWdu
-        aW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJsaW9uIiwg
-        ImNoZWNrc3VtIjogIjEyNDAwZGM5NWMyM2E0YzE2MDcyNWE5MDg3MTZjZDNm
-        Y2RkN2E4OTgxNTg1NDM3YWI2NGNkNjJlZmEzZTRhZTQiLCAiZXBvY2giOiAi
-        MCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJhcmNo
-        IjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBl
-        X2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5
-        IjogeyJuYW1lIjogImNoZWV0YWgiLCAiY2hlY2tzdW0iOiAiNDIyZDBiYWEw
-        Y2Q5ZDc3MTNhZTc5NmU4ODZhMjNlMTdmNTc4ZjkyNGY3NDg4MGRlYmRiYjdk
-        NjVmYjM2OGRhZSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwg
-        InJlbGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3Vt
-        dHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmlu
-        Z19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiZWxlcGhhbnQi
-        LCAiY2hlY2tzdW0iOiAiM2UxYzcwY2QxYjQyMTMyOGFjYWY2Mzk3Y2IzZDE2
-        MTQ1MzA2YmI5NWY2NWQxYjA5NWZjMzEzNzJhMGE3MDFmMyIsICJlcG9jaCI6
-        ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgImFy
-        Y2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5
-        cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9r
-        ZXkiOiB7Im5hbWUiOiAibW9ua2V5IiwgImNoZWNrc3VtIjogIjBlOGZhNTBk
-        MDEyOGZiYWJjN2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJj
-        ODRkZTg1MDFkYjEiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIs
-        ICJyZWxlYXNlIjogIjAuOCIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1
-        bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25p
-        bmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogInBlbmd1aW4i
-        LCAiY2hlY2tzdW0iOiAiM2ZjYjJjOTI3ZGU5ZTEzYmY2ODQ2OTAzMmEyOGIx
-        MzlkM2U1YWQyZTU4NTY0ZmMyMTBmZDZlNDg2MzViZTY5NCIsICJlcG9jaCI6
-        ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgImFy
-        Y2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5
-        cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9r
-        ZXkiOiB7Im5hbWUiOiAia2FuZ2Fyb28iLCAiY2hlY2tzdW0iOiAiODMzYWY1
-        OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTliZjYx
-        MGRkNjEwM2NlNGNjOCIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4y
-        IiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1
-        bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25p
-        bmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogIndhbHJ1cyIs
-        ICJjaGVja3N1bSI6ICI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3Yjdm
-        ODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwgImVwb2NoIjog
-        IjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJj
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InNpZ25pbmdfa2V5IjogbnVs
+        bCwgInVuaXRfa2V5IjogeyJuYW1lIjogImxpb24iLCAiY2hlY2tzdW0iOiAi
+        MTI0MDBkYzk1YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0
+        MzdhYjY0Y2Q2MmVmYTNlNGFlNCIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24i
+        OiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwg
+        ImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0s
+        IHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAi
+        Y2hlZXRhaCIsICJjaGVja3N1bSI6ICI0MjJkMGJhYTBjZDlkNzcxM2FlNzk2
+        ZTg4NmEyM2UxN2Y1NzhmOTI0Zjc0ODgwZGViZGJiN2Q2NWZiMzY4ZGFlIiwg
+        ImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIw
+        LjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1
+        NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJzaWduaW5nX2tleSI6IG51bGws
+        ICJ1bml0X2tleSI6IHsibmFtZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6
+        ICIzZTFjNzBjZDFiNDIxMzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1
+        ZDFiMDk1ZmMzMTM3MmEwYTcwMWYzIiwgImVwb2NoIjogIjAiLCAidmVyc2lv
+        biI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gi
+        LCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0i
+        fSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6
+        ICJtb25rZXkiLCAiY2hlY2tzdW0iOiAiMGU4ZmE1MGQwMTI4ZmJhYmM3Y2Nj
+        NTYzMmUzZmEyNWQzOWIwMjgwMTY5ZjYxNjZjYjhlMmM4NGRlODUwMWRiMSIs
+        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAi
+        MC44IiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEy
+        NTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19rZXkiOiBudWxs
+        LCAidW5pdF9rZXkiOiB7Im5hbWUiOiAicGVuZ3VpbiIsICJjaGVja3N1bSI6
+        ICIzZmNiMmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJlNTg1
+        NjRmYzIxMGZkNmU0ODYzNWJlNjk0IiwgImVwb2NoIjogIjAiLCAidmVyc2lv
+        biI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gi
+        LCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0i
+        fSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6
+        ICJ3YWxydXMiLCAiY2hlY2tzdW0iOiAiNTE2YTIyY2NjMGNiZTNlY2IyY2Jl
+        ZTFjNjI2YTM5YjkxNzY3ZGJmMGY4MTVhZmRhN2I3MzNhYTU2NTIzMTQyYyIs
+        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC43MSIsICJyZWxlYXNlIjog
+        IjEiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1
+        NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJzaWduaW5nX2tleSI6IG51bGws
+        ICJ1bml0X2tleSI6IHsibmFtZSI6ICJ3YWxydXMiLCAiY2hlY2tzdW0iOiAi
+        NmU4ZDZkYzA1N2UzZTJjOTgxOWYwZGM3ZTZjN2I3Zjg2YmYyZTg1NzFiYmE0
+        MTRhZGVjN2ZiNjIxYTQ2MWRmZCIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24i
+        OiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwg
+        ImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0s
+        IHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAi
+        YXJtYWRpbGxvIiwgImNoZWNrc3VtIjogIjhkMzE5OTA1ZWVkYjVhNTI0N2Uz
+        YTM1MjU4ODlhMjhkNWQ2NGU4MjIwMDc0MTNkMDI1ODdiNmY1MWFiM2I2NWEi
+        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJyZWxlYXNlIjog
+        IjEiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1
+        NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJzaWduaW5nX2tleSI6IG51bGws
+        ICJ1bml0X2tleSI6IHsibmFtZSI6ICJkdWNrIiwgImNoZWNrc3VtIjogIjk2
+        ZjM3ODc3NTE4YTFmZTZlYTJlMTdmNGNlMWZjODFiNDA5MDgwNDNiY2JlZDc2
+        NzQ0YjNkN2QzOGE3NzRiYzciLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjog
+        IjAuNiIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hl
+        Y2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJz
+        aWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJhcm1h
+        ZGlsbG8iLCAiY2hlY2tzdW0iOiAiYWJmNjkxZWU1YjQ4ZTQ0NjMyNjg1OWI4
+        ZDhhOGRmMmEyNDExYjdlZGEyYzA4ZDA1ODllNmYzZDhkMWZmMzk5ZiIsICJl
+        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMi4xIiwgInJlbGVhc2UiOiAiMSIs
+        ICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0s
+        ICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVu
+        aXRfa2V5IjogeyJuYW1lIjogImthbmdhcm9vIiwgImNoZWNrc3VtIjogIjgz
+        M2FmNTk0YmMwYmEzMTI1NjA0NWVkMWZiMTdkM2RmMmQ4MzQxYTg5YjBjNWE5
+        YmY2MTBkZDYxMDNjZTRjYzgiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjog
+        IjAuMiIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hl
+        Y2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJz
+        aWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJkdWNr
+        IiwgImNoZWNrc3VtIjogIjViZDM2M2I4NjBhZDY3ODMyMTdjYmNhM2JiYzNl
+        ZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4ZTNmNjZjMjQ3MTIiLCAiZXBvY2gi
+        OiAiMCIsICJ2ZXJzaW9uIjogIjAuNyIsICJyZWxlYXNlIjogIjEiLCAiYXJj
         aCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlw
         ZV9pZCI6ICJycG0ifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tl
-        eSI6IHsibmFtZSI6ICJhcm1hZGlsbG8iLCAiY2hlY2tzdW0iOiAiOGQzMTk5
-        MDVlZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQxM2QwMjU4
-        N2I2ZjUxYWIzYjY1YSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4y
-        IiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1
-        bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25p
-        bmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogImR1Y2siLCAi
-        Y2hlY2tzdW0iOiAiOTZmMzc4Nzc1MThhMWZlNmVhMmUxN2Y0Y2UxZmM4MWI0
-        MDkwODA0M2JjYmVkNzY3NDRiM2Q3ZDM4YTc3NGJjNyIsICJlcG9jaCI6ICIw
-        IiwgInZlcnNpb24iOiAiMC42IiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjog
-        Im5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lk
-        IjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5Ijog
-        eyJuYW1lIjogImFybWFkaWxsbyIsICJjaGVja3N1bSI6ICJhYmY2OTFlZTVi
-        NDhlNDQ2MzI2ODU5YjhkOGE4ZGYyYTI0MTFiN2VkYTJjMDhkMDU4OWU2ZjNk
-        OGQxZmYzOTlmIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIyLjEiLCAi
+        eSI6IHsibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVja3N1bSI6ICI4NjVhNGM4
+        OTQ4NWJkZDk3MjNhM2M0MDcyODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2JhM2Qw
+        OTdjM2YyNTZiMmZkIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMi
+        LCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3Vt
+        dHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmlu
+        Z19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiZWxlcGhhbnQi
+        LCAiY2hlY2tzdW0iOiAiMzMzNTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJlODM4
+        ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0MzlkZGQxMjViOSIsICJlcG9jaCI6
+        ICIwIiwgInZlcnNpb24iOiAiMC4yIiwgInJlbGVhc2UiOiAiMSIsICJhcmNo
+        IjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBl
+        X2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5
+        IjogeyJuYW1lIjogImFybWFkaWxsbyIsICJjaGVja3N1bSI6ICJhZjQ3ODEz
+        MmY4ODJlNDJkNGY1NWI5NTNjYjg0NjgyN2M0OGYyZDI5YjdjNmU5YmJhODk4
+        YTYxZGRjMjdiNTg5IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjEi
+        LCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3Vt
+        dHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmlu
+        Z19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAid2FscnVzIiwg
+        ImNoZWNrc3VtIjogIjc0NTMzZmJkNGY5YWRhOWUwMmE2MzYxY2JiZjAxNGI4
+        ZmY4OGRmZjhkNjk3ODVlYzQ4Yjc3ZTAxODk4ZTdjMzEiLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjUuMjEiLCAicmVsZWFzZSI6ICIxIiwgImFyY2gi
+        OiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVf
+        aWQiOiAicnBtIn0sIHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXki
+        OiB7Im5hbWUiOiAiZ2lyYWZmZSIsICJjaGVja3N1bSI6ICJmMjVkNjdkMWQ5
+        ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJkZTZkMTky
+        MjAwOWY5ZjE0IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAi
+        cmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10
+        eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJzaWduaW5n
+        X2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJzcXVpcnJlbCIs
+        ICJjaGVja3N1bSI6ICIyNTE3NjhiZGQxNWYxM2Q3ODQ4N2MyNzYzOGFhNmFl
+        Y2QwMTU1MWUyNTM3NTYwOTNjZGUxYzBhZTg3OGExN2QyIiwgImVwb2NoIjog
+        IjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJj
+        aCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlw
+        ZV9pZCI6ICJycG0ifV0sICJ1bml0c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRl
+        ciI6IFtdfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5
+        MzNmNDMyZGI2MDc3YTc5NjVlODcifSwgImlkIjogIjVkNjkzM2Y0MzJkYjYw
+        NzdhNzk2NWU4NyJ9
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:28 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/ebe6c4da-4bb7-4a3e-9ef2-9a8bdac4d0d1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:28 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"407c3fa85ed9e5400f475538747ac35b-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '432'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9lYmU2YzRk
+        YS00YmI3LTRhM2UtOWVmMi05YThiZGFjNGQwZDEvIiwgInRhc2tfaWQiOiAi
+        ZWJlNmM0ZGEtNGJiNy00YTNlLTllZjItOWE4YmRhYzRkMGQxIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjI4WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjI4
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNfZmFpbGVkX3Np
+        Z25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNWQ2OTMzZjQzMmRiNjA3N2E3OTY1ZTljIn0sICJpZCI6ICI1
+        ZDY5MzNmNDMyZGI2MDc3YTc5NjVlOWMifQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/d8f142f2-5aa5-4bcf-8baa-4ac1c938e821/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:29 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"1f3827bbbe3828b53cbec346b6088d56-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '434'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9kOGYxNDJm
+        Mi01YWE1LTRiY2YtOGJhYS00YWMxYzkzOGU4MjEvIiwgInRhc2tfaWQiOiAi
+        ZDhmMTQyZjItNWFhNS00YmNmLThiYWEtNGFjMWM5MzhlODIxIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjI4WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjI4
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNfZmFpbGVkX3Np
+        Z25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNWQ2OTMzZjQzMmRiNjA3N2E3OTY1ZWI5In0sICJpZCI6ICI1
+        ZDY5MzNmNDMyZGI2MDc3YTc5NjVlYjkifQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/b63509e5-b1d4-48a0-b410-fb367e905f05/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:29 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"e78d57641a8ac187dd6ddf390b9027fc-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '516'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9iNjM1MDll
+        NS1iMWQ0LTQ4YTAtYjQxMC1mYjM2N2U5MDVmMDUvIiwgInRhc2tfaWQiOiAi
+        YjYzNTA5ZTUtYjFkNC00OGEwLWI0MTAtZmIzNjdlOTA1ZjA1IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjI4WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjI4
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJpZCI6
+        ICJLQVRFTExPLVJIU0EtMjAxMDowODU4In0sICJ0eXBlX2lkIjogImVycmF0
+        dW0ifSwgeyJ1bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTI6
+        MDA1OSJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7
+        ImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjAxMTEifSwgInR5cGVfaWQiOiAi
+        ZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEt
+        MjAxMDowMDAyIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1bml0X2tl
+        eSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMifSwgInR5cGVf
+        aWQiOiAiZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExP
+        LVJIRUEtMjAxMDowMDAxIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifV0sICJ1
+        bml0c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzNmNDMyZGI2MDc3YTc5NjVl
+        ZWQifSwgImlkIjogIjVkNjkzM2Y0MzJkYjYwNzdhNzk2NWVlZCJ9
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/b797dac8-4cf5-4fd4-86a3-422836cce72b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:29 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"254e5d35a3a3dd196dc173fe9b822201-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '492'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9iNzk3ZGFj
+        OC00Y2Y1LTRmZDQtODZhMy00MjI4MzZjY2U3MmIvIiwgInRhc2tfaWQiOiAi
+        Yjc5N2RhYzgtNGNmNS00ZmQ0LTg2YTMtNDIyODM2Y2NlNzJiIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjI5WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjI5
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBv
+        X2lkIjogIjNfdmlldzEiLCAiaWQiOiAiYmlyZCJ9LCAidHlwZV9pZCI6ICJw
+        YWNrYWdlX2dyb3VwIn0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiM192
+        aWV3MSIsICJpZCI6ICJtYW1tYWwifSwgInR5cGVfaWQiOiAicGFja2FnZV9n
+        cm91cCJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW3si
+        dW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImlkIjogImJp
+        cmQifSwgInR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9LCB7InVuaXRfa2V5
+        IjogeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJpZCI6ICJtYW1tYWwifSwg
+        InR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9XX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZjQzMmRiNjA3N2E3OTY1ZjBhIn0s
+        ICJpZCI6ICI1ZDY5MzNmNDMyZGI2MDc3YTc5NjVmMGEifQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/e6eba749-3d56-4e13-8fde-3d6f17f2c5b2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:29 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"54fd7c7ae278f40fcad4b789cdd7feac-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '434'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9lNmViYTc0
+        OS0zZDU2LTRlMTMtOGZkZS0zZDZmMTdmMmM1YjIvIiwgInRhc2tfaWQiOiAi
+        ZTZlYmE3NDktM2Q1Ni00ZTEzLThmZGUtM2Q2ZjE3ZjJjNWIyIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjI5WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjI5
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNfZmFpbGVkX3Np
+        Z25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNWQ2OTMzZjQzMmRiNjA3N2E3OTY1ZjIyIn0sICJpZCI6ICI1
+        ZDY5MzNmNDMyZGI2MDc3YTc5NjVmMjIifQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/251be40e-7ebd-4341-9687-f43cee0c684b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:29 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"b19f487ab3ec15c95f268e96bbdd4358-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '501'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yNTFiZTQw
+        ZS03ZWJkLTQzNDEtOTY4Ny1mNDNjZWUwYzY4NGIvIiwgInRhc2tfaWQiOiAi
+        MjUxYmU0MGUtN2ViZC00MzQxLTk2ODctZjQzY2VlMGM2ODRiIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjI5WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjI5
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBv
+        X2lkIjogIjNfdmlldzEiLCAiZGF0YV90eXBlIjogInByb2R1Y3RpZCJ9LCAi
+        dHlwZV9pZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIn0sIHsidW5pdF9r
+        ZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIsICJkYXRhX3R5cGUiOiAic3dp
+        ZHRhZ3MifSwgInR5cGVfaWQiOiAieXVtX3JlcG9fbWV0YWRhdGFfZmlsZSJ9
+        XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW3sidW5pdF9r
+        ZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImRhdGFfdHlwZSI6ICJz
+        d2lkdGFncyJ9LCAidHlwZV9pZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxl
+        In0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImRh
+        dGFfdHlwZSI6ICJwcm9kdWN0aWQifSwgInR5cGVfaWQiOiAieXVtX3JlcG9f
+        bWV0YWRhdGFfZmlsZSJ9XX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRv
+        aWQiOiAiNWQ2OTMzZjQzMmRiNjA3N2E3OTY1ZjM1In0sICJpZCI6ICI1ZDY5
+        MzNmNDMyZGI2MDc3YTc5NjVmMzUifQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:29 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/d46a1f43-bee9-4bea-8768-c4a8e52bd879/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:30 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"f77c28fa7927e6673ac64f7c5c924971-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '516'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9kNDZhMWY0
+        My1iZWU5LTRiZWEtODc2OC1jNGE4ZTUyYmQ4NzkvIiwgInRhc2tfaWQiOiAi
+        ZDQ2YTFmNDMtYmVlOS00YmVhLTg3NjgtYzRhOGU1MmJkODc5IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjI5WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjI5
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJ2YXJp
+        YW50IjogIlRlc3RWYXJpYW50IiwgInZlcnNpb24iOiAiMTYiLCAiYXJjaCI6
+        ICJ4ODZfNjQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHktVGVzdFZhcmlhbnQt
+        MTYteDg2XzY0IiwgImZhbWlseSI6ICJUZXN0IEZhbWlseSJ9LCAidHlwZV9p
+        ZCI6ICJkaXN0cmlidXRpb24ifV0sICJ1bml0c19mYWlsZWRfc2lnbmF0dXJl
+        X2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1ZDY5MzNmNDMyZGI2MDc3YTc5NjVmNDIifSwgImlkIjogIjVkNjkzM2Y0
+        MzJkYjYwNzdhNzk2NWY0MiJ9
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:30 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/866cd6b3-0a58-45e6-a58f-aad8cb970e12/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:30 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"e4ef692ceaea32460300917b82c579b6-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '961'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84NjZjZDZi
+        My0wYTU4LTQ1ZTYtYTU4Zi1hYWQ4Y2I5NzBlMTIvIiwgInRhc2tfaWQiOiAi
+        ODY2Y2Q2YjMtMGE1OC00NWU2LWE1OGYtYWFkOGNiOTcwZTEyIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjI5WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjI5
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJjb250
+        ZXh0IjogImRlYWRiZWVmIiwgInZlcnNpb24iOiAyMDE4MDcwNDI0NDIwNSwg
+        ImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAi
+        MCJ9LCAidHlwZV9pZCI6ICJtb2R1bGVtZCJ9LCB7InVuaXRfa2V5IjogeyJj
+        b250ZXh0IjogImMwZmZlZTQyIiwgInZlcnNpb24iOiAyMDE4MDcwNzE0NDIw
+        MywgImFyY2giOiAieDg2XzY0IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVh
+        bSI6ICIwLjcxIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0sIHsidW5pdF9r
+        ZXkiOiB7ImNvbnRleHQiOiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6IDIwMTgw
+        NzMwMjMzMTAyLCAiYXJjaCI6ICJub2FyY2giLCAibmFtZSI6ICJkdWNrIiwg
+        InN0cmVhbSI6ICIwIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0sIHsic2ln
+        bmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAid2FscnVz
+        IiwgImNoZWNrc3VtIjogIjUxNmEyMmNjYzBjYmUzZWNiMmNiZWUxYzYyNmEz
+        OWI5MTc2N2RiZjBmODE1YWZkYTdiNzMzYWE1NjUyMzE0MmMiLCAiZXBvY2gi
+        OiAiMCIsICJ2ZXJzaW9uIjogIjAuNzEiLCAicmVsZWFzZSI6ICIxIiwgImFy
+        Y2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5
+        cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9r
+        ZXkiOiB7Im5hbWUiOiAiZHVjayIsICJjaGVja3N1bSI6ICI1YmQzNjNiODYw
+        YWQ2NzgzMjE3Y2JjYTNiYmMzZWYyNjBmOThkMTQwZmZiMTIxYmY0YzIwOGUz
+        ZjY2YzI0NzEyIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjciLCAi
         cmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlw
         ZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19r
-        ZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAid2FscnVzIiwgImNo
-        ZWNrc3VtIjogIjUxNmEyMmNjYzBjYmUzZWNiMmNiZWUxYzYyNmEzOWI5MTc2
-        N2RiZjBmODE1YWZkYTdiNzMzYWE1NjUyMzE0MmMiLCAiZXBvY2giOiAiMCIs
-        ICJ2ZXJzaW9uIjogIjAuNzEiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAi
-        bm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQi
-        OiAicnBtIn0sIHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7
-        Im5hbWUiOiAiZHVjayIsICJjaGVja3N1bSI6ICI1YmQzNjNiODYwYWQ2Nzgz
-        MjE3Y2JjYTNiYmMzZWYyNjBmOThkMTQwZmZiMTIxYmY0YzIwOGUzZjY2YzI0
-        NzEyIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjciLCAicmVsZWFz
-        ZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJz
-        aGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19rZXkiOiBu
-        dWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAia2FuZ2Fyb28iLCAiY2hlY2tz
-        dW0iOiAiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAyZjAy
-        NGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsICJlcG9jaCI6ICIwIiwgInZl
-        cnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5vYXJj
-        aCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJw
-        bSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1l
-        IjogImVsZXBoYW50IiwgImNoZWNrc3VtIjogIjMzMzUxZmQ2YzJhMzhlNWQ0
-        OWFlYTc4OGEyZTgzOGVhY2Q2NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1
-        YjkiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMiIsICJyZWxlYXNl
-        IjogIjEiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNo
-        YTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJzaWduaW5nX2tleSI6IG51
-        bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJhcm1hZGlsbG8iLCAiY2hlY2tz
-        dW0iOiAiYWY0NzgxMzJmODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQy
-        OWI3YzZlOWJiYTg5OGE2MWRkYzI3YjU4OSIsICJlcG9jaCI6ICIwIiwgInZl
-        cnNpb24iOiAiMC4xIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5vYXJj
-        aCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJw
-        bSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1l
-        IjogIndhbHJ1cyIsICJjaGVja3N1bSI6ICI3NDUzM2ZiZDRmOWFkYTllMDJh
-        NjM2MWNiYmYwMTRiOGZmODhkZmY4ZDY5Nzg1ZWM0OGI3N2UwMTg5OGU3YzMx
-        IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICI1LjIxIiwgInJlbGVhc2Ui
-        OiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hh
-        MjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVs
-        bCwgInVuaXRfa2V5IjogeyJuYW1lIjogImdpcmFmZmUiLCAiY2hlY2tzdW0i
-        OiAiZjI1ZDY3ZDFkOWRhMDRmMTJlNTdjYTMyMzI0N2I0Mzg5MWFjNDY1MzNl
-        MzU1YjgyZGU2ZDE5MjIwMDlmOWYxNCIsICJlcG9jaCI6ICIwIiwgInZlcnNp
-        b24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgImFyY2giOiAibm9hcmNo
+        ZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAia2FuZ2Fyb28iLCAi
+        Y2hlY2tzdW0iOiAiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5
+        MjAyZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsICJlcG9jaCI6ICIw
+        IiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjog
+        Im5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lk
+        IjogInJwbSJ9LCB7InVuaXRfa2V5IjogeyJjb250ZXh0IjogImRlYWRiZWVm
+        IiwgInZlcnNpb24iOiAyMDE4MDcwNDExMTcxOSwgImFyY2giOiAibm9hcmNo
+        IiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAic3RyZWFtIjogIjAifSwgInR5cGVf
+        aWQiOiAibW9kdWxlbWQifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0
+        X2tleSI6IHsibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVja3N1bSI6ICI4MzNh
+        ZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIwYzVhOWJm
+        NjEwZGQ2MTAzY2U0Y2M4IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIw
+        LjIiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNr
+        c3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2ln
+        bmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAid2FscnVz
+        IiwgImNoZWNrc3VtIjogIjc0NTMzZmJkNGY5YWRhOWUwMmE2MzYxY2JiZjAx
+        NGI4ZmY4OGRmZjhkNjk3ODVlYzQ4Yjc3ZTAxODk4ZTdjMzEiLCAiZXBvY2gi
+        OiAiMCIsICJ2ZXJzaW9uIjogIjUuMjEiLCAicmVsZWFzZSI6ICIxIiwgImFy
+        Y2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5
+        cGVfaWQiOiAicnBtIn0sIHsidW5pdF9rZXkiOiB7ImNvbnRleHQiOiAiZGVh
+        ZGJlZWYiLCAidmVyc2lvbiI6IDIwMTgwNzMwMjIzNDA3LCAiYXJjaCI6ICJu
+        b2FyY2giLCAibmFtZSI6ICJrYW5nYXJvbyIsICJzdHJlYW0iOiAiMCJ9LCAi
+        dHlwZV9pZCI6ICJtb2R1bGVtZCJ9LCB7InVuaXRfa2V5IjogeyJjb250ZXh0
+        IjogImRlYWRiZWVmIiwgInZlcnNpb24iOiAyMDE4MDcwNDE0NDIwMywgImFy
+        Y2giOiAieDg2XzY0IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICI1
+        LjIxIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0sIHsic2lnbmluZ19rZXki
+        OiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiZHVjayIsICJjaGVja3N1
+        bSI6ICI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQz
+        YmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3IiwgImVwb2NoIjogIjAiLCAidmVy
+        c2lvbiI6ICIwLjYiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNo
         IiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBt
-        In0sIHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUi
-        OiAic3F1aXJyZWwiLCAiY2hlY2tzdW0iOiAiMjUxNzY4YmRkMTVmMTNkNzg0
-        ODdjMjc2MzhhYTZhZWNkMDE1NTFlMjUzNzU2MDkzY2RlMWMwYWU4NzhhMTdk
-        MiIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2Ui
-        OiAiMC44IiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJz
-        aGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn1dLCAidW5pdHNfZmFpbGVkX3Np
-        Z25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
-        IiRvaWQiOiAiNWQ0ODdmNzRhYjM2Y2UzZmU1MWRlOTRiIn0sICJpZCI6ICI1
-        ZDQ4N2Y3NGFiMzZjZTNmZTUxZGU5NGIifQ==
+        In1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZjQzMmRiNjA3
+        N2E3OTY1ZjVlIn0sICJpZCI6ICI1ZDY5MzNmNDMyZGI2MDc3YTc5NjVmNWUi
+        fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:48 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:30 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/52f6ca85-4713-43bd-8bb7-c7bdf217635b/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/6d29cc1d-3058-4a44-8ca8-fc73cd769019/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:48 GMT
+      - Fri, 30 Aug 2019 14:34:31 GMT
       Server:
       - Apache
       Etag:
-      - '"d5f716d537032793f5b352d6dffc811d-gzip"'
+      - '"d7f8da3fb1dfedd1ca0bacb4bf412e75-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '803'
+      - '508'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1826,534 +2040,67 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81MmY2Y2E4
-        NS00NzEzLTQzYmQtOGJiNy1jN2JkZjIxNzYzNWIvIiwgInRhc2tfaWQiOiAi
-        NTJmNmNhODUtNDcxMy00M2JkLThiYjctYzdiZGYyMTc2MzViIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82ZDI5Y2Mx
+        ZC0zMDU4LTRhNDQtOGNhOC1mYzczY2Q3NjkwMTkvIiwgInRhc2tfaWQiOiAi
+        NmQyOWNjMWQtMzA1OC00YTQ0LThjYTgtZmM3M2NkNzY5MDE5IiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjQ4WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjQ4
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjI5WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjI5
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbXSwgInVu
-        aXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW119LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3Zjc0YWIzNmNlM2ZlNTFkZTk1
-        OSJ9LCAiaWQiOiAiNWQ0ODdmNzRhYjM2Y2UzZmU1MWRlOTU5In0=
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBv
+        X2lkIjogIjNfdmlldzEiLCAibmFtZSI6ICJrYW5nYXJvbyJ9LCAidHlwZV9p
+        ZCI6ICJtb2R1bGVtZF9kZWZhdWx0cyJ9LCB7InVuaXRfa2V5IjogeyJyZXBv
+        X2lkIjogIjNfdmlldzEiLCAibmFtZSI6ICJ3YWxydXMifSwgInR5cGVfaWQi
+        OiAibW9kdWxlbWRfZGVmYXVsdHMifSwgeyJ1bml0X2tleSI6IHsicmVwb19p
+        ZCI6ICIzX3ZpZXcxIiwgIm5hbWUiOiAiZHVjayJ9LCAidHlwZV9pZCI6ICJt
+        b2R1bGVtZF9kZWZhdWx0cyJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVf
+        ZmlsdGVyIjogW3sidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3
+        IiwgIm5hbWUiOiAia2FuZ2Fyb28ifSwgInR5cGVfaWQiOiAibW9kdWxlbWRf
+        ZGVmYXVsdHMifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRvcmFf
+        MTciLCAibmFtZSI6ICJkdWNrIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2Rl
+        ZmF1bHRzIn0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3
+        IiwgIm5hbWUiOiAid2FscnVzIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2Rl
+        ZmF1bHRzIn1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        ZDY5MzNmNDMyZGI2MDc3YTc5NjVmNzgifSwgImlkIjogIjVkNjkzM2Y0MzJk
+        YjYwNzdhNzk2NWY3OCJ9
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:48 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:31 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/281655a6-7ffe-4626-95a9-d0803b7d46ed/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:48 GMT
+      - Fri, 30 Aug 2019 14:34:31 GMT
       Server:
       - Apache
       Etag:
-      - '"91387d95c1ac2883e5884a04651653d0-gzip"'
+      - '"837009970d3a2c9b9d29eb90ff4cf0a8-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '803'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yODE2NTVh
-        Ni03ZmZlLTQ2MjYtOTVhOS1kMDgwM2I3ZDQ2ZWQvIiwgInRhc2tfaWQiOiAi
-        MjgxNjU1YTYtN2ZmZS00NjI2LTk1YTktZDA4MDNiN2Q0NmVkIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjQ4WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjQ4
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbXSwgInVu
-        aXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW119LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3Zjc0YWIzNmNlM2ZlNTFkZTk3
-        MiJ9LCAiaWQiOiAiNWQ0ODdmNzRhYjM2Y2UzZmU1MWRlOTcyIn0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:48 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/c061bd20-1dc0-4701-ac2e-e87f3da33f17/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:11:48 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"77b3e1ef1a40194847d4b0804576152b-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1222'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9jMDYxYmQy
-        MC0xZGMwLTQ3MDEtYWMyZS1lODdmM2RhMzNmMTcvIiwgInRhc2tfaWQiOiAi
-        YzA2MWJkMjAtMWRjMC00NzAxLWFjMmUtZTg3ZjNkYTMzZjE3IiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjQ4WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjQ4
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJ1bml0
-        X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTI6MDA1OSJ9LCAidHlw
-        ZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7ImlkIjogIktBVEVM
-        TE8tUkhTQS0yMDEwOjA4NTgifSwgInR5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7
-        InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDowMTExIn0s
-        ICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1bml0X2tleSI6IHsiaWQiOiAi
-        S0FURUxMTy1SSEVBLTIwMTA6MDAwMiJ9LCAidHlwZV9pZCI6ICJlcnJhdHVt
-        In0sIHsidW5pdF9rZXkiOiB7ImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjk5
-        MTQzIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1bml0X2tleSI6IHsi
-        aWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSJ9LCAidHlwZV9pZCI6ICJl
-        cnJhdHVtIn1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBb
-        XX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmNzRh
-        YjM2Y2UzZmU1MWRlOWEyIn0sICJpZCI6ICI1ZDQ4N2Y3NGFiMzZjZTNmZTUx
-        ZGU5YTIifQ==
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:48 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/27c142aa-980b-47d6-8a36-e30df81e228d/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:11:48 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"145fa6e4a13b0f0ce053fda889d809e9-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1127'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yN2MxNDJh
-        YS05ODBiLTQ3ZDYtOGEzNi1lMzBkZjgxZTIyOGQvIiwgInRhc2tfaWQiOiAi
-        MjdjMTQyYWEtOTgwYi00N2Q2LThhMzYtZTMwZGY4MWUyMjhkIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjQ4WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjQ4
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJ1bml0
-        X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImlkIjogImJpcmQifSwg
-        InR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9LCB7InVuaXRfa2V5IjogeyJy
-        ZXBvX2lkIjogIjNfdmlldzEiLCAiaWQiOiAibWFtbWFsIn0sICJ0eXBlX2lk
-        IjogInBhY2thZ2VfZ3JvdXAifV0sICJ1bml0c19mYWlsZWRfc2lnbmF0dXJl
-        X2ZpbHRlciI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lkIjogIkZlZG9yYV8x
-        NyIsICJpZCI6ICJiaXJkIn0sICJ0eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAi
-        fSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiaWQi
-        OiAibWFtbWFsIn0sICJ0eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAifV19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3Zjc0YWIzNmNl
-        M2ZlNTFkZTlkMSJ9LCAiaWQiOiAiNWQ0ODdmNzRhYjM2Y2UzZmU1MWRlOWQx
-        In0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:48 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/24f66375-8767-4649-a9fa-ec0b98c8a88b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:11:48 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"34eaacf5fea3149a5172d924ab25b32d-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1205'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yNGY2NjM3
-        NS04NzY3LTQ2NDktYTlmYS1lYzBiOThjOGE4OGIvIiwgInRhc2tfaWQiOiAi
-        MjRmNjYzNzUtODc2Ny00NjQ5LWE5ZmEtZWMwYjk4YzhhODhiIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjQ4WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjQ4
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJ1bml0
-        X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImRhdGFfdHlwZSI6ICJw
-        cm9kdWN0aWQifSwgInR5cGVfaWQiOiAieXVtX3JlcG9fbWV0YWRhdGFfZmls
-        ZSJ9LCB7InVuaXRfa2V5IjogeyJyZXBvX2lkIjogIjNfdmlldzEiLCAiZGF0
-        YV90eXBlIjogInN3aWR0YWdzIn0sICJ0eXBlX2lkIjogInl1bV9yZXBvX21l
-        dGFkYXRhX2ZpbGUifV0sICJ1bml0c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRl
-        ciI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJk
-        YXRhX3R5cGUiOiAic3dpZHRhZ3MifSwgInR5cGVfaWQiOiAieXVtX3JlcG9f
-        bWV0YWRhdGFfZmlsZSJ9LCB7InVuaXRfa2V5IjogeyJyZXBvX2lkIjogIkZl
-        ZG9yYV8xNyIsICJkYXRhX3R5cGUiOiAicHJvZHVjdGlkIn0sICJ0eXBlX2lk
-        IjogInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUifV19LCAiZXJyb3IiOiBudWxs
-        LCAiX2lkIjogeyIkb2lkIjogIjVkNDg3Zjc0YWIzNmNlM2ZlNTFkZTllNiJ9
-        LCAiaWQiOiAiNWQ0ODdmNzRhYjM2Y2UzZmU1MWRlOWU2In0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:48 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/acc02694-5366-4c7a-b6b9-4c2ab8c94e45/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:11:49 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"269b136617bcb0ddd793ae6356db120a-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '976'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9hY2MwMjY5
-        NC01MzY2LTRjN2EtYjZiOS00YzJhYjhjOTRlNDUvIiwgInRhc2tfaWQiOiAi
-        YWNjMDI2OTQtNTM2Ni00YzdhLWI2YjktNGMyYWI4Yzk0ZTQ1IiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjQ4WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjQ4
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJ1bml0
-        X2tleSI6IHsidmFyaWFudCI6ICJUZXN0VmFyaWFudCIsICJ2ZXJzaW9uIjog
-        IjE2IiwgImFyY2giOiAieDg2XzY0IiwgImlkIjogImtzLVRlc3QgRmFtaWx5
-        LVRlc3RWYXJpYW50LTE2LXg4Nl82NCIsICJmYW1pbHkiOiAiVGVzdCBGYW1p
-        bHkifSwgInR5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIn1dLCAidW5pdHNfZmFp
-        bGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJf
-        aWQiOiB7IiRvaWQiOiAiNWQ0ODdmNzRhYjM2Y2UzZmU1MWRlOWZiIn0sICJp
-        ZCI6ICI1ZDQ4N2Y3NGFiMzZjZTNmZTUxZGU5ZmIifQ==
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:49 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/c8259d94-7c61-4e6f-b75d-d42fa1d4ba64/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:11:49 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"91e604d972ada5c16bd62f71a2150935-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3119'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9jODI1OWQ5
-        NC03YzYxLTRlNmYtYjc1ZC1kNDJmYTFkNGJhNjQvIiwgInRhc2tfaWQiOiAi
-        YzgyNTlkOTQtN2M2MS00ZTZmLWI3NWQtZDQyZmExZDRiYTY0IiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjQ4WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjQ4
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJ1bml0
-        X2tleSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJzaW9uIjogMjAx
-        ODA3MDQyNDQyMDUsICJhcmNoIjogIm5vYXJjaCIsICJuYW1lIjogImR1Y2si
-        LCAic3RyZWFtIjogIjAifSwgInR5cGVfaWQiOiAibW9kdWxlbWQifSwgeyJ1
-        bml0X2tleSI6IHsiY29udGV4dCI6ICJjMGZmZWU0MiIsICJ2ZXJzaW9uIjog
-        MjAxODA3MDcxNDQyMDMsICJhcmNoIjogIng4Nl82NCIsICJuYW1lIjogIndh
-        bHJ1cyIsICJzdHJlYW0iOiAiMC43MSJ9LCAidHlwZV9pZCI6ICJtb2R1bGVt
-        ZCJ9LCB7InVuaXRfa2V5IjogeyJjb250ZXh0IjogImRlYWRiZWVmIiwgInZl
-        cnNpb24iOiAyMDE4MDczMDIzMzEwMiwgImFyY2giOiAibm9hcmNoIiwgIm5h
-        bWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCJ9LCAidHlwZV9pZCI6ICJtb2R1
-        bGVtZCJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJu
-        YW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6ICI1MTZhMjJjY2MwY2JlM2Vj
-        YjJjYmVlMWM2MjZhMzliOTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMx
-        NDJjIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjcxIiwgInJlbGVh
-        c2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAi
-        c2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5Ijog
-        bnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogImR1Y2siLCAiY2hlY2tzdW0i
-        OiAiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZm
-        YjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsICJlcG9jaCI6ICIwIiwgInZlcnNp
-        b24iOiAiMC43IiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIs
-        ICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9
-        LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjog
-        Imthbmdhcm9vIiwgImNoZWNrc3VtIjogIjg2NWE0Yzg5NDg1YmRkOTcyM2Ez
-        YzQwNzI4MGMxNDFlOTIwMmYwMjRlN2RiMzhjYmEzZDA5N2MzZjI1NmIyZmQi
-        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjog
-        IjEiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1
-        NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJ1bml0X2tleSI6IHsiY29udGV4
-        dCI6ICJkZWFkYmVlZiIsICJ2ZXJzaW9uIjogMjAxODA3MDQxMTE3MTksICJh
-        cmNoIjogIm5vYXJjaCIsICJuYW1lIjogImthbmdhcm9vIiwgInN0cmVhbSI6
-        ICIwIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0sIHsic2lnbmluZ19rZXki
-        OiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAia2FuZ2Fyb28iLCAiY2hl
-        Y2tzdW0iOiAiODMzYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgz
-        NDFhODliMGM1YTliZjYxMGRkNjEwM2NlNGNjOCIsICJlcG9jaCI6ICIwIiwg
-        InZlcnNpb24iOiAiMC4yIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5v
-        YXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjog
-        InJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJu
-        YW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6ICI3NDUzM2ZiZDRmOWFkYTll
-        MDJhNjM2MWNiYmYwMTRiOGZmODhkZmY4ZDY5Nzg1ZWM0OGI3N2UwMTg5OGU3
-        YzMxIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICI1LjIxIiwgInJlbGVh
-        c2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAi
-        c2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InVuaXRfa2V5IjogeyJj
-        b250ZXh0IjogImRlYWRiZWVmIiwgInZlcnNpb24iOiAyMDE4MDczMDIyMzQw
-        NywgImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAic3Ry
-        ZWFtIjogIjAifSwgInR5cGVfaWQiOiAibW9kdWxlbWQifSwgeyJ1bml0X2tl
-        eSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJzaW9uIjogMjAxODA3
-        MDQxNDQyMDMsICJhcmNoIjogIng4Nl82NCIsICJuYW1lIjogIndhbHJ1cyIs
-        ICJzdHJlYW0iOiAiNS4yMSJ9LCAidHlwZV9pZCI6ICJtb2R1bGVtZCJ9LCB7
-        InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogImR1
-        Y2siLCAiY2hlY2tzdW0iOiAiOTZmMzc4Nzc1MThhMWZlNmVhMmUxN2Y0Y2Ux
-        ZmM4MWI0MDkwODA0M2JjYmVkNzY3NDRiM2Q3ZDM4YTc3NGJjNyIsICJlcG9j
-        aCI6ICIwIiwgInZlcnNpb24iOiAiMC42IiwgInJlbGVhc2UiOiAiMSIsICJh
-        cmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0
-        eXBlX2lkIjogInJwbSJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmls
-        dGVyIjogW119LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVk
-        NDg3Zjc0YWIzNmNlM2ZlNTFkZWExNyJ9LCAiaWQiOiAiNWQ0ODdmNzRhYjM2
-        Y2UzZmU1MWRlYTE3In0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:49 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/e6f350ab-370c-44fe-bb11-d1efd0ce823f/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:11:50 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"ddd30ed455c1a3edfd616a0dc4e8d73e-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1333'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9lNmYzNTBh
-        Yi0zNzBjLTQ0ZmUtYmIxMS1kMWVmZDBjZTgyM2YvIiwgInRhc2tfaWQiOiAi
-        ZTZmMzUwYWItMzcwYy00NGZlLWJiMTEtZDFlZmQwY2U4MjNmIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjQ4WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjQ4
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJ1bml0
-        X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgIm5hbWUiOiAia2FuZ2Fy
-        b28ifSwgInR5cGVfaWQiOiAibW9kdWxlbWRfZGVmYXVsdHMifSwgeyJ1bml0
-        X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgIm5hbWUiOiAid2FscnVz
-        In0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2RlZmF1bHRzIn0sIHsidW5pdF9r
-        ZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIsICJuYW1lIjogImR1Y2sifSwg
-        InR5cGVfaWQiOiAibW9kdWxlbWRfZGVmYXVsdHMifV0sICJ1bml0c19mYWls
-        ZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lk
-        IjogIkZlZG9yYV8xNyIsICJuYW1lIjogImthbmdhcm9vIn0sICJ0eXBlX2lk
-        IjogIm1vZHVsZW1kX2RlZmF1bHRzIn0sIHsidW5pdF9rZXkiOiB7InJlcG9f
-        aWQiOiAiRmVkb3JhXzE3IiwgIm5hbWUiOiAiZHVjayJ9LCAidHlwZV9pZCI6
-        ICJtb2R1bGVtZF9kZWZhdWx0cyJ9LCB7InVuaXRfa2V5IjogeyJyZXBvX2lk
-        IjogIkZlZG9yYV8xNyIsICJuYW1lIjogIndhbHJ1cyJ9LCAidHlwZV9pZCI6
-        ICJtb2R1bGVtZF9kZWZhdWx0cyJ9XX0sICJlcnJvciI6IG51bGwsICJfaWQi
-        OiB7IiRvaWQiOiAiNWQ0ODdmNzRhYjM2Y2UzZmU1MWRlYTM3In0sICJpZCI6
-        ICI1ZDQ4N2Y3NGFiMzZjZTNmZTUxZGVhMzcifQ==
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:50 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/?details=true
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:11:50 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"1cfedead71041fe1cdb83970a32560a2-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2648'
+      - '787'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2362,94 +2109,94 @@ http_interactions:
         eyJzY3JhdGNocGFkIjogeyJjaGVja3N1bV90eXBlIjogInNoYTI1NiJ9LCAi
         ZGlzcGxheV9uYW1lIjogIkZlZG9yYSAxNyB4ODZfNjQiLCAiZGVzY3JpcHRp
         b24iOiBudWxsLCAiZGlzdHJpYnV0b3JzIjogW3sicmVwb19pZCI6ICJGZWRv
-        cmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6NDZa
+        cmFfMTciLCAibGFzdF91cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6MjZa
         IiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvRmVkb3Jh
         XzE3L2Rpc3RyaWJ1dG9ycy9leHBvcnRfZGlzdHJpYnV0b3IvIiwgImxhc3Rf
         b3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3B1Ymxpc2giOiBudWxsLCAi
         ZGlzdHJpYnV0b3JfdHlwZV9pZCI6ICJleHBvcnRfZGlzdHJpYnV0b3IiLCAi
         YXV0b19wdWJsaXNoIjogZmFsc2UsICJzY3JhdGNocGFkIjoge30sICJfbnMi
-        OiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3
-        ZjcyYWNlMjNmMDdhNjdlMGU3YiJ9LCAiY29uZmlnIjogeyJodHRwIjogZmFs
+        OiAicmVwb19kaXN0cmlidXRvcnMiLCAiX2lkIjogeyIkb2lkIjogIjVkNjkz
+        M2YyN2FjY2U5MDdlNGQ3ZjJhNiJ9LCAiY29uZmlnIjogeyJodHRwIjogZmFs
         c2UsICJyZWxhdGl2ZV91cmwiOiAiQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5
         L2ZlZG9yYV8xN19sYWJlbCIsICJodHRwcyI6IGZhbHNlfSwgImlkIjogImV4
         cG9ydF9kaXN0cmlidXRvciJ9LCB7InJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        Imxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjQ2WiIsICJfaHJl
+        Imxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjI2WiIsICJfaHJl
         ZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0ZlZG9yYV8xNy9kaXN0
         cmlidXRvcnMvRmVkb3JhXzE3X2Nsb25lLyIsICJsYXN0X292ZXJyaWRlX2Nv
         bmZpZyI6IHt9LCAibGFzdF9wdWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9y
         X3R5cGVfaWQiOiAieXVtX2Nsb25lX2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVi
         bGlzaCI6IGZhbHNlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9f
-        ZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y3MmFjZTIz
-        ZjA3YTY3ZTBlN2EifSwgImNvbmZpZyI6IHsiZGVzdGluYXRpb25fZGlzdHJp
+        ZGlzdHJpYnV0b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzNmMjdhY2Nl
+        OTA3ZTRkN2YyYTUifSwgImNvbmZpZyI6IHsiZGVzdGluYXRpb25fZGlzdHJp
         YnV0b3JfaWQiOiAiRmVkb3JhXzE3In0sICJpZCI6ICJGZWRvcmFfMTdfY2xv
         bmUifSwgeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0X3VwZGF0ZWQi
-        OiAiMjAxOS0wOC0wNVQxOToxMTo0NloiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
+        OiAiMjAxOS0wOC0zMFQxNDozNDoyNloiLCAiX2hyZWYiOiAiL3B1bHAvYXBp
         L3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvZGlzdHJpYnV0b3JzL0ZlZG9y
         YV8xNy8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVi
-        bGlzaCI6ICIyMDE5LTA4LTA1VDE5OjExOjQ3WiIsICJkaXN0cmlidXRvcl90
+        bGlzaCI6ICIyMDE5LTA4LTMwVDE0OjM0OjI4WiIsICJkaXN0cmlidXRvcl90
         eXBlX2lkIjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0
         cnVlLCAic2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0
-        b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y3MmFjZTIzZjA3YTY3ZTBl
-        NzkifSwgImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBm
+        b3JzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzNmMjdhY2NlOTA3ZTRkN2Yy
+        YTQifSwgImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBm
         YWxzZSwgImh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0Nv
         cnBvcmF0aW9uL2xpYnJhcnkvZmVkb3JhXzE3X2xhYmVsIn0sICJpZCI6ICJG
-        ZWRvcmFfMTcifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAxOS0wOC0wNVQx
-        OToxMTo0N1oiLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
+        ZWRvcmFfMTcifV0sICJsYXN0X3VuaXRfYWRkZWQiOiAiMjAxOS0wOC0zMFQx
+        NDozNDoyOFoiLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7Im1vZHVsZW1kX2RlZmF1bHRzIjogMywgImVycmF0dW0iOiA2
         LCAicGFja2FnZV9ncm91cCI6IDIsICJwYWNrYWdlX2NhdGVnb3J5IjogMSwg
         ImRpc3RyaWJ1dGlvbiI6IDEsICJtb2R1bGVtZCI6IDYsICJycG0iOiAxOCwg
         Inl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiOiAyfSwgIl9ucyI6ICJyZXBvcyIs
         ICJpbXBvcnRlcnMiOiBbeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJsYXN0
-        X3VwZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo0NloiLCAiX2hyZWYiOiAi
+        X3VwZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDoyNloiLCAiX2hyZWYiOiAi
         L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvaW1wb3J0ZXJz
         L3l1bV9pbXBvcnRlci8iLCAiX25zIjogInJlcG9faW1wb3J0ZXJzIiwgImlt
         cG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImxhc3Rfb3ZlcnJp
-        ZGVfY29uZmlnIjoge30sICJsYXN0X3N5bmMiOiAiMjAxOS0wOC0wNVQxOTox
-        MTo0N1oiLCAic2NyYXRjaHBhZCI6IHsicmVwb21kX3JldmlzaW9uIjogMTU2
+        ZGVfY29uZmlnIjoge30sICJsYXN0X3N5bmMiOiAiMjAxOS0wOC0zMFQxNDoz
+        NDoyOFoiLCAic2NyYXRjaHBhZCI6IHsicmVwb21kX3JldmlzaW9uIjogMTU2
         Mjc4MzM0NSwgInJlcG9tZF9jaGVja3N1bSI6ICIyOTFhZjNkN2M2ZGNlZTQ1
         YWM1ODdmYWEwYTIxZjdjNzI2NGMxNTZhYzQ4MDY3YjkxODFmMzk1ZDVlMjVi
-        MTA5In0sICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmNzJhY2UyM2YwN2E2N2Uw
-        ZTc4In0sICJjb25maWciOiB7ImZlZWQiOiAiZmlsZTovLy92YXIvd3d3L3Rl
+        MTA5In0sICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZjI3YWNjZTkwN2U0ZDdm
+        MmEzIn0sICJjb25maWciOiB7ImZlZWQiOiAiZmlsZTovLy92YXIvd3d3L3Rl
         c3RfcmVwb3Mvem9vIiwgInNzbF92YWxpZGF0aW9uIjogdHJ1ZSwgInJlbW92
         ZV9taXNzaW5nIjogdHJ1ZSwgImRvd25sb2FkX3BvbGljeSI6ICJvbl9kZW1h
         bmQiLCAicHJveHlfaG9zdCI6ICIifSwgImlkIjogInl1bV9pbXBvcnRlciJ9
         XSwgImxvY2FsbHlfc3RvcmVkX3VuaXRzIjogMzgsICJfaWQiOiB7IiRvaWQi
-        OiAiNWQ0ODdmNzJhY2UyM2YwN2E2N2UwZTc3In0sICJ0b3RhbF9yZXBvc2l0
+        OiAiNWQ2OTMzZjI3YWNjZTkwN2U0ZDdmMmEyIn0sICJ0b3RhbF9yZXBvc2l0
         b3J5X3VuaXRzIjogMzksICJpZCI6ICJGZWRvcmFfMTciLCAiX2hyZWYiOiAi
         L3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFfMTcvIn0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:50 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:31 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:50 GMT
+      - Fri, 30 Aug 2019 14:34:31 GMT
       Server:
       - Apache
       Etag:
-      - '"04f1d3f6947331511bde7fa2efb980c2-gzip"'
+      - '"994e2afe4c45b0dbc881401f6baca304-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2306'
+      - '624'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2458,79 +2205,79 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MTktMDgtMDVUMTk6MTE6NDhaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        MTktMDgtMzBUMTQ6MzQ6MjhaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
         ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3Ry
         aWJ1dG9yLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9w
         dWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0
         X2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRj
         aHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6
-        IHsiJG9pZCI6ICI1ZDQ4N2Y3NGFjZTIzZjA3YTY3ZTBlODAifSwgImNvbmZp
+        IHsiJG9pZCI6ICI1ZDY5MzNmNDdhY2NlOTA3ZTM4MWNlYjYifSwgImNvbmZp
         ZyI6IHsiaHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29y
         cG9yYXRpb24vbGlicmFyeS9MaWJyYXJ5Vmlldy9mZWRvcmFfMTdfbGFiZWwi
         LCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6ICJleHBvcnRfZGlzdHJpYnV0b3Ii
         fSwgeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MTktMDgtMDVUMTk6MTE6NDhaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        MTktMDgtMzBUMTQ6MzQ6MjhaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
         ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvM192aWV3MV9jbG9u
         ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
         aCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9jbG9uZV9k
         aXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hw
         YWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7
-        IiRvaWQiOiAiNWQ0ODdmNzRhY2UyM2YwN2E2N2UwZTdmIn0sICJjb25maWci
+        IiRvaWQiOiAiNWQ2OTMzZjQ3YWNjZTkwN2UzODFjZWI1In0sICJjb25maWci
         OiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogIjNfdmlldzEifSwg
         ImlkIjogIjNfdmlldzFfY2xvbmUifSwgeyJyZXBvX2lkIjogIjNfdmlldzEi
-        LCAibGFzdF91cGRhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6NDhaIiwgIl9o
+        LCAibGFzdF91cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6MjhaIiwgIl9o
         cmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0
         cmlidXRvcnMvM192aWV3MS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7
         fSwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lk
         IjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAi
         c2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwg
-        Il9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y3NGFjZTIzZjA3YTY3ZTBlN2UifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1ZDY5MzNmNDdhY2NlOTA3ZTM4MWNlYjQifSwg
         ImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwg
         Imh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0NvcnBvcmF0
         aW9uL2xpYnJhcnkvTGlicmFyeVZpZXcvZmVkb3JhXzE3X2xhYmVsIn0sICJp
         ZCI6ICIzX3ZpZXcxIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIwMTktMDgt
-        MDVUMTk6MTE6NDhaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
+        MzBUMTQ6MzQ6MjlaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
         ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
         aXRfY291bnRzIjogeyJwYWNrYWdlX2dyb3VwIjogMiwgIm1vZHVsZW1kIjog
         NiwgIm1vZHVsZW1kX2RlZmF1bHRzIjogMywgImVycmF0dW0iOiA2LCAiZGlz
         dHJpYnV0aW9uIjogMSwgInJwbSI6IDE4LCAieXVtX3JlcG9fbWV0YWRhdGFf
         ZmlsZSI6IDJ9LCAiX25zIjogInJlcG9zIiwgImltcG9ydGVycyI6IFt7InJl
-        cG9faWQiOiAiM192aWV3MSIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wOC0w
-        NVQxOToxMTo0OFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRv
+        cG9faWQiOiAiM192aWV3MSIsICJsYXN0X3VwZGF0ZWQiOiAiMjAxOS0wOC0z
+        MFQxNDozNDoyOFoiLCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRv
         cmllcy8zX3ZpZXcxL2ltcG9ydGVycy95dW1faW1wb3J0ZXIvIiwgIl9ucyI6
         ICJyZXBvX2ltcG9ydGVycyIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9p
         bXBvcnRlciIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9z
         eW5jIjogbnVsbCwgInNjcmF0Y2hwYWQiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3Zjc0YWNlMjNmMDdhNjdlMGU3ZCJ9LCAiY29uZmlnIjoge30s
+        IjogIjVkNjkzM2Y0N2FjY2U5MDdlMzgxY2ViMyJ9LCAiY29uZmlnIjoge30s
         ICJpZCI6ICJ5dW1faW1wb3J0ZXIifV0sICJsb2NhbGx5X3N0b3JlZF91bml0
-        cyI6IDM3LCAiX2lkIjogeyIkb2lkIjogIjVkNDg3Zjc0YWNlMjNmMDdhNjdl
-        MGU3YyJ9LCAidG90YWxfcmVwb3NpdG9yeV91bml0cyI6IDM4LCAiaWQiOiAi
+        cyI6IDM3LCAiX2lkIjogeyIkb2lkIjogIjVkNjkzM2Y0N2FjY2U5MDdlMzgx
+        Y2ViMiJ9LCAidG90YWxfcmVwb3NpdG9yeV91bml0cyI6IDM4LCAiaWQiOiAi
         M192aWV3MSIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVz
         LzNfdmlldzEvIn0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:50 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:32 GMT
 - request:
     method: delete
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:50 GMT
+      - Fri, 30 Aug 2019 14:34:32 GMT
       Server:
       - Apache
       Content-Length:
@@ -2541,41 +2288,41 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzM1NWE1NTkyLTMyNDAtNGE0ZC1iMGU5LTI3N2I4N2JjZWI5Zi8iLCAi
-        dGFza19pZCI6ICIzNTVhNTU5Mi0zMjQwLTRhNGQtYjBlOS0yNzdiODdiY2Vi
-        OWYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2Q4N2ZmMTUyLTQ3MDItNDlmOS1hZjg5LWRkZTIzZDVlOTJiYy8iLCAi
+        dGFza19pZCI6ICJkODdmZjE1Mi00NzAyLTQ5ZjktYWY4OS1kZGUyM2Q1ZTky
+        YmMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:50 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:32 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/355a5592-3240-4a4d-b0e9-277b87bceb9f/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/d87ff152-4702-49f9-af89-dde23d5e92bc/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:51 GMT
+      - Fri, 30 Aug 2019 14:34:32 GMT
       Server:
       - Apache
       Etag:
-      - '"003655f408a6fa54af25271f3778934f-gzip"'
+      - '"f0744c65e0a3958cd3a75c5186591b2e-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '689'
+      - '372'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2583,44 +2330,45 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zNTVhNTU5Mi0zMjQwLTRhNGQtYjBlOS0yNzdiODdiY2Vi
-        OWYvIiwgInRhc2tfaWQiOiAiMzU1YTU1OTItMzI0MC00YTRkLWIwZTktMjc3
-        Yjg3YmNlYjlmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9kODdmZjE1Mi00NzAyLTQ5ZjktYWY4OS1kZGUyM2Q1ZTky
+        YmMvIiwgInRhc2tfaWQiOiAiZDg3ZmYxNTItNDcwMi00OWY5LWFmODktZGRl
+        MjNkNWU5MmJjIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE5LTA4LTA1VDE5OjExOjUwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjUwWiIsICJ0cmFjZWJh
+        MDE5LTA4LTMwVDE0OjM0OjMyWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjMyWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
-        ImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
-        X3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVk
-        NDg3Zjc2YWIzNmNlM2ZlNTFkZWJlMCJ9LCAiaWQiOiAiNWQ0ODdmNzZhYjM2
-        Y2UzZmU1MWRlYmUwIn0=
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        LmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2
+        ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZjgzMmRiNjA3
+        N2E3OTY2MTJhIn0sICJpZCI6ICI1ZDY5MzNmODMyZGI2MDc3YTc5NjYxMmEi
+        fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:51 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:32 GMT
 - request:
     method: delete
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:51 GMT
+      - Fri, 30 Aug 2019 14:34:32 GMT
       Server:
       - Apache
       Content-Length:
@@ -2631,41 +2379,41 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2QwMjU0ZDQxLTI4MTItNDIwNi1iYjcwLTZjZjMyYmQ1NDA1Mi8iLCAi
-        dGFza19pZCI6ICJkMDI1NGQ0MS0yODEyLTQyMDYtYmI3MC02Y2YzMmJkNTQw
-        NTIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzI2YmMxNDdlLThkZTctNDAxYi1hMTAxLTBmNDM0YzA5MWJmMi8iLCAi
+        dGFza19pZCI6ICIyNmJjMTQ3ZS04ZGU3LTQwMWItYTEwMS0wZjQzNGMwOTFi
+        ZjIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:51 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:32 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/d0254d41-2812-4206-bb70-6cf32bd54052/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/26bc147e-8de7-401b-a101-0f434c091bf2/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:51 GMT
+      - Fri, 30 Aug 2019 14:34:32 GMT
       Server:
       - Apache
       Etag:
-      - '"ce70d608be2cbf778a2fda32b640d620-gzip"'
+      - '"115b2430756fce1288fd4118cb0a0526-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '687'
+      - '371'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2673,20 +2421,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9kMDI1NGQ0MS0yODEyLTQyMDYtYmI3MC02Y2YzMmJkNTQw
-        NTIvIiwgInRhc2tfaWQiOiAiZDAyNTRkNDEtMjgxMi00MjA2LWJiNzAtNmNm
-        MzJiZDU0MDUyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
+        aS92Mi90YXNrcy8yNmJjMTQ3ZS04ZGU3LTQwMWItYTEwMS0wZjQzNGMwOTFi
+        ZjIvIiwgInRhc2tfaWQiOiAiMjZiYzE0N2UtOGRlNy00MDFiLWExMDEtMGY0
+        MzRjMDkxYmYyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
         IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo1MVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo1MVoiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDozMloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDozMloiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9y
-        dCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
-        ZGV2ZWwubG9jYWxob3N0LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJm
-        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
-        b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20iLCAicmVzdWx0
-        IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4
-        N2Y3N2FiMzZjZTNmZTUxZGVjMmUifSwgImlkIjogIjVkNDg3Zjc3YWIzNmNl
-        M2ZlNTFkZWMyZSJ9
+        dCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJA
+        Y2VudG9zNy1rYXRlbGxvLWRldmVsLTIuY2Fubm9sby5leGFtcGxlLmNvbS5k
+        cTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRldmVs
+        LTIuY2Fubm9sby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNjkzM2Y4MzJkYjYwNzdh
+        Nzk2NjE3OCJ9LCAiaWQiOiAiNWQ2OTMzZjgzMmRiNjA3N2E3OTY2MTc4In0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:51 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:32 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/copy_rpm_filenames.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/copy_rpm_filenames.yml
@@ -2,26 +2,26 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:52 GMT
+      - Fri, 30 Aug 2019 14:34:33 GMT
       Server:
       - Apache
       Content-Length:
@@ -41,10 +41,10 @@ http_interactions:
         ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
         bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:52 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:33 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -75,21 +75,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '1043'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 201
       message: CREATED
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:52 GMT
+      - Fri, 30 Aug 2019 14:34:33 GMT
       Server:
       - Apache
       Content-Length:
@@ -106,14 +106,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWQ0ODdmNzhhY2UyM2YwN2E1MDZkZDIyIn0sICJpZCI6ICJGZWRvcmFfMTci
+        NWQ2OTMzZjk3YWNjZTkwN2U1N2E0ZGFlIn0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:52 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:33 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -122,21 +122,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '53'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:52 GMT
+      - Fri, 30 Aug 2019 14:34:33 GMT
       Server:
       - Apache
       Content-Length:
@@ -147,41 +147,41 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzlmYjA3NWJhLTEzMDktNGY3Ni05NjIxLWZhZDFhMGM2YWEwYi8iLCAi
-        dGFza19pZCI6ICI5ZmIwNzViYS0xMzA5LTRmNzYtOTYyMS1mYWQxYTBjNmFh
-        MGIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2M4N2YwYzJiLTRhNDktNDJkZi1hOTg4LTc2ZTEzMWQzYTY0Mi8iLCAi
+        dGFza19pZCI6ICJjODdmMGMyYi00YTQ5LTQyZGYtYTk4OC03NmUxMzFkM2E2
+        NDIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:52 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:33 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/9fb075ba-1309-4f76-9621-fad1a0c6aa0b/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/c87f0c2b-4a49-42df-a988-76e131d3a642/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:53 GMT
+      - Fri, 30 Aug 2019 14:34:35 GMT
       Server:
       - Apache
       Etag:
-      - '"b46cd77a3aa4d2024ba119f33e854dcb-gzip"'
+      - '"5b99dbb4de03e2cc5b385fe552aee118-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
+      - '723'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -189,16 +189,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85ZmIwNzViYS0xMzA5LTRmNzYtOTYyMS1mYWQxYTBjNmFh
-        MGIvIiwgInRhc2tfaWQiOiAiOWZiMDc1YmEtMTMwOS00Zjc2LTk2MjEtZmFk
-        MWEwYzZhYTBiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9jODdmMGMyYi00YTQ5LTQyZGYtYTk4OC03NmUxMzFkM2E2
+        NDIvIiwgInRhc2tfaWQiOiAiYzg3ZjBjMmItNGE0OS00MmRmLWE5ODgtNzZl
+        MTMxZDNhNjQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDozNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDozM1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzYyZjA3ZDUtZDEyZi00YTBkLTk1OTgtZDdlYzFiOGJk
-        NGI0LyIsICJ0YXNrX2lkIjogImM2MmYwN2Q1LWQxMmYtNGEwZC05NTk4LWQ3
-        ZWMxYjhiZDRiNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvZTVmODNhNDktNGVkMC00ZDIwLTk5MjctMDQ5MGZmODMz
+        NGNiLyIsICJ0YXNrX2lkIjogImU1ZjgzYTQ5LTRlZDAtNGQyMC05OTI3LTA0
+        OTBmZjgzMzRjYiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -210,69 +210,70 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjExOjUzWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y3OWFjZTIzZjBhMTQ5NDQ1NWMiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3Zjc4YWIzNmNlM2ZlNTFkZWM5YiJ9LCAiaWQiOiAiNWQ0ODdm
-        NzhhYjM2Y2UzZmU1MWRlYzliIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        Mi5jYW5ub2xvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjMzWiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6MzVa
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
+        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3ZlZF9jb3VudCI6
+        IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVkNjkzM2ZiN2FjY2U5
+        MGI2MzlmYzZmNCIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJp
+        dGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90
+        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
+        X2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZjkz
+        MmRiNjA3N2E3OTY2MWYzIn0sICJpZCI6ICI1ZDY5MzNmOTMyZGI2MDc3YTc5
+        NjYxZjMifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:53 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:35 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/9fb075ba-1309-4f76-9621-fad1a0c6aa0b/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/c87f0c2b-4a49-42df-a988-76e131d3a642/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:53 GMT
+      - Fri, 30 Aug 2019 14:34:35 GMT
       Server:
       - Apache
       Etag:
-      - '"b46cd77a3aa4d2024ba119f33e854dcb-gzip"'
+      - '"5b99dbb4de03e2cc5b385fe552aee118-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
+      - '723'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -280,16 +281,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85ZmIwNzViYS0xMzA5LTRmNzYtOTYyMS1mYWQxYTBjNmFh
-        MGIvIiwgInRhc2tfaWQiOiAiOWZiMDc1YmEtMTMwOS00Zjc2LTk2MjEtZmFk
-        MWEwYzZhYTBiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9jODdmMGMyYi00YTQ5LTQyZGYtYTk4OC03NmUxMzFkM2E2
+        NDIvIiwgInRhc2tfaWQiOiAiYzg3ZjBjMmItNGE0OS00MmRmLWE5ODgtNzZl
+        MTMxZDNhNjQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDozNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDozM1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzYyZjA3ZDUtZDEyZi00YTBkLTk1OTgtZDdlYzFiOGJk
-        NGI0LyIsICJ0YXNrX2lkIjogImM2MmYwN2Q1LWQxMmYtNGEwZC05NTk4LWQ3
-        ZWMxYjhiZDRiNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvZTVmODNhNDktNGVkMC00ZDIwLTk5MjctMDQ5MGZmODMz
+        NGNiLyIsICJ0YXNrX2lkIjogImU1ZjgzYTQ5LTRlZDAtNGQyMC05OTI3LTA0
+        OTBmZjgzMzRjYiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -301,69 +302,70 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjExOjUzWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y3OWFjZTIzZjBhMTQ5NDQ1NWMiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3Zjc4YWIzNmNlM2ZlNTFkZWM5YiJ9LCAiaWQiOiAiNWQ0ODdm
-        NzhhYjM2Y2UzZmU1MWRlYzliIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        Mi5jYW5ub2xvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjMzWiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6MzVa
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
+        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3ZlZF9jb3VudCI6
+        IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVkNjkzM2ZiN2FjY2U5
+        MGI2MzlmYzZmNCIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJp
+        dGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90
+        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
+        X2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZjkz
+        MmRiNjA3N2E3OTY2MWYzIn0sICJpZCI6ICI1ZDY5MzNmOTMyZGI2MDc3YTc5
+        NjYxZjMifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:53 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:35 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/9fb075ba-1309-4f76-9621-fad1a0c6aa0b/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/c87f0c2b-4a49-42df-a988-76e131d3a642/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:53 GMT
+      - Fri, 30 Aug 2019 14:34:35 GMT
       Server:
       - Apache
       Etag:
-      - '"b46cd77a3aa4d2024ba119f33e854dcb-gzip"'
+      - '"5b99dbb4de03e2cc5b385fe552aee118-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
+      - '723'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -371,16 +373,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85ZmIwNzViYS0xMzA5LTRmNzYtOTYyMS1mYWQxYTBjNmFh
-        MGIvIiwgInRhc2tfaWQiOiAiOWZiMDc1YmEtMTMwOS00Zjc2LTk2MjEtZmFk
-        MWEwYzZhYTBiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9jODdmMGMyYi00YTQ5LTQyZGYtYTk4OC03NmUxMzFkM2E2
+        NDIvIiwgInRhc2tfaWQiOiAiYzg3ZjBjMmItNGE0OS00MmRmLWE5ODgtNzZl
+        MTMxZDNhNjQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDozNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDozM1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzYyZjA3ZDUtZDEyZi00YTBkLTk1OTgtZDdlYzFiOGJk
-        NGI0LyIsICJ0YXNrX2lkIjogImM2MmYwN2Q1LWQxMmYtNGEwZC05NTk4LWQ3
-        ZWMxYjhiZDRiNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvZTVmODNhNDktNGVkMC00ZDIwLTk5MjctMDQ5MGZmODMz
+        NGNiLyIsICJ0YXNrX2lkIjogImU1ZjgzYTQ5LTRlZDAtNGQyMC05OTI3LTA0
+        OTBmZjgzMzRjYiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -392,69 +394,70 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjExOjUzWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y3OWFjZTIzZjBhMTQ5NDQ1NWMiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3Zjc4YWIzNmNlM2ZlNTFkZWM5YiJ9LCAiaWQiOiAiNWQ0ODdm
-        NzhhYjM2Y2UzZmU1MWRlYzliIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        Mi5jYW5ub2xvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjMzWiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6MzVa
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
+        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3ZlZF9jb3VudCI6
+        IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVkNjkzM2ZiN2FjY2U5
+        MGI2MzlmYzZmNCIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJp
+        dGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90
+        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
+        X2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZjkz
+        MmRiNjA3N2E3OTY2MWYzIn0sICJpZCI6ICI1ZDY5MzNmOTMyZGI2MDc3YTc5
+        NjYxZjMifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:53 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:35 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/9fb075ba-1309-4f76-9621-fad1a0c6aa0b/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/c87f0c2b-4a49-42df-a988-76e131d3a642/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:53 GMT
+      - Fri, 30 Aug 2019 14:34:35 GMT
       Server:
       - Apache
       Etag:
-      - '"b46cd77a3aa4d2024ba119f33e854dcb-gzip"'
+      - '"5b99dbb4de03e2cc5b385fe552aee118-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
+      - '723'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -462,16 +465,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85ZmIwNzViYS0xMzA5LTRmNzYtOTYyMS1mYWQxYTBjNmFh
-        MGIvIiwgInRhc2tfaWQiOiAiOWZiMDc1YmEtMTMwOS00Zjc2LTk2MjEtZmFk
-        MWEwYzZhYTBiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9jODdmMGMyYi00YTQ5LTQyZGYtYTk4OC03NmUxMzFkM2E2
+        NDIvIiwgInRhc2tfaWQiOiAiYzg3ZjBjMmItNGE0OS00MmRmLWE5ODgtNzZl
+        MTMxZDNhNjQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDozNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDozM1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzYyZjA3ZDUtZDEyZi00YTBkLTk1OTgtZDdlYzFiOGJk
-        NGI0LyIsICJ0YXNrX2lkIjogImM2MmYwN2Q1LWQxMmYtNGEwZC05NTk4LWQ3
-        ZWMxYjhiZDRiNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvZTVmODNhNDktNGVkMC00ZDIwLTk5MjctMDQ5MGZmODMz
+        NGNiLyIsICJ0YXNrX2lkIjogImU1ZjgzYTQ5LTRlZDAtNGQyMC05OTI3LTA0
+        OTBmZjgzMzRjYiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -483,69 +486,70 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjExOjUzWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y3OWFjZTIzZjBhMTQ5NDQ1NWMiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3Zjc4YWIzNmNlM2ZlNTFkZWM5YiJ9LCAiaWQiOiAiNWQ0ODdm
-        NzhhYjM2Y2UzZmU1MWRlYzliIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        Mi5jYW5ub2xvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjMzWiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6MzVa
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
+        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3ZlZF9jb3VudCI6
+        IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVkNjkzM2ZiN2FjY2U5
+        MGI2MzlmYzZmNCIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJp
+        dGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90
+        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
+        X2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZjkz
+        MmRiNjA3N2E3OTY2MWYzIn0sICJpZCI6ICI1ZDY5MzNmOTMyZGI2MDc3YTc5
+        NjYxZjMifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:53 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:35 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/9fb075ba-1309-4f76-9621-fad1a0c6aa0b/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/c87f0c2b-4a49-42df-a988-76e131d3a642/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:53 GMT
+      - Fri, 30 Aug 2019 14:34:35 GMT
       Server:
       - Apache
       Etag:
-      - '"b46cd77a3aa4d2024ba119f33e854dcb-gzip"'
+      - '"5b99dbb4de03e2cc5b385fe552aee118-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
+      - '723'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -553,16 +557,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85ZmIwNzViYS0xMzA5LTRmNzYtOTYyMS1mYWQxYTBjNmFh
-        MGIvIiwgInRhc2tfaWQiOiAiOWZiMDc1YmEtMTMwOS00Zjc2LTk2MjEtZmFk
-        MWEwYzZhYTBiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9jODdmMGMyYi00YTQ5LTQyZGYtYTk4OC03NmUxMzFkM2E2
+        NDIvIiwgInRhc2tfaWQiOiAiYzg3ZjBjMmItNGE0OS00MmRmLWE5ODgtNzZl
+        MTMxZDNhNjQyIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDozNVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDozM1oiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzYyZjA3ZDUtZDEyZi00YTBkLTk1OTgtZDdlYzFiOGJk
-        NGI0LyIsICJ0YXNrX2lkIjogImM2MmYwN2Q1LWQxMmYtNGEwZC05NTk4LWQ3
-        ZWMxYjhiZDRiNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvZTVmODNhNDktNGVkMC00ZDIwLTk5MjctMDQ5MGZmODMz
+        NGNiLyIsICJ0YXNrX2lkIjogImU1ZjgzYTQ5LTRlZDAtNGQyMC05OTI3LTA0
+        OTBmZjgzMzRjYiJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -574,433 +578,70 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjExOjUzWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y3OWFjZTIzZjBhMTQ5NDQ1NWMiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3Zjc4YWIzNmNlM2ZlNTFkZWM5YiJ9LCAiaWQiOiAiNWQ0ODdm
-        NzhhYjM2Y2UzZmU1MWRlYzliIn0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        Mi5jYW5ub2xvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjMzWiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6MzVa
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
+        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3ZlZF9jb3VudCI6
+        IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVkNjkzM2ZiN2FjY2U5
+        MGI2MzlmYzZmNCIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJp
+        dGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90
+        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
+        X2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZjkz
+        MmRiNjA3N2E3OTY2MWYzIn0sICJpZCI6ICI1ZDY5MzNmOTMyZGI2MDc3YTc5
+        NjYxZjMifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:53 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:35 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/9fb075ba-1309-4f76-9621-fad1a0c6aa0b/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/e5f83a49-4ed0-4d20-9927-0490ff8334cb/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:53 GMT
+      - Fri, 30 Aug 2019 14:34:35 GMT
       Server:
       - Apache
       Etag:
-      - '"b46cd77a3aa4d2024ba119f33e854dcb-gzip"'
+      - '"b86a5b0088065681b1d663e1310a0701-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85ZmIwNzViYS0xMzA5LTRmNzYtOTYyMS1mYWQxYTBjNmFh
-        MGIvIiwgInRhc2tfaWQiOiAiOWZiMDc1YmEtMTMwOS00Zjc2LTk2MjEtZmFk
-        MWEwYzZhYTBiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzYyZjA3ZDUtZDEyZi00YTBkLTk1OTgtZDdlYzFiOGJk
-        NGI0LyIsICJ0YXNrX2lkIjogImM2MmYwN2Q1LWQxMmYtNGEwZC05NTk4LWQ3
-        ZWMxYjhiZDRiNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjExOjUzWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y3OWFjZTIzZjBhMTQ5NDQ1NWMiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3Zjc4YWIzNmNlM2ZlNTFkZWM5YiJ9LCAiaWQiOiAiNWQ0ODdm
-        NzhhYjM2Y2UzZmU1MWRlYzliIn0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:53 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/9fb075ba-1309-4f76-9621-fad1a0c6aa0b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:11:53 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"b46cd77a3aa4d2024ba119f33e854dcb-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2405'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85ZmIwNzViYS0xMzA5LTRmNzYtOTYyMS1mYWQxYTBjNmFh
-        MGIvIiwgInRhc2tfaWQiOiAiOWZiMDc1YmEtMTMwOS00Zjc2LTk2MjEtZmFk
-        MWEwYzZhYTBiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzYyZjA3ZDUtZDEyZi00YTBkLTk1OTgtZDdlYzFiOGJk
-        NGI0LyIsICJ0YXNrX2lkIjogImM2MmYwN2Q1LWQxMmYtNGEwZC05NTk4LWQ3
-        ZWMxYjhiZDRiNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjExOjUzWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y3OWFjZTIzZjBhMTQ5NDQ1NWMiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3Zjc4YWIzNmNlM2ZlNTFkZWM5YiJ9LCAiaWQiOiAiNWQ0ODdm
-        NzhhYjM2Y2UzZmU1MWRlYzliIn0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:53 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/9fb075ba-1309-4f76-9621-fad1a0c6aa0b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:11:53 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"b46cd77a3aa4d2024ba119f33e854dcb-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2405'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85ZmIwNzViYS0xMzA5LTRmNzYtOTYyMS1mYWQxYTBjNmFh
-        MGIvIiwgInRhc2tfaWQiOiAiOWZiMDc1YmEtMTMwOS00Zjc2LTk2MjEtZmFk
-        MWEwYzZhYTBiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzYyZjA3ZDUtZDEyZi00YTBkLTk1OTgtZDdlYzFiOGJk
-        NGI0LyIsICJ0YXNrX2lkIjogImM2MmYwN2Q1LWQxMmYtNGEwZC05NTk4LWQ3
-        ZWMxYjhiZDRiNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjExOjUzWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y3OWFjZTIzZjBhMTQ5NDQ1NWMiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3Zjc4YWIzNmNlM2ZlNTFkZWM5YiJ9LCAiaWQiOiAiNWQ0ODdm
-        NzhhYjM2Y2UzZmU1MWRlYzliIn0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:53 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/9fb075ba-1309-4f76-9621-fad1a0c6aa0b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:11:53 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"b46cd77a3aa4d2024ba119f33e854dcb-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2405'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy85ZmIwNzViYS0xMzA5LTRmNzYtOTYyMS1mYWQxYTBjNmFh
-        MGIvIiwgInRhc2tfaWQiOiAiOWZiMDc1YmEtMTMwOS00Zjc2LTk2MjEtZmFk
-        MWEwYzZhYTBiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo1M1oiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvYzYyZjA3ZDUtZDEyZi00YTBkLTk1OTgtZDdlYzFiOGJk
-        NGI0LyIsICJ0YXNrX2lkIjogImM2MmYwN2Q1LWQxMmYtNGEwZC05NTk4LWQ3
-        ZWMxYjhiZDRiNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjExOjUzWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y3OWFjZTIzZjBhMTQ5NDQ1NWMiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3Zjc4YWIzNmNlM2ZlNTFkZWM5YiJ9LCAiaWQiOiAiNWQ0ODdm
-        NzhhYjM2Y2UzZmU1MWRlYzliIn0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:53 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/c62f07d5-d12f-4a0d-9598-d7ec1b8bd4b4/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:11:53 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"f9595bab23d46f308207fb7a46010560-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '8529'
+      - '1369'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1008,199 +649,200 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy9jNjJmMDdkNS1kMTJmLTRhMGQtOTU5OC1kN2Vj
-        MWI4YmQ0YjQvIiwgInRhc2tfaWQiOiAiYzYyZjA3ZDUtZDEyZi00YTBkLTk1
-        OTgtZDdlYzFiOGJkNGI0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy9lNWY4M2E0OS00ZWQwLTRkMjAtOTkyNy0wNDkw
+        ZmY4MzM0Y2IvIiwgInRhc2tfaWQiOiAiZTVmODNhNDktNGVkMC00ZDIwLTk5
+        MjctMDQ5MGZmODMzNGNiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxOS0wOC0wNVQxOToxMTo1M1oiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo1M1oiLCAi
+        bWUiOiAiMjAxOS0wOC0zMFQxNDozNDozNVoiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDozNVoiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI2Mzg5ZjdlMi1mMGY1LTRmNmUtOWIyYi05Y2QyMGFh
-        YjIwZTEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICIxNWViZTk4YS0yNThmLTQ4MTUtYTMwYy0yOWE2OTlj
+        MWE3N2UiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiMTMxYzIzYjctMDIwMS00YzU2LWFjZjMtNjc1Y2I5Y2M1ZWY5Iiwg
+        aWQiOiAiN2ZiNmNmZWYtMmFhMy00Y2E3LTlkZGMtMGFhODg0YmQ5NGQ4Iiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVz
         Y3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJy
         cG1zIiwgIml0ZW1zX3RvdGFsIjogMTgsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiNjg2YjdlMS1hOGMyLTQxZmYtOGY0
-        MC01NTQ2YzI3NzUyMmYiLCAibnVtX3Byb2Nlc3NlZCI6IDE4fSwgeyJudW1f
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIwODM3NjBlMC02NzUzLTRjYTEtODBk
+        MC1lNDY5NmYwN2FjNGMiLCAibnVtX3Byb2Nlc3NlZCI6IDE4fSwgeyJudW1f
         c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRh
         IFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjog
         MSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        ZDdlY2IxN2YtMjdmZS00NzIxLWI5MDUtM2JjMDc1YjJkNTBiIiwgIm51bV9w
+        N2ZlNjlkZjgtMGIxNS00YTNiLTgwNTAtNTU4ZGRmNTY1ZDhiIiwgIm51bV9w
         cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlv
         biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
         IiwgIml0ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
         cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogIjBiZmZkNmE3LTM1NzQtNDM5My05ZDIzLTNj
-        NTVkNjlhZmIxNyIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
+        cyI6IDAsICJzdGVwX2lkIjogIjJmNTgwNTA3LTllMmMtNDA3YS1hMWYzLWQx
+        MWE5ZTQ4MWNkZSIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
         c3MiOiA5LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwg
         InN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0
         YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjJmN2U2
-        ZDhjLTAyMDUtNDQyZi04NzczLTJkMTE5NGI2MWZlNiIsICJudW1fcHJvY2Vz
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImRlMGYx
+        NWU1LWE1ZDQtNDJiYi1iZmM3LTc3N2U2MjMyNzc3OSIsICJudW1fcHJvY2Vz
         c2VkIjogOX0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAi
         UHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIs
         ICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI2ZjMxYzlhNC04Nzg4LTQ1ZDAtOTAxNy02MTQ3
-        Nzk2NTlmODkiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICJkYjM1ZWQyMy1jMGM0LTQ4YjQtYTVhMi1jYmYy
+        NWY1M2ZmNzAiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNz
         IjogMiwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwg
         InN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDIsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkYjFh
-        ZWFlYy0yYWUwLTQ1NzAtYjcwYi1hZDMzZWEzMjEzNzYiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJjNGJh
+        MGJkYy0xNzZmLTRjZjktOTllMy0wZTY0NTRjMzc0OTMiLCAibnVtX3Byb2Nl
         c3NlZCI6IDJ9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2Vf
         cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNzAzZTI1My1iMmQ4
-        LTQ0MWYtYmZhYi1hNzQwMzQ4MjY1NWMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzMjA4ODBjZC05Yzdk
+        LTQ2YjQtYTU5Mi05N2QyOTQyZmZkMzMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRp
         bmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxp
         dGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI2ZGE5ODhhNi0zNjllLTQ3NWQtYjNlNC03
-        MDBmN2M3NmRlMTIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIzNTVkYTM5NC0yMWJmLTQ2ZDctYWU1NC00
+        MTExM2NiZTU4YWIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0
         YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVt
         c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICI4NzdmMjM0Yy0zYzI5LTQ5MjEtODYxNi02ZDAzYzgxMGVl
-        MmMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICJkNDA4ZjlhZS1kOWI2LTQ3YWItOWZiZi0xNjY4ODI1ZGI3
+        OGYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVw
         X3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
         OiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4OTM4MTM1ZS1h
-        MzZlLTQ0NWYtYjY5OS04NzEyNmFkYTllOTAiLCAibnVtX3Byb2Nlc3NlZCI6
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJlNTc4M2I0Yi02
+        ODhkLTQ3OWItYWU4Yy0wZjNlMTBjOWJjMDkiLCAibnVtX3Byb2Nlc3NlZCI6
         IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
         c2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2Rp
         cmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
         RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIyZjhkNzRiMi04MzlkLTQ0OTAt
-        OTg0Ni01M2Y5ODczN2M0NGQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJiZTg2MTgyYy0zNTgyLTQzNzgt
+        ODUyMi1lNWE0Y2Q5YzIwYzUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
         bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGlu
         Z3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
         YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjMxMjMxZDYzLWMyMjctNDQ1Yi05ODRh
-        LWZmZjhhNWRmYTgyOSIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29y
-        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwu
-        bG9jYWxob3N0LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0Ijog
-        InN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVk
-        b3JhXzE3IiwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1M1oiLCAi
-        X25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIy
-        MDE5LTA4LTA1VDE5OjExOjUzWiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlz
-        dHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFy
-        eSI6IHsiZ2VuZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNI
-        RUQiLCAicmVtb3ZlX29sZF9yZXBvZGF0YSI6ICJGSU5JU0hFRCIsICJtb2R1
-        bGVzIjogIkZJTklTSEVEIiwgImNsb3NlX3JlcG9fbWV0YWRhdGEiOiAiRklO
-        SVNIRUQiLCAiZHJwbXMiOiAiU0tJUFBFRCIsICJjb21wcyI6ICJGSU5JU0hF
-        RCIsICJkaXN0cmlidXRpb24iOiAiRklOSVNIRUQiLCAicmVwb3ZpZXciOiAi
-        U0tJUFBFRCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJGSU5JU0hFRCIsICJl
-        cnJhdGEiOiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAiRklOSVNIRUQifSwg
-        ImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiRmVk
-        b3JhXzE3IiwgImlkIjogIjVkNDg3Zjc5YWNlMjNmMGExNDk0NDU1ZCIsICJk
-        ZXRhaWxzIjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2Mzg5
-        ZjdlMi1mMGY1LTRmNmUtOWIyYi05Y2QyMGFhYjIwZTEiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMTMxYzIzYjctMDIw
-        MS00YzU2LWFjZjMtNjc1Y2I5Y2M1ZWY5IiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFs
-        IjogMTgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICJiNjg2YjdlMS1hOGMyLTQxZmYtOGY0MC01NTQ2YzI3NzUyMmYiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDE4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
-        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQ
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiZDdlY2IxN2YtMjdmZS00NzIx
-        LWI5MDUtM2JjMDc1YjJkNTBiIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
-        dW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVy
-        cmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjog
-        NiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        IjBiZmZkNmE3LTM1NzQtNDM5My05ZDIzLTNjNTVkNjlhZmIxNyIsICJudW1f
-        cHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nlc3MiOiA5LCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1
-        bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjJmN2U2ZDhjLTAyMDUtNDQyZi04Nzcz
-        LTJkMTE5NGI2MWZlNiIsICJudW1fcHJvY2Vzc2VkIjogOX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBm
-        aWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI2
-        ZjMxYzlhNC04Nzg4LTQ1ZDAtOTAxNy02MTQ3Nzk2NTlmODkiLCAibnVtX3By
-        b2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMiwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRh
-        ZGF0YSIsICJpdGVtc190b3RhbCI6IDIsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkYjFhZWFlYy0yYWUwLTQ1NzAtYjcw
-        Yi1hZDMzZWEzMjEzNzYiLCAibnVtX3Byb2Nlc3NlZCI6IDJ9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRh
-        ZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjNkYTFmNGFiLTgyYjAtNDNlMi1hOWI2
+        LTZlNGM2MWZkZjc1OCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxs
+        by1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        ImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJl
+        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3Rh
+        cnRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjM1WiIsICJfbnMiOiAicmVwb19w
+        dWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTktMDgtMzBUMTQ6
+        MzQ6MzVaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBl
+        X2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0
+        ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJycG1zIjogIkZJTklTSEVEIiwgImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJyZW1vdmVf
+        b2xkX3JlcG9kYXRhIjogIkZJTklTSEVEIiwgIm1vZHVsZXMiOiAiRklOSVNI
+        RUQiLCAiY2xvc2VfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJkcnBt
+        cyI6ICJTS0lQUEVEIiwgImNvbXBzIjogIkZJTklTSEVEIiwgImRpc3RyaWJ1
+        dGlvbiI6ICJGSU5JU0hFRCIsICJyZXBvdmlldyI6ICJTS0lQUEVEIiwgInB1
+        Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5J
+        U0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2Fn
+        ZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQi
+        OiAiNWQ2OTMzZmI3YWNjZTkwYjYzOWZjNmY1IiwgImRldGFpbHMiOiBbeyJu
+        dW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcg
+        cmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE1ZWJlOThhLTI1OGYtNDgx
+        NS1hMzBjLTI5YTY5OWMxYTc3ZSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        aXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlv
+        biIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICI3ZmI2Y2ZlZi0yYWEzLTRjYTctOWRkYy0w
+        YWE4ODRiZDk0ZDgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMTgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAi
+        c3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiAxOCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjA4Mzc2MGUw
+        LTY3NTMtNGNhMS04MGQwLWU0Njk2ZjA3YWM0YyIsICJudW1fcHJvY2Vzc2Vk
+        IjogMTh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAi
+        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICJhNzAzZTI1My1iMmQ4LTQ0MWYtYmZhYi1hNzQwMzQ4
-        MjY1NWMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwg
-        InN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwi
-        OiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI2ZGE5ODhhNi0zNjllLTQ3NWQtYjNlNC03MDBmN2M3NmRlMTIiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0
-        aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAi
-        cmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4NzdmMjM0
-        Yy0zYzI5LTQ5MjEtODYxNi02ZDAzYzgxMGVlMmMiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdl
-        bmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXci
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI4OTM4MTM1ZS1hMzZlLTQ0NWYtYjY5OS04NzEy
-        NmFkYTllOTAiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2Vi
-        IiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICIyZjhkNzRiMi04MzlkLTQ0OTAtOTg0Ni01M2Y5ODczN2M0NGQi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
-        c2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        LCAic3RlcF9pZCI6ICI3ZmU2OWRmOC0wYjE1LTRhM2ItODA1MC01NThkZGY1
+        NjVkOGIiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        NiwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBf
+        dHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiA2LCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMmY1ODA1MDctOWUy
+        Yy00MDdhLWExZjMtZDExYTllNDgxY2RlIiwgIm51bV9wcm9jZXNzZWQiOiA2
+        fSwgeyJudW1fc3VjY2VzcyI6IDksICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNf
+        dG90YWwiOiA5LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiZGUwZjE1ZTUtYTVkNC00MmJiLWJmYzctNzc3ZTYyMzI3Nzc5
+        IiwgIm51bV9wcm9jZXNzZWQiOiA5fSwgeyJudW1fc3VjY2VzcyI6IDMsICJk
+        ZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90
+        eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImRiMzVlZDIzLWMwYzQt
+        NDhiNC1hNWEyLWNiZjI1ZjUzZmY3MCIsICJudW1fcHJvY2Vzc2VkIjogM30s
+        IHsibnVtX3N1Y2Nlc3MiOiAyLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogImM0YmEwYmRjLTE3NmYtNGNmOS05OWUzLTBlNjQ1NGMzNzQ5
+        MyIsICJudW1fcHJvY2Vzc2VkIjogMn0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBf
+        dHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjog
+        MSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        IjMyMDg4MGNkLTljN2QtNDZiNC1hNTkyLTk3ZDI5NDJmZmQzMyIsICJudW1f
+        cHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjog
+        ImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjM1NWRhMzk0LTIx
+        YmYtNDZkNy1hZTU0LTQxMTEzY2JlNThhYiIsICJudW1fcHJvY2Vzc2VkIjog
+        MH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zp
+        bmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3Jl
+        cG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImQ0MDhmOWFlLWQ5YjYtNDdhYi05
+        ZmJmLTE2Njg4MjVkYjc4ZiIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1M
+        IGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjMxMjMxZDYzLWMyMjctNDQ1Yi05ODRhLWZmZjhhNWRmYTgyOSIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
-        JG9pZCI6ICI1ZDQ4N2Y3OWFiMzZjZTNmZTUxZGVmNTgifSwgImlkIjogIjVk
-        NDg3Zjc5YWIzNmNlM2ZlNTFkZWY1OCJ9
+        IjogImU1NzgzYjRiLTY4OGQtNDc5Yi1hZThjLTBmM2UxMGM5YmMwOSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
+        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImJlODYx
+        ODJjLTM1ODItNDM3OC04NTIyLWU1YTRjZDljMjBjNSIsICJudW1fcHJvY2Vz
+        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
+        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiM2RhMWY0YWIt
+        ODJiMC00M2UyLWE5YjYtNmU0YzYxZmRmNzU4IiwgIm51bV9wcm9jZXNzZWQi
+        OiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNjkz
+        M2ZiMzJkYjYwNzdhNzk2NmM3ZiJ9LCAiaWQiOiAiNWQ2OTMzZmIzMmRiNjA3
+        N2E3OTY2YzdmIn0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:53 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:35 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1225,21 +867,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '790'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 201
       message: CREATED
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:53 GMT
+      - Fri, 30 Aug 2019 14:34:35 GMT
       Server:
       - Apache
       Content-Length:
@@ -1256,14 +898,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWQ0ODdmNzlhY2UyM2YwN2E2N2UwZTg0In0sICJpZCI6ICIzX3ZpZXcxIiwg
+        NWQ2OTMzZmI3YWNjZTkwN2U0ZDdmMmFiIn0sICJpZCI6ICIzX3ZpZXcxIiwg
         Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS8i
         fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:53 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:35 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1274,182 +916,73 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '174'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:53 GMT
+      - Fri, 30 Aug 2019 14:34:35 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '10992'
+      - '2057'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJ3YWxydXMtMC43MS0xLnNy
-        Yy5ycG0iLCAibmFtZSI6ICJ3YWxydXMiLCAiY2hlY2tzdW0iOiAiNTE2YTIy
-        Y2NjMGNiZTNlY2IyY2JlZTFjNjI2YTM5YjkxNzY3ZGJmMGY4MTVhZmRhN2I3
-        MzNhYTU2NTIzMTQyYyIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBv
-        ZiB3YWxydXMiLCAiZmlsZW5hbWUiOiAid2FscnVzLTAuNzEtMS5ub2FyY2gu
-        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjcxIiwgImlzX21v
-        ZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVs
-        ZWFzZSI6ICIxIiwgIl9pZCI6ICIwNzI2MDI4ZC1kM2EwLTQxYzYtYTNjMi1i
-        ODIxM2Q0ODA1NzMiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAi
-        MjAxOS0wOC0wNVQxOToxMTo1MloiLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAiY3JlYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjUyWiIsICJ1bml0X3R5
-        cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiMDcyNjAyOGQtZDNhMC00MWM2
-        LWEzYzItYjgyMTNkNDgwNTczIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y3
-        OGFiMzZjZTNmZTUxZGVkMWMifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJw
-        bSI6ICJlbGVwaGFudC0wLjItMS5zcmMucnBtIiwgIm5hbWUiOiAiZWxlcGhh
-        bnQiLCAiY2hlY2tzdW0iOiAiMzMzNTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJl
-        ODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0MzlkZGQxMjViOSIsICJzdW1t
-        YXJ5IjogIkZha2UgcHJvdmlkZSBmb3IgZWxlcGhhbnQuIiwgImZpbGVuYW1l
-        IjogImVsZXBoYW50LTAuMi0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIs
-        ICJ2ZXJzaW9uIjogIjAuMiIsICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjog
-        IjE3MmM3OTZiLTJiZDMtNDA5NS1hN2E1LTI3Y2RlOGMwOWRlYSIsICJhcmNo
-        IjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjUy
-        WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTkt
-        MDgtMDVUMTk6MTE6NTJaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5p
-        dF9pZCI6ICIxNzJjNzk2Yi0yYmQzLTQwOTUtYTdhNS0yN2NkZThjMDlkZWEi
-        LCAiX2lkIjogeyIkb2lkIjogIjVkNDg3Zjc4YWIzNmNlM2ZlNTFkZWQ5NyJ9
-        fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImthbmdhcm9vLTAuMy0x
-        LnNyYy5ycG0iLCAibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVja3N1bSI6ICI4
-        NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcyODBjMTQxZTkyMDJmMDI0ZTdkYjM4
-        Y2JhM2QwOTdjM2YyNTZiMmZkIiwgInN1bW1hcnkiOiAiaG9wIGxpa2UgYSBr
-        YW5nYXJvbyBpbiBBdXN0cmFsaWEiLCAiZmlsZW5hbWUiOiAia2FuZ2Fyb28t
-        MC4zLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAi
-        MC4zIiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6
-        ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICIyZDQ5MWU4My01MGM0
-        LTRjMjUtOTgwNS0zNzNmMjcwZDVlMjEiLCAiYXJjaCI6ICJub2FyY2gifSwg
-        InVwZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjUy
-        WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiMmQ0OTFl
-        ODMtNTBjNC00YzI1LTk4MDUtMzczZjI3MGQ1ZTIxIiwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1ZDQ4N2Y3OGFiMzZjZTNmZTUxZGVjZmUifX0sIHsibWV0YWRhdGEi
-        OiB7InNvdXJjZXJwbSI6ICJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCAi
-        bmFtZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFiNDIx
-        MzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEw
-        YTcwMWYzIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBo
-        YW50IiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJw
-        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVs
-        YXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVh
-        c2UiOiAiMC44IiwgIl9pZCI6ICIyZjAwZTcxMC0yYmQ2LTRmNGQtODhlNS04
-        NWNjZDBlZjhjYzAiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAi
-        MjAxOS0wOC0wNVQxOToxMTo1MloiLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAiY3JlYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjUyWiIsICJ1bml0X3R5
-        cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiMmYwMGU3MTAtMmJkNi00ZjRk
-        LTg4ZTUtODVjY2QwZWY4Y2MwIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y3
-        OGFiMzZjZTNmZTUxZGVjZjMifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJw
-        bSI6ICJhcm1hZGlsbG8tMC4yLTEuc3JjLnJwbSIsICJuYW1lIjogImFybWFk
-        aWxsbyIsICJjaGVja3N1bSI6ICI4ZDMxOTkwNWVlZGI1YTUyNDdlM2EzNTI1
-        ODg5YTI4ZDVkNjRlODIyMDA3NDEzZDAyNTg3YjZmNTFhYjNiNjVhIiwgInN1
-        bW1hcnkiOiAiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwgImZpbGVu
-        YW1lIjogImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwgImVwb2NoIjog
-        IjAiLCAidmVyc2lvbiI6ICIwLjIiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAi
-        X2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9p
-        ZCI6ICIzM2RjYzViMy1mMWQ0LTRiZTYtYTBjZC1hZmJkOGM0MGY2ZjMiLCAi
-        YXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOTox
-        MTo1MloiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIy
-        MDE5LTA4LTA1VDE5OjExOjUyWiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwg
-        InVuaXRfaWQiOiAiMzNkY2M1YjMtZjFkNC00YmU2LWEwY2QtYWZiZDhjNDBm
-        NmYzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y3OGFiMzZjZTNmZTUxZGVk
-        ODUifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJrYW5nYXJvby0w
-        LjItMS5zcmMucnBtIiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAiY2hlY2tzdW0i
-        OiAiODMzYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODli
-        MGM1YTliZjYxMGRkNjEwM2NlNGNjOCIsICJzdW1tYXJ5IjogIkEgZHVtbXkg
-        cGFja2FnZSBvZiBrYW5nYXJvbyIsICJmaWxlbmFtZSI6ICJrYW5nYXJvby0w
-        LjItMS5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIw
-        LjIiLCAiaXNfbW9kdWxhciI6IHRydWUsICJfY29udGVudF90eXBlX2lkIjog
-        InJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjM5MTBlODk3LThlZDQt
-        NGMxMi05Mjk3LWViMDBjMmVhMWY3MCIsICJhcmNoIjogIm5vYXJjaCJ9LCAi
-        dXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjUyWiIsICJyZXBvX2lkIjog
-        IkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6NTJa
-        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIzOTEwZTg5
-        Ny04ZWQ0LTRjMTItOTI5Ny1lYjAwYzJlYTFmNzAiLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3Zjc4YWIzNmNlM2ZlNTFkZWQ1YyJ9fSwgeyJtZXRhZGF0YSI6
-        IHsic291cmNlcnBtIjogImR1Y2stMC43LTEuc3JjLnJwbSIsICJuYW1lIjog
-        ImR1Y2siLCAiY2hlY2tzdW0iOiAiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2Ez
-        YmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsICJz
-        dW1tYXJ5IjogIlF1YWNrIGxpa2UgYSBkdWNrIGF0IHRoZSBwYXJrLiIsICJm
-        aWxlbmFtZSI6ICJkdWNrLTAuNy0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
-        MCIsICJ2ZXJzaW9uIjogIjAuNyIsICJpc19tb2R1bGFyIjogdHJ1ZSwgIl9j
-        b250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMSIsICJfaWQi
-        OiAiNGRlYjE3MWItZDQ5MC00MDhjLTlhNGMtYTc3NDc1OGRmMjMzIiwgImFy
-        Y2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6
-        NTJaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo1MloiLCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1
-        bml0X2lkIjogIjRkZWIxNzFiLWQ0OTAtNDA4Yy05YTRjLWE3NzQ3NThkZjIz
-        MyIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmNzhhYjM2Y2UzZmU1MWRlZDEz
-        In19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAicGVuZ3Vpbi0wLjMt
-        MC44LnNyYy5ycG0iLCAibmFtZSI6ICJwZW5ndWluIiwgImNoZWNrc3VtIjog
-        IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFkMmU1ODU2
-        NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBh
-        Y2thZ2Ugb2YgcGVuZ3VpbiIsICJmaWxlbmFtZSI6ICJwZW5ndWluLTAuMy0w
-        Ljgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4z
-        IiwgImlzX21vZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAi
-        cnBtIiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICI1OGI0YWY3Ni1hM2Jj
-        LTRjNDMtYWJhZi0xZDcxNTQ5OWJiYTgiLCAiYXJjaCI6ICJub2FyY2gifSwg
-        InVwZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjUy
-        WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiNThiNGFm
-        NzYtYTNiYy00YzQzLWFiYWYtMWQ3MTU0OTliYmE4IiwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1ZDQ4N2Y3OGFiMzZjZTNmZTUxZGVkNjUifX0sIHsibWV0YWRhdGEi
-        OiB7InNvdXJjZXJwbSI6ICJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwgIm5h
-        bWUiOiAibW9ua2V5IiwgImNoZWNrc3VtIjogIjBlOGZhNTBkMDEyOGZiYWJj
-        N2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1MDFk
-        YjEiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgbW9ua2V5Iiwg
-        ImZpbGVuYW1lIjogIm1vbmtleS0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBv
-        Y2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFyIjogZmFs
-        c2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjAu
-        OCIsICJfaWQiOiAiNTljN2MzYTgtY2I3ZS00ZDdlLWIzNjItODZkZDhmZDlh
-        MDNlIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMTktMDgt
-        MDVUMTk6MTE6NTJaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
-        ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAidW5pdF90eXBlX2lkIjog
-        InJwbSIsICJ1bml0X2lkIjogIjU5YzdjM2E4LWNiN2UtNGQ3ZS1iMzYyLTg2
-        ZGQ4ZmQ5YTAzZSIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmNzhhYjM2Y2Uz
-        ZmU1MWRlZDUwIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAid2Fs
-        cnVzLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1cyIsICJjaGVj
-        a3N1bSI6ICI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJl
-        ODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwgInN1bW1hcnkiOiAiQSBk
-        dW1teSBwYWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6ICJ3YWxydXMt
-        MC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
-        ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9p
-        ZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjVhODNmZDU2
-        LTUyNjItNGI1OC05NTBkLWU5MTc2NmI2N2RkYSIsICJhcmNoIjogIm5vYXJj
-        aCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjUyWiIsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTktMDgtMDVUMTk6
-        MTE6NTJaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI1
-        YTgzZmQ1Ni01MjYyLTRiNTgtOTUwZC1lOTE3NjZiNjdkZGEiLCAiX2lkIjog
-        eyIkb2lkIjogIjVkNDg3Zjc4YWIzNmNlM2ZlNTFkZWQ3OCJ9fSwgeyJtZXRh
-        ZGF0YSI6IHsic291cmNlcnBtIjogImFybWFkaWxsby0wLjEtMS5zcmMucnBt
-        IiwgIm5hbWUiOiAiYXJtYWRpbGxvIiwgImNoZWNrc3VtIjogImFmNDc4MTMy
-        Zjg4MmU0MmQ0ZjU1Yjk1M2NiODQ2ODI3YzQ4ZjJkMjliN2M2ZTliYmE4OThh
-        NjFkZGMyN2I1ODkiLCAic3VtbWFyeSI6ICJGYWtlIHByb3ZpZGUgZm9yIGFy
-        bWFkaWxsby4iLCAiZmlsZW5hbWUiOiAiYXJtYWRpbGxvLTAuMS0xLm5vYXJj
-        aC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMSIsICJpc19t
-        b2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJy
-        ZWxlYXNlIjogIjEiLCAiX2lkIjogIjY4YzBjYjgxLWUxZTAtNGNmOS1iM2I1
-        LTcwNDZjNGExNzlkMyIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6
-        ICIyMDE5LTA4LTA1VDE5OjExOjUyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8x
-        NyIsICJjcmVhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6NTJaIiwgInVuaXRf
-        dHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI2OGMwY2I4MS1lMWUwLTRj
-        ZjktYjNiNS03MDQ2YzRhMTc5ZDMiLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3
-        Zjc4YWIzNmNlM2ZlNTFkZWNlYSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNl
+        W3sibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJrYW5nYXJvby0wLjItMS5z
+        cmMucnBtIiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAiY2hlY2tzdW0iOiAiODMz
+        YWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTli
+        ZjYxMGRkNjEwM2NlNGNjOCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2Fn
+        ZSBvZiBrYW5nYXJvbyIsICJmaWxlbmFtZSI6ICJrYW5nYXJvby0wLjItMS5u
+        b2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjIiLCAi
+        aXNfbW9kdWxhciI6IHRydWUsICJfY29udGVudF90eXBlX2lkIjogInJwbSIs
+        ICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjA0YjM3ZTdhLTE4ZDgtNDJiZi1i
+        N2FhLWFjOTY3MzRmODE4NyIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRl
+        ZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjM0WiIsICJyZXBvX2lkIjogIkZlZG9y
+        YV8xNyIsICJjcmVhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6MzRaIiwgInVu
+        aXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIwNGIzN2U3YS0xOGQ4
+        LTQyYmYtYjdhYS1hYzk2NzM0ZjgxODciLCAiX2lkIjogeyIkb2lkIjogIjVk
+        NjkzM2ZhMzJkYjYwNzdhNzk2NjJhYSJ9fSwgeyJtZXRhZGF0YSI6IHsic291
+        cmNlcnBtIjogIm1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJt
+        b25rZXkiLCAiY2hlY2tzdW0iOiAiMGU4ZmE1MGQwMTI4ZmJhYmM3Y2NjNTYz
+        MmUzZmEyNWQzOWIwMjgwMTY5ZjYxNjZjYjhlMmM4NGRlODUwMWRiMSIsICJz
+        dW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCAiZmlsZW5h
+        bWUiOiAibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIw
+        IiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIiOiBmYWxzZSwgIl9j
+        b250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMC44IiwgIl9p
+        ZCI6ICIwNmFjNjM0ZS05MWY4LTQxNjMtODQ2NS0yYmRkNGU2MzIyMjYiLCAi
+        YXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDoz
+        NDozNFoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIy
+        MDE5LTA4LTMwVDE0OjM0OjM0WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwg
+        InVuaXRfaWQiOiAiMDZhYzYzNGUtOTFmOC00MTYzLTg0NjUtMmJkZDRlNjMy
+        MjI2IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzNmYTMyZGI2MDc3YTc5NjYy
+        YTEifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJsaW9uLTAuMy0w
+        Ljguc3JjLnJwbSIsICJuYW1lIjogImxpb24iLCAiY2hlY2tzdW0iOiAiMTI0
+        MDBkYzk1YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0Mzdh
+        YjY0Y2Q2MmVmYTNlNGFlNCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2Fn
+        ZSBvZiBsaW9uIiwgImZpbGVuYW1lIjogImxpb24tMC4zLTAuOC5ub2FyY2gu
+        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9k
+        dWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVs
+        ZWFzZSI6ICIwLjgiLCAiX2lkIjogIjFiMjJlMTFkLWYwZWUtNGU0OC05NjE3
+        LWU1MTFiNjQxYzE0MCIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6
+        ICIyMDE5LTA4LTMwVDE0OjM0OjM0WiIsICJyZXBvX2lkIjogIkZlZG9yYV8x
+        NyIsICJjcmVhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6MzRaIiwgInVuaXRf
+        dHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIxYjIyZTExZC1mMGVlLTRl
+        NDgtOTYxNy1lNTExYjY0MWMxNDAiLCAiX2lkIjogeyIkb2lkIjogIjVkNjkz
+        M2ZhMzJkYjYwNzdhNzk2NjI4MiJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNl
         cnBtIjogImFybWFkaWxsby0yLjEtMS5zcmMucnBtIiwgIm5hbWUiOiAiYXJt
         YWRpbGxvIiwgImNoZWNrc3VtIjogImFiZjY5MWVlNWI0OGU0NDYzMjY4NTli
         OGQ4YThkZjJhMjQxMWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCAi
@@ -1457,99 +990,208 @@ http_interactions:
         ZW5hbWUiOiAiYXJtYWRpbGxvLTIuMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2gi
         OiAiMCIsICJ2ZXJzaW9uIjogIjIuMSIsICJpc19tb2R1bGFyIjogZmFsc2Us
         ICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAi
-        X2lkIjogIjgyZGRhYzgxLTAyNjAtNGEzNS04NDA4LTAxZWVkMTkyMGZhNyIs
-        ICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5
-        OjExOjUyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjog
-        IjIwMTktMDgtMDVUMTk6MTE6NTJaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0i
-        LCAidW5pdF9pZCI6ICI4MmRkYWM4MS0wMjYwLTRhMzUtODQwOC0wMWVlZDE5
-        MjBmYTciLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3Zjc4YWIzNmNlM2ZlNTFk
-        ZWQzYyJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogIndhbHJ1cy01
-        LjIxLTEuc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6
-        ICI3NDUzM2ZiZDRmOWFkYTllMDJhNjM2MWNiYmYwMTRiOGZmODhkZmY4ZDY5
-        Nzg1ZWM0OGI3N2UwMTg5OGU3YzMxIiwgInN1bW1hcnkiOiAiQSBkdW1teSBw
-        YWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6ICJ3YWxydXMtNS4yMS0x
-        Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjUuMjEi
-        LCAiaXNfbW9kdWxhciI6IHRydWUsICJfY29udGVudF90eXBlX2lkIjogInJw
-        bSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImE2NDYyNDA3LWQ0YjMtNGI4
-        MC1hMmRjLTcxMTE4NzExZWJhMCIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBk
-        YXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjUyWiIsICJyZXBvX2lkIjogIkZl
-        ZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6NTJaIiwg
-        InVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJhNjQ2MjQwNy1k
-        NGIzLTRiODAtYTJkYy03MTExODcxMWViYTAiLCAiX2lkIjogeyIkb2lkIjog
-        IjVkNDg3Zjc4YWIzNmNlM2ZlNTFkZWQ4ZSJ9fSwgeyJtZXRhZGF0YSI6IHsi
-        c291cmNlcnBtIjogImxpb24tMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAi
-        bGlvbiIsICJjaGVja3N1bSI6ICIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4
-        NzE2Y2QzZmNkZDdhODk4MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0IiwgInN1
-        bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGxpb24iLCAiZmlsZW5hbWUi
-        OiAibGlvbi0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2
-        ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29udGVu
-        dF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAi
-        YjgzMTM1MGItYmI0My00YzdkLWIwZjItN2E0MGMyY2QwMjQ2IiwgImFyY2gi
-        OiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6NTJa
+        X2lkIjogIjFlYTA5YjgzLTViMjUtNDViYy1iMDAyLTE5ZTgyM2UzZGExNiIs
+        ICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0
+        OjM0OjM0WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjog
+        IjIwMTktMDgtMzBUMTQ6MzQ6MzRaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0i
+        LCAidW5pdF9pZCI6ICIxZWEwOWI4My01YjI1LTQ1YmMtYjAwMi0xOWU4MjNl
+        M2RhMTYiLCAiX2lkIjogeyIkb2lkIjogIjVkNjkzM2ZhMzJkYjYwNzdhNzk2
+        NjI4ZCJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogInBlbmd1aW4t
+        MC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAicGVuZ3VpbiIsICJjaGVja3N1
+        bSI6ICIzZmNiMmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJl
+        NTg1NjRmYzIxMGZkNmU0ODYzNWJlNjk0IiwgInN1bW1hcnkiOiAiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCAiZmlsZW5hbWUiOiAicGVuZ3Vpbi0w
+        LjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjog
+        IjAuMyIsICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lk
+        IjogInJwbSIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiMWY5YmY1ODYt
+        OWZmMi00MTFjLTljNTYtNWQyOTcxYmFjYWEyIiwgImFyY2giOiAibm9hcmNo
+        In0sICJ1cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6MzRaIiwgInJlcG9f
+        aWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0zMFQxNDoz
+        NDozNFoiLCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjFm
+        OWJmNTg2LTlmZjItNDExYy05YzU2LTVkMjk3MWJhY2FhMiIsICJfaWQiOiB7
+        IiRvaWQiOiAiNWQ2OTMzZmEzMmRiNjA3N2E3OTY2MmIzIn19LCB7Im1ldGFk
+        YXRhIjogeyJzb3VyY2VycG0iOiAiYXJtYWRpbGxvLTAuMS0xLnNyYy5ycG0i
+        LCAibmFtZSI6ICJhcm1hZGlsbG8iLCAiY2hlY2tzdW0iOiAiYWY0NzgxMzJm
+        ODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3YzZlOWJiYTg5OGE2
+        MWRkYzI3YjU4OSIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlkZSBmb3IgYXJt
+        YWRpbGxvLiIsICJmaWxlbmFtZSI6ICJhcm1hZGlsbG8tMC4xLTEubm9hcmNo
+        LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4xIiwgImlzX21v
+        ZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJl
+        bGVhc2UiOiAiMSIsICJfaWQiOiAiMzBiZjE4OTYtZDExZS00ZTg0LWI1ZmUt
+        M2E2ZThhNGVhN2E1IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjog
+        IjIwMTktMDgtMzBUMTQ6MzQ6MzRaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3
+        IiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDozNFoiLCAidW5pdF90
+        eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjMwYmYxODk2LWQxMWUtNGU4
+        NC1iNWZlLTNhNmU4YTRlYTdhNSIsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMz
+        ZmEzMmRiNjA3N2E3OTY2MjQyIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2Vy
+        cG0iOiAid2FscnVzLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1
+        cyIsICJjaGVja3N1bSI6ICI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3
+        YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwgInN1bW1h
+        cnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6
+        ICJ3YWxydXMtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAi
+        dmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRl
+        bnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjog
+        IjM1NWJmYWE0LTIxNGQtNGE4Yi05ZjQzLTM5NDIwYmZmYTdmYiIsICJhcmNo
+        IjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjM0
+        WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTkt
+        MDgtMzBUMTQ6MzQ6MzRaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5p
+        dF9pZCI6ICIzNTViZmFhNC0yMTRkLTRhOGItOWY0My0zOTQyMGJmZmE3ZmIi
+        LCAiX2lkIjogeyIkb2lkIjogIjVkNjkzM2ZhMzJkYjYwNzdhNzk2NjJjNSJ9
+        fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImthbmdhcm9vLTAuMy0x
+        LnNyYy5ycG0iLCAibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVja3N1bSI6ICI4
+        NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcyODBjMTQxZTkyMDJmMDI0ZTdkYjM4
+        Y2JhM2QwOTdjM2YyNTZiMmZkIiwgInN1bW1hcnkiOiAiaG9wIGxpa2UgYSBr
+        YW5nYXJvbyBpbiBBdXN0cmFsaWEiLCAiZmlsZW5hbWUiOiAia2FuZ2Fyb28t
+        MC4zLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAi
+        MC4zIiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6
+        ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI4NTUxYmRjOS02MTNm
+        LTRkYjItYThkZS1lOTkzZjk5YmQ2ZTUiLCAiYXJjaCI6ICJub2FyY2gifSwg
+        InVwZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDozNFoiLCAicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjM0
+        WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiODU1MWJk
+        YzktNjEzZi00ZGIyLWE4ZGUtZTk5M2Y5OWJkNmU1IiwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1ZDY5MzNmYTMyZGI2MDc3YTc5NjYyNTQifX0sIHsibWV0YWRhdGEi
+        OiB7InNvdXJjZXJwbSI6ICJnaXJhZmZlLTAuMy0wLjguc3JjLnJwbSIsICJu
+        YW1lIjogImdpcmFmZmUiLCAiY2hlY2tzdW0iOiAiZjI1ZDY3ZDFkOWRhMDRm
+        MTJlNTdjYTMyMzI0N2I0Mzg5MWFjNDY1MzNlMzU1YjgyZGU2ZDE5MjIwMDlm
+        OWYxNCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZl
+        IiwgImZpbGVuYW1lIjogImdpcmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwg
+        ImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6
+        IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6
+        ICIwLjgiLCAiX2lkIjogIjhiYTI1MDFkLTZiZTQtNGVkZi1iMmEwLWM1M2U0
+        ZWVhYmNiOSIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDE5
+        LTA4LTMwVDE0OjM0OjM0WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJj
+        cmVhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6MzRaIiwgInVuaXRfdHlwZV9p
+        ZCI6ICJycG0iLCAidW5pdF9pZCI6ICI4YmEyNTAxZC02YmU0LTRlZGYtYjJh
+        MC1jNTNlNGVlYWJjYjkiLCAiX2lkIjogeyIkb2lkIjogIjVkNjkzM2ZhMzJk
+        YjYwNzdhNzk2NjI3OCJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjog
+        InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogInNxdWlycmVs
+        IiwgImNoZWNrc3VtIjogIjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2
+        YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCAic3VtbWFy
+        eSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCAiZmlsZW5hbWUi
+        OiAic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAi
+        LCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2Nv
+        bnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lk
+        IjogIjhmZDQzMDViLTFkODEtNDA0Mi04ODU3LWJlMjE5MmJmMzE0NyIsICJh
+        cmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0
+        OjM0WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIw
+        MTktMDgtMzBUMTQ6MzQ6MzRaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAi
+        dW5pdF9pZCI6ICI4ZmQ0MzA1Yi0xZDgxLTQwNDItODg1Ny1iZTIxOTJiZjMx
+        NDciLCAiX2lkIjogeyIkb2lkIjogIjVkNjkzM2ZhMzJkYjYwNzdhNzk2NjI1
+        ZCJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImVsZXBoYW50LTAu
+        My0wLjguc3JjLnJwbSIsICJuYW1lIjogImVsZXBoYW50IiwgImNoZWNrc3Vt
+        IjogIjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVm
+        NjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCAic3VtbWFyeSI6ICJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQt
+        MC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
+        ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9p
+        ZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjk0NDE4NzFl
+        LTIxNDYtNDRhNC04NTQ0LWUzOTAyY2RhNjZlYiIsICJhcmNoIjogIm5vYXJj
+        aCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjM0WiIsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTktMDgtMzBUMTQ6
+        MzQ6MzRaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI5
+        NDQxODcxZS0yMTQ2LTQ0YTQtODU0NC1lMzkwMmNkYTY2ZWIiLCAiX2lkIjog
+        eyIkb2lkIjogIjVkNjkzM2ZhMzJkYjYwNzdhNzk2NjI0YiJ9fSwgeyJtZXRh
+        ZGF0YSI6IHsic291cmNlcnBtIjogImR1Y2stMC42LTEuc3JjLnJwbSIsICJu
+        YW1lIjogImR1Y2siLCAiY2hlY2tzdW0iOiAiOTZmMzc4Nzc1MThhMWZlNmVh
+        MmUxN2Y0Y2UxZmM4MWI0MDkwODA0M2JjYmVkNzY3NDRiM2Q3ZDM4YTc3NGJj
+        NyIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBkdWNrIiwgImZp
+        bGVuYW1lIjogImR1Y2stMC42LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIw
+        IiwgInZlcnNpb24iOiAiMC42IiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2Nv
+        bnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6
+        ICI5NTJmZDk0MS1iOGExLTRhNGYtYjI0Yy00N2NiMTQzZjJmYjIiLCAiYXJj
+        aCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDoz
+        NFoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5
+        LTA4LTMwVDE0OjM0OjM0WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVu
+        aXRfaWQiOiAiOTUyZmQ5NDEtYjhhMS00YTRmLWIyNGMtNDdjYjE0M2YyZmIy
+        IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzNmYTMyZGI2MDc3YTc5NjYyOTgi
+        fX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJkdWNrLTAuNy0xLnNy
+        Yy5ycG0iLCAibmFtZSI6ICJkdWNrIiwgImNoZWNrc3VtIjogIjViZDM2M2I4
+        NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4
+        ZTNmNjZjMjQ3MTIiLCAic3VtbWFyeSI6ICJRdWFjayBsaWtlIGEgZHVjayBh
+        dCB0aGUgcGFyay4iLCAiZmlsZW5hbWUiOiAiZHVjay0wLjctMS5ub2FyY2gu
+        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjciLCAiaXNfbW9k
+        dWxhciI6IHRydWUsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxl
+        YXNlIjogIjEiLCAiX2lkIjogImExOGRmNjI5LWE1NWEtNDMyYy1iZDcxLTZi
+        NGUxYTE2ZDdiNiIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIy
+        MDE5LTA4LTMwVDE0OjM0OjM0WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
+        ICJjcmVhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6MzRaIiwgInVuaXRfdHlw
+        ZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJhMThkZjYyOS1hNTVhLTQzMmMt
+        YmQ3MS02YjRlMWExNmQ3YjYiLCAiX2lkIjogeyIkb2lkIjogIjVkNjkzM2Zh
+        MzJkYjYwNzdhNzk2NjI2NiJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBt
+        IjogImNoZWV0YWgtMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAiY2hlZXRh
+        aCIsICJjaGVja3N1bSI6ICI0MjJkMGJhYTBjZDlkNzcxM2FlNzk2ZTg4NmEy
+        M2UxN2Y1NzhmOTI0Zjc0ODgwZGViZGJiN2Q2NWZiMzY4ZGFlIiwgInN1bW1h
+        cnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCAiZmlsZW5hbWUi
+        OiAiY2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29u
+        dGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQi
+        OiAiYTQ0OWNjNjUtZWQ4Yy00Y2UzLWFlMTItODg1OGI0ZTBiYWY3IiwgImFy
+        Y2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6
+        MzRaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAx
+        OS0wOC0zMFQxNDozNDozNFoiLCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1
+        bml0X2lkIjogImE0NDljYzY1LWVkOGMtNGNlMy1hZTEyLTg4NThiNGUwYmFm
+        NyIsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZmEzMmRiNjA3N2E3OTY2MmJj
+        In19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAid2FscnVzLTUuMjEt
+        MS5zcmMucnBtIiwgIm5hbWUiOiAid2FscnVzIiwgImNoZWNrc3VtIjogIjc0
+        NTMzZmJkNGY5YWRhOWUwMmE2MzYxY2JiZjAxNGI4ZmY4OGRmZjhkNjk3ODVl
+        YzQ4Yjc3ZTAxODk4ZTdjMzEiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2th
+        Z2Ugb2Ygd2FscnVzIiwgImZpbGVuYW1lIjogIndhbHJ1cy01LjIxLTEubm9h
+        cmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiNS4yMSIsICJp
+        c19tb2R1bGFyIjogdHJ1ZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwg
+        InJlbGVhc2UiOiAiMSIsICJfaWQiOiAiYmE3NzFkZjgtM2VmZC00OTJiLTkx
+        YTQtNjJhMmY5OGQwMjhhIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVk
+        IjogIjIwMTktMDgtMzBUMTQ6MzQ6MzRaIiwgInJlcG9faWQiOiAiRmVkb3Jh
+        XzE3IiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDozNFoiLCAidW5p
+        dF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogImJhNzcxZGY4LTNlZmQt
+        NDkyYi05MWE0LTYyYTJmOThkMDI4YSIsICJfaWQiOiB7IiRvaWQiOiAiNWQ2
+        OTMzZmEzMmRiNjA3N2E3OTY2MmQ3In19LCB7Im1ldGFkYXRhIjogeyJzb3Vy
+        Y2VycG0iOiAid2FscnVzLTAuNzEtMS5zcmMucnBtIiwgIm5hbWUiOiAid2Fs
+        cnVzIiwgImNoZWNrc3VtIjogIjUxNmEyMmNjYzBjYmUzZWNiMmNiZWUxYzYy
+        NmEzOWI5MTc2N2RiZjBmODE1YWZkYTdiNzMzYWE1NjUyMzE0MmMiLCAic3Vt
+        bWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwgImZpbGVuYW1l
+        IjogIndhbHJ1cy0wLjcxLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwg
+        InZlcnNpb24iOiAiMC43MSIsICJpc19tb2R1bGFyIjogdHJ1ZSwgIl9jb250
+        ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAi
+        ZDdkMjQ0NDAtYWY5Ny00ODVjLThmNWMtNDdlMDRiMjgxMGFkIiwgImFyY2gi
+        OiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6MzRa
         IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAxOS0w
-        OC0wNVQxOToxMTo1MloiLCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0
-        X2lkIjogImI4MzEzNTBiLWJiNDMtNGM3ZC1iMGYyLTdhNDBjMmNkMDI0NiIs
-        ICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmNzhhYjM2Y2UzZmU1MWRlZDJlIn19
-        LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAiZHVjay0wLjYtMS5zcmMu
-        cnBtIiwgIm5hbWUiOiAiZHVjayIsICJjaGVja3N1bSI6ICI5NmYzNzg3NzUx
-        OGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQzYmNiZWQ3Njc0NGIzZDdk
-        MzhhNzc0YmM3IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGR1
-        Y2siLCAiZmlsZW5hbWUiOiAiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwgImVw
-        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjYiLCAiaXNfbW9kdWxhciI6IHRy
-        dWUsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEi
-        LCAiX2lkIjogImNlMDkzNzJhLWExYTAtNGFlYi1iZjJjLWY2MGEwYTFmYWQ5
-        NSIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTA1
-        VDE5OjExOjUyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
-        IjogIjIwMTktMDgtMDVUMTk6MTE6NTJaIiwgInVuaXRfdHlwZV9pZCI6ICJy
-        cG0iLCAidW5pdF9pZCI6ICJjZTA5MzcyYS1hMWEwLTRhZWItYmYyYy1mNjBh
-        MGExZmFkOTUiLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3Zjc4YWIzNmNlM2Zl
-        NTFkZWQ0NSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogInNxdWly
-        cmVsLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogInNxdWlycmVsIiwgImNo
-        ZWNrc3VtIjogIjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCAic3VtbWFyeSI6ICJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCAiZmlsZW5hbWUiOiAic3F1
-        aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVy
-        c2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRf
-        dHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogImQ4
-        OTc0MjM1LWQ4MjAtNGMwMC1iNTRiLWQ4ZjQ3NzQ3M2UwMCIsICJhcmNoIjog
-        Im5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjUyWiIs
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTktMDgt
-        MDVUMTk6MTE6NTJaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9p
-        ZCI6ICJkODk3NDIzNS1kODIwLTRjMDAtYjU0Yi1kOGY0Nzc0NzNlMDAiLCAi
-        X2lkIjogeyIkb2lkIjogIjVkNDg3Zjc4YWIzNmNlM2ZlNTFkZWQwYSJ9fSwg
-        eyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImdpcmFmZmUtMC4zLTAuOC5z
-        cmMucnBtIiwgIm5hbWUiOiAiZ2lyYWZmZSIsICJjaGVja3N1bSI6ICJmMjVk
-        NjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJk
-        ZTZkMTkyMjAwOWY5ZjE0IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdl
-        IG9mIGdpcmFmZmUiLCAiZmlsZW5hbWUiOiAiZ2lyYWZmZS0wLjMtMC44Lm5v
-        YXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJp
-        c19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIs
-        ICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiZTFjMzRiZjYtMWVjNi00ODYw
-        LWI3OTktZDAyODY1OWNhYTczIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRh
-        dGVkIjogIjIwMTktMDgtMDVUMTk6MTE6NTJaIiwgInJlcG9faWQiOiAiRmVk
-        b3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAi
-        dW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogImUxYzM0YmY2LTFl
-        YzYtNDg2MC1iNzk5LWQwMjg2NTljYWE3MyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWQ0ODdmNzhhYjM2Y2UzZmU1MWRlZDI1In19LCB7Im1ldGFkYXRhIjogeyJz
-        b3VyY2VycG0iOiAiY2hlZXRhaC0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6
-        ICJjaGVldGFoIiwgImNoZWNrc3VtIjogIjQyMmQwYmFhMGNkOWQ3NzEzYWU3
-        OTZlODg2YTIzZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUi
-        LCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsICJm
-        aWxlbmFtZSI6ICJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9j
-        aCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIiOiBmYWxz
-        ZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMC44
-        IiwgIl9pZCI6ICJmMTYzZmI3MC0wYTI4LTQyMjAtOWEwNi1hMTliMTI0MTQ3
-        MzkiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0w
-        NVQxOToxMTo1MloiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRl
-        ZCI6ICIyMDE5LTA4LTA1VDE5OjExOjUyWiIsICJ1bml0X3R5cGVfaWQiOiAi
-        cnBtIiwgInVuaXRfaWQiOiAiZjE2M2ZiNzAtMGEyOC00MjIwLTlhMDYtYTE5
-        YjEyNDE0NzM5IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y3OGFiMzZjZTNm
-        ZTUxZGVkNmUifX1d
+        OC0zMFQxNDozNDozNFoiLCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0
+        X2lkIjogImQ3ZDI0NDQwLWFmOTctNDg1Yy04ZjVjLTQ3ZTA0YjI4MTBhZCIs
+        ICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZmEzMmRiNjA3N2E3OTY2MjZmIn19
+        LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAiYXJtYWRpbGxvLTAuMi0x
+        LnNyYy5ycG0iLCAibmFtZSI6ICJhcm1hZGlsbG8iLCAiY2hlY2tzdW0iOiAi
+        OGQzMTk5MDVlZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQx
+        M2QwMjU4N2I2ZjUxYWIzYjY1YSIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlk
+        ZSBmb3IgYXJtYWRpbGxvLiIsICJmaWxlbmFtZSI6ICJhcm1hZGlsbG8tMC4y
+        LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4y
+        IiwgImlzX21vZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAi
+        cnBtIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiZGQ0NjZiM2MtMGNhMS00
+        MjAwLTk0ZDctYTdmZGE1M2ZjMDI2IiwgImFyY2giOiAibm9hcmNoIn0sICJ1
+        cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6MzRaIiwgInJlcG9faWQiOiAi
+        RmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDozNFoi
+        LCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogImRkNDY2YjNj
+        LTBjYTEtNDIwMC05NGQ3LWE3ZmRhNTNmYzAyNiIsICJfaWQiOiB7IiRvaWQi
+        OiAiNWQ2OTMzZmEzMmRiNjA3N2E3OTY2MmNlIn19LCB7Im1ldGFkYXRhIjog
+        eyJzb3VyY2VycG0iOiAiZWxlcGhhbnQtMC4yLTEuc3JjLnJwbSIsICJuYW1l
+        IjogImVsZXBoYW50IiwgImNoZWNrc3VtIjogIjMzMzUxZmQ2YzJhMzhlNWQ0
+        OWFlYTc4OGEyZTgzOGVhY2Q2NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1
+        YjkiLCAic3VtbWFyeSI6ICJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50LiIs
+        ICJmaWxlbmFtZSI6ICJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBtIiwgImVw
+        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjIiLCAiaXNfbW9kdWxhciI6IGZh
+        bHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIx
+        IiwgIl9pZCI6ICJlMmEzZGY1OC05MWQ2LTQ2M2MtOTVlMi1lYWQ2ZGEzYTA4
+        MDkiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0z
+        MFQxNDozNDozNFoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRl
+        ZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjM0WiIsICJ1bml0X3R5cGVfaWQiOiAi
+        cnBtIiwgInVuaXRfaWQiOiAiZTJhM2RmNTgtOTFkNi00NjNjLTk1ZTItZWFk
+        NmRhM2EwODA5IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzNmYTMyZGI2MDc3
+        YTc5NjYyZTAifX1d
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:53 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:35 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1560,21 +1202,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '177'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:53 GMT
+      - Fri, 30 Aug 2019 14:34:35 GMT
       Server:
       - Apache
       Content-Length:
@@ -1587,10 +1229,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:54 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:35 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1599,158 +1241,158 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '60'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:54 GMT
+      - Fri, 30 Aug 2019 14:34:35 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '5435'
+      - '1311'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
         W3sibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
-        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzFiLzJmMDAzOTY0YmI2NDIxZGU3
-        NDI3N2RiMTljOWNhOGQzMzNhYmE5NjM5MzkxMGM3ODBlNTcwMGRjOGE4M2Ez
-        IiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
-        OiBbImR1Y2stMDowLjYtMS5ub2FyY2giXSwgImNoZWNrc3VtIjogIjZiZDlk
-        OTA5YzkyNzA1NzFiODExZTUwMjcwOWVhN2I1NjE1MGQ0NGEyYjRiMzRjZmQy
-        NWU1MmE4MWM1YmZjZTciLCAiX2xhc3RfdXBkYXRlZCI6IDE1NjUwMzIwOTYs
-        ICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2ZpbGVzIjog
-        eyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNrIDAuNiBt
-        b2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3
-        MDQyNDQyMDUsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQi
-        OiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVu
-        ZGVuY2llcyI6IFtdLCAiX2lkIjogIjA5NzQ2YTlhLTUwMjYtNGVmMi1hNWM1
-        LWM1YjA4MTcwZjQ0YSIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNjcmlwdGlv
-        biI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC42IHBhY2thZ2UifSwgInVw
-        ZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjUyWiIs
-        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICIwOTc0
-        NmE5YS01MDI2LTRlZjItYTVjNS1jNWIwODE3MGY0NGEiLCAiX2lkIjogeyIk
-        b2lkIjogIjVkNDg3Zjc4YWIzNmNlM2ZlNTFkZWUwZiJ9fSwgeyJtZXRhZGF0
+        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kL2VhL2E4NzIwM2FhNzFhY2QwOWVk
+        NGM4NzBlMDg3NTQ5ZGEyYTVkMmNhYzdjYjllZWQ3ZTdiMDYzYmY5ZjQ5N2E5
+        IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICIwLjcxIiwgImFydGlm
+        YWN0cyI6IFsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCAiY2hlY2tzdW0i
+        OiAiODNmNmFmZjMyNjE0ODU3ZTk5MDk4NzZhNGZiN2E5NWQ1OTE5NWZkOThi
+        OWEyN2EwNjRhOTQyZWNiYzRmNDY4MiIsICJfbGFzdF91cGRhdGVkIjogMTU2
+        NzE3NTY2MSwgIl9jb250ZW50X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAicHJv
+        ZmlsZXMiOiB7ImRlZmF1bHQiOiBbIndhbHJ1cyJdLCAiZmxpcHBlciI6IFsi
+        d2FscnVzIl19LCAic3VtbWFyeSI6ICJXYWxydXMgMC43MSBtb2R1bGUiLCAi
+        ZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3MDcxNDQyMDMs
+        ICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQiOiAiYzBmZmVl
+        NDIiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVuZGVuY2llcyI6
+        IFtdLCAiX2lkIjogIjBiZWU4ZTBjLWFlYWEtNGE4MS04YWZmLWQxODNjMDQ4
+        NTIxNyIsICJhcmNoIjogIng4Nl82NCIsICJkZXNjcmlwdGlvbiI6ICJBIG1v
+        ZHVsZSBmb3IgdGhlIHdhbHJ1cyAwLjcxIHBhY2thZ2UifSwgInVwZGF0ZWQi
+        OiAiMjAxOS0wOC0zMFQxNDozNDozNFoiLCAicmVwb19pZCI6ICJGZWRvcmFf
+        MTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjM0WiIsICJ1bml0
+        X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICIwYmVlOGUwYy1h
+        ZWFhLTRhODEtOGFmZi1kMTgzYzA0ODUyMTciLCAiX2lkIjogeyIkb2lkIjog
+        IjVkNjkzM2ZhMzJkYjYwNzdhNzk2NjM1OSJ9fSwgeyJtZXRhZGF0YSI6IHsi
+        X3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQvdW5pdHMv
+        bW9kdWxlbWQvNDEvOWMyNmNhMDMyMmYwNDU4YWI3NGY1ODc2ZTI5YTM2NmY4
+        MGMyYjQ5MDIwZjY2M2FiYjlmZjRiYmRjYmQ2Y2MiLCAibmFtZSI6ICJ3YWxy
+        dXMiLCAic3RyZWFtIjogIjUuMjEiLCAiYXJ0aWZhY3RzIjogWyJ3YWxydXMt
+        MDo1LjIxLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICJmYzBjYjk1MGU1M2M1
+        ZWE5OWIwM2JjYWM0MjcyNWM2MDI5NWYxNDhhYWFkZTFhN2NlNmM3ZDgwMjhh
+        MDczYjU5IiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTY3MTc1NjYxLCAiX2NvbnRl
+        bnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxlcyI6IHsiZGVmYXVs
+        dCI6IFsid2FscnVzIl19LCAic3VtbWFyeSI6ICJXYWxydXMgNS4yMSBtb2R1
+        bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3MDQx
+        NDQyMDMsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQiOiAi
+        ZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVuZGVu
+        Y2llcyI6IFtdLCAiX2lkIjogIjM0YTk5YzA1LWJmMjgtNDQ5ZC1hN2FhLTU4
+        MDY1ZmY4ODRiOCIsICJhcmNoIjogIng4Nl82NCIsICJkZXNjcmlwdGlvbiI6
+        ICJBIG1vZHVsZSBmb3IgdGhlIHdhbHJ1cyA1LjIxIHBhY2thZ2UifSwgInVw
+        ZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDozNFoiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjM0WiIs
+        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICIzNGE5
+        OWMwNS1iZjI4LTQ0OWQtYTdhYS01ODA2NWZmODg0YjgiLCAiX2lkIjogeyIk
+        b2lkIjogIjVkNjkzM2ZhMzJkYjYwNzdhNzk2NjM0ZiJ9fSwgeyJtZXRhZGF0
         YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQv
         dW5pdHMvbW9kdWxlbWQvMDQvZjU1ODZlZTE0ZGU0ZTM1YzY3YWIwOGQyNmNi
         N2EwNWU3ZmZmMGRlMDdkY2VhYjY2MTMzYTU4MjBjMzgyY2UiLCAibmFtZSI6
         ICJkdWNrIiwgInN0cmVhbSI6ICIwIiwgImFydGlmYWN0cyI6IFsiZHVjay0w
         OjAuNy0xLm5vYXJjaCJdLCAiY2hlY2tzdW0iOiAiZGQ2MjFjMDU4Y2RlMWU2
         NzU3OGZkYzE3MTMzMjQ1YTY1MTc5NmFmYzA4NzNkODU2Yjc5MGE3ZjcwMjgy
-        NTAyMSIsICJfbGFzdF91cGRhdGVkIjogMTU2NTAzMjA5NiwgIl9jb250ZW50
+        NTAyMSIsICJfbGFzdF91cGRhdGVkIjogMTU2NzE3NTY2MSwgIl9jb250ZW50
         X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAicHJvZmlsZXMiOiB7ImRlZmF1bHQi
         OiBbImR1Y2siXX0sICJzdW1tYXJ5IjogIkR1Y2sgMC43IG1vZHVsZSIsICJk
         b3dubG9hZGVkIjogdHJ1ZSwgInZlcnNpb24iOiAyMDE4MDczMDIzMzEwMiwg
         InB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiY29udGV4dCI6ICJkZWFkYmVl
         ZiIsICJfbnMiOiAidW5pdHNfbW9kdWxlbWQiLCAiZGVwZW5kZW5jaWVzIjog
-        W10sICJfaWQiOiAiMWRiNjRjYWItMGE1ZS00YmQ4LWJmNTItNDFiMDdkY2Nk
-        NTM2IiwgImFyY2giOiAibm9hcmNoIiwgImRlc2NyaXB0aW9uIjogIkEgbW9k
+        W10sICJfaWQiOiAiNzNkYTgxYTAtMDVjZi00NTljLWIzMDEtMjBmMDI1ZDJj
+        MDU0IiwgImFyY2giOiAibm9hcmNoIiwgImRlc2NyaXB0aW9uIjogIkEgbW9k
         dWxlIGZvciB0aGUgZHVjayAwLjcgcGFja2FnZSJ9LCAidXBkYXRlZCI6ICIy
-        MDE5LTA4LTA1VDE5OjExOjUyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
-        ICJjcmVhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6NTJaIiwgInVuaXRfdHlw
-        ZV9pZCI6ICJtb2R1bGVtZCIsICJ1bml0X2lkIjogIjFkYjY0Y2FiLTBhNWUt
-        NGJkOC1iZjUyLTQxYjA3ZGNjZDUzNiIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0
-        ODdmNzhhYjM2Y2UzZmU1MWRlZTA0In19LCB7Im1ldGFkYXRhIjogeyJfc3Rv
-        cmFnZV9wYXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0cy9tb2R1
-        bGVtZC9lYS9hODcyMDNhYTcxYWNkMDllZDRjODcwZTA4NzU0OWRhMmE1ZDJj
-        YWM3Y2I5ZWVkN2U3YjA2M2JmOWY0OTdhOSIsICJuYW1lIjogIndhbHJ1cyIs
-        ICJzdHJlYW0iOiAiMC43MSIsICJhcnRpZmFjdHMiOiBbIndhbHJ1cy0wOjAu
-        NzEtMS5ub2FyY2giXSwgImNoZWNrc3VtIjogIjgzZjZhZmYzMjYxNDg1N2U5
-        OTA5ODc2YTRmYjdhOTVkNTkxOTVmZDk4YjlhMjdhMDY0YTk0MmVjYmM0ZjQ2
-        ODIiLCAiX2xhc3RfdXBkYXRlZCI6IDE1NjUwMzIwOTYsICJfY29udGVudF90
-        eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2ZpbGVzIjogeyJkZWZhdWx0Ijog
-        WyJ3YWxydXMiXSwgImZsaXBwZXIiOiBbIndhbHJ1cyJdfSwgInN1bW1hcnki
-        OiAiV2FscnVzIDAuNzEgbW9kdWxlIiwgImRvd25sb2FkZWQiOiB0cnVlLCAi
-        dmVyc2lvbiI6IDIwMTgwNzA3MTQ0MjAzLCAicHVscF91c2VyX21ldGFkYXRh
-        Ijoge30sICJjb250ZXh0IjogImMwZmZlZTQyIiwgIl9ucyI6ICJ1bml0c19t
-        b2R1bGVtZCIsICJkZXBlbmRlbmNpZXMiOiBbXSwgIl9pZCI6ICIyYjM0YWY5
-        Ni1jMTRkLTQwY2EtYjA4Ni1kZDg2MDk2MThlOWIiLCAiYXJjaCI6ICJ4ODZf
-        NjQiLCAiZGVzY3JpcHRpb24iOiAiQSBtb2R1bGUgZm9yIHRoZSB3YWxydXMg
-        MC43MSBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6
-        NTJaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo1MloiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1k
-        IiwgInVuaXRfaWQiOiAiMmIzNGFmOTYtYzE0ZC00MGNhLWIwODYtZGQ4NjA5
-        NjE4ZTliIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y3OGFiMzZjZTNmZTUx
-        ZGVlMjQifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zh
-        ci9saWIvcHVscC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzQxLzljMjZjYTAz
-        MjJmMDQ1OGFiNzRmNTg3NmUyOWEzNjZmODBjMmI0OTAyMGY2NjNhYmI5ZmY0
-        YmJkY2JkNmNjIiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICI1LjIx
-        IiwgImFydGlmYWN0cyI6IFsid2FscnVzLTA6NS4yMS0xLm5vYXJjaCJdLCAi
-        Y2hlY2tzdW0iOiAiZmMwY2I5NTBlNTNjNWVhOTliMDNiY2FjNDI3MjVjNjAy
-        OTVmMTQ4YWFhZGUxYTdjZTZjN2Q4MDI4YTA3M2I1OSIsICJfbGFzdF91cGRh
-        dGVkIjogMTU2NTAzMjA5NiwgIl9jb250ZW50X3R5cGVfaWQiOiAibW9kdWxl
-        bWQiLCAicHJvZmlsZXMiOiB7ImRlZmF1bHQiOiBbIndhbHJ1cyJdfSwgInN1
-        bW1hcnkiOiAiV2FscnVzIDUuMjEgbW9kdWxlIiwgImRvd25sb2FkZWQiOiB0
-        cnVlLCAidmVyc2lvbiI6IDIwMTgwNzA0MTQ0MjAzLCAicHVscF91c2VyX21l
-        dGFkYXRhIjoge30sICJjb250ZXh0IjogImRlYWRiZWVmIiwgIl9ucyI6ICJ1
-        bml0c19tb2R1bGVtZCIsICJkZXBlbmRlbmNpZXMiOiBbXSwgIl9pZCI6ICJi
-        MWViZDJlOC0xNDg3LTQxNjctYTdhNi1kYTM2N2ExODFlY2IiLCAiYXJjaCI6
-        ICJ4ODZfNjQiLCAiZGVzY3JpcHRpb24iOiAiQSBtb2R1bGUgZm9yIHRoZSB3
-        YWxydXMgNS4yMSBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMDVU
-        MTk6MTE6NTJaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQi
-        OiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAidW5pdF90eXBlX2lkIjogIm1v
-        ZHVsZW1kIiwgInVuaXRfaWQiOiAiYjFlYmQyZTgtMTQ4Ny00MTY3LWE3YTYt
-        ZGEzNjdhMTgxZWNiIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y3OGFiMzZj
-        ZTNmZTUxZGVlMWIifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgi
-        OiAiL3Zhci9saWIvcHVscC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzkwLzY2
-        ZjZiNDNiMWI0ZGYwOWY4YTY4Nzk3YTA3YTg0ZmQzZjU1ZTQ3NGY3ZDM5OTNl
-        ZjJhOGRjNzQxOGQxMDAxIiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAic3RyZWFt
-        IjogIjAiLCAiYXJ0aWZhY3RzIjogWyJrYW5nYXJvby0wOjAuMi0xLm5vYXJj
-        aCJdLCAiY2hlY2tzdW0iOiAiZTgyMGUwOGMwNWFhNzM2Y2U1MzAwNjZjNjg4
-        Mjg4YmY1NzQ2MDk4MjY3YzI4MjQyNzllMzZjOWE3MmU2YjljZSIsICJfbGFz
-        dF91cGRhdGVkIjogMTU2NTAzMjA5NiwgIl9jb250ZW50X3R5cGVfaWQiOiAi
-        bW9kdWxlbWQiLCAicHJvZmlsZXMiOiB7ImRlZmF1bHQiOiBbImthbmdhcm9v
-        Il19LCAic3VtbWFyeSI6ICJLYW5nYXJvbyAwLjIgbW9kdWxlIiwgImRvd25s
-        b2FkZWQiOiB0cnVlLCAidmVyc2lvbiI6IDIwMTgwNzA0MTExNzE5LCAicHVs
-        cF91c2VyX21ldGFkYXRhIjoge30sICJjb250ZXh0IjogImRlYWRiZWVmIiwg
-        Il9ucyI6ICJ1bml0c19tb2R1bGVtZCIsICJkZXBlbmRlbmNpZXMiOiBbXSwg
-        Il9pZCI6ICJjYjk0NDA0NC05NWYxLTQ0OTktYjgwNy01ZTgzZTc4NzMyMTYi
-        LCAiYXJjaCI6ICJub2FyY2giLCAiZGVzY3JpcHRpb24iOiAiQSBtb2R1bGUg
-        Zm9yIHRoZSBrYW5nYXJvbyAwLjIgcGFja2FnZSJ9LCAidXBkYXRlZCI6ICIy
-        MDE5LTA4LTA1VDE5OjExOjUyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
-        ICJjcmVhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6NTJaIiwgInVuaXRfdHlw
-        ZV9pZCI6ICJtb2R1bGVtZCIsICJ1bml0X2lkIjogImNiOTQ0MDQ0LTk1ZjEt
-        NDQ5OS1iODA3LTVlODNlNzg3MzIxNiIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0
-        ODdmNzhhYjM2Y2UzZmU1MWRlZGZiIn19LCB7Im1ldGFkYXRhIjogeyJfc3Rv
+        MDE5LTA4LTMwVDE0OjM0OjM0WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
+        ICJjcmVhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6MzRaIiwgInVuaXRfdHlw
+        ZV9pZCI6ICJtb2R1bGVtZCIsICJ1bml0X2lkIjogIjczZGE4MWEwLTA1Y2Yt
+        NDU5Yy1iMzAxLTIwZjAyNWQyYzA1NCIsICJfaWQiOiB7IiRvaWQiOiAiNWQ2
+        OTMzZmEzMmRiNjA3N2E3OTY2MzNkIn19LCB7Im1ldGFkYXRhIjogeyJfc3Rv
         cmFnZV9wYXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0cy9tb2R1
         bGVtZC83OC82ODcyN2JjYzJhOWQ5YTYwM2JlMWJkNDA3ZjQ3ZWQ4N2I5NmIx
         MmVkNmNkNTU1NmJjZGNlYTkxZGE5ODBlMCIsICJuYW1lIjogImthbmdhcm9v
         IiwgInN0cmVhbSI6ICIwIiwgImFydGlmYWN0cyI6IFsia2FuZ2Fyb28tMDow
         LjMtMS5ub2FyY2giXSwgImNoZWNrc3VtIjogIjA5MDBkZDBmYWE2N2Y5Mzg2
         NzdjNGJhYWNmMDA1ZWM5ZDI0ODI3YWZhMjExY2I0MTU3ZWQ4NmQzNWNjODNm
-        ZGUiLCAiX2xhc3RfdXBkYXRlZCI6IDE1NjUwMzIwOTYsICJfY29udGVudF90
+        ZGUiLCAiX2xhc3RfdXBkYXRlZCI6IDE1NjcxNzU2NjEsICJfY29udGVudF90
         eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2ZpbGVzIjogeyJkZWZhdWx0Ijog
         WyJrYW5nYXJvbyJdfSwgInN1bW1hcnkiOiAiS2FuZ2Fyb28gMC4zIG1vZHVs
         ZSIsICJkb3dubG9hZGVkIjogdHJ1ZSwgInZlcnNpb24iOiAyMDE4MDczMDIy
         MzQwNywgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiY29udGV4dCI6ICJk
         ZWFkYmVlZiIsICJfbnMiOiAidW5pdHNfbW9kdWxlbWQiLCAiZGVwZW5kZW5j
-        aWVzIjogW10sICJfaWQiOiAiZDE2MTBkODYtY2IzOS00NTFkLWE4MjUtZGIw
-        NmViZGJhMzkxIiwgImFyY2giOiAibm9hcmNoIiwgImRlc2NyaXB0aW9uIjog
+        aWVzIjogW10sICJfaWQiOiAiNzk1YWM0ZmEtNGQ4Yi00YjFjLThlZDktNmNk
+        ZmNkYTkyNmY2IiwgImFyY2giOiAibm9hcmNoIiwgImRlc2NyaXB0aW9uIjog
         IkEgbW9kdWxlIGZvciB0aGUga2FuZ2Fyb28gMC4zIHBhY2thZ2UifSwgInVw
-        ZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjUyWiIs
-        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICJkMTYx
-        MGQ4Ni1jYjM5LTQ1MWQtYTgyNS1kYjA2ZWJkYmEzOTEiLCAiX2lkIjogeyIk
-        b2lkIjogIjVkNDg3Zjc4YWIzNmNlM2ZlNTFkZWRlNyJ9fV0=
+        ZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDozNFoiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjM0WiIs
+        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICI3OTVh
+        YzRmYS00ZDhiLTRiMWMtOGVkOS02Y2RmY2RhOTI2ZjYiLCAiX2lkIjogeyIk
+        b2lkIjogIjVkNjkzM2ZhMzJkYjYwNzdhNzk2NjMyYiJ9fSwgeyJtZXRhZGF0
+        YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQv
+        dW5pdHMvbW9kdWxlbWQvOTAvNjZmNmI0M2IxYjRkZjA5ZjhhNjg3OTdhMDdh
+        ODRmZDNmNTVlNDc0ZjdkMzk5M2VmMmE4ZGM3NDE4ZDEwMDEiLCAibmFtZSI6
+        ICJrYW5nYXJvbyIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMiOiBbImth
+        bmdhcm9vLTA6MC4yLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICJlODIwZTA4
+        YzA1YWE3MzZjZTUzMDA2NmM2ODgyODhiZjU3NDYwOTgyNjdjMjgyNDI3OWUz
+        NmM5YTcyZTZiOWNlIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTY3MTc1NjYxLCAi
+        X2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxlcyI6IHsi
+        ZGVmYXVsdCI6IFsia2FuZ2Fyb28iXX0sICJzdW1tYXJ5IjogIkthbmdhcm9v
+        IDAuMiBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjog
+        MjAxODA3MDQxMTE3MTksICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNv
+        bnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwg
+        ImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogIjlhNjM4YWNhLTdiZjQtNDE4
+        MS1iMGEzLTM4ZTAwMGFlYTgxNCIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNj
+        cmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGthbmdhcm9vIDAuMiBwYWNr
+        YWdlIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6MzRaIiwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0zMFQx
+        NDozNDozNFoiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInVuaXRf
+        aWQiOiAiOWE2MzhhY2EtN2JmNC00MTgxLWIwYTMtMzhlMDAwYWVhODE0Iiwg
+        Il9pZCI6IHsiJG9pZCI6ICI1ZDY5MzNmYTMyZGI2MDc3YTc5NjYzMzQifX0s
+        IHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
+        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzFiLzJmMDAzOTY0YmI2NDIxZGU3
+        NDI3N2RiMTljOWNhOGQzMzNhYmE5NjM5MzkxMGM3ODBlNTcwMGRjOGE4M2Ez
+        IiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
+        OiBbImR1Y2stMDowLjYtMS5ub2FyY2giXSwgImNoZWNrc3VtIjogIjZiZDlk
+        OTA5YzkyNzA1NzFiODExZTUwMjcwOWVhN2I1NjE1MGQ0NGEyYjRiMzRjZmQy
+        NWU1MmE4MWM1YmZjZTciLCAiX2xhc3RfdXBkYXRlZCI6IDE1NjcxNzU2NjEs
+        ICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2ZpbGVzIjog
+        eyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNrIDAuNiBt
+        b2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3
+        MDQyNDQyMDUsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQi
+        OiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVu
+        ZGVuY2llcyI6IFtdLCAiX2lkIjogImVjMmQ2NWZmLTAyZGItNDg0MS04MzVl
+        LTkzMGI3ZjcxYTMzNiIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNjcmlwdGlv
+        biI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC42IHBhY2thZ2UifSwgInVw
+        ZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDozNFoiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjM0WiIs
+        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICJlYzJk
+        NjVmZi0wMmRiLTQ4NDEtODM1ZS05MzBiN2Y3MWEzMzYiLCAiX2lkIjogeyIk
+        b2lkIjogIjVkNjkzM2ZhMzJkYjYwNzdhNzk2NjM0NiJ9fV0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:54 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:35 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1759,21 +1401,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '63'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:54 GMT
+      - Fri, 30 Aug 2019 14:34:35 GMT
       Server:
       - Apache
       Content-Length:
@@ -1786,10 +1428,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:54 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:35 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1798,240 +1440,240 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '59'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:54 GMT
+      - Fri, 30 Aug 2019 14:34:36 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '9105'
+      - '1948'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAx
+        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTExLTEwIDAwOjAwOjAw
         IiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjog
-        W10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDowMDAx
-        IiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6
-        ICIiLCAidGl0bGUiOiAiRW1wdHkgZXJyYXRhIiwgIl9ucyI6ICJ1bml0c19l
-        cnJhdHVtIiwgInZlcnNpb24iOiAiMSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjog
-        ZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3QiOiBbXSwgInN0
-        YXR1cyI6ICJzdGFibGUiLCAidXBkYXRlZCI6ICIiLCAiZGVzY3JpcHRpb24i
-        OiAiRW1wdHkgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTY1MDMyMzEz
-        LCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6ICIi
-        LCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIi
-        LCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICIwMDVmZTMzMy1mMTM5LTQ2Zjct
-        ODM0ZC1jYjk4OWYyN2Y5ZWEifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0wNVQx
-        OToxMTo1M1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6
-        ICIyMDE5LTA4LTA1VDE5OjExOjUzWiIsICJ1bml0X3R5cGVfaWQiOiAiZXJy
-        YXR1bSIsICJ1bml0X2lkIjogIjAwNWZlMzMzLWYxMzktNDZmNy04MzRkLWNi
-        OTg5ZjI3ZjllYSIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmNzlhYjM2Y2Uz
-        ZmU1MWRlZTY3In19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMC0w
-        MS0wMSAwMTowMTowMSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAi
-        cmVmZXJlbmNlcyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJf
-        Y29udGVudF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1S
-        SEVBLTIwMTA6MDAwMiIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20i
-        LCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIk9uZSBwYWNrYWdlIGVycmF0
-        YSIsICJfbnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAi
-        cmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIs
-        ICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3
-        dy5mZWRvcmFwcm9qZWN0Lm9yZyIsICJuYW1lIjogImVsZXBoYW50IiwgInN1
-        bSI6IG51bGwsICJmaWxlbmFtZSI6ICJlbGVwaGFudC0wLjMtMC44Lm5vYXJj
-        aC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxl
-        YXNlIjogIjAuOCIsICJhcmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiY29s
-        bGVjdGlvbi0wIiwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6ICJzdGFibGUi
-        LCAidXBkYXRlZCI6ICIiLCAiZGVzY3JpcHRpb24iOiAiT25lIHBhY2thZ2Ug
-        ZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTY1MDMyMzEzLCAicmVzdGFy
-        dF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRz
-        IjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIiLCAicmVsZWFz
-        ZSI6ICIxIiwgIl9pZCI6ICIxZWRlYzQyMy0yMmZiLTRjMjItODgzNy0zYzFj
-        NDMwYWQ5ZTkifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1M1oi
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjExOjUzWiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJ1
-        bml0X2lkIjogIjFlZGVjNDIzLTIyZmItNGMyMi04ODM3LTNjMWM0MzBhZDll
-        OSIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmNzlhYjM2Y2UzZmU1MWRlZWEw
-        In19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMC0wMS0wMSAwMTow
-        MTowMSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVmZXJlbmNl
-        cyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90
-        eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6
-        OTkxNDMiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNldmVy
-        aXR5IjogIiIsICJ0aXRsZSI6ICJBcm1hZGlsbG8iLCAiX25zIjogInVuaXRz
+        W3siaHJlZiI6ICJodHRwczovL3Jobi5yZWRoYXQuY29tL2VycmF0YS9SSFNB
+        LTIwMTAtMDg1OC5odG1sIiwgInR5cGUiOiAic2VsZiIsICJpZCI6IG51bGws
+        ICJ0aXRsZSI6ICJSSFNBLTIwMTA6MDg1OCJ9LCB7ImhyZWYiOiAiaHR0cHM6
+        Ly9idWd6aWxsYS5yZWRoYXQuY29tL2J1Z3ppbGxhL3Nob3dfYnVnLmNnaT9p
+        ZD02Mjc4ODIiLCAidHlwZSI6ICJidWd6aWxsYSIsICJpZCI6ICI2Mjc4ODIi
+        LCAidGl0bGUiOiAiQ1ZFLTIwMTAtMDQwNSBiemlwMjogaW50ZWdlciBvdmVy
+        ZmxvdyBmbGF3IGluIEJaMl9kZWNvbXByZXNzIn0sIHsiaHJlZiI6ICJodHRw
+        czovL3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5L2RhdGEvY3ZlL0NWRS0yMDEw
+        LTA0MDUuaHRtbCIsICJ0eXBlIjogImN2ZSIsICJpZCI6ICJDVkUtMjAxMC0w
+        NDA1IiwgInRpdGxlIjogIkNWRS0yMDEwLTA0MDUifSwgeyJocmVmIjogImh0
+        dHA6Ly93d3cucmVkaGF0LmNvbS9zZWN1cml0eS91cGRhdGVzL2NsYXNzaWZp
+        Y2F0aW9uLyNpbXBvcnRhbnQiLCAidHlwZSI6ICJvdGhlciIsICJpZCI6IG51
+        bGwsICJ0aXRsZSI6IG51bGx9XSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9
+        LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVM
+        TE8tUkhTQS0yMDEwOjA4NTgiLCAiZnJvbSI6ICJzZWN1cml0eUByZWRoYXQu
+        Y29tIiwgInNldmVyaXR5IjogIkltcG9ydGFudCIsICJ0aXRsZSI6ICJJbXBv
+        cnRhbnQ6IGJ6aXAyIHNlY3VyaXR5IHVwZGF0ZSIsICJfbnMiOiAidW5pdHNf
+        ZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjMiLCAicmVib290X3N1Z2dlc3RlZCI6
+        IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFj
+        a2FnZXMiOiBbeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBt
+        IiwgIm5hbWUiOiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1NiIsICI4
+        MDJmNDM5OWRiZGQwMTQ3NmUyNTRjM2IzMmM0MGFmZjU5Y2Y1ZDIzYTQ1ZmE0
+        ODhjNjkxN2NlODkwNGQ2YjRkIl0sICJmaWxlbmFtZSI6ICJiemlwMi1saWJz
+        LTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6ICIwIiwgInZl
+        cnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2gi
+        OiAieDg2XzY0In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3Jj
+        LnJwbSIsICJuYW1lIjogImJ6aXAyLWRldmVsIiwgInN1bSI6IFsic2hhMjU2
+        IiwgImVhNjdjNjY0ZGExZmY5NmE2ZGM5NGQzMzAwOWI3M2Q4ZmFiMzFiNTk4
+        MjQxODNmYjQ1ZTliYTJlYmY4MmQ1ODMiXSwgImZpbGVuYW1lIjogImJ6aXAy
+        LWRldmVsLTEuMC41LTcuZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
+        cmNoIjogImk2ODYifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5z
+        cmMucnBtIiwgIm5hbWUiOiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1
+        NiIsICJjOWYwNjRhNjg2MjU3M2ZiOWYyYTZhZmY3YzM2MjFmMTk0MGI0OTJk
+        ZjJlZGZjMmViYmRjMGI4MzA1ZjUxMTQ3Il0sICJmaWxlbmFtZSI6ICJiemlw
+        Mi1saWJzLTEuMC41LTcuZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
+        cmNoIjogImk2ODYifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5z
+        cmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwiLCAic3VtIjogWyJzaGEy
+        NTYiLCAiN2Y2MzEyNGU0NjU1YjdjOTJkMjNlYzRjMzgyMjZmNWQzNzQ2NTY4
+        ODUzZGZmNzUwZmM4NWUwNThlNzRiNWNmNiJdLCAiZmlsZW5hbWUiOiAiYnpp
+        cDItZGV2ZWwtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjog
+        IjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAi
+        LCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5l
+        bDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDIiLCAic3VtIjogWyJzaGEy
+        NTYiLCAiYjhhM2Y3MmJjMmIwZDg5YmE3MzcwOTlhYzk4YmY4ZDJhZjRiZWEw
+        MmQzMTg4NGMwMmRiOTdmN2Y2NmMzZDVjMiJdLCAiZmlsZW5hbWUiOiAiYnpp
+        cDItMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjogIjAiLCAi
+        dmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJj
+        aCI6ICJ4ODZfNjQifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9y
+        dCI6ICIifV0sICJzdGF0dXMiOiAiZmluYWwiLCAidXBkYXRlZCI6ICIyMDEw
+        LTExLTEwIDAwOjAwOjAwIiwgImRlc2NyaXB0aW9uIjogImJ6aXAyIGlzIGEg
+        ZnJlZWx5IGF2YWlsYWJsZSwgaGlnaC1xdWFsaXR5IGRhdGEgY29tcHJlc3Nv
+        ci4gSXQgcHJvdmlkZXMgYm90aFxubGliYnoyIGxpYnJhcnkgbXVzdCBiZSBy
+        ZXN0YXJ0ZWQgZm9yIHRoZSB1cGRhdGUgdG8gdGFrZSBlZmZlY3QuIiwgIl9s
+        YXN0X3VwZGF0ZWQiOiAxNTY3MTc1Njc0LCAicmVzdGFydF9zdWdnZXN0ZWQi
+        OiBmYWxzZSwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIkNvcHlyaWdo
+        dCAyMDEwIFJlZCBIYXQgSW5jIiwgInNvbHV0aW9uIjogIkJlZm9yZSBhcHBs
+        eWluZyB0aGlzIHVwZGF0ZSwgbWFrZSBzdXJlIGFsbCBwcmV2aW91c2x5LXJl
+        bGVhc2VkIGVycmF0YVxucmVsZXZhbnQgdG8geW91ciBzeXN0ZW0gaGF2ZSBi
+        ZWVuIGFwcGxpZWQuXG5cblRoaXMgdXBkYXRlIGlzIGF2YWlsYWJsZSB2aWEg
+        dGhlIFJlZCBIYXQgTmV0d29yay4gRGV0YWlscyBvbiBob3cgdG9cbnVzZSB0
+        aGUgUmVkIEhhdCBOZXR3b3JrIHRvIGFwcGx5IHRoaXMgdXBkYXRlIGFyZSBh
+        dmFpbGFibGUgYXRcbmh0dHA6Ly9rYmFzZS5yZWRoYXQuY29tL2ZhcS9kb2Nz
+        L0RPQy0xMTI1OSIsICJzdW1tYXJ5IjogIlVwZGF0ZWQgYnppcDIgcGFja2Fn
+        ZXMgdGhhdCBmaXggb25lIHNlY3VyaXR5IGlzc3VlIiwgInJlbGVhc2UiOiAi
+        IiwgIl9pZCI6ICI0YmM2ZGRiNy1hNGU1LTRkYTUtODM0YS00OTVhYWI2ODZh
+        NDgifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDozNFoiLCAicmVw
+        b19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTMwVDE0
+        OjM0OjM0WiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJ1bml0X2lk
+        IjogIjRiYzZkZGI3LWE0ZTUtNGRhNS04MzRhLTQ5NWFhYjY4NmE0OCIsICJf
+        aWQiOiB7IiRvaWQiOiAiNWQ2OTMzZmEzMmRiNjA3N2E3OTY2M2IwIn19LCB7
+        Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMi0wMS0wMSAwMTowMTowMSIs
+        ICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVmZXJlbmNlcyI6IFtd
+        LCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lk
+        IjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6MDExMSIs
+        ICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAi
+        IiwgInRpdGxlIjogIkR1cGxpY2F0ZWQgcGFja2FnZSBlcnJhdGEiLCAiX25z
+        IjogInVuaXRzX2VycmF0dW0iLCAidmVyc2lvbiI6ICIxIiwgInJlYm9vdF9z
+        dWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlz
+        dCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogImh0dHA6Ly93d3cuZmVkb3Jh
+        cHJvamVjdC5vcmciLCAibmFtZSI6ICJsaW9uIiwgInN1bSI6IG51bGwsICJm
+        aWxlbmFtZSI6ICJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6
+        ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgImFy
+        Y2giOiAibm9hcmNoIn0sIHsic3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJv
+        amVjdC5vcmciLCAibmFtZSI6ICJlbGVwaGFudCIsICJzdW0iOiBudWxsLCAi
+        ZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVw
+        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgi
+        LCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIs
+        ICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQi
+        OiAiIiwgImRlc2NyaXB0aW9uIjogIkR1cGxpY2F0ZSBPbmUgcGFja2FnZSBl
+        cnJhdGEiLCAiX2xhc3RfdXBkYXRlZCI6IDE1NjcxNzU2NzQsICJyZXN0YXJ0
+        X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMi
+        OiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNl
+        IjogIjEiLCAiX2lkIjogIjUyYmE2NTI1LWU5NTktNGNjZC04YWNiLWY1MjQ5
+        OTdiNjM1YiJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjM0WiIs
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTktMDgt
+        MzBUMTQ6MzQ6MzRaIiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVu
+        aXRfaWQiOiAiNTJiYTY1MjUtZTk1OS00Y2NkLThhY2ItZjUyNDk5N2I2MzVi
+        IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzNmYTMyZGI2MDc3YTc5NjY0MDci
+        fX0sIHsibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAx
+        OjAxIiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2Vz
+        IjogW10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5
+        cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDow
+        MDAyIiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNvbSIsICJzZXZlcml0
+        eSI6ICIiLCAidGl0bGUiOiAiT25lIHBhY2thZ2UgZXJyYXRhIiwgIl9ucyI6
+        ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMSIsICJyZWJvb3Rfc3Vn
+        Z2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3Qi
+        OiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRwOi8vd3d3LmZlZG9yYXBy
+        b2plY3Qub3JnIiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAic3VtIjogbnVsbCwg
+        ImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsICJl
+        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44
+        IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJjb2xsZWN0aW9uLTAi
+        LCAic2hvcnQiOiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIsICJ1cGRhdGVk
+        IjogIiIsICJkZXNjcmlwdGlvbiI6ICJPbmUgcGFja2FnZSBlcnJhdGEiLCAi
+        X2xhc3RfdXBkYXRlZCI6IDE1NjcxNzU2NzQsICJyZXN0YXJ0X3N1Z2dlc3Rl
+        ZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMiOiAiIiwgInNv
+        bHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAi
+        X2lkIjogIjZkMmNhYTMzLTczNjYtNDUzMi05ZjNkLWVhYjgzNzAyZTJhMCJ9
+        LCAidXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjM0WiIsICJyZXBvX2lk
+        IjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6
+        MzRaIiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVuaXRfaWQiOiAi
+        NmQyY2FhMzMtNzM2Ni00NTMyLTlmM2QtZWFiODM3MDJlMmEwIiwgIl9pZCI6
+        IHsiJG9pZCI6ICI1ZDY5MzNmYTMyZGI2MDc3YTc5NjYzY2YifX0sIHsibWV0
+        YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAxIiwgInJl
+        bG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjogW10sICJw
+        dWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAi
+        ZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDo5OTE0MyIsICJm
+        cm9tIjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwg
+        InRpdGxlIjogIkFybWFkaWxsbyIsICJfbnMiOiAidW5pdHNfZXJyYXR1bSIs
+        ICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAi
+        dHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBb
+        eyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIsICJuYW1l
+        IjogImFybWFkaWxsbyIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiYXJt
+        YWRpbGxvLTIuMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJz
+        aW9uIjogIjIuMSIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2gi
+        fV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJz
+        dGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9u
+        IjogIkFybWFkaWxsbyIsICJfbGFzdF91cGRhdGVkIjogMTU2NzE3NTY3NCwg
+        InJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwg
+        InJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwg
+        InJlbGVhc2UiOiAiMSIsICJfaWQiOiAiYjFiNzQ3NTAtMGYxMC00M2M0LTgy
+        YmMtMTk1ZjE3NjAxOTBkIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6
+        MzQ6MzRaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAi
+        MjAxOS0wOC0zMFQxNDozNDozNFoiLCAidW5pdF90eXBlX2lkIjogImVycmF0
+        dW0iLCAidW5pdF9pZCI6ICJiMWI3NDc1MC0wZjEwLTQzYzQtODJiYy0xOTVm
+        MTc2MDE5MGQiLCAiX2lkIjogeyIkb2lkIjogIjVkNjkzM2ZhMzJkYjYwNzdh
+        Nzk2NjNlOSJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTgtMDEt
+        MjcgMTY6MDg6MDkiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJl
+        ZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2Nv
+        bnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhF
+        QS0yMDEyOjAwNTkiLCAiZnJvbSI6ICJlcnJhdGFAcmVkaGF0LmNvbSIsICJz
+        ZXZlcml0eSI6ICIiLCAidGl0bGUiOiAiRHVja19LYW5nYXJvb19FcnJhdHVt
+        IiwgIl9ucyI6ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMSIsICJy
+        ZWJvb3Rfc3VnZ2VzdGVkIjogZmFsc2UsICJ0eXBlIjogImVuaGFuY2VtZW50
+        IiwgInBrZ2xpc3QiOiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRwOi8v
+        d3d3LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAiZHVjayIsICJzdW0i
+        OiBudWxsLCAiZmlsZW5hbWUiOiAiZHVjay0wLjctMS5ub2FyY2gucnBtIiwg
+        ImVwb2NoIjogbnVsbCwgInZlcnNpb24iOiAiMC43IiwgInJlbGVhc2UiOiAi
+        MSIsICJhcmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiY29sbGVjdGlvbi0w
+        IiwgIm1vZHVsZSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJzaW9u
+        IjogIjIwMTgwNzMwMjMzMTAyIiwgImFyY2giOiAibm9hcmNoIiwgIm5hbWUi
+        OiAiZHVjayIsICJzdHJlYW0iOiAiMCJ9LCAic2hvcnQiOiAiIn0sIHsicGFj
+        a2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9y
+        ZyIsICJuYW1lIjogImthbmdhcm9vIiwgInN1bSI6IG51bGwsICJmaWxlbmFt
+        ZSI6ICJrYW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwgImVwb2NoIjogbnVs
+        bCwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjog
+        Im5vYXJjaCJ9XSwgIm5hbWUiOiAiY29sbGVjdGlvbi0xIiwgIm1vZHVsZSI6
+        IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJzaW9uIjogIjIwMTgwNzMw
+        MjIzNDA3IiwgImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAia2FuZ2Fyb28i
+        LCAic3RyZWFtIjogIjAifSwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6ICJz
+        dGFibGUiLCAidXBkYXRlZCI6ICIyMDE4LTA3LTIwIDA2OjAwOjAxIFVUQyIs
+        ICJkZXNjcmlwdGlvbiI6ICJEdWNrX0thbmdhcm9fRXJyYXR1bSBkZXNjcmlw
+        dGlvbiIsICJfbGFzdF91cGRhdGVkIjogMTU2NzE3NTY3NCwgInJlc3RhcnRf
+        c3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6
+        ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVhc2Ui
+        OiAiMSIsICJfaWQiOiAiYzY4ZDEzOTUtZGZiNS00MjdhLWI0OWQtOTFhZmM4
+        NGVmYjVkIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6MzRaIiwg
+        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0z
+        MFQxNDozNDozNFoiLCAidW5pdF90eXBlX2lkIjogImVycmF0dW0iLCAidW5p
+        dF9pZCI6ICJjNjhkMTM5NS1kZmI1LTQyN2EtYjQ5ZC05MWFmYzg0ZWZiNWQi
+        LCAiX2lkIjogeyIkb2lkIjogIjVkNjkzM2ZhMzJkYjYwNzdhNzk2NjQyMiJ9
+        fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTAtMDEtMDEgMDE6MDE6
+        MDEiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMi
+        OiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlw
+        ZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjAw
+        MDEiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5
+        IjogIiIsICJ0aXRsZSI6ICJFbXB0eSBlcnJhdGEiLCAiX25zIjogInVuaXRz
         X2VycmF0dW0iLCAidmVyc2lvbiI6ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQi
-        OiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFt7InBh
-        Y2thZ2VzIjogW3sic3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5v
-        cmciLCAibmFtZSI6ICJhcm1hZGlsbG8iLCAic3VtIjogbnVsbCwgImZpbGVu
-        YW1lIjogImFybWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwgImVwb2NoIjog
-        IjAiLCAidmVyc2lvbiI6ICIyLjEiLCAicmVsZWFzZSI6ICIxIiwgImFyY2gi
-        OiAibm9hcmNoIn1dLCAibmFtZSI6ICJjb2xsZWN0aW9uLTAiLCAic2hvcnQi
-        OiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIsICJ1cGRhdGVkIjogIiIsICJk
-        ZXNjcmlwdGlvbiI6ICJBcm1hZGlsbG8iLCAiX2xhc3RfdXBkYXRlZCI6IDE1
-        NjUwMzIzMTMsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNv
-        dW50IjogIiIsICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1t
-        YXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjcwYjYwNjk3LTY3
-        MWQtNGY1OS1hNWJhLTA3MTE1ZjEwMTI0OCJ9LCAidXBkYXRlZCI6ICIyMDE5
-        LTA4LTA1VDE5OjExOjUzWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJj
-        cmVhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6NTNaIiwgInVuaXRfdHlwZV9p
-        ZCI6ICJlcnJhdHVtIiwgInVuaXRfaWQiOiAiNzBiNjA2OTctNjcxZC00ZjU5
-        LWE1YmEtMDcxMTVmMTAxMjQ4IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y3
-        OWFiMzZjZTNmZTUxZGVlYmQifX0sIHsibWV0YWRhdGEiOiB7Imlzc3VlZCI6
-        ICIyMDEwLTExLTEwIDAwOjAwOjAwIiwgInJlbG9naW5fc3VnZ2VzdGVkIjog
-        ZmFsc2UsICJyZWZlcmVuY2VzIjogW3siaHJlZiI6ICJodHRwczovL3Jobi5y
-        ZWRoYXQuY29tL2VycmF0YS9SSFNBLTIwMTAtMDg1OC5odG1sIiwgInR5cGUi
-        OiAic2VsZiIsICJpZCI6IG51bGwsICJ0aXRsZSI6ICJSSFNBLTIwMTA6MDg1
-        OCJ9LCB7ImhyZWYiOiAiaHR0cHM6Ly9idWd6aWxsYS5yZWRoYXQuY29tL2J1
-        Z3ppbGxhL3Nob3dfYnVnLmNnaT9pZD02Mjc4ODIiLCAidHlwZSI6ICJidWd6
-        aWxsYSIsICJpZCI6ICI2Mjc4ODIiLCAidGl0bGUiOiAiQ1ZFLTIwMTAtMDQw
-        NSBiemlwMjogaW50ZWdlciBvdmVyZmxvdyBmbGF3IGluIEJaMl9kZWNvbXBy
-        ZXNzIn0sIHsiaHJlZiI6ICJodHRwczovL3d3dy5yZWRoYXQuY29tL3NlY3Vy
-        aXR5L2RhdGEvY3ZlL0NWRS0yMDEwLTA0MDUuaHRtbCIsICJ0eXBlIjogImN2
-        ZSIsICJpZCI6ICJDVkUtMjAxMC0wNDA1IiwgInRpdGxlIjogIkNWRS0yMDEw
-        LTA0MDUifSwgeyJocmVmIjogImh0dHA6Ly93d3cucmVkaGF0LmNvbS9zZWN1
-        cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCAidHlw
-        ZSI6ICJvdGhlciIsICJpZCI6IG51bGwsICJ0aXRsZSI6IG51bGx9XSwgInB1
-        bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJl
-        cnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCAiZnJv
-        bSI6ICJzZWN1cml0eUByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIkltcG9y
-        dGFudCIsICJ0aXRsZSI6ICJJbXBvcnRhbnQ6IGJ6aXAyIHNlY3VyaXR5IHVw
-        ZGF0ZSIsICJfbnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjMi
-        LCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0
-        eSIsICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiYnppcDIt
-        MS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwi
-        LCAic3VtIjogWyJzaGEyNTYiLCAiZWE2N2M2NjRkYTFmZjk2YTZkYzk0ZDMz
-        MDA5YjczZDhmYWIzMWI1OTgyNDE4M2ZiNDVlOWJhMmViZjgyZDU4MyJdLCAi
-        ZmlsZW5hbWUiOiAiYnppcDItZGV2ZWwtMS4wLjUtNy5lbDZfMC5pNjg2LnJw
-        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFz
-        ZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlw
-        Mi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJz
-        IiwgInN1bSI6IFsic2hhMjU2IiwgImM5ZjA2NGE2ODYyNTczZmI5ZjJhNmFm
-        ZjdjMzYyMWYxOTQwYjQ5MmRmMmVkZmMyZWJiZGMwYjgzMDVmNTExNDciXSwg
-        ImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC5pNjg2LnJw
-        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFz
-        ZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlw
-        Mi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMiIsICJz
-        dW0iOiBbInNoYTI1NiIsICJiOGEzZjcyYmMyYjBkODliYTczNzA5OWFjOThi
-        ZjhkMmFmNGJlYTAyZDMxODg0YzAyZGI5N2Y3ZjY2YzNkNWMyIl0sICJmaWxl
-        bmFtZSI6ICJiemlwMi0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0iLCAiZXBv
-        Y2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5l
-        bDZfMCIsICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6ICJiemlwMi0xLjAu
-        NS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1kZXZlbCIsICJz
-        dW0iOiBbInNoYTI1NiIsICI3ZjYzMTI0ZTQ2NTViN2M5MmQyM2VjNGMzODIy
-        NmY1ZDM3NDY1Njg4NTNkZmY3NTBmYzg1ZTA1OGU3NGI1Y2Y2Il0sICJmaWxl
-        bmFtZSI6ICJiemlwMi1kZXZlbC0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0i
-        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2Ui
-        OiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6ICJiemlw
-        Mi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJz
-        IiwgInN1bSI6IFsic2hhMjU2IiwgIjgwMmY0Mzk5ZGJkZDAxNDc2ZTI1NGMz
-        YjMyYzQwYWZmNTljZjVkMjNhNDVmYTQ4OGM2OTE3Y2U4OTA0ZDZiNGQiXSwg
-        ImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC54ODZfNjQu
-        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxl
-        YXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifV0sICJuYW1lIjog
-        ImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAiZmlu
-        YWwiLCAidXBkYXRlZCI6ICIyMDEwLTExLTEwIDAwOjAwOjAwIiwgImRlc2Ny
-        aXB0aW9uIjogImJ6aXAyIGlzIGEgZnJlZWx5IGF2YWlsYWJsZSwgaGlnaC1x
-        dWFsaXR5IGRhdGEgY29tcHJlc3Nvci4gSXQgcHJvdmlkZXMgYm90aFxubGli
-        YnoyIGxpYnJhcnkgbXVzdCBiZSByZXN0YXJ0ZWQgZm9yIHRoZSB1cGRhdGUg
-        dG8gdGFrZSBlZmZlY3QuIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTY1MDMyMzEz
-        LCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6ICIi
-        LCAicmlnaHRzIjogIkNvcHlyaWdodCAyMDEwIFJlZCBIYXQgSW5jIiwgInNv
-        bHV0aW9uIjogIkJlZm9yZSBhcHBseWluZyB0aGlzIHVwZGF0ZSwgbWFrZSBz
-        dXJlIGFsbCBwcmV2aW91c2x5LXJlbGVhc2VkIGVycmF0YVxucmVsZXZhbnQg
-        dG8geW91ciBzeXN0ZW0gaGF2ZSBiZWVuIGFwcGxpZWQuXG5cblRoaXMgdXBk
-        YXRlIGlzIGF2YWlsYWJsZSB2aWEgdGhlIFJlZCBIYXQgTmV0d29yay4gRGV0
-        YWlscyBvbiBob3cgdG9cbnVzZSB0aGUgUmVkIEhhdCBOZXR3b3JrIHRvIGFw
-        cGx5IHRoaXMgdXBkYXRlIGFyZSBhdmFpbGFibGUgYXRcbmh0dHA6Ly9rYmFz
-        ZS5yZWRoYXQuY29tL2ZhcS9kb2NzL0RPQy0xMTI1OSIsICJzdW1tYXJ5Ijog
-        IlVwZGF0ZWQgYnppcDIgcGFja2FnZXMgdGhhdCBmaXggb25lIHNlY3VyaXR5
-        IGlzc3VlIiwgInJlbGVhc2UiOiAiIiwgIl9pZCI6ICJjZTJiNzRjNi1hZWU1
-        LTQxYTYtODZmNi01ZTQ0MTFmZWJiNGIifSwgInVwZGF0ZWQiOiAiMjAxOS0w
-        OC0wNVQxOToxMTo1M1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3Jl
-        YXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjUzWiIsICJ1bml0X3R5cGVfaWQi
-        OiAiZXJyYXR1bSIsICJ1bml0X2lkIjogImNlMmI3NGM2LWFlZTUtNDFhNi04
-        NmY2LTVlNDQxMWZlYmI0YiIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmNzlh
-        YjM2Y2UzZmU1MWRlZTgxIn19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAi
-        MjAxOC0wMS0yNyAxNjowODowOSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZh
-        bHNlLCAicmVmZXJlbmNlcyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjog
-        e30sICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiS0FU
-        RUxMTy1SSEVBLTIwMTI6MDA1OSIsICJmcm9tIjogImVycmF0YUByZWRoYXQu
-        Y29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6ICJEdWNrX0thbmdhcm9v
-        X0VycmF0dW0iLCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAidmVyc2lvbiI6
-        ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAiZW5o
-        YW5jZW1lbnQiLCAicGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjog
-        Imh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJkdWNr
-        IiwgInN1bSI6IG51bGwsICJmaWxlbmFtZSI6ICJkdWNrLTAuNy0xLm5vYXJj
-        aC5ycG0iLCAiZXBvY2giOiBudWxsLCAidmVyc2lvbiI6ICIwLjciLCAicmVs
-        ZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJjb2xs
-        ZWN0aW9uLTAiLCAibW9kdWxlIjogeyJjb250ZXh0IjogImRlYWRiZWVmIiwg
-        InZlcnNpb24iOiAiMjAxODA3MzAyMzMxMDIiLCAiYXJjaCI6ICJub2FyY2gi
-        LCAibmFtZSI6ICJkdWNrIiwgInN0cmVhbSI6ICIwIn0sICJzaG9ydCI6ICIi
-        fSwgeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRwOi8vd3d3LmZlZG9yYXBy
-        b2plY3Qub3JnIiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAic3VtIjogbnVsbCwg
-        ImZpbGVuYW1lIjogImthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCAiZXBv
-        Y2giOiBudWxsLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIxIiwg
-        ImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJjb2xsZWN0aW9uLTEiLCAi
-        bW9kdWxlIjogeyJjb250ZXh0IjogImRlYWRiZWVmIiwgInZlcnNpb24iOiAi
-        MjAxODA3MzAyMjM0MDciLCAiYXJjaCI6ICJub2FyY2giLCAibmFtZSI6ICJr
-        YW5nYXJvbyIsICJzdHJlYW0iOiAiMCJ9LCAic2hvcnQiOiAiIn1dLCAic3Rh
-        dHVzIjogInN0YWJsZSIsICJ1cGRhdGVkIjogIjIwMTgtMDctMjAgMDY6MDA6
-        MDEgVVRDIiwgImRlc2NyaXB0aW9uIjogIkR1Y2tfS2FuZ2Fyb19FcnJhdHVt
-        IGRlc2NyaXB0aW9uIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTY1MDMyMzEzLCAi
-        cmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6ICIiLCAi
-        cmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIiLCAi
-        cmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJmZTUxOTZjNi04YjNkLTRlZDItOTc0
-        Ni0zZDQ1Yjg5MWY0NjcifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOTox
-        MTo1M1oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIy
-        MDE5LTA4LTA1VDE5OjExOjUzWiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1
-        bSIsICJ1bml0X2lkIjogImZlNTE5NmM2LThiM2QtNGVkMi05NzQ2LTNkNDVi
-        ODkxZjQ2NyIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmNzlhYjM2Y2UzZmU1
-        MWRlZWY4In19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMi0wMS0w
-        MSAwMTowMTowMSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVm
-        ZXJlbmNlcyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29u
-        dGVudF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1SSEVB
-        LTIwMTA6MDExMSIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20iLCAi
-        c2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIkR1cGxpY2F0ZWQgcGFja2FnZSBl
-        cnJhdGEiLCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAidmVyc2lvbiI6ICIx
-        IiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJp
-        dHkiLCAicGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogImh0dHA6
-        Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJlbGVwaGFudCIs
-        ICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5u
-        b2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAi
-        cmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifSwgeyJzcmMiOiAi
-        aHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIsICJuYW1lIjogImxpb24i
-        LCAic3VtIjogbnVsbCwgImZpbGVuYW1lIjogImxpb24tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVs
-        ZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogImNv
-        bGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxl
-        IiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjogIkR1cGxpY2F0ZSBP
-        bmUgcGFja2FnZSBlcnJhdGEiLCAiX2xhc3RfdXBkYXRlZCI6IDE1NjUwMzIz
-        MTMsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50Ijog
+        OiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFtdLCAi
+        c3RhdHVzIjogInN0YWJsZSIsICJ1cGRhdGVkIjogIiIsICJkZXNjcmlwdGlv
+        biI6ICJFbXB0eSBlcnJhdGEiLCAiX2xhc3RfdXBkYXRlZCI6IDE1NjcxNzU2
+        NzQsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50Ijog
         IiIsICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5Ijog
-        IiIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImZmOTVmZWM1LWFmNDMtNGVl
-        OC1hZTkzLTZhOGViNDdkM2JhYSJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTA1
-        VDE5OjExOjUzWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
-        IjogIjIwMTktMDgtMDVUMTk6MTE6NTNaIiwgInVuaXRfdHlwZV9pZCI6ICJl
-        cnJhdHVtIiwgInVuaXRfaWQiOiAiZmY5NWZlYzUtYWY0My00ZWU4LWFlOTMt
-        NmE4ZWI0N2QzYmFhIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y3OWFiMzZj
-        ZTNmZTUxZGVlZDkifX1d
+        IiIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImRjODM2NDUyLWJmYjItNDRi
+        MS05YThlLWIzYmU5YTc1ZTczNSJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTMw
+        VDE0OjM0OjM0WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
+        IjogIjIwMTktMDgtMzBUMTQ6MzQ6MzRaIiwgInVuaXRfdHlwZV9pZCI6ICJl
+        cnJhdHVtIiwgInVuaXRfaWQiOiAiZGM4MzY0NTItYmZiMi00NGIxLTlhOGUt
+        YjNiZTlhNzVlNzM1IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzNmYTMyZGI2
+        MDc3YTc5NjYzOTYifX1d
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:54 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2040,21 +1682,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '62'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:54 GMT
+      - Fri, 30 Aug 2019 14:34:36 GMT
       Server:
       - Apache
       Content-Length:
@@ -2067,10 +1709,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:54 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2079,27 +1721,27 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '65'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:54 GMT
+      - Fri, 30 Aug 2019 14:34:36 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1486'
+      - '441'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2109,41 +1751,41 @@ http_interactions:
         ZW5ndWluIl0sICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImJp
         cmQiLCAidXNlcl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAi
         X25zIjogInVuaXRzX3BhY2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6
-        IDE1NjUwMzIwOTYsICJvcHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0
+        IDE1NjcxNzU2NjEsICJvcHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0
         cmFuc2xhdGVkX25hbWUiOiB7fSwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24i
         OiB7fSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNr
         YWdlX25hbWVzIjogW10sICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2Vf
-        Z3JvdXAiLCAiaWQiOiAiYmlyZCIsICJfaWQiOiAiYTVlMDM1NjctMTkxOS00
-        NTc3LWFlNWEtNGUxYTgwNGFhYjJhIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0
+        Z3JvdXAiLCAiaWQiOiAiYmlyZCIsICJfaWQiOiAiNGUxZjFmOWQtZGYzOS00
+        NWYxLWEyMmQtYjdlODY0ZTZmMGFhIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0
         LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQi
-        OiAiMjAxOS0wOC0wNVQxOToxMTo1M1oiLCAicmVwb19pZCI6ICJGZWRvcmFf
-        MTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjUzWiIsICJ1bml0
-        X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0X2lkIjogImE1ZTAz
-        NTY3LTE5MTktNDU3Ny1hZTVhLTRlMWE4MDRhYWIyYSIsICJfaWQiOiB7IiRv
-        aWQiOiAiNWQ0ODdmNzlhYjM2Y2UzZmU1MWRlZjA4In19LCB7Im1ldGFkYXRh
+        OiAiMjAxOS0wOC0zMFQxNDozNDozNFoiLCAicmVwb19pZCI6ICJGZWRvcmFf
+        MTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjM0WiIsICJ1bml0
+        X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0X2lkIjogIjRlMWYx
+        ZjlkLWRmMzktNDVmMS1hMjJkLWI3ZTg2NGU2ZjBhYSIsICJfaWQiOiB7IiRv
+        aWQiOiAiNWQ2OTMzZmEzMmRiNjA3N2E3OTY2NDMyIn19LCB7Im1ldGFkYXRh
         IjogeyJtYW5kYXRvcnlfcGFja2FnZV9uYW1lcyI6IFsiZWxlcGhhbnQsZ2ly
         YWZmZSxjaGVldGFoLGxpb24sbW9ua2V5LHBlbmd1aW4sc3F1aXJyZWwsd2Fs
         cnVzIiwgInBlbmd1aW4iXSwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5h
         bWUiOiAibWFtbWFsIiwgInVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0
         IjogdHJ1ZSwgIl9ucyI6ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0
-        X3VwZGF0ZWQiOiAxNTY1MDMyMDk2LCAib3B0aW9uYWxfcGFja2FnZV9uYW1l
+        X3VwZGF0ZWQiOiAxNTY3MTc1NjYxLCAib3B0aW9uYWxfcGFja2FnZV9uYW1l
         cyI6IFtdLCAidHJhbnNsYXRlZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rl
         c2NyaXB0aW9uIjoge30sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRl
         ZmF1bHRfcGFja2FnZV9uYW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6
-        ICJwYWNrYWdlX2dyb3VwIiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiZDA0
-        ZDRmZjgtYjU3ZS00ZTU2LTgwODUtOTliMzU1NTgyYmQzIiwgImRpc3BsYXlf
+        ICJwYWNrYWdlX2dyb3VwIiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiY2Fl
+        MGFiMmUtMjljZC00YjEzLWFlZjEtZjUxYWQzOWNiMThlIiwgImRpc3BsYXlf
         b3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtd
-        fSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1M1oiLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjEx
-        OjUzWiIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0
-        X2lkIjogImQwNGQ0ZmY4LWI1N2UtNGU1Ni04MDg1LTk5YjM1NTU4MmJkMyIs
-        ICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmNzlhYjM2Y2UzZmU1MWRlZjE2In19
+        fSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDozNFoiLCAicmVwb19p
+        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0
+        OjM0WiIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0
+        X2lkIjogImNhZTBhYjJlLTI5Y2QtNGIxMy1hZWYxLWY1MWFkMzljYjE4ZSIs
+        ICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZmEzMmRiNjA3N2E3OTY2NDNlIn19
         XQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:54 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2152,21 +1794,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '68'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:54 GMT
+      - Fri, 30 Aug 2019 14:34:36 GMT
       Server:
       - Apache
       Content-Length:
@@ -2179,10 +1821,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:54 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2191,74 +1833,74 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '74'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:54 GMT
+      - Fri, 30 Aug 2019 14:34:36 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1656'
+      - '550'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
         W3sibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
-        cC9jb250ZW50L3VuaXRzL3l1bV9yZXBvX21ldGFkYXRhX2ZpbGUvYjQvNWYz
-        YTU5ZWY0MTllODNiMzBkZDA1ZjIyYTUxZWExZWZlMzA1N2RiNmE3NDc0MDBh
-        ZTMxOGQ2NTc3NzJiMWYvMGQxZWI3Mzg2N2M0NTliODZkMTU4Y2RhZDI2NjAw
-        MmU0NTg4MTQwNTFlMzU1Mjk5NzA1M2QzNTY3MTQ0YTdlMi1wcm9kdWN0aWQu
-        Z3oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiZGF0YV90eXBlIjogInBy
-        b2R1Y3RpZCIsICJjaGVja3N1bSI6ICIwZDFlYjczODY3YzQ1OWI4NmQxNThj
-        ZGFkMjY2MDAyZTQ1ODgxNDA1MWUzNTUyOTk3MDUzZDM1NjcxNDRhN2UyIiwg
-        Il9sYXN0X3VwZGF0ZWQiOiAxNTY1MDMyMzEyLCAiX2NvbnRlbnRfdHlwZV9p
-        ZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIiwgImRvd25sb2FkZWQiOiB0
-        cnVlLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfbnMiOiAidW5pdHNf
-        eXVtX3JlcG9fbWV0YWRhdGFfZmlsZSIsICJjaGVja3N1bV90eXBlIjogInNo
-        YTI1NiIsICJfaWQiOiAiNDRjNGE3NTYtYzkzNi00NmJjLTg3MGUtMmYxNTI4
-        OTY5ZWVjIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6NTJaIiwg
-        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0w
-        NVQxOToxMTo1MloiLCAidW5pdF90eXBlX2lkIjogInl1bV9yZXBvX21ldGFk
-        YXRhX2ZpbGUiLCAidW5pdF9pZCI6ICI0NGM0YTc1Ni1jOTM2LTQ2YmMtODcw
-        ZS0yZjE1Mjg5NjllZWMiLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3Zjc4YWIz
-        NmNlM2ZlNTFkZWNjYiJ9fSwgeyJtZXRhZGF0YSI6IHsiX3N0b3JhZ2VfcGF0
-        aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQvdW5pdHMveXVtX3JlcG9fbWV0
-        YWRhdGFfZmlsZS85ZS9iNjY2MGRlZjEzM2U1Yjg2N2JiZWEwODM2MTNhNjVj
-        NDk4ZDU4YWYwMWMwMGFmNTkyNTllODk4ZWYwOTFiMS81NjljMGFjMzI0MzJh
-        MjEzMDg2NzkzYTcwNTAyMjI4YTJiZTk5NWJjNTEzNDgwMWZlMTU4MmM0MDhm
-        OGQ5NzFiLXN3aWR0YWdzLnhtbC5neiIsICJyZXBvX2lkIjogIkZlZG9yYV8x
-        NyIsICJkYXRhX3R5cGUiOiAic3dpZHRhZ3MiLCAiY2hlY2tzdW0iOiAiNTY5
-        YzBhYzMyNDMyYTIxMzA4Njc5M2E3MDUwMjIyOGEyYmU5OTViYzUxMzQ4MDFm
-        ZTE1ODJjNDA4ZjhkOTcxYiIsICJfbGFzdF91cGRhdGVkIjogMTU2NTAzMjMx
-        MiwgIl9jb250ZW50X3R5cGVfaWQiOiAieXVtX3JlcG9fbWV0YWRhdGFfZmls
+        cC9jb250ZW50L3VuaXRzL3l1bV9yZXBvX21ldGFkYXRhX2ZpbGUvOWUvYjY2
+        NjBkZWYxMzNlNWI4NjdiYmVhMDgzNjEzYTY1YzQ5OGQ1OGFmMDFjMDBhZjU5
+        MjU5ZTg5OGVmMDkxYjEvNTY5YzBhYzMyNDMyYTIxMzA4Njc5M2E3MDUwMjIy
+        OGEyYmU5OTViYzUxMzQ4MDFmZTE1ODJjNDA4ZjhkOTcxYi1zd2lkdGFncy54
+        bWwuZ3oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiZGF0YV90eXBlIjog
+        InN3aWR0YWdzIiwgImNoZWNrc3VtIjogIjU2OWMwYWMzMjQzMmEyMTMwODY3
+        OTNhNzA1MDIyMjhhMmJlOTk1YmM1MTM0ODAxZmUxNTgyYzQwOGY4ZDk3MWIi
+        LCAiX2xhc3RfdXBkYXRlZCI6IDE1NjcxNzU2NzQsICJfY29udGVudF90eXBl
+        X2lkIjogInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiLCAiZG93bmxvYWRlZCI6
+        IHRydWUsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9ucyI6ICJ1bml0
+        c195dW1fcmVwb19tZXRhZGF0YV9maWxlIiwgImNoZWNrc3VtX3R5cGUiOiAi
+        c2hhMjU2IiwgIl9pZCI6ICJiNWQyZDIxZi02MGM1LTQ2ZWEtODFhYi1kOTg2
+        ZjY5NDQ5NzYifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDozNFoi
+        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4
+        LTMwVDE0OjM0OjM0WiIsICJ1bml0X3R5cGVfaWQiOiAieXVtX3JlcG9fbWV0
+        YWRhdGFfZmlsZSIsICJ1bml0X2lkIjogImI1ZDJkMjFmLTYwYzUtNDZlYS04
+        MWFiLWQ5ODZmNjk0NDk3NiIsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZmEz
+        MmRiNjA3N2E3OTY2MjFjIn19LCB7Im1ldGFkYXRhIjogeyJfc3RvcmFnZV9w
+        YXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0cy95dW1fcmVwb19t
+        ZXRhZGF0YV9maWxlL2I0LzVmM2E1OWVmNDE5ZTgzYjMwZGQwNWYyMmE1MWVh
+        MWVmZTMwNTdkYjZhNzQ3NDAwYWUzMThkNjU3NzcyYjFmLzBkMWViNzM4Njdj
+        NDU5Yjg2ZDE1OGNkYWQyNjYwMDJlNDU4ODE0MDUxZTM1NTI5OTcwNTNkMzU2
+        NzE0NGE3ZTItcHJvZHVjdGlkLmd6IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3
+        IiwgImRhdGFfdHlwZSI6ICJwcm9kdWN0aWQiLCAiY2hlY2tzdW0iOiAiMGQx
+        ZWI3Mzg2N2M0NTliODZkMTU4Y2RhZDI2NjAwMmU0NTg4MTQwNTFlMzU1Mjk5
+        NzA1M2QzNTY3MTQ0YTdlMiIsICJfbGFzdF91cGRhdGVkIjogMTU2NzE3NTY3
+        NCwgIl9jb250ZW50X3R5cGVfaWQiOiAieXVtX3JlcG9fbWV0YWRhdGFfZmls
         ZSIsICJkb3dubG9hZGVkIjogdHJ1ZSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6
         IHt9LCAiX25zIjogInVuaXRzX3l1bV9yZXBvX21ldGFkYXRhX2ZpbGUiLCAi
-        Y2hlY2tzdW1fdHlwZSI6ICJzaGEyNTYiLCAiX2lkIjogImZhZjdjOWRlLTc0
-        NzktNDkxMi1hMGEzLTY0MTUzYWUyZGNkYyJ9LCAidXBkYXRlZCI6ICIyMDE5
-        LTA4LTA1VDE5OjExOjUyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJj
-        cmVhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6NTJaIiwgInVuaXRfdHlwZV9p
-        ZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIiwgInVuaXRfaWQiOiAiZmFm
-        N2M5ZGUtNzQ3OS00OTEyLWEwYTMtNjQxNTNhZTJkY2RjIiwgIl9pZCI6IHsi
-        JG9pZCI6ICI1ZDQ4N2Y3OGFiMzZjZTNmZTUxZGVjYzQifX1d
+        Y2hlY2tzdW1fdHlwZSI6ICJzaGEyNTYiLCAiX2lkIjogImM5ZDYzMDhmLTY2
+        NzQtNDhkNC1hMDVhLTZkMWViN2VjMWE2NCJ9LCAidXBkYXRlZCI6ICIyMDE5
+        LTA4LTMwVDE0OjM0OjM0WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJj
+        cmVhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6MzRaIiwgInVuaXRfdHlwZV9p
+        ZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIiwgInVuaXRfaWQiOiAiYzlk
+        NjMwOGYtNjY3NC00OGQ0LWEwNWEtNmQxZWI3ZWMxYTY0IiwgIl9pZCI6IHsi
+        JG9pZCI6ICI1ZDY5MzNmYTMyZGI2MDc3YTc5NjYyMjMifX1d
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:54 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2267,21 +1909,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '77'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:54 GMT
+      - Fri, 30 Aug 2019 14:34:36 GMT
       Server:
       - Apache
       Content-Length:
@@ -2294,10 +1936,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:54 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2308,21 +1950,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '150'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:54 GMT
+      - Fri, 30 Aug 2019 14:34:36 GMT
       Server:
       - Apache
       Content-Length:
@@ -2335,10 +1977,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:54 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: 'eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkaXN0cmlidXRpb24iXX19
@@ -2347,27 +1989,27 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '42'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:54 GMT
+      - Fri, 30 Aug 2019 14:34:36 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1198'
+      - '533'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2387,51 +2029,51 @@ http_interactions:
         cy9kaXN0cmlidXRpb24vOWIvODMxMjU2YTEyNDcxOGJmMzkxNjZiNTY0ZDhl
         Njg5OTU0ZmYwYThmMGY0NzliYTI0Y2ZhMjYzNTAxMDliYzUiLCAiZmFtaWx5
         IjogIlRlc3QgRmFtaWx5IiwgImRvd25sb2FkZWQiOiBmYWxzZSwgInRpbWVz
-        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTU2NTAz
-        MjMxMiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
+        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTU2NzE3
+        NTY3NCwgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
         cmlhbnQiOiAiVGVzdFZhcmlhbnQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHkt
         VGVzdFZhcmlhbnQtMTYteDg2XzY0IiwgInZlcnNpb24iOiAiMTYiLCAidmVy
         c2lvbl9zb3J0X2luZGV4IjogIjAyLTE2IiwgInB1bHBfdXNlcl9tZXRhZGF0
-        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogIjQwOGE5Njg4LTY2
-        ZmQtNDU1Ni05ZTU3LTMxOWI2ZDk2Y2Y2YiIsICJhcmNoIjogIng4Nl82NCIs
+        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogImU0NWRmNzI1LWJj
+        ZWMtNGM3Mi05NDQ3LTAyZjczMTM1Nzc4YyIsICJhcmNoIjogIng4Nl82NCIs
         ICJfbnMiOiAidW5pdHNfZGlzdHJpYnV0aW9uIn0sICJ1cGRhdGVkIjogIjIw
-        MTktMDgtMDVUMTk6MTE6NTJaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        ImNyZWF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1MloiLCAidW5pdF90eXBl
-        X2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogIjQwOGE5Njg4LTY2
-        ZmQtNDU1Ni05ZTU3LTMxOWI2ZDk2Y2Y2YiIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWQ0ODdmNzhhYjM2Y2UzZmU1MWRlZGRiIn19XQ==
+        MTktMDgtMzBUMTQ6MzQ6MzRaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
+        ImNyZWF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDozNFoiLCAidW5pdF90eXBl
+        X2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogImU0NWRmNzI1LWJj
+        ZWMtNGM3Mi05NDQ3LTAyZjczMTM1Nzc4YyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWQ2OTMzZmEzMmRiNjA3N2E3OTY2MzFhIn19XQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:54 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
         eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
         cGVfaWRzIjpbInJwbSJdLCJmaWx0ZXJzIjp7InVuaXQiOnsiZmlsZW5hbWUi
-        OnsiJGluIjpbImVsZXBoYW50LTAuMi0xLm5vYXJjaC5ycG0iXX19fSwiZmll
+        OnsiJGluIjpbIm1vbmtleS0wLjMtMC44Lm5vYXJjaC5ycG0iXX19fSwiZmll
         bGRzIjp7InVuaXQiOlsibmFtZSIsImVwb2NoIiwidmVyc2lvbiIsInJlbGVh
         c2UiLCJhcmNoIiwiY2hlY2tzdW10eXBlIiwiY2hlY2tzdW0iXX19LCJvdmVy
         cmlkZV9jb25maWciOnt9fQ==
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '241'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:54 GMT
+      - Fri, 30 Aug 2019 14:34:36 GMT
       Server:
       - Apache
       Content-Length:
@@ -2442,41 +2084,41 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2ZhZTY3YjAyLTVhZWItNGFhOC04YWQxLTg0NzBiZDFmYWRhNS8iLCAi
-        dGFza19pZCI6ICJmYWU2N2IwMi01YWViLTRhYTgtOGFkMS04NDcwYmQxZmFk
-        YTUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzkzZTNiMDA1LWE1N2QtNDM4OS05NDVjLTRjOWJhNTQwYThkOC8iLCAi
+        dGFza19pZCI6ICI5M2UzYjAwNS1hNTdkLTQzODktOTQ1Yy00YzliYTU0MGE4
+        ZDgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:54 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
         eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
         cGVfaWRzIjpbInJwbSJdLCJmaWx0ZXJzIjp7InVuaXQiOnsiZmlsZW5hbWUi
-        OnsiJGluIjpbIndhbHJ1cy0wLjcxLTEubm9hcmNoLnJwbSIsImthbmdhcm9v
-        LTAuMy0xLm5vYXJjaC5ycG0iLCJrYW5nYXJvby0wLjItMS5ub2FyY2gucnBt
-        IiwiZHVjay0wLjctMS5ub2FyY2gucnBtIiwid2FscnVzLTUuMjEtMS5ub2Fy
-        Y2gucnBtIiwiZHVjay0wLjYtMS5ub2FyY2gucnBtIl19fX19fQ==
+        OnsiJGluIjpbImthbmdhcm9vLTAuMi0xLm5vYXJjaC5ycG0iLCJrYW5nYXJv
+        by0wLjMtMS5ub2FyY2gucnBtIiwiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwi
+        ZHVjay0wLjctMS5ub2FyY2gucnBtIiwid2FscnVzLTUuMjEtMS5ub2FyY2gu
+        cnBtIiwid2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIl19fX19fQ==
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '262'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:54 GMT
+      - Fri, 30 Aug 2019 14:34:36 GMT
       Server:
       - Apache
       Content-Length:
@@ -2487,14 +2129,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzA4YTM2ZDkwLTJiNzQtNDU1YS04ODM1LWUwMjgxZGU4YzRiMS8iLCAi
-        dGFza19pZCI6ICIwOGEzNmQ5MC0yYjc0LTQ1NWEtODgzNS1lMDI4MWRlOGM0
-        YjEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2E1MWRkODczLTI5YmQtNGE0ZC1hNjYzLWQ4NjUwYTMzMTNiMC8iLCAi
+        dGFza19pZCI6ICJhNTFkZDg3My0yOWJkLTRhNGQtYTY2My1kODY1MGEzMzEz
+        YjAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:54 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2503,21 +2145,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '76'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:54 GMT
+      - Fri, 30 Aug 2019 14:34:36 GMT
       Server:
       - Apache
       Content-Length:
@@ -2528,14 +2170,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2Y2ODM0OWU4LWZiZmQtNDY5ZC1hMmYwLTgxZWFhNTc4YzJhZS8iLCAi
-        dGFza19pZCI6ICJmNjgzNDllOC1mYmZkLTQ2OWQtYTJmMC04MWVhYTU3OGMy
-        YWUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzI2NWUyNDVlLWU2MTgtNDQ5Yi04YTUxLWJmNTYyMGUyNjkyYS8iLCAi
+        dGFza19pZCI6ICIyNjVlMjQ1ZS1lNjE4LTQ0OWItOGE1MS1iZjU2MjBlMjY5
+        MmEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:54 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2544,21 +2186,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '79'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:54 GMT
+      - Fri, 30 Aug 2019 14:34:36 GMT
       Server:
       - Apache
       Content-Length:
@@ -2569,14 +2211,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzNkYmQ3Mjg3LTkzNDQtNDE0MC1iYjJiLTFmZWI0ODZhMTdkMS8iLCAi
-        dGFza19pZCI6ICIzZGJkNzI4Ny05MzQ0LTQxNDAtYmIyYi0xZmViNDg2YTE3
-        ZDEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzY5OGNiMzY2LTIyOGMtNDk4MS1iNDBlLTVjNWQ0MjNmYmY3Yy8iLCAi
+        dGFza19pZCI6ICI2OThjYjM2Ni0yMjhjLTQ5ODEtYjQwZS01YzVkNDIzZmJm
+        N2MifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:54 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2585,21 +2227,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '85'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:54 GMT
+      - Fri, 30 Aug 2019 14:34:36 GMT
       Server:
       - Apache
       Content-Length:
@@ -2610,14 +2252,56 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2NlZTQ3M2YwLTUzNTYtNDM2OC1iMzZkLWEwZDc1ZGY3NmJiOC8iLCAi
-        dGFza19pZCI6ICJjZWU0NzNmMC01MzU2LTQzNjgtYjM2ZC1hMGQ3NWRmNzZi
-        YjgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzIxZWUzNTRiLTA5MGEtNGNjMC1hMzQzLWYxYzBlM2IzZGY1Yy8iLCAi
+        dGFza19pZCI6ICIyMWVlMzU0Yi0wOTBhLTRjYzAtYTM0My1mMWMwZTNiM2Rm
+        NWMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:54 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInBhY2thZ2VfZW52aXJvbm1lbnQiXSwiZmlsdGVycyI6e319
+        fQ==
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '91'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:36 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzAyYWYxYzAwLWU4MzYtNDFlMi1iNjc4LTgzZjk1MWExOGYxYi8iLCAi
+        dGFza19pZCI6ICIwMmFmMWMwMC1lODM2LTQxZTItYjY3OC04M2Y5NTFhMThm
+        MWIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2627,21 +2311,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '94'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:54 GMT
+      - Fri, 30 Aug 2019 14:34:36 GMT
       Server:
       - Apache
       Content-Length:
@@ -2652,14 +2336,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzExZGQ3NTE1LWRkYzktNDdhYS05N2RjLTAxMThkNDRjMzg0Ni8iLCAi
-        dGFza19pZCI6ICIxMWRkNzUxNS1kZGM5LTQ3YWEtOTdkYy0wMTE4ZDQ0YzM4
-        NDYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2UzYWQ4YWEwLTBlODgtNDdhZS04Y2Q4LWI1OGI3NDNjZDg5Ny8iLCAi
+        dGFza19pZCI6ICJlM2FkOGFhMC0wZTg4LTQ3YWUtOGNkOC1iNThiNzQzY2Q4
+        OTcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:54 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2668,21 +2352,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '84'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:54 GMT
+      - Fri, 30 Aug 2019 14:34:36 GMT
       Server:
       - Apache
       Content-Length:
@@ -2693,14 +2377,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzcyYzEyNTBjLWM2ZjctNDYyNC1iNWVlLTMyOWQxNzUwNjA2Mi8iLCAi
-        dGFza19pZCI6ICI3MmMxMjUwYy1jNmY3LTQ2MjQtYjVlZS0zMjlkMTc1MDYw
-        NjIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2MyZmY3MzFmLWQyNzYtNDg3YS04Y2UxLTcxN2Y5NGIxM2UxYS8iLCAi
+        dGFza19pZCI6ICJjMmZmNzMxZi1kMjc2LTQ4N2EtOGNlMS03MTdmOTRiMTNl
+        MWEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:54 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2709,21 +2393,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '80'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:54 GMT
+      - Fri, 30 Aug 2019 14:34:36 GMT
       Server:
       - Apache
       Content-Length:
@@ -2734,14 +2418,14 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2NiYTBhYmU3LWE3ZGMtNDVlYy1hN2U1LWZiMzU1NWQ3MTQ3Yy8iLCAi
-        dGFza19pZCI6ICJjYmEwYWJlNy1hN2RjLTQ1ZWMtYTdlNS1mYjM1NTVkNzE0
-        N2MifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2YxMWU1ZmU5LWQxOTYtNDQzZS1iNTM4LWRlZGEwMTQ2YjMyOC8iLCAi
+        dGFza19pZCI6ICJmMTFlNWZlOS1kMTk2LTQ0M2UtYjUzOC1kZWRhMDE0NmIz
+        MjgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:55 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2750,21 +2434,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '89'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:55 GMT
+      - Fri, 30 Aug 2019 14:34:36 GMT
       Server:
       - Apache
       Content-Length:
@@ -2775,41 +2459,41 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2I1NDBmMTNiLTBlNzQtNDI1OS04ZTBkLTg1ZGExY2Q2MDE4My8iLCAi
-        dGFza19pZCI6ICJiNTQwZjEzYi0wZTc0LTQyNTktOGUwZC04NWRhMWNkNjAx
-        ODMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzk1YjVhZjQ1LTE0MDEtNGZjZC04YzhhLWJhZDJlOTI0NDVmNS8iLCAi
+        dGFza19pZCI6ICI5NWI1YWY0NS0xNDAxLTRmY2QtOGM4YS1iYWQyZTkyNDQ1
+        ZjUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:55 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/fae67b02-5aeb-4aa8-8ad1-8470bd1fada5/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/93e3b005-a57d-4389-945c-4c9ba540a8d8/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:55 GMT
+      - Fri, 30 Aug 2019 14:34:36 GMT
       Server:
       - Apache
       Etag:
-      - '"312fea7279b38b5079f073c46eb9d428-gzip"'
+      - '"afbc8d09437a85b80ced9b61beaf67a1-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1048'
+      - '562'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2817,60 +2501,60 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9mYWU2N2Iw
-        Mi01YWViLTRhYTgtOGFkMS04NDcwYmQxZmFkYTUvIiwgInRhc2tfaWQiOiAi
-        ZmFlNjdiMDItNWFlYi00YWE4LThhZDEtODQ3MGJkMWZhZGE1IiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy85M2UzYjAw
+        NS1hNTdkLTQzODktOTQ1Yy00YzliYTU0MGE4ZDgvIiwgInRhc2tfaWQiOiAi
+        OTNlM2IwMDUtYTU3ZC00Mzg5LTk0NWMtNGM5YmE1NDBhOGQ4IiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjU0WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjU0
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjM2WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjM2
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJzaWdu
-        aW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJlbGVwaGFu
-        dCIsICJjaGVja3N1bSI6ICIzMzM1MWZkNmMyYTM4ZTVkNDlhZWE3ODhhMmU4
-        MzhlYWNkNjU0Y2Y2MWQ0NzZiYTViNjVkZTQzOWRkZDEyNWI5IiwgImVwb2No
-        IjogIjAiLCAidmVyc2lvbiI6ICIwLjIiLCAicmVsZWFzZSI6ICIxIiwgImFy
-        Y2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5
-        cGVfaWQiOiAicnBtIn1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0
-        ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ0
-        ODdmN2FhYjM2Y2UzZmU1MWRmMTM3In0sICJpZCI6ICI1ZDQ4N2Y3YWFiMzZj
-        ZTNmZTUxZGYxMzcifQ==
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InNpZ25pbmdfa2V5IjogbnVs
+        bCwgInVuaXRfa2V5IjogeyJuYW1lIjogIm1vbmtleSIsICJjaGVja3N1bSI6
+        ICIwZThmYTUwZDAxMjhmYmFiYzdjY2M1NjMyZTNmYTI1ZDM5YjAyODAxNjlm
+        NjE2NmNiOGUyYzg0ZGU4NTAxZGIxIiwgImVwb2NoIjogIjAiLCAidmVyc2lv
+        biI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gi
+        LCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0i
+        fV0sICJ1bml0c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVy
+        cm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzNmYzMyZGI2MDc3
+        YTc5NjZlMjYifSwgImlkIjogIjVkNjkzM2ZjMzJkYjYwNzdhNzk2NmUyNiJ9
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:55 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/08a36d90-2b74-455a-8835-e0281de8c4b1/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/a51dd873-29bd-4a4d-a663-d8650a3313b0/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:55 GMT
+      - Fri, 30 Aug 2019 14:34:36 GMT
       Server:
       - Apache
       Etag:
-      - '"7b329c2ddb34aefb3c7a99569eeed7e5-gzip"'
+      - '"ba960473b9d9aabc555075fbc68c2e0d-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2273'
+      - '824'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -2878,500 +2562,88 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8wOGEzNmQ5
-        MC0yYjc0LTQ1NWEtODgzNS1lMDI4MWRlOGM0YjEvIiwgInRhc2tfaWQiOiAi
-        MDhhMzZkOTAtMmI3NC00NTVhLTg4MzUtZTAyODFkZThjNGIxIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9hNTFkZDg3
+        My0yOWJkLTRhNGQtYTY2My1kODY1MGEzMzEzYjAvIiwgInRhc2tfaWQiOiAi
+        YTUxZGQ4NzMtMjliZC00YTRkLWE2NjMtZDg2NTBhMzMxM2IwIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjU0WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjU0
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjM2WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjM2
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJzaWdu
-        aW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJrYW5nYXJv
-        byIsICJjaGVja3N1bSI6ICI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3
-        ZDNkZjJkODM0MWE4OWIwYzVhOWJmNjEwZGQ2MTAzY2U0Y2M4IiwgImVwb2No
-        IjogIjAiLCAidmVyc2lvbiI6ICIwLjIiLCAicmVsZWFzZSI6ICIxIiwgImFy
-        Y2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5
-        cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9r
-        ZXkiOiB7Im5hbWUiOiAid2FscnVzIiwgImNoZWNrc3VtIjogIjc0NTMzZmJk
-        NGY5YWRhOWUwMmE2MzYxY2JiZjAxNGI4ZmY4OGRmZjhkNjk3ODVlYzQ4Yjc3
-        ZTAxODk4ZTdjMzEiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjUuMjEi
-        LCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3Vt
-        dHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmlu
-        Z19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAid2FscnVzIiwg
-        ImNoZWNrc3VtIjogIjUxNmEyMmNjYzBjYmUzZWNiMmNiZWUxYzYyNmEzOWI5
-        MTc2N2RiZjBmODE1YWZkYTdiNzMzYWE1NjUyMzE0MmMiLCAiZXBvY2giOiAi
-        MCIsICJ2ZXJzaW9uIjogIjAuNzEiLCAicmVsZWFzZSI6ICIxIiwgImFyY2gi
-        OiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVf
-        aWQiOiAicnBtIn0sIHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXki
-        OiB7Im5hbWUiOiAiZHVjayIsICJjaGVja3N1bSI6ICI1YmQzNjNiODYwYWQ2
-        NzgzMjE3Y2JjYTNiYmMzZWYyNjBmOThkMTQwZmZiMTIxYmY0YzIwOGUzZjY2
-        YzI0NzEyIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjciLCAicmVs
-        ZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6
-        ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19rZXki
-        OiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAia2FuZ2Fyb28iLCAiY2hl
-        Y2tzdW0iOiAiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAy
-        ZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsICJlcG9jaCI6ICIwIiwg
-        InZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5v
-        YXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjog
-        InJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJu
-        YW1lIjogImR1Y2siLCAiY2hlY2tzdW0iOiAiOTZmMzc4Nzc1MThhMWZlNmVh
-        MmUxN2Y0Y2UxZmM4MWI0MDkwODA0M2JjYmVkNzY3NDRiM2Q3ZDM4YTc3NGJj
-        NyIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC42IiwgInJlbGVhc2Ui
-        OiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hh
-        MjU2In0sICJ0eXBlX2lkIjogInJwbSJ9XSwgInVuaXRzX2ZhaWxlZF9zaWdu
-        YXR1cmVfZmlsdGVyIjogW119LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
-        b2lkIjogIjVkNDg3ZjdhYWIzNmNlM2ZlNTFkZjE0YiJ9LCAiaWQiOiAiNWQ0
-        ODdmN2FhYjM2Y2UzZmU1MWRmMTRiIn0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:55 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/f68349e8-fbfd-469d-a2f0-81eaa578c2ae/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:11:55 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"32372570dd455f567e5a9621a685e862-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '803'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9mNjgzNDll
-        OC1mYmZkLTQ2OWQtYTJmMC04MWVhYTU3OGMyYWUvIiwgInRhc2tfaWQiOiAi
-        ZjY4MzQ5ZTgtZmJmZC00NjlkLWEyZjAtODFlYWE1NzhjMmFlIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjU0WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjU0
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbXSwgInVu
-        aXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW119LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3ZjdhYWIzNmNlM2ZlNTFkZjE3
-        MCJ9LCAiaWQiOiAiNWQ0ODdmN2FhYjM2Y2UzZmU1MWRmMTcwIn0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:55 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/3dbd7287-9344-4140-bb2b-1feb486a17d1/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:11:55 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"c6b2f9524bc3d36f28ae613673ce436d-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1222'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8zZGJkNzI4
-        Ny05MzQ0LTQxNDAtYmIyYi0xZmViNDg2YTE3ZDEvIiwgInRhc2tfaWQiOiAi
-        M2RiZDcyODctOTM0NC00MTQwLWJiMmItMWZlYjQ4NmExN2QxIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjU0WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjU0
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJ1bml0
-        X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTI6MDA1OSJ9LCAidHlw
-        ZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7ImlkIjogIktBVEVM
-        TE8tUkhTQS0yMDEwOjA4NTgifSwgInR5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7
-        InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDowMTExIn0s
-        ICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1bml0X2tleSI6IHsiaWQiOiAi
-        S0FURUxMTy1SSEVBLTIwMTA6MDAwMiJ9LCAidHlwZV9pZCI6ICJlcnJhdHVt
-        In0sIHsidW5pdF9rZXkiOiB7ImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjk5
-        MTQzIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1bml0X2tleSI6IHsi
-        aWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSJ9LCAidHlwZV9pZCI6ICJl
-        cnJhdHVtIn1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBb
-        XX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmN2Fh
-        YjM2Y2UzZmU1MWRmMTk1In0sICJpZCI6ICI1ZDQ4N2Y3YWFiMzZjZTNmZTUx
-        ZGYxOTUifQ==
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:55 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/cee473f0-5356-4368-b36d-a0d75df76bb8/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:11:55 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"27c326c553cb14c18e3b89ea19bff743-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1127'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9jZWU0NzNm
-        MC01MzU2LTQzNjgtYjM2ZC1hMGQ3NWRmNzZiYjgvIiwgInRhc2tfaWQiOiAi
-        Y2VlNDczZjAtNTM1Ni00MzY4LWIzNmQtYTBkNzVkZjc2YmI4IiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjU1WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjU0
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJ1bml0
-        X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImlkIjogImJpcmQifSwg
-        InR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9LCB7InVuaXRfa2V5IjogeyJy
-        ZXBvX2lkIjogIjNfdmlldzEiLCAiaWQiOiAibWFtbWFsIn0sICJ0eXBlX2lk
-        IjogInBhY2thZ2VfZ3JvdXAifV0sICJ1bml0c19mYWlsZWRfc2lnbmF0dXJl
-        X2ZpbHRlciI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lkIjogIkZlZG9yYV8x
-        NyIsICJpZCI6ICJiaXJkIn0sICJ0eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAi
-        fSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiaWQi
-        OiAibWFtbWFsIn0sICJ0eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAifV19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3ZjdhYWIzNmNl
-        M2ZlNTFkZjFiYiJ9LCAiaWQiOiAiNWQ0ODdmN2FhYjM2Y2UzZmU1MWRmMWJi
-        In0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:55 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/11dd7515-ddc9-47aa-97dc-0118d44c3846/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:11:55 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"9a2663c3fc133ea29dbcd12d6661b7cc-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1205'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8xMWRkNzUx
-        NS1kZGM5LTQ3YWEtOTdkYy0wMTE4ZDQ0YzM4NDYvIiwgInRhc2tfaWQiOiAi
-        MTFkZDc1MTUtZGRjOS00N2FhLTk3ZGMtMDExOGQ0NGMzODQ2IiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjU1WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjU1
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJ1bml0
-        X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImRhdGFfdHlwZSI6ICJw
-        cm9kdWN0aWQifSwgInR5cGVfaWQiOiAieXVtX3JlcG9fbWV0YWRhdGFfZmls
-        ZSJ9LCB7InVuaXRfa2V5IjogeyJyZXBvX2lkIjogIjNfdmlldzEiLCAiZGF0
-        YV90eXBlIjogInN3aWR0YWdzIn0sICJ0eXBlX2lkIjogInl1bV9yZXBvX21l
-        dGFkYXRhX2ZpbGUifV0sICJ1bml0c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRl
-        ciI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJk
-        YXRhX3R5cGUiOiAic3dpZHRhZ3MifSwgInR5cGVfaWQiOiAieXVtX3JlcG9f
-        bWV0YWRhdGFfZmlsZSJ9LCB7InVuaXRfa2V5IjogeyJyZXBvX2lkIjogIkZl
-        ZG9yYV8xNyIsICJkYXRhX3R5cGUiOiAicHJvZHVjdGlkIn0sICJ0eXBlX2lk
-        IjogInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUifV19LCAiZXJyb3IiOiBudWxs
-        LCAiX2lkIjogeyIkb2lkIjogIjVkNDg3ZjdhYWIzNmNlM2ZlNTFkZjFkOSJ9
-        LCAiaWQiOiAiNWQ0ODdmN2FhYjM2Y2UzZmU1MWRmMWQ5In0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:55 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/72c1250c-c6f7-4624-b5ee-329d17506062/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:11:55 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"57ddbece6dffd33222fbfa5a5ac53ad3-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '976'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy83MmMxMjUw
-        Yy1jNmY3LTQ2MjQtYjVlZS0zMjlkMTc1MDYwNjIvIiwgInRhc2tfaWQiOiAi
-        NzJjMTI1MGMtYzZmNy00NjI0LWI1ZWUtMzI5ZDE3NTA2MDYyIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjU1WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjU1
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJ1bml0
-        X2tleSI6IHsidmFyaWFudCI6ICJUZXN0VmFyaWFudCIsICJ2ZXJzaW9uIjog
-        IjE2IiwgImFyY2giOiAieDg2XzY0IiwgImlkIjogImtzLVRlc3QgRmFtaWx5
-        LVRlc3RWYXJpYW50LTE2LXg4Nl82NCIsICJmYW1pbHkiOiAiVGVzdCBGYW1p
-        bHkifSwgInR5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIn1dLCAidW5pdHNfZmFp
-        bGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJf
-        aWQiOiB7IiRvaWQiOiAiNWQ0ODdmN2FhYjM2Y2UzZmU1MWRmMjA0In0sICJp
-        ZCI6ICI1ZDQ4N2Y3YWFiMzZjZTNmZTUxZGYyMDQifQ==
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:55 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/cba0abe7-a7dc-45ec-a7e5-fb3555d7147c/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:11:56 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"d7c2067393389d799062a9cff7ac425b-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3119'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9jYmEwYWJl
-        Ny1hN2RjLTQ1ZWMtYTdlNS1mYjM1NTVkNzE0N2MvIiwgInRhc2tfaWQiOiAi
-        Y2JhMGFiZTctYTdkYy00NWVjLWE3ZTUtZmIzNTU1ZDcxNDdjIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjU1WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjU1
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJ1bml0
-        X2tleSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJzaW9uIjogMjAx
-        ODA3MDQyNDQyMDUsICJhcmNoIjogIm5vYXJjaCIsICJuYW1lIjogImR1Y2si
-        LCAic3RyZWFtIjogIjAifSwgInR5cGVfaWQiOiAibW9kdWxlbWQifSwgeyJ1
-        bml0X2tleSI6IHsiY29udGV4dCI6ICJjMGZmZWU0MiIsICJ2ZXJzaW9uIjog
-        MjAxODA3MDcxNDQyMDMsICJhcmNoIjogIng4Nl82NCIsICJuYW1lIjogIndh
-        bHJ1cyIsICJzdHJlYW0iOiAiMC43MSJ9LCAidHlwZV9pZCI6ICJtb2R1bGVt
-        ZCJ9LCB7InVuaXRfa2V5IjogeyJjb250ZXh0IjogImRlYWRiZWVmIiwgInZl
-        cnNpb24iOiAyMDE4MDczMDIzMzEwMiwgImFyY2giOiAibm9hcmNoIiwgIm5h
-        bWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCJ9LCAidHlwZV9pZCI6ICJtb2R1
-        bGVtZCJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJu
-        YW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6ICI1MTZhMjJjY2MwY2JlM2Vj
-        YjJjYmVlMWM2MjZhMzliOTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMx
-        NDJjIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjcxIiwgInJlbGVh
-        c2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAi
-        c2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5Ijog
-        bnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogImR1Y2siLCAiY2hlY2tzdW0i
-        OiAiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZm
-        YjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsICJlcG9jaCI6ICIwIiwgInZlcnNp
-        b24iOiAiMC43IiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIs
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InNpZ25pbmdfa2V5IjogbnVs
+        bCwgInVuaXRfa2V5IjogeyJuYW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6
+        ICI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzliOTE3NjdkYmYwZjgx
+        NWFmZGE3YjczM2FhNTY1MjMxNDJjIiwgImVwb2NoIjogIjAiLCAidmVyc2lv
+        biI6ICIwLjcxIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIs
         ICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9
         LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjog
-        Imthbmdhcm9vIiwgImNoZWNrc3VtIjogIjg2NWE0Yzg5NDg1YmRkOTcyM2Ez
-        YzQwNzI4MGMxNDFlOTIwMmYwMjRlN2RiMzhjYmEzZDA5N2MzZjI1NmIyZmQi
-        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjog
-        IjEiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1
-        NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJ1bml0X2tleSI6IHsiY29udGV4
-        dCI6ICJkZWFkYmVlZiIsICJ2ZXJzaW9uIjogMjAxODA3MDQxMTE3MTksICJh
-        cmNoIjogIm5vYXJjaCIsICJuYW1lIjogImthbmdhcm9vIiwgInN0cmVhbSI6
-        ICIwIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0sIHsic2lnbmluZ19rZXki
-        OiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAia2FuZ2Fyb28iLCAiY2hl
-        Y2tzdW0iOiAiODMzYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgz
-        NDFhODliMGM1YTliZjYxMGRkNjEwM2NlNGNjOCIsICJlcG9jaCI6ICIwIiwg
-        InZlcnNpb24iOiAiMC4yIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5v
-        YXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjog
-        InJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJu
-        YW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6ICI3NDUzM2ZiZDRmOWFkYTll
-        MDJhNjM2MWNiYmYwMTRiOGZmODhkZmY4ZDY5Nzg1ZWM0OGI3N2UwMTg5OGU3
-        YzMxIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICI1LjIxIiwgInJlbGVh
-        c2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAi
-        c2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InVuaXRfa2V5IjogeyJj
-        b250ZXh0IjogImRlYWRiZWVmIiwgInZlcnNpb24iOiAyMDE4MDczMDIyMzQw
-        NywgImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAic3Ry
-        ZWFtIjogIjAifSwgInR5cGVfaWQiOiAibW9kdWxlbWQifSwgeyJ1bml0X2tl
-        eSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJzaW9uIjogMjAxODA3
-        MDQxNDQyMDMsICJhcmNoIjogIng4Nl82NCIsICJuYW1lIjogIndhbHJ1cyIs
-        ICJzdHJlYW0iOiAiNS4yMSJ9LCAidHlwZV9pZCI6ICJtb2R1bGVtZCJ9LCB7
-        InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogImR1
-        Y2siLCAiY2hlY2tzdW0iOiAiOTZmMzc4Nzc1MThhMWZlNmVhMmUxN2Y0Y2Ux
-        ZmM4MWI0MDkwODA0M2JjYmVkNzY3NDRiM2Q3ZDM4YTc3NGJjNyIsICJlcG9j
-        aCI6ICIwIiwgInZlcnNpb24iOiAiMC42IiwgInJlbGVhc2UiOiAiMSIsICJh
-        cmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0
-        eXBlX2lkIjogInJwbSJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmls
-        dGVyIjogW119LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVk
-        NDg3ZjdhYWIzNmNlM2ZlNTFkZjIyYiJ9LCAiaWQiOiAiNWQ0ODdmN2FhYjM2
-        Y2UzZmU1MWRmMjJiIn0=
+        IndhbHJ1cyIsICJjaGVja3N1bSI6ICI3NDUzM2ZiZDRmOWFkYTllMDJhNjM2
+        MWNiYmYwMTRiOGZmODhkZmY4ZDY5Nzg1ZWM0OGI3N2UwMTg5OGU3YzMxIiwg
+        ImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICI1LjIxIiwgInJlbGVhc2UiOiAi
+        MSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2
+        In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwg
+        InVuaXRfa2V5IjogeyJuYW1lIjogImthbmdhcm9vIiwgImNoZWNrc3VtIjog
+        IjgzM2FmNTk0YmMwYmEzMTI1NjA0NWVkMWZiMTdkM2RmMmQ4MzQxYTg5YjBj
+        NWE5YmY2MTBkZDYxMDNjZTRjYzgiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9u
+        IjogIjAuMiIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2giLCAi
+        Y2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwg
+        eyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJk
+        dWNrIiwgImNoZWNrc3VtIjogIjViZDM2M2I4NjBhZDY3ODMyMTdjYmNhM2Ji
+        YzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4ZTNmNjZjMjQ3MTIiLCAiZXBv
+        Y2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuNyIsICJyZWxlYXNlIjogIjEiLCAi
+        YXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAi
+        dHlwZV9pZCI6ICJycG0ifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0
+        X2tleSI6IHsibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVja3N1bSI6ICI4NjVh
+        NGM4OTQ4NWJkZDk3MjNhM2M0MDcyODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2Jh
+        M2QwOTdjM2YyNTZiMmZkIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIw
+        LjMiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNr
+        c3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2ln
+        bmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiZHVjayIs
+        ICJjaGVja3N1bSI6ICI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgx
+        YjQwOTA4MDQzYmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3IiwgImVwb2NoIjog
+        IjAiLCAidmVyc2lvbiI6ICIwLjYiLCAicmVsZWFzZSI6ICIxIiwgImFyY2gi
+        OiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVf
+        aWQiOiAicnBtIn1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIi
+        OiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMz
+        ZmMzMmRiNjA3N2E3OTY2ZTM2In0sICJpZCI6ICI1ZDY5MzNmYzMyZGI2MDc3
+        YTc5NjZlMzYifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:56 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/b540f13b-0e74-4259-8e0d-85da1cd60183/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/265e245e-e618-449b-8a51-bf5620e2692a/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:57 GMT
+      - Fri, 30 Aug 2019 14:34:36 GMT
       Server:
       - Apache
       Etag:
-      - '"4d261629725ef7f9a5bbe9120d265b4b-gzip"'
+      - '"121458e0de2f10a97b9606e6f1ffb13a-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1333'
+      - '435'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3379,66 +2651,540 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9iNTQwZjEz
-        Yi0wZTc0LTQyNTktOGUwZC04NWRhMWNkNjAxODMvIiwgInRhc2tfaWQiOiAi
-        YjU0MGYxM2ItMGU3NC00MjU5LThlMGQtODVkYTFjZDYwMTgzIiwgInRhZ3Mi
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yNjVlMjQ1
+        ZS1lNjE4LTQ0OWItOGE1MS1iZjU2MjBlMjY5MmEvIiwgInRhc2tfaWQiOiAi
+        MjY1ZTI0NWUtZTYxOC00NDliLThhNTEtYmY1NjIwZTI2OTJhIiwgInRhZ3Mi
         OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
         eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjU1WiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjU1
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjM2WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjM2
         WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
         cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJ1bml0
-        X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgIm5hbWUiOiAia2FuZ2Fy
-        b28ifSwgInR5cGVfaWQiOiAibW9kdWxlbWRfZGVmYXVsdHMifSwgeyJ1bml0
-        X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgIm5hbWUiOiAid2FscnVz
-        In0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2RlZmF1bHRzIn0sIHsidW5pdF9r
-        ZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIsICJuYW1lIjogImR1Y2sifSwg
-        InR5cGVfaWQiOiAibW9kdWxlbWRfZGVmYXVsdHMifV0sICJ1bml0c19mYWls
-        ZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lk
-        IjogIkZlZG9yYV8xNyIsICJuYW1lIjogImthbmdhcm9vIn0sICJ0eXBlX2lk
-        IjogIm1vZHVsZW1kX2RlZmF1bHRzIn0sIHsidW5pdF9rZXkiOiB7InJlcG9f
-        aWQiOiAiRmVkb3JhXzE3IiwgIm5hbWUiOiAiZHVjayJ9LCAidHlwZV9pZCI6
-        ICJtb2R1bGVtZF9kZWZhdWx0cyJ9LCB7InVuaXRfa2V5IjogeyJyZXBvX2lk
-        IjogIkZlZG9yYV8xNyIsICJuYW1lIjogIndhbHJ1cyJ9LCAidHlwZV9pZCI6
-        ICJtb2R1bGVtZF9kZWZhdWx0cyJ9XX0sICJlcnJvciI6IG51bGwsICJfaWQi
-        OiB7IiRvaWQiOiAiNWQ0ODdmN2JhYjM2Y2UzZmU1MWRmMjY0In0sICJpZCI6
-        ICI1ZDQ4N2Y3YmFiMzZjZTNmZTUxZGYyNjQifQ==
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNfZmFpbGVkX3Np
+        Z25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNWQ2OTMzZmMzMmRiNjA3N2E3OTY2ZTVjIn0sICJpZCI6ICI1
+        ZDY5MzNmYzMyZGI2MDc3YTc5NjZlNWMifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:57 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/698cb366-228c-4981-b40e-5c5d423fbf7c/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:57 GMT
+      - Fri, 30 Aug 2019 14:34:36 GMT
       Server:
       - Apache
       Etag:
-      - '"07ebdc5c89732762501cdc53048c8efa-gzip"'
+      - '"877951c250927825392c6464043f8991-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2305'
+      - '517'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82OThjYjM2
+        Ni0yMjhjLTQ5ODEtYjQwZS01YzVkNDIzZmJmN2MvIiwgInRhc2tfaWQiOiAi
+        Njk4Y2IzNjYtMjI4Yy00OTgxLWI0MGUtNWM1ZDQyM2ZiZjdjIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjM2WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjM2
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJpZCI6
+        ICJLQVRFTExPLVJIU0EtMjAxMDowODU4In0sICJ0eXBlX2lkIjogImVycmF0
+        dW0ifSwgeyJ1bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTI6
+        MDA1OSJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7
+        ImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjAxMTEifSwgInR5cGVfaWQiOiAi
+        ZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEt
+        MjAxMDowMDAyIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1bml0X2tl
+        eSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMifSwgInR5cGVf
+        aWQiOiAiZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExP
+        LVJIRUEtMjAxMDowMDAxIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifV0sICJ1
+        bml0c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzNmYzMyZGI2MDc3YTc5NjZl
+        NjcifSwgImlkIjogIjVkNjkzM2ZjMzJkYjYwNzdhNzk2NmU2NyJ9
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/21ee354b-090a-4cc0-a343-f1c0e3b3df5c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:36 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"7ec849e83723847f16be22f7a1b3d22c-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '490'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yMWVlMzU0
+        Yi0wOTBhLTRjYzAtYTM0My1mMWMwZTNiM2RmNWMvIiwgInRhc2tfaWQiOiAi
+        MjFlZTM1NGItMDkwYS00Y2MwLWEzNDMtZjFjMGUzYjNkZjVjIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjM2WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjM2
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBv
+        X2lkIjogIjNfdmlldzEiLCAiaWQiOiAiYmlyZCJ9LCAidHlwZV9pZCI6ICJw
+        YWNrYWdlX2dyb3VwIn0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiM192
+        aWV3MSIsICJpZCI6ICJtYW1tYWwifSwgInR5cGVfaWQiOiAicGFja2FnZV9n
+        cm91cCJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW3si
+        dW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImlkIjogImJp
+        cmQifSwgInR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9LCB7InVuaXRfa2V5
+        IjogeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJpZCI6ICJtYW1tYWwifSwg
+        InR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9XX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZmMzMmRiNjA3N2E3OTY2ZTc1In0s
+        ICJpZCI6ICI1ZDY5MzNmYzMyZGI2MDc3YTc5NjZlNzUifQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:36 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/02af1c00-e836-41e2-b678-83f951a18f1b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:37 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"52784a60725019d5a9739ba371b22617-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '434'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8wMmFmMWMw
+        MC1lODM2LTQxZTItYjY3OC04M2Y5NTFhMThmMWIvIiwgInRhc2tfaWQiOiAi
+        MDJhZjFjMDAtZTgzNi00MWUyLWI2NzgtODNmOTUxYTE4ZjFiIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjM2WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjM2
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNfZmFpbGVkX3Np
+        Z25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNWQ2OTMzZmMzMmRiNjA3N2E3OTY2ZThmIn0sICJpZCI6ICI1
+        ZDY5MzNmYzMyZGI2MDc3YTc5NjZlOGYifQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:37 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/e3ad8aa0-0e88-47ae-8cd8-b58b743cd897/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:37 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"a2dd704fac1c07a27d377a04afbb2e8b-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '500'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9lM2FkOGFh
+        MC0wZTg4LTQ3YWUtOGNkOC1iNThiNzQzY2Q4OTcvIiwgInRhc2tfaWQiOiAi
+        ZTNhZDhhYTAtMGU4OC00N2FlLThjZDgtYjU4Yjc0M2NkODk3IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjM2WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjM2
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBv
+        X2lkIjogIjNfdmlldzEiLCAiZGF0YV90eXBlIjogInByb2R1Y3RpZCJ9LCAi
+        dHlwZV9pZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIn0sIHsidW5pdF9r
+        ZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIsICJkYXRhX3R5cGUiOiAic3dp
+        ZHRhZ3MifSwgInR5cGVfaWQiOiAieXVtX3JlcG9fbWV0YWRhdGFfZmlsZSJ9
+        XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW3sidW5pdF9r
+        ZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImRhdGFfdHlwZSI6ICJz
+        d2lkdGFncyJ9LCAidHlwZV9pZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxl
+        In0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImRh
+        dGFfdHlwZSI6ICJwcm9kdWN0aWQifSwgInR5cGVfaWQiOiAieXVtX3JlcG9f
+        bWV0YWRhdGFfZmlsZSJ9XX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRv
+        aWQiOiAiNWQ2OTMzZmMzMmRiNjA3N2E3OTY2ZWI1In0sICJpZCI6ICI1ZDY5
+        MzNmYzMyZGI2MDc3YTc5NjZlYjUifQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:37 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/c2ff731f-d276-487a-8ce1-717f94b13e1a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:38 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"b74bf31f4d958f74abb9d63dcf924bac-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '517'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9jMmZmNzMx
+        Zi1kMjc2LTQ4N2EtOGNlMS03MTdmOTRiMTNlMWEvIiwgInRhc2tfaWQiOiAi
+        YzJmZjczMWYtZDI3Ni00ODdhLThjZTEtNzE3Zjk0YjEzZTFhIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjM2WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjM2
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJ2YXJp
+        YW50IjogIlRlc3RWYXJpYW50IiwgInZlcnNpb24iOiAiMTYiLCAiYXJjaCI6
+        ICJ4ODZfNjQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHktVGVzdFZhcmlhbnQt
+        MTYteDg2XzY0IiwgImZhbWlseSI6ICJUZXN0IEZhbWlseSJ9LCAidHlwZV9p
+        ZCI6ICJkaXN0cmlidXRpb24ifV0sICJ1bml0c19mYWlsZWRfc2lnbmF0dXJl
+        X2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1ZDY5MzNmYzMyZGI2MDc3YTc5NjZlYzUifSwgImlkIjogIjVkNjkzM2Zj
+        MzJkYjYwNzdhNzk2NmVjNSJ9
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:38 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/f11e5fe9-d196-443e-b538-deda0146b328/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:39 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"bb107e8013bc29b360754fc9bfeaa4fa-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '959'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9mMTFlNWZl
+        OS1kMTk2LTQ0M2UtYjUzOC1kZWRhMDE0NmIzMjgvIiwgInRhc2tfaWQiOiAi
+        ZjExZTVmZTktZDE5Ni00NDNlLWI1MzgtZGVkYTAxNDZiMzI4IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjM3WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjM3
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJjb250
+        ZXh0IjogImRlYWRiZWVmIiwgInZlcnNpb24iOiAyMDE4MDcwNDI0NDIwNSwg
+        ImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAi
+        MCJ9LCAidHlwZV9pZCI6ICJtb2R1bGVtZCJ9LCB7InVuaXRfa2V5IjogeyJj
+        b250ZXh0IjogImMwZmZlZTQyIiwgInZlcnNpb24iOiAyMDE4MDcwNzE0NDIw
+        MywgImFyY2giOiAieDg2XzY0IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVh
+        bSI6ICIwLjcxIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0sIHsidW5pdF9r
+        ZXkiOiB7ImNvbnRleHQiOiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6IDIwMTgw
+        NzMwMjMzMTAyLCAiYXJjaCI6ICJub2FyY2giLCAibmFtZSI6ICJkdWNrIiwg
+        InN0cmVhbSI6ICIwIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0sIHsic2ln
+        bmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAid2FscnVz
+        IiwgImNoZWNrc3VtIjogIjUxNmEyMmNjYzBjYmUzZWNiMmNiZWUxYzYyNmEz
+        OWI5MTc2N2RiZjBmODE1YWZkYTdiNzMzYWE1NjUyMzE0MmMiLCAiZXBvY2gi
+        OiAiMCIsICJ2ZXJzaW9uIjogIjAuNzEiLCAicmVsZWFzZSI6ICIxIiwgImFy
+        Y2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5
+        cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9r
+        ZXkiOiB7Im5hbWUiOiAiZHVjayIsICJjaGVja3N1bSI6ICI1YmQzNjNiODYw
+        YWQ2NzgzMjE3Y2JjYTNiYmMzZWYyNjBmOThkMTQwZmZiMTIxYmY0YzIwOGUz
+        ZjY2YzI0NzEyIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjciLCAi
+        cmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlw
+        ZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19r
+        ZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAia2FuZ2Fyb28iLCAi
+        Y2hlY2tzdW0iOiAiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5
+        MjAyZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsICJlcG9jaCI6ICIw
+        IiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjog
+        Im5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lk
+        IjogInJwbSJ9LCB7InVuaXRfa2V5IjogeyJjb250ZXh0IjogImRlYWRiZWVm
+        IiwgInZlcnNpb24iOiAyMDE4MDcwNDExMTcxOSwgImFyY2giOiAibm9hcmNo
+        IiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAic3RyZWFtIjogIjAifSwgInR5cGVf
+        aWQiOiAibW9kdWxlbWQifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0
+        X2tleSI6IHsibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVja3N1bSI6ICI4MzNh
+        ZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIwYzVhOWJm
+        NjEwZGQ2MTAzY2U0Y2M4IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIw
+        LjIiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNr
+        c3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2ln
+        bmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAid2FscnVz
+        IiwgImNoZWNrc3VtIjogIjc0NTMzZmJkNGY5YWRhOWUwMmE2MzYxY2JiZjAx
+        NGI4ZmY4OGRmZjhkNjk3ODVlYzQ4Yjc3ZTAxODk4ZTdjMzEiLCAiZXBvY2gi
+        OiAiMCIsICJ2ZXJzaW9uIjogIjUuMjEiLCAicmVsZWFzZSI6ICIxIiwgImFy
+        Y2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5
+        cGVfaWQiOiAicnBtIn0sIHsidW5pdF9rZXkiOiB7ImNvbnRleHQiOiAiZGVh
+        ZGJlZWYiLCAidmVyc2lvbiI6IDIwMTgwNzMwMjIzNDA3LCAiYXJjaCI6ICJu
+        b2FyY2giLCAibmFtZSI6ICJrYW5nYXJvbyIsICJzdHJlYW0iOiAiMCJ9LCAi
+        dHlwZV9pZCI6ICJtb2R1bGVtZCJ9LCB7InVuaXRfa2V5IjogeyJjb250ZXh0
+        IjogImRlYWRiZWVmIiwgInZlcnNpb24iOiAyMDE4MDcwNDE0NDIwMywgImFy
+        Y2giOiAieDg2XzY0IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICI1
+        LjIxIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0sIHsic2lnbmluZ19rZXki
+        OiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiZHVjayIsICJjaGVja3N1
+        bSI6ICI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQz
+        YmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3IiwgImVwb2NoIjogIjAiLCAidmVy
+        c2lvbiI6ICIwLjYiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNo
+        IiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBt
+        In1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZmMzMmRiNjA3
+        N2E3OTY2ZWU1In0sICJpZCI6ICI1ZDY5MzNmYzMyZGI2MDc3YTc5NjZlZTUi
+        fQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:39 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/95b5af45-1401-4fcd-8c8a-bad2e92445f5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:39 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"5428ba21043cd952eb3b90d72f4f2d90-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '509'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy85NWI1YWY0
+        NS0xNDAxLTRmY2QtOGM4YS1iYWQyZTkyNDQ1ZjUvIiwgInRhc2tfaWQiOiAi
+        OTViNWFmNDUtMTQwMS00ZmNkLThjOGEtYmFkMmU5MjQ0NWY1IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjM3WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjM3
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBv
+        X2lkIjogIjNfdmlldzEiLCAibmFtZSI6ICJrYW5nYXJvbyJ9LCAidHlwZV9p
+        ZCI6ICJtb2R1bGVtZF9kZWZhdWx0cyJ9LCB7InVuaXRfa2V5IjogeyJyZXBv
+        X2lkIjogIjNfdmlldzEiLCAibmFtZSI6ICJ3YWxydXMifSwgInR5cGVfaWQi
+        OiAibW9kdWxlbWRfZGVmYXVsdHMifSwgeyJ1bml0X2tleSI6IHsicmVwb19p
+        ZCI6ICIzX3ZpZXcxIiwgIm5hbWUiOiAiZHVjayJ9LCAidHlwZV9pZCI6ICJt
+        b2R1bGVtZF9kZWZhdWx0cyJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVf
+        ZmlsdGVyIjogW3sidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3
+        IiwgIm5hbWUiOiAia2FuZ2Fyb28ifSwgInR5cGVfaWQiOiAibW9kdWxlbWRf
+        ZGVmYXVsdHMifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRvcmFf
+        MTciLCAibmFtZSI6ICJkdWNrIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2Rl
+        ZmF1bHRzIn0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3
+        IiwgIm5hbWUiOiAid2FscnVzIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2Rl
+        ZmF1bHRzIn1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        ZDY5MzNmYzMyZGI2MDc3YTc5NjZlZjYifSwgImlkIjogIjVkNjkzM2ZjMzJk
+        YjYwNzdhNzk2NmVmNiJ9
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:39 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/?details=true
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:40 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"7d436166ead92c6b4fbd186afdc9e4d9-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '624'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3447,79 +3193,79 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MTktMDgtMDVUMTk6MTE6NTNaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        MTktMDgtMzBUMTQ6MzQ6MzVaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
         ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3Ry
         aWJ1dG9yLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9w
         dWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0
         X2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRj
         aHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6
-        IHsiJG9pZCI6ICI1ZDQ4N2Y3OWFjZTIzZjA3YTY3ZTBlODgifSwgImNvbmZp
+        IHsiJG9pZCI6ICI1ZDY5MzNmYjdhY2NlOTA3ZTRkN2YyYWYifSwgImNvbmZp
         ZyI6IHsiaHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29y
         cG9yYXRpb24vbGlicmFyeS9MaWJyYXJ5Vmlldy9mZWRvcmFfMTdfbGFiZWwi
         LCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6ICJleHBvcnRfZGlzdHJpYnV0b3Ii
         fSwgeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MTktMDgtMDVUMTk6MTE6NTNaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        MTktMDgtMzBUMTQ6MzQ6MzVaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
         ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvM192aWV3MV9jbG9u
         ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
         aCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9jbG9uZV9k
         aXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hw
         YWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7
-        IiRvaWQiOiAiNWQ0ODdmNzlhY2UyM2YwN2E2N2UwZTg3In0sICJjb25maWci
+        IiRvaWQiOiAiNWQ2OTMzZmI3YWNjZTkwN2U0ZDdmMmFlIn0sICJjb25maWci
         OiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogIjNfdmlldzEifSwg
         ImlkIjogIjNfdmlldzFfY2xvbmUifSwgeyJyZXBvX2lkIjogIjNfdmlldzEi
-        LCAibGFzdF91cGRhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6NTNaIiwgIl9o
+        LCAibGFzdF91cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6MzVaIiwgIl9o
         cmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0
         cmlidXRvcnMvM192aWV3MS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7
         fSwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lk
         IjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAi
         c2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwg
-        Il9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y3OWFjZTIzZjA3YTY3ZTBlODYifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1ZDY5MzNmYjdhY2NlOTA3ZTRkN2YyYWQifSwg
         ImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwg
         Imh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0NvcnBvcmF0
         aW9uL2xpYnJhcnkvTGlicmFyeVZpZXcvZmVkb3JhXzE3X2xhYmVsIn0sICJp
         ZCI6ICIzX3ZpZXcxIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIwMTktMDgt
-        MDVUMTk6MTE6NTVaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
+        MzBUMTQ6MzQ6MzdaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
         ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJjb250ZW50X3Vu
         aXRfY291bnRzIjogeyJwYWNrYWdlX2dyb3VwIjogMiwgIm1vZHVsZW1kIjog
         NiwgIm1vZHVsZW1kX2RlZmF1bHRzIjogMywgImVycmF0dW0iOiA2LCAiZGlz
         dHJpYnV0aW9uIjogMSwgInJwbSI6IDcsICJ5dW1fcmVwb19tZXRhZGF0YV9m
         aWxlIjogMn0sICJfbnMiOiAicmVwb3MiLCAiaW1wb3J0ZXJzIjogW3sicmVw
-        b19pZCI6ICIzX3ZpZXcxIiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTA1
-        VDE5OjExOjUzWiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
+        b19pZCI6ICIzX3ZpZXcxIiwgImxhc3RfdXBkYXRlZCI6ICIyMDE5LTA4LTMw
+        VDE0OjM0OjM1WiIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9y
         aWVzLzNfdmlldzEvaW1wb3J0ZXJzL3l1bV9pbXBvcnRlci8iLCAiX25zIjog
         InJlcG9faW1wb3J0ZXJzIiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2lt
         cG9ydGVyIiwgImxhc3Rfb3ZlcnJpZGVfY29uZmlnIjoge30sICJsYXN0X3N5
         bmMiOiBudWxsLCAic2NyYXRjaHBhZCI6IG51bGwsICJfaWQiOiB7IiRvaWQi
-        OiAiNWQ0ODdmNzlhY2UyM2YwN2E2N2UwZTg1In0sICJjb25maWciOiB7fSwg
+        OiAiNWQ2OTMzZmI3YWNjZTkwN2U0ZDdmMmFjIn0sICJjb25maWciOiB7fSwg
         ImlkIjogInl1bV9pbXBvcnRlciJ9XSwgImxvY2FsbHlfc3RvcmVkX3VuaXRz
-        IjogMjYsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmNzlhY2UyM2YwN2E2N2Uw
-        ZTg0In0sICJ0b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMjcsICJpZCI6ICIz
+        IjogMjYsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTMzZmI3YWNjZTkwN2U0ZDdm
+        MmFiIn0sICJ0b3RhbF9yZXBvc2l0b3J5X3VuaXRzIjogMjcsICJpZCI6ICIz
         X3ZpZXcxIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMv
         M192aWV3MS8ifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:57 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:40 GMT
 - request:
     method: delete
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:57 GMT
+      - Fri, 30 Aug 2019 14:34:40 GMT
       Server:
       - Apache
       Content-Length:
@@ -3530,41 +3276,41 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2E2NjNmMDMyLTdhMDctNDk1NC1iMDliLWJhM2FhNDYyNzc1Zi8iLCAi
-        dGFza19pZCI6ICJhNjYzZjAzMi03YTA3LTQ5NTQtYjA5Yi1iYTNhYTQ2Mjc3
-        NWYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2VmZjM0OGFjLTk2MzUtNGQyNS1hNzg2LWE2ZGExZGJjYTAyOC8iLCAi
+        dGFza19pZCI6ICJlZmYzNDhhYy05NjM1LTRkMjUtYTc4Ni1hNmRhMWRiY2Ew
+        MjgifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:57 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:40 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/a663f032-7a07-4954-b09b-ba3aa462775f/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/eff348ac-9635-4d25-a786-a6da1dbca028/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:57 GMT
+      - Fri, 30 Aug 2019 14:34:40 GMT
       Server:
       - Apache
       Etag:
-      - '"eccdb79a41268ae02a64922b714e7f4e-gzip"'
+      - '"e876abee3a17256ca25ea88736694cdf-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '689'
+      - '373'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3572,44 +3318,45 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9hNjYzZjAzMi03YTA3LTQ5NTQtYjA5Yi1iYTNhYTQ2Mjc3
-        NWYvIiwgInRhc2tfaWQiOiAiYTY2M2YwMzItN2EwNy00OTU0LWIwOWItYmEz
-        YWE0NjI3NzVmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy9lZmYzNDhhYy05NjM1LTRkMjUtYTc4Ni1hNmRhMWRiY2Ew
+        MjgvIiwgInRhc2tfaWQiOiAiZWZmMzQ4YWMtOTYzNS00ZDI1LWE3ODYtYTZk
+        YTFkYmNhMDI4IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE5LTA4LTA1VDE5OjExOjU3WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjExOjU3WiIsICJ0cmFjZWJh
+        MDE5LTA4LTMwVDE0OjM0OjQwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjQwWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
-        ImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
-        X3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVk
-        NDg3ZjdkYWIzNmNlM2ZlNTFkZjM5MyJ9LCAiaWQiOiAiNWQ0ODdmN2RhYjM2
-        Y2UzZmU1MWRmMzkzIn0=
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        LmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2
+        ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTM0MDAzMmRiNjA3
+        N2E3OTY3MGQzIn0sICJpZCI6ICI1ZDY5MzQwMDMyZGI2MDc3YTc5NjcwZDMi
+        fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:57 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:40 GMT
 - request:
     method: delete
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:58 GMT
+      - Fri, 30 Aug 2019 14:34:40 GMT
       Server:
       - Apache
       Content-Length:
@@ -3620,41 +3367,41 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2Y4MDNkYWNhLWI0N2ItNGU4OC05NTNjLTY0NmUzNWRkZDI4MC8iLCAi
-        dGFza19pZCI6ICJmODAzZGFjYS1iNDdiLTRlODgtOTUzYy02NDZlMzVkZGQy
-        ODAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2FmYzNmZWQzLTE4YzEtNDM3ZS04ZGQ1LTQ3YWRmNmVjZGZiZS8iLCAi
+        dGFza19pZCI6ICJhZmMzZmVkMy0xOGMxLTQzN2UtOGRkNS00N2FkZjZlY2Rm
+        YmUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:58 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:40 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/f803daca-b47b-4e88-953c-646e35ddd280/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/afc3fed3-18c1-437e-8dd5-47adf6ecdfbe/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:58 GMT
+      - Fri, 30 Aug 2019 14:34:40 GMT
       Server:
       - Apache
       Etag:
-      - '"7773c494d621b4ef0eb807bc4186f390-gzip"'
+      - '"81285509a4656b8dba3a1848670aa992-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '687'
+      - '370'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -3662,20 +3409,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mODAzZGFjYS1iNDdiLTRlODgtOTUzYy02NDZlMzVkZGQy
-        ODAvIiwgInRhc2tfaWQiOiAiZjgwM2RhY2EtYjQ3Yi00ZTg4LTk1M2MtNjQ2
-        ZTM1ZGRkMjgwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
+        aS92Mi90YXNrcy9hZmMzZmVkMy0xOGMxLTQzN2UtOGRkNS00N2FkZjZlY2Rm
+        YmUvIiwgInRhc2tfaWQiOiAiYWZjM2ZlZDMtMThjMS00MzdlLThkZDUtNDdh
+        ZGY2ZWNkZmJlIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
         IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo1OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo1OFoiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDo0MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDo0MFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9y
-        dCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
-        ZGV2ZWwubG9jYWxob3N0LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJm
-        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
-        b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20iLCAicmVzdWx0
-        IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4
-        N2Y3ZWFiMzZjZTNmZTUxZGYzZTEifSwgImlkIjogIjVkNDg3ZjdlYWIzNmNl
-        M2ZlNTFkZjNlMSJ9
+        dCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJA
+        Y2VudG9zNy1rYXRlbGxvLWRldmVsLTIuY2Fubm9sby5leGFtcGxlLmNvbS5k
+        cTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRldmVs
+        LTIuY2Fubm9sby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNjkzNDAwMzJkYjYwNzdh
+        Nzk2NzEyMiJ9LCAiaWQiOiAiNWQ2OTM0MDAzMmRiNjA3N2E3OTY3MTIyIn0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:58 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:40 GMT
 recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/errata_filter.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/repository/yum_vcr_copy/errata_filter.yml
@@ -2,26 +2,26 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 404
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:59 GMT
+      - Fri, 30 Aug 2019 14:34:41 GMT
       Server:
       - Apache
       Content-Length:
@@ -41,10 +41,10 @@ http_interactions:
         ZG9yYV8xNyIsICJzdWJfZXJyb3JzIjogW119LCAidHJhY2ViYWNrIjogbnVs
         bCwgInJlc291cmNlcyI6IHsicmVwb3NpdG9yeSI6ICJGZWRvcmFfMTcifX0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:59 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:41 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -75,21 +75,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '1043'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 201
       message: CREATED
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:59 GMT
+      - Fri, 30 Aug 2019 14:34:41 GMT
       Server:
       - Apache
       Content-Length:
@@ -106,14 +106,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWQ0ODdmN2ZhY2UyM2YwN2E1MDZkZDM0In0sICJpZCI6ICJGZWRvcmFfMTci
+        NWQ2OTM0MDE3YWNjZTkwN2U0ZDdmMmI1In0sICJpZCI6ICJGZWRvcmFfMTci
         LCAiX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3JlcG9zaXRvcmllcy9GZWRvcmFf
         MTcvIn0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:59 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:41 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/actions/sync/
     body:
       encoding: UTF-8
       base64_string: |
@@ -122,21 +122,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '53'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:11:59 GMT
+      - Fri, 30 Aug 2019 14:34:41 GMT
       Server:
       - Apache
       Content-Length:
@@ -147,41 +147,41 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzFmNTJjYmQ4LTM2M2QtNGQxYi05MWRmLWE1ZmUwODM4ODQyYi8iLCAi
-        dGFza19pZCI6ICIxZjUyY2JkOC0zNjNkLTRkMWItOTFkZi1hNWZlMDgzODg0
-        MmIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzYzYmI5MTU0LWNkN2MtNGRjZC1hNzhiLWJhZWYwMTk0NDQ4MC8iLCAi
+        dGFza19pZCI6ICI2M2JiOTE1NC1jZDdjLTRkY2QtYTc4Yi1iYWVmMDE5NDQ0
+        ODAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:11:59 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:41 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/1f52cbd8-363d-4d1b-91df-a5fe0838842b/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/63bb9154-cd7c-4dcd-a78b-baef01944480/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:00 GMT
+      - Fri, 30 Aug 2019 14:34:42 GMT
       Server:
       - Apache
       Etag:
-      - '"b2e995509e85cff48d13f8fbdee15c1a-gzip"'
+      - '"d495b7e8a69b408c007af677bebf7a54-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
+      - '716'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -189,16 +189,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xZjUyY2JkOC0zNjNkLTRkMWItOTFkZi1hNWZlMDgzODg0
-        MmIvIiwgInRhc2tfaWQiOiAiMWY1MmNiZDgtMzYzZC00ZDFiLTkxZGYtYTVm
-        ZTA4Mzg4NDJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy82M2JiOTE1NC1jZDdjLTRkY2QtYTc4Yi1iYWVmMDE5NDQ0
+        ODAvIiwgInRhc2tfaWQiOiAiNjNiYjkxNTQtY2Q3Yy00ZGNkLWE3OGItYmFl
+        ZjAxOTQ0NDgwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMjowMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDo0MloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDo0MloiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMjYxMjE4OTgtMDk0Mi00OTU5LTgzN2QtZDA5YzNmNGE5
-        NTI0LyIsICJ0YXNrX2lkIjogIjI2MTIxODk4LTA5NDItNDk1OS04MzdkLWQw
-        OWMzZjRhOTUyNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvMThkMWViMTgtMzQzYy00YTk5LTg2YWItYjI2ZTVjMzhi
+        MmQ5LyIsICJ0YXNrX2lkIjogIjE4ZDFlYjE4LTM0M2MtNGE5OS04NmFiLWIy
+        NmU1YzM4YjJkOSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -210,69 +210,70 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjEyOjAwWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y4MGFjZTIzZjBhMTQ5NDQ1ODgiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjdmYWIzNmNlM2ZlNTFkZjQ1NCJ9LCAiaWQiOiAiNWQ0ODdm
-        N2ZhYjM2Y2UzZmU1MWRmNDU0In0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        Mi5jYW5ub2xvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQyWiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDJa
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
+        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3ZlZF9jb3VudCI6
+        IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVkNjkzNDAyN2FjY2U5
+        MGI2MzlmYzcyMSIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJp
+        dGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90
+        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
+        X2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTM0MDEz
+        MmRiNjA3N2E3OTY3MTk2In0sICJpZCI6ICI1ZDY5MzQwMTMyZGI2MDc3YTc5
+        NjcxOTYifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:00 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:42 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/1f52cbd8-363d-4d1b-91df-a5fe0838842b/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/63bb9154-cd7c-4dcd-a78b-baef01944480/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:00 GMT
+      - Fri, 30 Aug 2019 14:34:43 GMT
       Server:
       - Apache
       Etag:
-      - '"b2e995509e85cff48d13f8fbdee15c1a-gzip"'
+      - '"d495b7e8a69b408c007af677bebf7a54-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
+      - '716'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -280,16 +281,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xZjUyY2JkOC0zNjNkLTRkMWItOTFkZi1hNWZlMDgzODg0
-        MmIvIiwgInRhc2tfaWQiOiAiMWY1MmNiZDgtMzYzZC00ZDFiLTkxZGYtYTVm
-        ZTA4Mzg4NDJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy82M2JiOTE1NC1jZDdjLTRkY2QtYTc4Yi1iYWVmMDE5NDQ0
+        ODAvIiwgInRhc2tfaWQiOiAiNjNiYjkxNTQtY2Q3Yy00ZGNkLWE3OGItYmFl
+        ZjAxOTQ0NDgwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMjowMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDo0MloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDo0MloiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMjYxMjE4OTgtMDk0Mi00OTU5LTgzN2QtZDA5YzNmNGE5
-        NTI0LyIsICJ0YXNrX2lkIjogIjI2MTIxODk4LTA5NDItNDk1OS04MzdkLWQw
-        OWMzZjRhOTUyNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvMThkMWViMTgtMzQzYy00YTk5LTg2YWItYjI2ZTVjMzhi
+        MmQ5LyIsICJ0YXNrX2lkIjogIjE4ZDFlYjE4LTM0M2MtNGE5OS04NmFiLWIy
+        NmU1YzM4YjJkOSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -301,69 +302,70 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjEyOjAwWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y4MGFjZTIzZjBhMTQ5NDQ1ODgiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjdmYWIzNmNlM2ZlNTFkZjQ1NCJ9LCAiaWQiOiAiNWQ0ODdm
-        N2ZhYjM2Y2UzZmU1MWRmNDU0In0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        Mi5jYW5ub2xvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQyWiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDJa
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
+        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3ZlZF9jb3VudCI6
+        IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVkNjkzNDAyN2FjY2U5
+        MGI2MzlmYzcyMSIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJp
+        dGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90
+        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
+        X2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTM0MDEz
+        MmRiNjA3N2E3OTY3MTk2In0sICJpZCI6ICI1ZDY5MzQwMTMyZGI2MDc3YTc5
+        NjcxOTYifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:00 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:43 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/1f52cbd8-363d-4d1b-91df-a5fe0838842b/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/63bb9154-cd7c-4dcd-a78b-baef01944480/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:00 GMT
+      - Fri, 30 Aug 2019 14:34:43 GMT
       Server:
       - Apache
       Etag:
-      - '"b2e995509e85cff48d13f8fbdee15c1a-gzip"'
+      - '"d495b7e8a69b408c007af677bebf7a54-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
+      - '716'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -371,16 +373,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xZjUyY2JkOC0zNjNkLTRkMWItOTFkZi1hNWZlMDgzODg0
-        MmIvIiwgInRhc2tfaWQiOiAiMWY1MmNiZDgtMzYzZC00ZDFiLTkxZGYtYTVm
-        ZTA4Mzg4NDJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy82M2JiOTE1NC1jZDdjLTRkY2QtYTc4Yi1iYWVmMDE5NDQ0
+        ODAvIiwgInRhc2tfaWQiOiAiNjNiYjkxNTQtY2Q3Yy00ZGNkLWE3OGItYmFl
+        ZjAxOTQ0NDgwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMjowMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDo0MloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDo0MloiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMjYxMjE4OTgtMDk0Mi00OTU5LTgzN2QtZDA5YzNmNGE5
-        NTI0LyIsICJ0YXNrX2lkIjogIjI2MTIxODk4LTA5NDItNDk1OS04MzdkLWQw
-        OWMzZjRhOTUyNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvMThkMWViMTgtMzQzYy00YTk5LTg2YWItYjI2ZTVjMzhi
+        MmQ5LyIsICJ0YXNrX2lkIjogIjE4ZDFlYjE4LTM0M2MtNGE5OS04NmFiLWIy
+        NmU1YzM4YjJkOSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -392,69 +394,70 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjEyOjAwWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y4MGFjZTIzZjBhMTQ5NDQ1ODgiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjdmYWIzNmNlM2ZlNTFkZjQ1NCJ9LCAiaWQiOiAiNWQ0ODdm
-        N2ZhYjM2Y2UzZmU1MWRmNDU0In0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        Mi5jYW5ub2xvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQyWiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDJa
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
+        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3ZlZF9jb3VudCI6
+        IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVkNjkzNDAyN2FjY2U5
+        MGI2MzlmYzcyMSIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJp
+        dGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90
+        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
+        X2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTM0MDEz
+        MmRiNjA3N2E3OTY3MTk2In0sICJpZCI6ICI1ZDY5MzQwMTMyZGI2MDc3YTc5
+        NjcxOTYifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:00 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:43 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/1f52cbd8-363d-4d1b-91df-a5fe0838842b/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/63bb9154-cd7c-4dcd-a78b-baef01944480/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:00 GMT
+      - Fri, 30 Aug 2019 14:34:43 GMT
       Server:
       - Apache
       Etag:
-      - '"b2e995509e85cff48d13f8fbdee15c1a-gzip"'
+      - '"d495b7e8a69b408c007af677bebf7a54-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
+      - '716'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -462,16 +465,16 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xZjUyY2JkOC0zNjNkLTRkMWItOTFkZi1hNWZlMDgzODg0
-        MmIvIiwgInRhc2tfaWQiOiAiMWY1MmNiZDgtMzYzZC00ZDFiLTkxZGYtYTVm
-        ZTA4Mzg4NDJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy82M2JiOTE1NC1jZDdjLTRkY2QtYTc4Yi1iYWVmMDE5NDQ0
+        ODAvIiwgInRhc2tfaWQiOiAiNjNiYjkxNTQtY2Q3Yy00ZGNkLWE3OGItYmFl
+        ZjAxOTQ0NDgwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMjowMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDo0MloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDo0MloiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMjYxMjE4OTgtMDk0Mi00OTU5LTgzN2QtZDA5YzNmNGE5
-        NTI0LyIsICJ0YXNrX2lkIjogIjI2MTIxODk4LTA5NDItNDk1OS04MzdkLWQw
-        OWMzZjRhOTUyNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
+        cGkvdjIvdGFza3MvMThkMWViMTgtMzQzYy00YTk5LTg2YWItYjI2ZTVjMzhi
+        MmQ5LyIsICJ0YXNrX2lkIjogIjE4ZDFlYjE4LTM0M2MtNGE5OS04NmFiLWIy
+        NmU1YzM4YjJkOSJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
         dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
         ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
         eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
@@ -483,524 +486,70 @@ http_interactions:
         aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
         RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
         YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjEyOjAwWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y4MGFjZTIzZjBhMTQ5NDQ1ODgiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjdmYWIzNmNlM2ZlNTFkZjQ1NCJ9LCAiaWQiOiAiNWQ0ODdm
-        N2ZhYjM2Y2UzZmU1MWRmNDU0In0=
+        cnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwt
+        Mi5jYW5ub2xvLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hl
+        ZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        IiwgInJlc3VsdCI6IHsicmVzdWx0IjogInN1Y2Nlc3MiLCAiaW1wb3J0ZXJf
+        aWQiOiAieXVtX2ltcG9ydGVyIiwgImV4Y2VwdGlvbiI6IG51bGwsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRl
+        ZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQyWiIsICJfbnMiOiAicmVwb19zeW5j
+        X3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDJa
+        IiwgImltcG9ydGVyX3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImVycm9y
+        X21lc3NhZ2UiOiBudWxsLCAic3VtbWFyeSI6IHsibW9kdWxlcyI6IHsic3Rh
+        dGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InN0YXRlIjogIkZJTklT
+        SEVEIn0sICJjb21wcyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdl
+        X2R1cGxpY2F0ZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmli
+        dXRpb24iOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJlcnJhdGEiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUiOiAiRklO
+        SVNIRUQifX0sICJhZGRlZF9jb3VudCI6IDM5LCAicmVtb3ZlZF9jb3VudCI6
+        IDAsICJ1cGRhdGVkX2NvdW50IjogMCwgImlkIjogIjVkNjkzNDAyN2FjY2U5
+        MGI2MzlmYzcyMSIsICJkZXRhaWxzIjogeyJtb2R1bGVzIjogeyJzdGF0ZSI6
+        ICJGSU5JU0hFRCJ9LCAiY29udGVudCI6IHsic2l6ZV90b3RhbCI6IDAsICJp
+        dGVtc19sZWZ0IjogMCwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgInNpemVfbGVmdCI6IDAsICJkZXRhaWxzIjogeyJycG1fdG90
+        YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6IDAsICJkcnBt
+        X2RvbmUiOiAwfSwgImVycm9yX2RldGFpbHMiOiBbXX0sICJjb21wcyI6IHsi
+        c3RhdGUiOiAiRklOSVNIRUQifSwgInB1cmdlX2R1cGxpY2F0ZXMiOiB7InN0
+        YXRlIjogIkZJTklTSEVEIn0sICJkaXN0cmlidXRpb24iOiB7Iml0ZW1zX3Rv
+        dGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMi
+        OiBbXSwgIml0ZW1zX2xlZnQiOiAwfSwgImVycmF0YSI6IHsic3RhdGUiOiAi
+        RklOSVNIRUQifSwgIm1ldGFkYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9
+        fX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTM0MDEz
+        MmRiNjA3N2E3OTY3MTk2In0sICJpZCI6ICI1ZDY5MzQwMTMyZGI2MDc3YTc5
+        NjcxOTYifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:00 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:43 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/1f52cbd8-363d-4d1b-91df-a5fe0838842b/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/18d1eb18-343c-4a99-86ab-b26e5c38b2d9/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:00 GMT
+      - Fri, 30 Aug 2019 14:34:43 GMT
       Server:
       - Apache
       Etag:
-      - '"b2e995509e85cff48d13f8fbdee15c1a-gzip"'
+      - '"44bbf2414adb3af593dbbe82e0152eb8-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2405'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xZjUyY2JkOC0zNjNkLTRkMWItOTFkZi1hNWZlMDgzODg0
-        MmIvIiwgInRhc2tfaWQiOiAiMWY1MmNiZDgtMzYzZC00ZDFiLTkxZGYtYTVm
-        ZTA4Mzg4NDJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMjowMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMjYxMjE4OTgtMDk0Mi00OTU5LTgzN2QtZDA5YzNmNGE5
-        NTI0LyIsICJ0YXNrX2lkIjogIjI2MTIxODk4LTA5NDItNDk1OS04MzdkLWQw
-        OWMzZjRhOTUyNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjEyOjAwWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y4MGFjZTIzZjBhMTQ5NDQ1ODgiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjdmYWIzNmNlM2ZlNTFkZjQ1NCJ9LCAiaWQiOiAiNWQ0ODdm
-        N2ZhYjM2Y2UzZmU1MWRmNDU0In0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:00 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/1f52cbd8-363d-4d1b-91df-a5fe0838842b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:00 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"b2e995509e85cff48d13f8fbdee15c1a-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2405'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xZjUyY2JkOC0zNjNkLTRkMWItOTFkZi1hNWZlMDgzODg0
-        MmIvIiwgInRhc2tfaWQiOiAiMWY1MmNiZDgtMzYzZC00ZDFiLTkxZGYtYTVm
-        ZTA4Mzg4NDJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMjowMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMjYxMjE4OTgtMDk0Mi00OTU5LTgzN2QtZDA5YzNmNGE5
-        NTI0LyIsICJ0YXNrX2lkIjogIjI2MTIxODk4LTA5NDItNDk1OS04MzdkLWQw
-        OWMzZjRhOTUyNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjEyOjAwWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y4MGFjZTIzZjBhMTQ5NDQ1ODgiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjdmYWIzNmNlM2ZlNTFkZjQ1NCJ9LCAiaWQiOiAiNWQ0ODdm
-        N2ZhYjM2Y2UzZmU1MWRmNDU0In0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:00 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/1f52cbd8-363d-4d1b-91df-a5fe0838842b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:00 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"b2e995509e85cff48d13f8fbdee15c1a-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2405'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xZjUyY2JkOC0zNjNkLTRkMWItOTFkZi1hNWZlMDgzODg0
-        MmIvIiwgInRhc2tfaWQiOiAiMWY1MmNiZDgtMzYzZC00ZDFiLTkxZGYtYTVm
-        ZTA4Mzg4NDJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMjowMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMjYxMjE4OTgtMDk0Mi00OTU5LTgzN2QtZDA5YzNmNGE5
-        NTI0LyIsICJ0YXNrX2lkIjogIjI2MTIxODk4LTA5NDItNDk1OS04MzdkLWQw
-        OWMzZjRhOTUyNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjEyOjAwWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y4MGFjZTIzZjBhMTQ5NDQ1ODgiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjdmYWIzNmNlM2ZlNTFkZjQ1NCJ9LCAiaWQiOiAiNWQ0ODdm
-        N2ZhYjM2Y2UzZmU1MWRmNDU0In0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:00 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/1f52cbd8-363d-4d1b-91df-a5fe0838842b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:00 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"b2e995509e85cff48d13f8fbdee15c1a-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2405'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xZjUyY2JkOC0zNjNkLTRkMWItOTFkZi1hNWZlMDgzODg0
-        MmIvIiwgInRhc2tfaWQiOiAiMWY1MmNiZDgtMzYzZC00ZDFiLTkxZGYtYTVm
-        ZTA4Mzg4NDJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMjowMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMjYxMjE4OTgtMDk0Mi00OTU5LTgzN2QtZDA5YzNmNGE5
-        NTI0LyIsICJ0YXNrX2lkIjogIjI2MTIxODk4LTA5NDItNDk1OS04MzdkLWQw
-        OWMzZjRhOTUyNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjEyOjAwWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y4MGFjZTIzZjBhMTQ5NDQ1ODgiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjdmYWIzNmNlM2ZlNTFkZjQ1NCJ9LCAiaWQiOiAiNWQ0ODdm
-        N2ZhYjM2Y2UzZmU1MWRmNDU0In0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:00 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/1f52cbd8-363d-4d1b-91df-a5fe0838842b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:00 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"b2e995509e85cff48d13f8fbdee15c1a-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2405'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8xZjUyY2JkOC0zNjNkLTRkMWItOTFkZi1hNWZlMDgzODg0
-        MmIvIiwgInRhc2tfaWQiOiAiMWY1MmNiZDgtMzYzZC00ZDFiLTkxZGYtYTVm
-        ZTA4Mzg4NDJiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
-        MTciLCAicHVscDphY3Rpb246c3luYyJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMjowMFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAidHJhY2ViYWNr
-        IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbeyJfaHJlZiI6ICIvcHVscC9h
-        cGkvdjIvdGFza3MvMjYxMjE4OTgtMDk0Mi00OTU5LTgzN2QtZDA5YzNmNGE5
-        NTI0LyIsICJ0YXNrX2lkIjogIjI2MTIxODk4LTA5NDItNDk1OS04MzdkLWQw
-        OWMzZjRhOTUyNCJ9XSwgInByb2dyZXNzX3JlcG9ydCI6IHsieXVtX2ltcG9y
-        dGVyIjogeyJjb250ZW50IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6
-        ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        eyJycG1fdG90YWwiOiAwLCAicnBtX2RvbmUiOiAwLCAiZHJwbV90b3RhbCI6
-        IDAsICJkcnBtX2RvbmUiOiAwfSwgInNpemVfdG90YWwiOiAwLCAic2l6ZV9s
-        ZWZ0IjogMCwgIml0ZW1zX2xlZnQiOiAwfSwgImNvbXBzIjogeyJzdGF0ZSI6
-        ICJGSU5JU0hFRCJ9LCAicHVyZ2VfZHVwbGljYXRlcyI6IHsic3RhdGUiOiAi
-        RklOSVNIRUQifSwgImRpc3RyaWJ1dGlvbiI6IHsiaXRlbXNfdG90YWwiOiAw
-        LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
-        aXRlbXNfbGVmdCI6IDB9LCAibW9kdWxlcyI6IHsic3RhdGUiOiAiRklOSVNI
-        RUQifSwgImVycmF0YSI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgIm1ldGFk
-        YXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9fX0sICJxdWV1ZSI6ICJyZXNl
-        cnZlZF9yZXNvdXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBs
-        ZS5jb20uZHEyIiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1l
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InJlc3VsdCI6ICJzdWNjZXNz
-        IiwgImltcG9ydGVyX2lkIjogInl1bV9pbXBvcnRlciIsICJleGNlcHRpb24i
-        OiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAidHJhY2ViYWNrIjog
-        bnVsbCwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAiX25z
-        IjogInJlcG9fc3luY19yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjEyOjAwWiIsICJpbXBvcnRlcl90eXBlX2lkIjogInl1bV9pbXBv
-        cnRlciIsICJlcnJvcl9tZXNzYWdlIjogbnVsbCwgInN1bW1hcnkiOiB7Im1v
-        ZHVsZXMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJjb250ZW50IjogeyJz
-        dGF0ZSI6ICJGSU5JU0hFRCJ9LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklT
-        SEVEIn0sICJwdXJnZV9kdXBsaWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hF
-        RCJ9LCAiZGlzdHJpYnV0aW9uIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAi
-        ZXJyYXRhIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAibWV0YWRhdGEiOiB7
-        InN0YXRlIjogIkZJTklTSEVEIn19LCAiYWRkZWRfY291bnQiOiAzOSwgInJl
-        bW92ZWRfY291bnQiOiAwLCAidXBkYXRlZF9jb3VudCI6IDAsICJpZCI6ICI1
-        ZDQ4N2Y4MGFjZTIzZjBhMTQ5NDQ1ODgiLCAiZGV0YWlscyI6IHsibW9kdWxl
-        cyI6IHsic3RhdGUiOiAiRklOSVNIRUQifSwgImNvbnRlbnQiOiB7InNpemVf
-        dG90YWwiOiAwLCAiaXRlbXNfbGVmdCI6IDAsICJpdGVtc190b3RhbCI6IDAs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJzaXplX2xlZnQiOiAwLCAiZGV0YWls
-        cyI6IHsicnBtX3RvdGFsIjogMCwgInJwbV9kb25lIjogMCwgImRycG1fdG90
-        YWwiOiAwLCAiZHJwbV9kb25lIjogMH0sICJlcnJvcl9kZXRhaWxzIjogW119
-        LCAiY29tcHMiOiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJwdXJnZV9kdXBs
-        aWNhdGVzIjogeyJzdGF0ZSI6ICJGSU5JU0hFRCJ9LCAiZGlzdHJpYnV0aW9u
-        IjogeyJpdGVtc190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
-        cnJvcl9kZXRhaWxzIjogW10sICJpdGVtc19sZWZ0IjogMH0sICJlcnJhdGEi
-        OiB7InN0YXRlIjogIkZJTklTSEVEIn0sICJtZXRhZGF0YSI6IHsic3RhdGUi
-        OiAiRklOSVNIRUQifX19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjdmYWIzNmNlM2ZlNTFkZjQ1NCJ9LCAiaWQiOiAiNWQ0ODdm
-        N2ZhYjM2Y2UzZmU1MWRmNDU0In0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:00 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/26121898-0942-4959-837d-d09c3f4a9524/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:00 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"d88c81a52a80735d078b855928856899-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '8529'
+      - '1380'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -1008,199 +557,200 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
-        dWxwL2FwaS92Mi90YXNrcy8yNjEyMTg5OC0wOTQyLTQ5NTktODM3ZC1kMDlj
-        M2Y0YTk1MjQvIiwgInRhc2tfaWQiOiAiMjYxMjE4OTgtMDk0Mi00OTU5LTgz
-        N2QtZDA5YzNmNGE5NTI0IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
+        dWxwL2FwaS92Mi90YXNrcy8xOGQxZWIxOC0zNDNjLTRhOTktODZhYi1iMjZl
+        NWMzOGIyZDkvIiwgInRhc2tfaWQiOiAiMThkMWViMTgtMzQzYy00YTk5LTg2
+        YWItYjI2ZTVjMzhiMmQ5IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpG
         ZWRvcmFfMTciLCAicHVscDphY3Rpb246cHVibGlzaCJdLCAiZmluaXNoX3Rp
-        bWUiOiAiMjAxOS0wOC0wNVQxOToxMjowMFoiLCAiX25zIjogInRhc2tfc3Rh
-        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMjowMFoiLCAi
+        bWUiOiAiMjAxOS0wOC0zMFQxNDozNDo0M1oiLCAiX25zIjogInRhc2tfc3Rh
+        dHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDo0MloiLCAi
         dHJhY2ViYWNrIjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dy
         ZXNzX3JlcG9ydCI6IHsiRmVkb3JhXzE3IjogW3sibnVtX3N1Y2Nlc3MiOiAx
         LCAiZGVzY3JpcHRpb24iOiAiSW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEi
         LCAic3RlcF90eXBlIjogImluaXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJp
         dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICI5ZjQ0YjlmYy1kZGRiLTRkMzEtYTY2MS03ZTUyMDc1
-        ZWU2ZTMiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
+        LCAic3RlcF9pZCI6ICJlNjIxNGExNS1iNmZhLTQ1NjctYTJkNy0yOWQwOWNi
+        OGQxNjkiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
         MSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZp
         bGVzIiwgInN0ZXBfdHlwZSI6ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90
         YWwiOiAxLCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6
         IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBf
-        aWQiOiAiY2ZiNDcxMGEtYzM4Yi00ZGIyLWJiNDAtMGExMTQ5MGQwMzNjIiwg
+        aWQiOiAiZTAwZDI5MzgtYjgyMi00MmZlLWIzNTItYzllOWZkMWZjNzY0Iiwg
         Im51bV9wcm9jZXNzZWQiOiAxfSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVz
         Y3JpcHRpb24iOiAiUHVibGlzaGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJy
         cG1zIiwgIml0ZW1zX3RvdGFsIjogMTgsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
         ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICIzYWI5OTYyZC03NTFjLTQwMjktOWI1
-        Yi01NTk2ZWM3OTFmNzEiLCAibnVtX3Byb2Nlc3NlZCI6IDE4fSwgeyJudW1f
+        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNmE2MGQ1YS0zOGY1LTRlOWItOWEz
+        Yy0zYWNjM2VkNDY0MTUiLCAibnVtX3Byb2Nlc3NlZCI6IDE4fSwgeyJudW1f
         c3VjY2VzcyI6IDAsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRh
         IFJQTXMiLCAic3RlcF90eXBlIjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjog
         MSwgInN0YXRlIjogIlNLSVBQRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAi
         ZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAi
-        NGNlN2IzMDUtNGRmZC00MWJlLWFhMDUtZGRhZTkwOTA5OGZkIiwgIm51bV9w
+        MTljODVhNzktN2Q3ZC00MWE2LThiMTctYjFhNGYzMjAzMGZmIiwgIm51bV9w
         cm9jZXNzZWQiOiAwfSwgeyJudW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlv
         biI6ICJQdWJsaXNoaW5nIEVycmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRh
         IiwgIml0ZW1zX3RvdGFsIjogNiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVy
         cm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJl
-        cyI6IDAsICJzdGVwX2lkIjogImFjN2Y4ODU0LWE2ZWMtNGU5Mi04YjI4LTgy
-        MzU5ODViZDU5NiIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
+        cyI6IDAsICJzdGVwX2lkIjogIjcyYTAyZjk3LTk5Y2UtNDNlYi04YzNiLWQ2
+        ZmI5Mzc2MTA4YyIsICJudW1fcHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nl
         c3MiOiA5LCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwg
         InN0ZXBfdHlwZSI6ICJtb2R1bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0
         YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
-        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM3ZWU3
-        NGM5LWVjY2QtNDUyNS05MTk0LTU1OWU2OGFhMTZlMSIsICJudW1fcHJvY2Vz
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjU2NzJl
+        ZTBiLTQyZDAtNDg2Ni1iNTRlLTY3NDZjODZiYTUyNyIsICJudW1fcHJvY2Vz
         c2VkIjogOX0sIHsibnVtX3N1Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAi
         UHVibGlzaGluZyBDb21wcyBmaWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIs
         ICJpdGVtc190b3RhbCI6IDMsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJv
         cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICJiYmU5Yjg1NS1hMjM1LTRkNjItOWRmNy01Zjll
-        MzM4YWEyMmMiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNz
+        OiAwLCAic3RlcF9pZCI6ICJiMzM5ZWEyNi05NDZlLTRlNjctYjExNC0zNDg5
+        MDQ3NzFhNTIiLCAibnVtX3Byb2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNz
         IjogMiwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwg
         InN0ZXBfdHlwZSI6ICJtZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDIsICJz
         dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4NmFi
-        NjU0Yy0xNmVhLTQxNGYtOGM0MC05MjY5MDM1YjgxNmMiLCAibnVtX3Byb2Nl
+        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0OWVj
+        NWViMC02NDI4LTQzYzktODY3NS1lOWE2NmJkODZiNGYiLCAibnVtX3Byb2Nl
         c3NlZCI6IDJ9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
         IkNsb3NpbmcgcmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2Vf
         cmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJG
         SU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIs
-        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICIxYzUzMDFlOS1jM2E5
-        LTQwY2UtYWU3NS00NzFkMTE2NDc0NjYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
+        ICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJkNWFmZTY3Ni01MGUx
+        LTQzZmItYTE0Ni04NzVhNmJkNmQ4MWUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9
         LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRp
         bmcgc3FsaXRlIGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxp
         dGUiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJl
         cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
-        ZXMiOiAwLCAic3RlcF9pZCI6ICI5ZjZiODVlMy1iZTAzLTRmMzAtYTQ4MC05
-        MWVhZmUyNWY2YmQiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
+        ZXMiOiAwLCAic3RlcF9pZCI6ICIxOTZmMGU4OS04NDU3LTRjMTktYWM2MC02
+        NDAyYjUwYjFjMDUiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNj
         ZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0
         YSIsICJzdGVwX3R5cGUiOiAicmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVt
         c190b3RhbCI6IDAsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRh
         aWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAi
-        c3RlcF9pZCI6ICI4MmYzOGNjYy0wMThmLTRlZTktOTc4OC05NjgzODU1Yzkx
-        Y2UiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
+        c3RlcF9pZCI6ICJjODhlYjI1My0zNDk3LTQ3ZmEtOWIzMS1iODVkNTc2NDQ2
+        MDEiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwg
         ImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVw
         X3R5cGUiOiAicmVwb3ZpZXciLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
         OiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjog
-        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI1ODZlNDA0OC1m
-        ODA1LTRiODQtYTI1OS05NGY3NjIyZmJlMDkiLCAibnVtX3Byb2Nlc3NlZCI6
+        IiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhNGQ5ODJjZi02
+        MDNkLTQ5N2QtOWMxYS1iNjhhM2Y3NDIzNTEiLCAibnVtX3Byb2Nlc3NlZCI6
         IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxp
         c2hpbmcgZmlsZXMgdG8gd2ViIiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2Rp
         cmVjdG9yeSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hF
         RCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1f
-        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI0Njc5YWRmMS00YzM1LTQzOTAt
-        YmQzYi0xODM0ZjNjZGUyYzgiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
+        ZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJhZGIzNmQxMi1iMzUzLTQ4NGMt
+        OWQxZS1mYzUxODIwOGFmNGUiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51
         bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGlu
         Z3MgRmlsZSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFk
         YXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwg
         ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogIjAzMGI3ZjM0LWQ1YWEtNGZhOS05NzVk
-        LTYyNzk5ZjgxNTc0NiIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
-        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9z
-        dC5leGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29y
-        a2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwu
-        bG9jYWxob3N0LmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsicmVzdWx0Ijog
-        InN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9faWQiOiAiRmVk
-        b3JhXzE3IiwgInN0YXJ0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjowMFoiLCAi
-        X25zIjogInJlcG9fcHVibGlzaF9yZXN1bHRzIiwgImNvbXBsZXRlZCI6ICIy
-        MDE5LTA4LTA1VDE5OjEyOjAwWiIsICJ0cmFjZWJhY2siOiBudWxsLCAiZGlz
-        dHJpYnV0b3JfdHlwZV9pZCI6ICJ5dW1fZGlzdHJpYnV0b3IiLCAic3VtbWFy
-        eSI6IHsiZ2VuZXJhdGUgc3FsaXRlIjogIlNLSVBQRUQiLCAicnBtcyI6ICJG
-        SU5JU0hFRCIsICJpbml0aWFsaXplX3JlcG9fbWV0YWRhdGEiOiAiRklOSVNI
-        RUQiLCAicmVtb3ZlX29sZF9yZXBvZGF0YSI6ICJGSU5JU0hFRCIsICJtb2R1
-        bGVzIjogIkZJTklTSEVEIiwgImNsb3NlX3JlcG9fbWV0YWRhdGEiOiAiRklO
-        SVNIRUQiLCAiZHJwbXMiOiAiU0tJUFBFRCIsICJjb21wcyI6ICJGSU5JU0hF
-        RCIsICJkaXN0cmlidXRpb24iOiAiRklOSVNIRUQiLCAicmVwb3ZpZXciOiAi
-        U0tJUFBFRCIsICJwdWJsaXNoX2RpcmVjdG9yeSI6ICJGSU5JU0hFRCIsICJl
-        cnJhdGEiOiAiRklOSVNIRUQiLCAibWV0YWRhdGEiOiAiRklOSVNIRUQifSwg
-        ImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3JfaWQiOiAiRmVk
-        b3JhXzE3IiwgImlkIjogIjVkNDg3ZjgwYWNlMjNmMGExNDk0NDU4OSIsICJk
-        ZXRhaWxzIjogW3sibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
-        SW5pdGlhbGl6aW5nIHJlcG8gbWV0YWRhdGEiLCAic3RlcF90eXBlIjogImlu
-        aXRpYWxpemVfcmVwb19tZXRhZGF0YSIsICJpdGVtc190b3RhbCI6IDEsICJz
-        dGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRh
-        aWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI5ZjQ0
-        YjlmYy1kZGRiLTRkMzEtYTY2MS03ZTUyMDc1ZWU2ZTMiLCAibnVtX3Byb2Nl
-        c3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjog
-        IlB1Ymxpc2hpbmcgRGlzdHJpYnV0aW9uIGZpbGVzIiwgInN0ZXBfdHlwZSI6
-        ICJkaXN0cmlidXRpb24iLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAi
-        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
-        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiY2ZiNDcxMGEtYzM4
-        Yi00ZGIyLWJiNDAtMGExMTQ5MGQwMzNjIiwgIm51bV9wcm9jZXNzZWQiOiAx
-        fSwgeyJudW1fc3VjY2VzcyI6IDE4LCAiZGVzY3JpcHRpb24iOiAiUHVibGlz
-        aGluZyBSUE1zIiwgInN0ZXBfdHlwZSI6ICJycG1zIiwgIml0ZW1zX3RvdGFs
-        IjogMTgsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjog
-        W10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9p
-        ZCI6ICIzYWI5OTYyZC03NTFjLTQwMjktOWI1Yi01NTk2ZWM3OTFmNzEiLCAi
-        bnVtX3Byb2Nlc3NlZCI6IDE4fSwgeyJudW1fc3VjY2VzcyI6IDAsICJkZXNj
-        cmlwdGlvbiI6ICJQdWJsaXNoaW5nIERlbHRhIFJQTXMiLCAic3RlcF90eXBl
-        IjogImRycG1zIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIlNLSVBQ
-        RUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVt
-        X2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNGNlN2IzMDUtNGRmZC00MWJl
-        LWFhMDUtZGRhZTkwOTA5OGZkIiwgIm51bV9wcm9jZXNzZWQiOiAwfSwgeyJu
-        dW1fc3VjY2VzcyI6IDYsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIEVy
-        cmF0YSIsICJzdGVwX3R5cGUiOiAiZXJyYXRhIiwgIml0ZW1zX3RvdGFsIjog
-        NiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
-        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
-        ImFjN2Y4ODU0LWE2ZWMtNGU5Mi04YjI4LTgyMzU5ODViZDU5NiIsICJudW1f
-        cHJvY2Vzc2VkIjogNn0sIHsibnVtX3N1Y2Nlc3MiOiA5LCAiZGVzY3JpcHRp
-        b24iOiAiUHVibGlzaGluZyBNb2R1bGVzIiwgInN0ZXBfdHlwZSI6ICJtb2R1
-        bGVzIiwgIml0ZW1zX3RvdGFsIjogOSwgInN0YXRlIjogIkZJTklTSEVEIiwg
-        ImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWls
-        dXJlcyI6IDAsICJzdGVwX2lkIjogImM3ZWU3NGM5LWVjY2QtNDUyNS05MTk0
-        LTU1OWU2OGFhMTZlMSIsICJudW1fcHJvY2Vzc2VkIjogOX0sIHsibnVtX3N1
-        Y2Nlc3MiOiAzLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBDb21wcyBm
-        aWxlIiwgInN0ZXBfdHlwZSI6ICJjb21wcyIsICJpdGVtc190b3RhbCI6IDMs
-        ICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJk
-        ZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICJi
-        YmU5Yjg1NS1hMjM1LTRkNjItOWRmNy01ZjllMzM4YWEyMmMiLCAibnVtX3By
-        b2Nlc3NlZCI6IDN9LCB7Im51bV9zdWNjZXNzIjogMiwgImRlc2NyaXB0aW9u
-        IjogIlB1Ymxpc2hpbmcgTWV0YWRhdGEuIiwgInN0ZXBfdHlwZSI6ICJtZXRh
-        ZGF0YSIsICJpdGVtc190b3RhbCI6IDIsICJzdGF0ZSI6ICJGSU5JU0hFRCIs
-        ICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFp
-        bHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4NmFiNjU0Yy0xNmVhLTQxNGYtOGM0
-        MC05MjY5MDM1YjgxNmMiLCAibnVtX3Byb2Nlc3NlZCI6IDJ9LCB7Im51bV9z
-        dWNjZXNzIjogMSwgImRlc2NyaXB0aW9uIjogIkNsb3NpbmcgcmVwbyBtZXRh
-        ZGF0YSIsICJzdGVwX3R5cGUiOiAiY2xvc2VfcmVwb19tZXRhZGF0YSIsICJp
-        dGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9k
+        dXJlcyI6IDAsICJzdGVwX2lkIjogIjA0YThmZDYxLTJjY2QtNDQ3Ni04NjYy
+        LTM2NDY0NTBiMDdjMCIsICJudW1fcHJvY2Vzc2VkIjogMX1dfSwgInF1ZXVl
+        IjogInJlc2VydmVkX3Jlc291cmNlX3dvcmtlci0yQGNlbnRvczcta2F0ZWxs
+        by1kZXZlbC0yLmNhbm5vbG8uZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
+        ImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
+        X3dvcmtlci0yQGNlbnRvczcta2F0ZWxsby1kZXZlbC0yLmNhbm5vbG8uZXhh
+        bXBsZS5jb20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJl
+        eGNlcHRpb24iOiBudWxsLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAic3Rh
+        cnRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQyWiIsICJfbnMiOiAicmVwb19w
+        dWJsaXNoX3Jlc3VsdHMiLCAiY29tcGxldGVkIjogIjIwMTktMDgtMzBUMTQ6
+        MzQ6NDNaIiwgInRyYWNlYmFjayI6IG51bGwsICJkaXN0cmlidXRvcl90eXBl
+        X2lkIjogInl1bV9kaXN0cmlidXRvciIsICJzdW1tYXJ5IjogeyJnZW5lcmF0
+        ZSBzcWxpdGUiOiAiU0tJUFBFRCIsICJycG1zIjogIkZJTklTSEVEIiwgImlu
+        aXRpYWxpemVfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJyZW1vdmVf
+        b2xkX3JlcG9kYXRhIjogIkZJTklTSEVEIiwgIm1vZHVsZXMiOiAiRklOSVNI
+        RUQiLCAiY2xvc2VfcmVwb19tZXRhZGF0YSI6ICJGSU5JU0hFRCIsICJkcnBt
+        cyI6ICJTS0lQUEVEIiwgImNvbXBzIjogIkZJTklTSEVEIiwgImRpc3RyaWJ1
+        dGlvbiI6ICJGSU5JU0hFRCIsICJyZXBvdmlldyI6ICJTS0lQUEVEIiwgInB1
+        Ymxpc2hfZGlyZWN0b3J5IjogIkZJTklTSEVEIiwgImVycmF0YSI6ICJGSU5J
+        U0hFRCIsICJtZXRhZGF0YSI6ICJGSU5JU0hFRCJ9LCAiZXJyb3JfbWVzc2Fn
+        ZSI6IG51bGwsICJkaXN0cmlidXRvcl9pZCI6ICJGZWRvcmFfMTciLCAiaWQi
+        OiAiNWQ2OTM0MDM3YWNjZTkwYjYzOWZjNzIyIiwgImRldGFpbHMiOiBbeyJu
+        dW1fc3VjY2VzcyI6IDEsICJkZXNjcmlwdGlvbiI6ICJJbml0aWFsaXppbmcg
+        cmVwbyBtZXRhZGF0YSIsICJzdGVwX3R5cGUiOiAiaW5pdGlhbGl6ZV9yZXBv
+        X21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjogMSwgInN0YXRlIjogIkZJTklT
+        SEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51
+        bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImU2MjE0YTE1LWI2ZmEtNDU2
+        Ny1hMmQ3LTI5ZDA5Y2I4ZDE2OSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsi
+        bnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGluZyBE
+        aXN0cmlidXRpb24gZmlsZXMiLCAic3RlcF90eXBlIjogImRpc3RyaWJ1dGlv
+        biIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJl
+        cnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVy
+        ZXMiOiAwLCAic3RlcF9pZCI6ICJlMDBkMjkzOC1iODIyLTQyZmUtYjM1Mi1j
+        OWU5ZmQxZmM3NjQiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNj
+        ZXNzIjogMTgsICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIFJQTXMiLCAi
+        c3RlcF90eXBlIjogInJwbXMiLCAiaXRlbXNfdG90YWwiOiAxOCwgInN0YXRl
+        IjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMi
+        OiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImE2YTYwZDVh
+        LTM4ZjUtNGU5Yi05YTNjLTNhY2MzZWQ0NjQxNSIsICJudW1fcHJvY2Vzc2Vk
+        IjogMTh9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIlB1
+        Ymxpc2hpbmcgRGVsdGEgUlBNcyIsICJzdGVwX3R5cGUiOiAiZHJwbXMiLCAi
+        aXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9k
         ZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAw
-        LCAic3RlcF9pZCI6ICIxYzUzMDFlOS1jM2E5LTQwY2UtYWU3NS00NzFkMTE2
-        NDc0NjYiLCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjog
-        MCwgImRlc2NyaXB0aW9uIjogIkdlbmVyYXRpbmcgc3FsaXRlIGZpbGVzIiwg
-        InN0ZXBfdHlwZSI6ICJnZW5lcmF0ZSBzcWxpdGUiLCAiaXRlbXNfdG90YWwi
-        OiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJvcl9kZXRhaWxzIjogW10s
-        ICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6
-        ICI5ZjZiODVlMy1iZTAzLTRmMzAtYTQ4MC05MWVhZmUyNWY2YmQiLCAibnVt
-        X3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjogMSwgImRlc2NyaXB0
-        aW9uIjogIlJlbW92aW5nIG9sZCByZXBvZGF0YSIsICJzdGVwX3R5cGUiOiAi
-        cmVtb3ZlX29sZF9yZXBvZGF0YSIsICJpdGVtc190b3RhbCI6IDAsICJzdGF0
-        ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxzIjogW10sICJkZXRhaWxz
-        IjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3RlcF9pZCI6ICI4MmYzOGNj
-        Yy0wMThmLTRlZTktOTc4OC05NjgzODU1YzkxY2UiLCAibnVtX3Byb2Nlc3Nl
-        ZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMCwgImRlc2NyaXB0aW9uIjogIkdl
-        bmVyYXRpbmcgSFRNTCBmaWxlcyIsICJzdGVwX3R5cGUiOiAicmVwb3ZpZXci
-        LCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUiOiAiU0tJUFBFRCIsICJlcnJv
-        cl9kZXRhaWxzIjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMi
-        OiAwLCAic3RlcF9pZCI6ICI1ODZlNDA0OC1mODA1LTRiODQtYTI1OS05NGY3
-        NjIyZmJlMDkiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNz
-        IjogMSwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgZmlsZXMgdG8gd2Vi
-        IiwgInN0ZXBfdHlwZSI6ICJwdWJsaXNoX2RpcmVjdG9yeSIsICJpdGVtc190
-        b3RhbCI6IDEsICJzdGF0ZSI6ICJGSU5JU0hFRCIsICJlcnJvcl9kZXRhaWxz
-        IjogW10sICJkZXRhaWxzIjogIiIsICJudW1fZmFpbHVyZXMiOiAwLCAic3Rl
-        cF9pZCI6ICI0Njc5YWRmMS00YzM1LTQzOTAtYmQzYi0xODM0ZjNjZGUyYzgi
-        LCAibnVtX3Byb2Nlc3NlZCI6IDF9LCB7Im51bV9zdWNjZXNzIjogMSwgImRl
-        c2NyaXB0aW9uIjogIldyaXRpbmcgTGlzdGluZ3MgRmlsZSIsICJzdGVwX3R5
-        cGUiOiAiaW5pdGlhbGl6ZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFs
-        IjogMSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBb
+        LCAic3RlcF9pZCI6ICIxOWM4NWE3OS03ZDdkLTQxYTYtOGIxNy1iMWE0ZjMy
+        MDMwZmYiLCAibnVtX3Byb2Nlc3NlZCI6IDB9LCB7Im51bV9zdWNjZXNzIjog
+        NiwgImRlc2NyaXB0aW9uIjogIlB1Ymxpc2hpbmcgRXJyYXRhIiwgInN0ZXBf
+        dHlwZSI6ICJlcnJhdGEiLCAiaXRlbXNfdG90YWwiOiA2LCAic3RhdGUiOiAi
+        RklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6ICIi
+        LCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiNzJhMDJmOTctOTlj
+        ZS00M2ViLThjM2ItZDZmYjkzNzYxMDhjIiwgIm51bV9wcm9jZXNzZWQiOiA2
+        fSwgeyJudW1fc3VjY2VzcyI6IDksICJkZXNjcmlwdGlvbiI6ICJQdWJsaXNo
+        aW5nIE1vZHVsZXMiLCAic3RlcF90eXBlIjogIm1vZHVsZXMiLCAiaXRlbXNf
+        dG90YWwiOiA5LCAic3RhdGUiOiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWls
+        cyI6IFtdLCAiZGV0YWlscyI6ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0
+        ZXBfaWQiOiAiNTY3MmVlMGItNDJkMC00ODY2LWI1NGUtNjc0NmM4NmJhNTI3
+        IiwgIm51bV9wcm9jZXNzZWQiOiA5fSwgeyJudW1fc3VjY2VzcyI6IDMsICJk
+        ZXNjcmlwdGlvbiI6ICJQdWJsaXNoaW5nIENvbXBzIGZpbGUiLCAic3RlcF90
+        eXBlIjogImNvbXBzIiwgIml0ZW1zX3RvdGFsIjogMywgInN0YXRlIjogIkZJ
+        TklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwg
+        Im51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImIzMzllYTI2LTk0NmUt
+        NGU2Ny1iMTE0LTM0ODkwNDc3MWE1MiIsICJudW1fcHJvY2Vzc2VkIjogM30s
+        IHsibnVtX3N1Y2Nlc3MiOiAyLCAiZGVzY3JpcHRpb24iOiAiUHVibGlzaGlu
+        ZyBNZXRhZGF0YS4iLCAic3RlcF90eXBlIjogIm1ldGFkYXRhIiwgIml0ZW1z
+        X3RvdGFsIjogMiwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFp
+        bHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJz
+        dGVwX2lkIjogIjQ5ZWM1ZWIwLTY0MjgtNDNjOS04Njc1LWU5YTY2YmQ4NmI0
+        ZiIsICJudW1fcHJvY2Vzc2VkIjogMn0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAi
+        ZGVzY3JpcHRpb24iOiAiQ2xvc2luZyByZXBvIG1ldGFkYXRhIiwgInN0ZXBf
+        dHlwZSI6ICJjbG9zZV9yZXBvX21ldGFkYXRhIiwgIml0ZW1zX3RvdGFsIjog
+        MSwgInN0YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwg
+        ImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjog
+        ImQ1YWZlNjc2LTUwZTEtNDNmYi1hMTQ2LTg3NWE2YmQ2ZDgxZSIsICJudW1f
+        cHJvY2Vzc2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRp
+        b24iOiAiR2VuZXJhdGluZyBzcWxpdGUgZmlsZXMiLCAic3RlcF90eXBlIjog
+        ImdlbmVyYXRlIHNxbGl0ZSIsICJpdGVtc190b3RhbCI6IDEsICJzdGF0ZSI6
+        ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAi
+        IiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogIjE5NmYwZTg5LTg0
+        NTctNGMxOS1hYzYwLTY0MDJiNTBiMWMwNSIsICJudW1fcHJvY2Vzc2VkIjog
+        MH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAiUmVtb3Zp
+        bmcgb2xkIHJlcG9kYXRhIiwgInN0ZXBfdHlwZSI6ICJyZW1vdmVfb2xkX3Jl
+        cG9kYXRhIiwgIml0ZW1zX3RvdGFsIjogMCwgInN0YXRlIjogIkZJTklTSEVE
+        IiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFpbHMiOiAiIiwgIm51bV9m
+        YWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImM4OGViMjUzLTM0OTctNDdmYS05
+        YjMxLWI4NWQ1NzY0NDYwMSIsICJudW1fcHJvY2Vzc2VkIjogMX0sIHsibnVt
+        X3N1Y2Nlc3MiOiAwLCAiZGVzY3JpcHRpb24iOiAiR2VuZXJhdGluZyBIVE1M
+        IGZpbGVzIiwgInN0ZXBfdHlwZSI6ICJyZXBvdmlldyIsICJpdGVtc190b3Rh
+        bCI6IDEsICJzdGF0ZSI6ICJTS0lQUEVEIiwgImVycm9yX2RldGFpbHMiOiBb
         XSwgImRldGFpbHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lk
-        IjogIjAzMGI3ZjM0LWQ1YWEtNGZhOS05NzVkLTYyNzk5ZjgxNTc0NiIsICJu
-        dW1fcHJvY2Vzc2VkIjogMX1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsi
-        JG9pZCI6ICI1ZDQ4N2Y4MGFiMzZjZTNmZTUxZGY3MGMifSwgImlkIjogIjVk
-        NDg3ZjgwYWIzNmNlM2ZlNTFkZjcwYyJ9
+        IjogImE0ZDk4MmNmLTYwM2QtNDk3ZC05YzFhLWI2OGEzZjc0MjM1MSIsICJu
+        dW1fcHJvY2Vzc2VkIjogMH0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3Jp
+        cHRpb24iOiAiUHVibGlzaGluZyBmaWxlcyB0byB3ZWIiLCAic3RlcF90eXBl
+        IjogInB1Ymxpc2hfZGlyZWN0b3J5IiwgIml0ZW1zX3RvdGFsIjogMSwgInN0
+        YXRlIjogIkZJTklTSEVEIiwgImVycm9yX2RldGFpbHMiOiBbXSwgImRldGFp
+        bHMiOiAiIiwgIm51bV9mYWlsdXJlcyI6IDAsICJzdGVwX2lkIjogImFkYjM2
+        ZDEyLWIzNTMtNDg0Yy05ZDFlLWZjNTE4MjA4YWY0ZSIsICJudW1fcHJvY2Vz
+        c2VkIjogMX0sIHsibnVtX3N1Y2Nlc3MiOiAxLCAiZGVzY3JpcHRpb24iOiAi
+        V3JpdGluZyBMaXN0aW5ncyBGaWxlIiwgInN0ZXBfdHlwZSI6ICJpbml0aWFs
+        aXplX3JlcG9fbWV0YWRhdGEiLCAiaXRlbXNfdG90YWwiOiAxLCAic3RhdGUi
+        OiAiRklOSVNIRUQiLCAiZXJyb3JfZGV0YWlscyI6IFtdLCAiZGV0YWlscyI6
+        ICIiLCAibnVtX2ZhaWx1cmVzIjogMCwgInN0ZXBfaWQiOiAiMDRhOGZkNjEt
+        MmNjZC00NDc2LTg2NjItMzY0NjQ1MGIwN2MwIiwgIm51bV9wcm9jZXNzZWQi
+        OiAxfV19LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNjkz
+        NDAyMzJkYjYwNzdhNzk2N2MwOCJ9LCAiaWQiOiAiNWQ2OTM0MDIzMmRiNjA3
+        N2E3OTY3YzA4In0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:00 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:43 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1225,21 +775,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '790'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 201
       message: CREATED
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:00 GMT
+      - Fri, 30 Aug 2019 14:34:43 GMT
       Server:
       - Apache
       Content-Length:
@@ -1256,14 +806,14 @@ http_interactions:
         ZWQiOiBudWxsLCAibm90ZXMiOiB7Il9yZXBvLXR5cGUiOiAicnBtLXJlcG8i
         fSwgImxhc3RfdW5pdF9yZW1vdmVkIjogbnVsbCwgImNvbnRlbnRfdW5pdF9j
         b3VudHMiOiB7fSwgIl9ucyI6ICJyZXBvcyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWQ0ODdmODBhY2UyM2YwN2E2N2UwZTkwIn0sICJpZCI6ICIzX3ZpZXcxIiwg
+        NWQ2OTM0MDM3YWNjZTkwN2U1N2E0ZGJlIn0sICJpZCI6ICIzX3ZpZXcxIiwg
         Il9ocmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS8i
         fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:00 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:43 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1274,182 +824,73 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '174'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:00 GMT
+      - Fri, 30 Aug 2019 14:34:43 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '10992'
+      - '2058'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJ3YWxydXMtMC43MS0xLnNy
-        Yy5ycG0iLCAibmFtZSI6ICJ3YWxydXMiLCAiY2hlY2tzdW0iOiAiNTE2YTIy
-        Y2NjMGNiZTNlY2IyY2JlZTFjNjI2YTM5YjkxNzY3ZGJmMGY4MTVhZmRhN2I3
-        MzNhYTU2NTIzMTQyYyIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBv
-        ZiB3YWxydXMiLCAiZmlsZW5hbWUiOiAid2FscnVzLTAuNzEtMS5ub2FyY2gu
-        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjcxIiwgImlzX21v
-        ZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVs
-        ZWFzZSI6ICIxIiwgIl9pZCI6ICIwNzI2MDI4ZC1kM2EwLTQxYzYtYTNjMi1i
-        ODIxM2Q0ODA1NzMiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAi
-        MjAxOS0wOC0wNVQxOToxMTo1OVoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAiY3JlYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjU5WiIsICJ1bml0X3R5
-        cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiMDcyNjAyOGQtZDNhMC00MWM2
-        LWEzYzItYjgyMTNkNDgwNTczIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y3
-        ZmFiMzZjZTNmZTUxZGY0ZDUifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJw
-        bSI6ICJlbGVwaGFudC0wLjItMS5zcmMucnBtIiwgIm5hbWUiOiAiZWxlcGhh
-        bnQiLCAiY2hlY2tzdW0iOiAiMzMzNTFmZDZjMmEzOGU1ZDQ5YWVhNzg4YTJl
-        ODM4ZWFjZDY1NGNmNjFkNDc2YmE1YjY1ZGU0MzlkZGQxMjViOSIsICJzdW1t
-        YXJ5IjogIkZha2UgcHJvdmlkZSBmb3IgZWxlcGhhbnQuIiwgImZpbGVuYW1l
-        IjogImVsZXBoYW50LTAuMi0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIs
-        ICJ2ZXJzaW9uIjogIjAuMiIsICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29u
-        dGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjog
-        IjE3MmM3OTZiLTJiZDMtNDA5NS1hN2E1LTI3Y2RlOGMwOWRlYSIsICJhcmNo
-        IjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjU5
-        WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTkt
-        MDgtMDVUMTk6MTE6NTlaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5p
-        dF9pZCI6ICIxNzJjNzk2Yi0yYmQzLTQwOTUtYTdhNS0yN2NkZThjMDlkZWEi
-        LCAiX2lkIjogeyIkb2lkIjogIjVkNDg3ZjdmYWIzNmNlM2ZlNTFkZjU1MCJ9
-        fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImthbmdhcm9vLTAuMy0x
-        LnNyYy5ycG0iLCAibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVja3N1bSI6ICI4
-        NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcyODBjMTQxZTkyMDJmMDI0ZTdkYjM4
-        Y2JhM2QwOTdjM2YyNTZiMmZkIiwgInN1bW1hcnkiOiAiaG9wIGxpa2UgYSBr
-        YW5nYXJvbyBpbiBBdXN0cmFsaWEiLCAiZmlsZW5hbWUiOiAia2FuZ2Fyb28t
-        MC4zLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAi
-        MC4zIiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6
-        ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICIyZDQ5MWU4My01MGM0
-        LTRjMjUtOTgwNS0zNzNmMjcwZDVlMjEiLCAiYXJjaCI6ICJub2FyY2gifSwg
-        InVwZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjU5
-        WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiMmQ0OTFl
-        ODMtNTBjNC00YzI1LTk4MDUtMzczZjI3MGQ1ZTIxIiwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1ZDQ4N2Y3ZmFiMzZjZTNmZTUxZGY0YjkifX0sIHsibWV0YWRhdGEi
-        OiB7InNvdXJjZXJwbSI6ICJlbGVwaGFudC0wLjMtMC44LnNyYy5ycG0iLCAi
-        bmFtZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFiNDIx
-        MzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEw
-        YTcwMWYzIiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGVsZXBo
-        YW50IiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJw
-        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVs
-        YXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVh
-        c2UiOiAiMC44IiwgIl9pZCI6ICIyZjAwZTcxMC0yYmQ2LTRmNGQtODhlNS04
-        NWNjZDBlZjhjYzAiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAi
-        MjAxOS0wOC0wNVQxOToxMTo1OVoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTci
-        LCAiY3JlYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjU5WiIsICJ1bml0X3R5
-        cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiMmYwMGU3MTAtMmJkNi00ZjRk
-        LTg4ZTUtODVjY2QwZWY4Y2MwIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y3
-        ZmFiMzZjZTNmZTUxZGY0YWMifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJw
-        bSI6ICJhcm1hZGlsbG8tMC4yLTEuc3JjLnJwbSIsICJuYW1lIjogImFybWFk
-        aWxsbyIsICJjaGVja3N1bSI6ICI4ZDMxOTkwNWVlZGI1YTUyNDdlM2EzNTI1
-        ODg5YTI4ZDVkNjRlODIyMDA3NDEzZDAyNTg3YjZmNTFhYjNiNjVhIiwgInN1
-        bW1hcnkiOiAiRmFrZSBwcm92aWRlIGZvciBhcm1hZGlsbG8uIiwgImZpbGVu
-        YW1lIjogImFybWFkaWxsby0wLjItMS5ub2FyY2gucnBtIiwgImVwb2NoIjog
-        IjAiLCAidmVyc2lvbiI6ICIwLjIiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAi
-        X2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9p
-        ZCI6ICIzM2RjYzViMy1mMWQ0LTRiZTYtYTBjZC1hZmJkOGM0MGY2ZjMiLCAi
-        YXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOTox
-        MTo1OVoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIy
-        MDE5LTA4LTA1VDE5OjExOjU5WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwg
-        InVuaXRfaWQiOiAiMzNkY2M1YjMtZjFkNC00YmU2LWEwY2QtYWZiZDhjNDBm
-        NmYzIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y3ZmFiMzZjZTNmZTUxZGY1
-        MzkifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJrYW5nYXJvby0w
-        LjItMS5zcmMucnBtIiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAiY2hlY2tzdW0i
-        OiAiODMzYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODli
-        MGM1YTliZjYxMGRkNjEwM2NlNGNjOCIsICJzdW1tYXJ5IjogIkEgZHVtbXkg
-        cGFja2FnZSBvZiBrYW5nYXJvbyIsICJmaWxlbmFtZSI6ICJrYW5nYXJvby0w
-        LjItMS5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIw
-        LjIiLCAiaXNfbW9kdWxhciI6IHRydWUsICJfY29udGVudF90eXBlX2lkIjog
-        InJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjM5MTBlODk3LThlZDQt
-        NGMxMi05Mjk3LWViMDBjMmVhMWY3MCIsICJhcmNoIjogIm5vYXJjaCJ9LCAi
-        dXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjU5WiIsICJyZXBvX2lkIjog
-        IkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6NTla
-        IiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIzOTEwZTg5
-        Ny04ZWQ0LTRjMTItOTI5Ny1lYjAwYzJlYTFmNzAiLCAiX2lkIjogeyIkb2lk
-        IjogIjVkNDg3ZjdmYWIzNmNlM2ZlNTFkZjUxMyJ9fSwgeyJtZXRhZGF0YSI6
-        IHsic291cmNlcnBtIjogImR1Y2stMC43LTEuc3JjLnJwbSIsICJuYW1lIjog
-        ImR1Y2siLCAiY2hlY2tzdW0iOiAiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2Ez
-        YmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsICJz
-        dW1tYXJ5IjogIlF1YWNrIGxpa2UgYSBkdWNrIGF0IHRoZSBwYXJrLiIsICJm
-        aWxlbmFtZSI6ICJkdWNrLTAuNy0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
-        MCIsICJ2ZXJzaW9uIjogIjAuNyIsICJpc19tb2R1bGFyIjogdHJ1ZSwgIl9j
-        b250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMSIsICJfaWQi
-        OiAiNGRlYjE3MWItZDQ5MC00MDhjLTlhNGMtYTc3NDc1OGRmMjMzIiwgImFy
-        Y2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6
-        NTlaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo1OVoiLCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1
-        bml0X2lkIjogIjRkZWIxNzFiLWQ0OTAtNDA4Yy05YTRjLWE3NzQ3NThkZjIz
-        MyIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmN2ZhYjM2Y2UzZmU1MWRmNGNj
-        In19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAicGVuZ3Vpbi0wLjMt
-        MC44LnNyYy5ycG0iLCAibmFtZSI6ICJwZW5ndWluIiwgImNoZWNrc3VtIjog
-        IjNmY2IyYzkyN2RlOWUxM2JmNjg0NjkwMzJhMjhiMTM5ZDNlNWFkMmU1ODU2
-        NGZjMjEwZmQ2ZTQ4NjM1YmU2OTQiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBh
-        Y2thZ2Ugb2YgcGVuZ3VpbiIsICJmaWxlbmFtZSI6ICJwZW5ndWluLTAuMy0w
-        Ljgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4z
-        IiwgImlzX21vZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAi
-        cnBtIiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICI1OGI0YWY3Ni1hM2Jj
-        LTRjNDMtYWJhZi0xZDcxNTQ5OWJiYTgiLCAiYXJjaCI6ICJub2FyY2gifSwg
-        InVwZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAicmVwb19pZCI6
-        ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjU5
-        WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiNThiNGFm
-        NzYtYTNiYy00YzQzLWFiYWYtMWQ3MTU0OTliYmE4IiwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1ZDQ4N2Y3ZmFiMzZjZTNmZTUxZGY1MWUifX0sIHsibWV0YWRhdGEi
-        OiB7InNvdXJjZXJwbSI6ICJtb25rZXktMC4zLTAuOC5zcmMucnBtIiwgIm5h
-        bWUiOiAibW9ua2V5IiwgImNoZWNrc3VtIjogIjBlOGZhNTBkMDEyOGZiYWJj
-        N2NjYzU2MzJlM2ZhMjVkMzliMDI4MDE2OWY2MTY2Y2I4ZTJjODRkZTg1MDFk
-        YjEiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgbW9ua2V5Iiwg
-        ImZpbGVuYW1lIjogIm1vbmtleS0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBv
-        Y2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFyIjogZmFs
-        c2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjAu
-        OCIsICJfaWQiOiAiNTljN2MzYTgtY2I3ZS00ZDdlLWIzNjItODZkZDhmZDlh
-        MDNlIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMTktMDgt
-        MDVUMTk6MTE6NTlaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0
-        ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAidW5pdF90eXBlX2lkIjog
-        InJwbSIsICJ1bml0X2lkIjogIjU5YzdjM2E4LWNiN2UtNGQ3ZS1iMzYyLTg2
-        ZGQ4ZmQ5YTAzZSIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmN2ZhYjM2Y2Uz
-        ZmU1MWRmNTA3In19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAid2Fs
-        cnVzLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1cyIsICJjaGVj
-        a3N1bSI6ICI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3YjdmODZiZjJl
-        ODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwgInN1bW1hcnkiOiAiQSBk
-        dW1teSBwYWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6ICJ3YWxydXMt
-        MC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
-        ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9p
-        ZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjVhODNmZDU2
-        LTUyNjItNGI1OC05NTBkLWU5MTc2NmI2N2RkYSIsICJhcmNoIjogIm5vYXJj
-        aCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjU5WiIsICJyZXBv
-        X2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTktMDgtMDVUMTk6
-        MTE6NTlaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI1
-        YTgzZmQ1Ni01MjYyLTRiNTgtOTUwZC1lOTE3NjZiNjdkZGEiLCAiX2lkIjog
-        eyIkb2lkIjogIjVkNDg3ZjdmYWIzNmNlM2ZlNTFkZjUzMCJ9fSwgeyJtZXRh
-        ZGF0YSI6IHsic291cmNlcnBtIjogImFybWFkaWxsby0wLjEtMS5zcmMucnBt
-        IiwgIm5hbWUiOiAiYXJtYWRpbGxvIiwgImNoZWNrc3VtIjogImFmNDc4MTMy
-        Zjg4MmU0MmQ0ZjU1Yjk1M2NiODQ2ODI3YzQ4ZjJkMjliN2M2ZTliYmE4OThh
-        NjFkZGMyN2I1ODkiLCAic3VtbWFyeSI6ICJGYWtlIHByb3ZpZGUgZm9yIGFy
-        bWFkaWxsby4iLCAiZmlsZW5hbWUiOiAiYXJtYWRpbGxvLTAuMS0xLm5vYXJj
-        aC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMSIsICJpc19t
-        b2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJy
-        ZWxlYXNlIjogIjEiLCAiX2lkIjogIjY4YzBjYjgxLWUxZTAtNGNmOS1iM2I1
-        LTcwNDZjNGExNzlkMyIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6
-        ICIyMDE5LTA4LTA1VDE5OjExOjU5WiIsICJyZXBvX2lkIjogIkZlZG9yYV8x
-        NyIsICJjcmVhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6NTlaIiwgInVuaXRf
-        dHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI2OGMwY2I4MS1lMWUwLTRj
-        ZjktYjNiNS03MDQ2YzRhMTc5ZDMiLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3
-        ZjdmYWIzNmNlM2ZlNTFkZjRhMyJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNl
+        W3sibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJrYW5nYXJvby0wLjItMS5z
+        cmMucnBtIiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAiY2hlY2tzdW0iOiAiODMz
+        YWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTli
+        ZjYxMGRkNjEwM2NlNGNjOCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2Fn
+        ZSBvZiBrYW5nYXJvbyIsICJmaWxlbmFtZSI6ICJrYW5nYXJvby0wLjItMS5u
+        b2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjIiLCAi
+        aXNfbW9kdWxhciI6IHRydWUsICJfY29udGVudF90eXBlX2lkIjogInJwbSIs
+        ICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjA0YjM3ZTdhLTE4ZDgtNDJiZi1i
+        N2FhLWFjOTY3MzRmODE4NyIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRl
+        ZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQyWiIsICJyZXBvX2lkIjogIkZlZG9y
+        YV8xNyIsICJjcmVhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDJaIiwgInVu
+        aXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIwNGIzN2U3YS0xOGQ4
+        LTQyYmYtYjdhYS1hYzk2NzM0ZjgxODciLCAiX2lkIjogeyIkb2lkIjogIjVk
+        NjkzNDAyMzJkYjYwNzdhNzk2NzI0OCJ9fSwgeyJtZXRhZGF0YSI6IHsic291
+        cmNlcnBtIjogIm1vbmtleS0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6ICJt
+        b25rZXkiLCAiY2hlY2tzdW0iOiAiMGU4ZmE1MGQwMTI4ZmJhYmM3Y2NjNTYz
+        MmUzZmEyNWQzOWIwMjgwMTY5ZjYxNjZjYjhlMmM4NGRlODUwMWRiMSIsICJz
+        dW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBtb25rZXkiLCAiZmlsZW5h
+        bWUiOiAibW9ua2V5LTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIw
+        IiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIiOiBmYWxzZSwgIl9j
+        b250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMC44IiwgIl9p
+        ZCI6ICIwNmFjNjM0ZS05MWY4LTQxNjMtODQ2NS0yYmRkNGU2MzIyMjYiLCAi
+        YXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDoz
+        NDo0MloiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIy
+        MDE5LTA4LTMwVDE0OjM0OjQyWiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwg
+        InVuaXRfaWQiOiAiMDZhYzYzNGUtOTFmOC00MTYzLTg0NjUtMmJkZDRlNjMy
+        MjI2IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzQwMjMyZGI2MDc3YTc5Njcy
+        M2YifX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJsaW9uLTAuMy0w
+        Ljguc3JjLnJwbSIsICJuYW1lIjogImxpb24iLCAiY2hlY2tzdW0iOiAiMTI0
+        MDBkYzk1YzIzYTRjMTYwNzI1YTkwODcxNmNkM2ZjZGQ3YTg5ODE1ODU0Mzdh
+        YjY0Y2Q2MmVmYTNlNGFlNCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2Fn
+        ZSBvZiBsaW9uIiwgImZpbGVuYW1lIjogImxpb24tMC4zLTAuOC5ub2FyY2gu
+        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9k
+        dWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVs
+        ZWFzZSI6ICIwLjgiLCAiX2lkIjogIjFiMjJlMTFkLWYwZWUtNGU0OC05NjE3
+        LWU1MTFiNjQxYzE0MCIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6
+        ICIyMDE5LTA4LTMwVDE0OjM0OjQyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8x
+        NyIsICJjcmVhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDJaIiwgInVuaXRf
+        dHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICIxYjIyZTExZC1mMGVlLTRl
+        NDgtOTYxNy1lNTExYjY0MWMxNDAiLCAiX2lkIjogeyIkb2lkIjogIjVkNjkz
+        NDAyMzJkYjYwNzdhNzk2NzIyNCJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNl
         cnBtIjogImFybWFkaWxsby0yLjEtMS5zcmMucnBtIiwgIm5hbWUiOiAiYXJt
         YWRpbGxvIiwgImNoZWNrc3VtIjogImFiZjY5MWVlNWI0OGU0NDYzMjY4NTli
         OGQ4YThkZjJhMjQxMWI3ZWRhMmMwOGQwNTg5ZTZmM2Q4ZDFmZjM5OWYiLCAi
@@ -1457,99 +898,208 @@ http_interactions:
         ZW5hbWUiOiAiYXJtYWRpbGxvLTIuMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2gi
         OiAiMCIsICJ2ZXJzaW9uIjogIjIuMSIsICJpc19tb2R1bGFyIjogZmFsc2Us
         ICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAi
-        X2lkIjogIjgyZGRhYzgxLTAyNjAtNGEzNS04NDA4LTAxZWVkMTkyMGZhNyIs
-        ICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5
-        OjExOjU5WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjog
-        IjIwMTktMDgtMDVUMTk6MTE6NTlaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0i
-        LCAidW5pdF9pZCI6ICI4MmRkYWM4MS0wMjYwLTRhMzUtODQwOC0wMWVlZDE5
-        MjBmYTciLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3ZjdmYWIzNmNlM2ZlNTFk
-        ZjRmNSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogIndhbHJ1cy01
-        LjIxLTEuc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6
-        ICI3NDUzM2ZiZDRmOWFkYTllMDJhNjM2MWNiYmYwMTRiOGZmODhkZmY4ZDY5
-        Nzg1ZWM0OGI3N2UwMTg5OGU3YzMxIiwgInN1bW1hcnkiOiAiQSBkdW1teSBw
-        YWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6ICJ3YWxydXMtNS4yMS0x
-        Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjUuMjEi
-        LCAiaXNfbW9kdWxhciI6IHRydWUsICJfY29udGVudF90eXBlX2lkIjogInJw
-        bSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImE2NDYyNDA3LWQ0YjMtNGI4
-        MC1hMmRjLTcxMTE4NzExZWJhMCIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBk
-        YXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjU5WiIsICJyZXBvX2lkIjogIkZl
-        ZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6NTlaIiwg
-        InVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJhNjQ2MjQwNy1k
-        NGIzLTRiODAtYTJkYy03MTExODcxMWViYTAiLCAiX2lkIjogeyIkb2lkIjog
-        IjVkNDg3ZjdmYWIzNmNlM2ZlNTFkZjU0NyJ9fSwgeyJtZXRhZGF0YSI6IHsi
-        c291cmNlcnBtIjogImxpb24tMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAi
-        bGlvbiIsICJjaGVja3N1bSI6ICIxMjQwMGRjOTVjMjNhNGMxNjA3MjVhOTA4
-        NzE2Y2QzZmNkZDdhODk4MTU4NTQzN2FiNjRjZDYyZWZhM2U0YWU0IiwgInN1
-        bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGxpb24iLCAiZmlsZW5hbWUi
-        OiAibGlvbi0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2
-        ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29udGVu
-        dF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAi
-        YjgzMTM1MGItYmI0My00YzdkLWIwZjItN2E0MGMyY2QwMjQ2IiwgImFyY2gi
-        OiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6NTla
+        X2lkIjogIjFlYTA5YjgzLTViMjUtNDViYy1iMDAyLTE5ZTgyM2UzZGExNiIs
+        ICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0
+        OjM0OjQyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjog
+        IjIwMTktMDgtMzBUMTQ6MzQ6NDJaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0i
+        LCAidW5pdF9pZCI6ICIxZWEwOWI4My01YjI1LTQ1YmMtYjAwMi0xOWU4MjNl
+        M2RhMTYiLCAiX2lkIjogeyIkb2lkIjogIjVkNjkzNDAyMzJkYjYwNzdhNzk2
+        NzIyZCJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogInBlbmd1aW4t
+        MC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAicGVuZ3VpbiIsICJjaGVja3N1
+        bSI6ICIzZmNiMmM5MjdkZTllMTNiZjY4NDY5MDMyYTI4YjEzOWQzZTVhZDJl
+        NTg1NjRmYzIxMGZkNmU0ODYzNWJlNjk0IiwgInN1bW1hcnkiOiAiQSBkdW1t
+        eSBwYWNrYWdlIG9mIHBlbmd1aW4iLCAiZmlsZW5hbWUiOiAicGVuZ3Vpbi0w
+        LjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjog
+        IjAuMyIsICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lk
+        IjogInJwbSIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiMWY5YmY1ODYt
+        OWZmMi00MTFjLTljNTYtNWQyOTcxYmFjYWEyIiwgImFyY2giOiAibm9hcmNo
+        In0sICJ1cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDJaIiwgInJlcG9f
+        aWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0zMFQxNDoz
+        NDo0MloiLCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjFm
+        OWJmNTg2LTlmZjItNDExYy05YzU2LTVkMjk3MWJhY2FhMiIsICJfaWQiOiB7
+        IiRvaWQiOiAiNWQ2OTM0MDIzMmRiNjA3N2E3OTY3MjUyIn19LCB7Im1ldGFk
+        YXRhIjogeyJzb3VyY2VycG0iOiAiYXJtYWRpbGxvLTAuMS0xLnNyYy5ycG0i
+        LCAibmFtZSI6ICJhcm1hZGlsbG8iLCAiY2hlY2tzdW0iOiAiYWY0NzgxMzJm
+        ODgyZTQyZDRmNTViOTUzY2I4NDY4MjdjNDhmMmQyOWI3YzZlOWJiYTg5OGE2
+        MWRkYzI3YjU4OSIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlkZSBmb3IgYXJt
+        YWRpbGxvLiIsICJmaWxlbmFtZSI6ICJhcm1hZGlsbG8tMC4xLTEubm9hcmNo
+        LnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4xIiwgImlzX21v
+        ZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJl
+        bGVhc2UiOiAiMSIsICJfaWQiOiAiMzBiZjE4OTYtZDExZS00ZTg0LWI1ZmUt
+        M2E2ZThhNGVhN2E1IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjog
+        IjIwMTktMDgtMzBUMTQ6MzQ6NDJaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3
+        IiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDo0MloiLCAidW5pdF90
+        eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjMwYmYxODk2LWQxMWUtNGU4
+        NC1iNWZlLTNhNmU4YTRlYTdhNSIsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTM0
+        MDIzMmRiNjA3N2E3OTY3MWUyIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2Vy
+        cG0iOiAid2FscnVzLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1
+        cyIsICJjaGVja3N1bSI6ICI2ZThkNmRjMDU3ZTNlMmM5ODE5ZjBkYzdlNmM3
+        YjdmODZiZjJlODU3MWJiYTQxNGFkZWM3ZmI2MjFhNDYxZGZkIiwgInN1bW1h
+        cnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6
+        ICJ3YWxydXMtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAi
+        dmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRl
+        bnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjog
+        IjM1NWJmYWE0LTIxNGQtNGE4Yi05ZjQzLTM5NDIwYmZmYTdmYiIsICJhcmNo
+        IjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQy
+        WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTkt
+        MDgtMzBUMTQ6MzQ6NDJaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5p
+        dF9pZCI6ICIzNTViZmFhNC0yMTRkLTRhOGItOWY0My0zOTQyMGJmZmE3ZmIi
+        LCAiX2lkIjogeyIkb2lkIjogIjVkNjkzNDAyMzJkYjYwNzdhNzk2NzI2OCJ9
+        fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImthbmdhcm9vLTAuMy0x
+        LnNyYy5ycG0iLCAibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVja3N1bSI6ICI4
+        NjVhNGM4OTQ4NWJkZDk3MjNhM2M0MDcyODBjMTQxZTkyMDJmMDI0ZTdkYjM4
+        Y2JhM2QwOTdjM2YyNTZiMmZkIiwgInN1bW1hcnkiOiAiaG9wIGxpa2UgYSBr
+        YW5nYXJvbyBpbiBBdXN0cmFsaWEiLCAiZmlsZW5hbWUiOiAia2FuZ2Fyb28t
+        MC4zLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAi
+        MC4zIiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6
+        ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI4NTUxYmRjOS02MTNm
+        LTRkYjItYThkZS1lOTkzZjk5YmQ2ZTUiLCAiYXJjaCI6ICJub2FyY2gifSwg
+        InVwZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDo0MloiLCAicmVwb19pZCI6
+        ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQy
+        WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiODU1MWJk
+        YzktNjEzZi00ZGIyLWE4ZGUtZTk5M2Y5OWJkNmU1IiwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1ZDY5MzQwMjMyZGI2MDc3YTc5NjcxZjcifX0sIHsibWV0YWRhdGEi
+        OiB7InNvdXJjZXJwbSI6ICJnaXJhZmZlLTAuMy0wLjguc3JjLnJwbSIsICJu
+        YW1lIjogImdpcmFmZmUiLCAiY2hlY2tzdW0iOiAiZjI1ZDY3ZDFkOWRhMDRm
+        MTJlNTdjYTMyMzI0N2I0Mzg5MWFjNDY1MzNlMzU1YjgyZGU2ZDE5MjIwMDlm
+        OWYxNCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBnaXJhZmZl
+        IiwgImZpbGVuYW1lIjogImdpcmFmZmUtMC4zLTAuOC5ub2FyY2gucnBtIiwg
+        ImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6
+        IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6
+        ICIwLjgiLCAiX2lkIjogIjhiYTI1MDFkLTZiZTQtNGVkZi1iMmEwLWM1M2U0
+        ZWVhYmNiOSIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDE5
+        LTA4LTMwVDE0OjM0OjQyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJj
+        cmVhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDJaIiwgInVuaXRfdHlwZV9p
+        ZCI6ICJycG0iLCAidW5pdF9pZCI6ICI4YmEyNTAxZC02YmU0LTRlZGYtYjJh
+        MC1jNTNlNGVlYWJjYjkiLCAiX2lkIjogeyIkb2lkIjogIjVkNjkzNDAyMzJk
+        YjYwNzdhNzk2NzIxYiJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjog
+        InNxdWlycmVsLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogInNxdWlycmVs
+        IiwgImNoZWNrc3VtIjogIjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2
+        YWVjZDAxNTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCAic3VtbWFy
+        eSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCAiZmlsZW5hbWUi
+        OiAic3F1aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAi
+        LCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2Nv
+        bnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lk
+        IjogIjhmZDQzMDViLTFkODEtNDA0Mi04ODU3LWJlMjE5MmJmMzE0NyIsICJh
+        cmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0
+        OjQyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIw
+        MTktMDgtMzBUMTQ6MzQ6NDJaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAi
+        dW5pdF9pZCI6ICI4ZmQ0MzA1Yi0xZDgxLTQwNDItODg1Ny1iZTIxOTJiZjMx
+        NDciLCAiX2lkIjogeyIkb2lkIjogIjVkNjkzNDAyMzJkYjYwNzdhNzk2NzIw
+        MCJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImVsZXBoYW50LTAu
+        My0wLjguc3JjLnJwbSIsICJuYW1lIjogImVsZXBoYW50IiwgImNoZWNrc3Vt
+        IjogIjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVm
+        NjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCAic3VtbWFyeSI6ICJBIGR1bW15
+        IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQt
+        MC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6
+        ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlwZV9p
+        ZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjk0NDE4NzFl
+        LTIxNDYtNDRhNC04NTQ0LWUzOTAyY2RhNjZlYiIsICJhcmNoIjogIm5vYXJj
+        aCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQyWiIsICJyZXBv
+        X2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTktMDgtMzBUMTQ6
+        MzQ6NDJaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICI5
+        NDQxODcxZS0yMTQ2LTQ0YTQtODU0NC1lMzkwMmNkYTY2ZWIiLCAiX2lkIjog
+        eyIkb2lkIjogIjVkNjkzNDAyMzJkYjYwNzdhNzk2NzFlZSJ9fSwgeyJtZXRh
+        ZGF0YSI6IHsic291cmNlcnBtIjogImR1Y2stMC42LTEuc3JjLnJwbSIsICJu
+        YW1lIjogImR1Y2siLCAiY2hlY2tzdW0iOiAiOTZmMzc4Nzc1MThhMWZlNmVh
+        MmUxN2Y0Y2UxZmM4MWI0MDkwODA0M2JjYmVkNzY3NDRiM2Q3ZDM4YTc3NGJj
+        NyIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBkdWNrIiwgImZp
+        bGVuYW1lIjogImR1Y2stMC42LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIw
+        IiwgInZlcnNpb24iOiAiMC42IiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2Nv
+        bnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6
+        ICI5NTJmZDk0MS1iOGExLTRhNGYtYjI0Yy00N2NiMTQzZjJmYjIiLCAiYXJj
+        aCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDo0
+        MloiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5
+        LTA4LTMwVDE0OjM0OjQyWiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVu
+        aXRfaWQiOiAiOTUyZmQ5NDEtYjhhMS00YTRmLWIyNGMtNDdjYjE0M2YyZmIy
+        IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzQwMjMyZGI2MDc3YTc5NjcyMzYi
+        fX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJkdWNrLTAuNy0xLnNy
+        Yy5ycG0iLCAibmFtZSI6ICJkdWNrIiwgImNoZWNrc3VtIjogIjViZDM2M2I4
+        NjBhZDY3ODMyMTdjYmNhM2JiYzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4
+        ZTNmNjZjMjQ3MTIiLCAic3VtbWFyeSI6ICJRdWFjayBsaWtlIGEgZHVjayBh
+        dCB0aGUgcGFyay4iLCAiZmlsZW5hbWUiOiAiZHVjay0wLjctMS5ub2FyY2gu
+        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjciLCAiaXNfbW9k
+        dWxhciI6IHRydWUsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxl
+        YXNlIjogIjEiLCAiX2lkIjogImExOGRmNjI5LWE1NWEtNDMyYy1iZDcxLTZi
+        NGUxYTE2ZDdiNiIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIy
+        MDE5LTA4LTMwVDE0OjM0OjQyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
+        ICJjcmVhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDJaIiwgInVuaXRfdHlw
+        ZV9pZCI6ICJycG0iLCAidW5pdF9pZCI6ICJhMThkZjYyOS1hNTVhLTQzMmMt
+        YmQ3MS02YjRlMWExNmQ3YjYiLCAiX2lkIjogeyIkb2lkIjogIjVkNjkzNDAy
+        MzJkYjYwNzdhNzk2NzIwOSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBt
+        IjogImNoZWV0YWgtMC4zLTAuOC5zcmMucnBtIiwgIm5hbWUiOiAiY2hlZXRh
+        aCIsICJjaGVja3N1bSI6ICI0MjJkMGJhYTBjZDlkNzcxM2FlNzk2ZTg4NmEy
+        M2UxN2Y1NzhmOTI0Zjc0ODgwZGViZGJiN2Q2NWZiMzY4ZGFlIiwgInN1bW1h
+        cnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGNoZWV0YWgiLCAiZmlsZW5hbWUi
+        OiAiY2hlZXRhaC0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFyIjogZmFsc2UsICJfY29u
+        dGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjAuOCIsICJfaWQi
+        OiAiYTQ0OWNjNjUtZWQ4Yy00Y2UzLWFlMTItODg1OGI0ZTBiYWY3IiwgImFy
+        Y2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6
+        NDJaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAx
+        OS0wOC0zMFQxNDozNDo0MloiLCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1
+        bml0X2lkIjogImE0NDljYzY1LWVkOGMtNGNlMy1hZTEyLTg4NThiNGUwYmFm
+        NyIsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTM0MDIzMmRiNjA3N2E3OTY3MjVk
+        In19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAid2FscnVzLTUuMjEt
+        MS5zcmMucnBtIiwgIm5hbWUiOiAid2FscnVzIiwgImNoZWNrc3VtIjogIjc0
+        NTMzZmJkNGY5YWRhOWUwMmE2MzYxY2JiZjAxNGI4ZmY4OGRmZjhkNjk3ODVl
+        YzQ4Yjc3ZTAxODk4ZTdjMzEiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2th
+        Z2Ugb2Ygd2FscnVzIiwgImZpbGVuYW1lIjogIndhbHJ1cy01LjIxLTEubm9h
+        cmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiNS4yMSIsICJp
+        c19tb2R1bGFyIjogdHJ1ZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwg
+        InJlbGVhc2UiOiAiMSIsICJfaWQiOiAiYmE3NzFkZjgtM2VmZC00OTJiLTkx
+        YTQtNjJhMmY5OGQwMjhhIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVk
+        IjogIjIwMTktMDgtMzBUMTQ6MzQ6NDJaIiwgInJlcG9faWQiOiAiRmVkb3Jh
+        XzE3IiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDo0MloiLCAidW5p
+        dF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogImJhNzcxZGY4LTNlZmQt
+        NDkyYi05MWE0LTYyYTJmOThkMDI4YSIsICJfaWQiOiB7IiRvaWQiOiAiNWQ2
+        OTM0MDIzMmRiNjA3N2E3OTY3MjdhIn19LCB7Im1ldGFkYXRhIjogeyJzb3Vy
+        Y2VycG0iOiAid2FscnVzLTAuNzEtMS5zcmMucnBtIiwgIm5hbWUiOiAid2Fs
+        cnVzIiwgImNoZWNrc3VtIjogIjUxNmEyMmNjYzBjYmUzZWNiMmNiZWUxYzYy
+        NmEzOWI5MTc2N2RiZjBmODE1YWZkYTdiNzMzYWE1NjUyMzE0MmMiLCAic3Vt
+        bWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwgImZpbGVuYW1l
+        IjogIndhbHJ1cy0wLjcxLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwg
+        InZlcnNpb24iOiAiMC43MSIsICJpc19tb2R1bGFyIjogdHJ1ZSwgIl9jb250
+        ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAi
+        ZDdkMjQ0NDAtYWY5Ny00ODVjLThmNWMtNDdlMDRiMjgxMGFkIiwgImFyY2gi
+        OiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDJa
         IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAxOS0w
-        OC0wNVQxOToxMTo1OVoiLCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0
-        X2lkIjogImI4MzEzNTBiLWJiNDMtNGM3ZC1iMGYyLTdhNDBjMmNkMDI0NiIs
-        ICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmN2ZhYjM2Y2UzZmU1MWRmNGVjIn19
-        LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAiZHVjay0wLjYtMS5zcmMu
-        cnBtIiwgIm5hbWUiOiAiZHVjayIsICJjaGVja3N1bSI6ICI5NmYzNzg3NzUx
-        OGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQzYmNiZWQ3Njc0NGIzZDdk
-        MzhhNzc0YmM3IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdlIG9mIGR1
-        Y2siLCAiZmlsZW5hbWUiOiAiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwgImVw
-        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjYiLCAiaXNfbW9kdWxhciI6IHRy
-        dWUsICJfY29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEi
-        LCAiX2lkIjogImNlMDkzNzJhLWExYTAtNGFlYi1iZjJjLWY2MGEwYTFmYWQ5
-        NSIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTA1
-        VDE5OjExOjU5WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
-        IjogIjIwMTktMDgtMDVUMTk6MTE6NTlaIiwgInVuaXRfdHlwZV9pZCI6ICJy
-        cG0iLCAidW5pdF9pZCI6ICJjZTA5MzcyYS1hMWEwLTRhZWItYmYyYy1mNjBh
-        MGExZmFkOTUiLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3ZjdmYWIzNmNlM2Zl
-        NTFkZjRmZSJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogInNxdWly
-        cmVsLTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogInNxdWlycmVsIiwgImNo
-        ZWNrc3VtIjogIjI1MTc2OGJkZDE1ZjEzZDc4NDg3YzI3NjM4YWE2YWVjZDAx
-        NTUxZTI1Mzc1NjA5M2NkZTFjMGFlODc4YTE3ZDIiLCAic3VtbWFyeSI6ICJB
-        IGR1bW15IHBhY2thZ2Ugb2Ygc3F1aXJyZWwiLCAiZmlsZW5hbWUiOiAic3F1
-        aXJyZWwtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVy
-        c2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRf
-        dHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogImQ4
-        OTc0MjM1LWQ4MjAtNGMwMC1iNTRiLWQ4ZjQ3NzQ3M2UwMCIsICJhcmNoIjog
-        Im5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjU5WiIs
-        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTktMDgt
-        MDVUMTk6MTE6NTlaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5pdF9p
-        ZCI6ICJkODk3NDIzNS1kODIwLTRjMDAtYjU0Yi1kOGY0Nzc0NzNlMDAiLCAi
-        X2lkIjogeyIkb2lkIjogIjVkNDg3ZjdmYWIzNmNlM2ZlNTFkZjRjMyJ9fSwg
-        eyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImdpcmFmZmUtMC4zLTAuOC5z
-        cmMucnBtIiwgIm5hbWUiOiAiZ2lyYWZmZSIsICJjaGVja3N1bSI6ICJmMjVk
-        NjdkMWQ5ZGEwNGYxMmU1N2NhMzIzMjQ3YjQzODkxYWM0NjUzM2UzNTViODJk
-        ZTZkMTkyMjAwOWY5ZjE0IiwgInN1bW1hcnkiOiAiQSBkdW1teSBwYWNrYWdl
-        IG9mIGdpcmFmZmUiLCAiZmlsZW5hbWUiOiAiZ2lyYWZmZS0wLjMtMC44Lm5v
-        YXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJp
-        c19tb2R1bGFyIjogZmFsc2UsICJfY29udGVudF90eXBlX2lkIjogInJwbSIs
-        ICJyZWxlYXNlIjogIjAuOCIsICJfaWQiOiAiZTFjMzRiZjYtMWVjNi00ODYw
-        LWI3OTktZDAyODY1OWNhYTczIiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRh
-        dGVkIjogIjIwMTktMDgtMDVUMTk6MTE6NTlaIiwgInJlcG9faWQiOiAiRmVk
-        b3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAi
-        dW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogImUxYzM0YmY2LTFl
-        YzYtNDg2MC1iNzk5LWQwMjg2NTljYWE3MyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWQ0ODdmN2ZhYjM2Y2UzZmU1MWRmNGRlIn19LCB7Im1ldGFkYXRhIjogeyJz
-        b3VyY2VycG0iOiAiY2hlZXRhaC0wLjMtMC44LnNyYy5ycG0iLCAibmFtZSI6
-        ICJjaGVldGFoIiwgImNoZWNrc3VtIjogIjQyMmQwYmFhMGNkOWQ3NzEzYWU3
-        OTZlODg2YTIzZTE3ZjU3OGY5MjRmNzQ4ODBkZWJkYmI3ZDY1ZmIzNjhkYWUi
-        LCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgY2hlZXRhaCIsICJm
-        aWxlbmFtZSI6ICJjaGVldGFoLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9j
-        aCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgImlzX21vZHVsYXIiOiBmYWxz
-        ZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMC44
-        IiwgIl9pZCI6ICJmMTYzZmI3MC0wYTI4LTQyMjAtOWEwNi1hMTliMTI0MTQ3
-        MzkiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0w
-        NVQxOToxMTo1OVoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRl
-        ZCI6ICIyMDE5LTA4LTA1VDE5OjExOjU5WiIsICJ1bml0X3R5cGVfaWQiOiAi
-        cnBtIiwgInVuaXRfaWQiOiAiZjE2M2ZiNzAtMGEyOC00MjIwLTlhMDYtYTE5
-        YjEyNDE0NzM5IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y3ZmFiMzZjZTNm
-        ZTUxZGY1MjcifX1d
+        OC0zMFQxNDozNDo0MloiLCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0
+        X2lkIjogImQ3ZDI0NDQwLWFmOTctNDg1Yy04ZjVjLTQ3ZTA0YjI4MTBhZCIs
+        ICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTM0MDIzMmRiNjA3N2E3OTY3MjEyIn19
+        LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAiYXJtYWRpbGxvLTAuMi0x
+        LnNyYy5ycG0iLCAibmFtZSI6ICJhcm1hZGlsbG8iLCAiY2hlY2tzdW0iOiAi
+        OGQzMTk5MDVlZWRiNWE1MjQ3ZTNhMzUyNTg4OWEyOGQ1ZDY0ZTgyMjAwNzQx
+        M2QwMjU4N2I2ZjUxYWIzYjY1YSIsICJzdW1tYXJ5IjogIkZha2UgcHJvdmlk
+        ZSBmb3IgYXJtYWRpbGxvLiIsICJmaWxlbmFtZSI6ICJhcm1hZGlsbG8tMC4y
+        LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4y
+        IiwgImlzX21vZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQiOiAi
+        cnBtIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiZGQ0NjZiM2MtMGNhMS00
+        MjAwLTk0ZDctYTdmZGE1M2ZjMDI2IiwgImFyY2giOiAibm9hcmNoIn0sICJ1
+        cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDJaIiwgInJlcG9faWQiOiAi
+        RmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDo0Mloi
+        LCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogImRkNDY2YjNj
+        LTBjYTEtNDIwMC05NGQ3LWE3ZmRhNTNmYzAyNiIsICJfaWQiOiB7IiRvaWQi
+        OiAiNWQ2OTM0MDIzMmRiNjA3N2E3OTY3MjcxIn19LCB7Im1ldGFkYXRhIjog
+        eyJzb3VyY2VycG0iOiAiZWxlcGhhbnQtMC4yLTEuc3JjLnJwbSIsICJuYW1l
+        IjogImVsZXBoYW50IiwgImNoZWNrc3VtIjogIjMzMzUxZmQ2YzJhMzhlNWQ0
+        OWFlYTc4OGEyZTgzOGVhY2Q2NTRjZjYxZDQ3NmJhNWI2NWRlNDM5ZGRkMTI1
+        YjkiLCAic3VtbWFyeSI6ICJGYWtlIHByb3ZpZGUgZm9yIGVsZXBoYW50LiIs
+        ICJmaWxlbmFtZSI6ICJlbGVwaGFudC0wLjItMS5ub2FyY2gucnBtIiwgImVw
+        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjIiLCAiaXNfbW9kdWxhciI6IGZh
+        bHNlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIx
+        IiwgIl9pZCI6ICJlMmEzZGY1OC05MWQ2LTQ2M2MtOTVlMi1lYWQ2ZGEzYTA4
+        MDkiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0z
+        MFQxNDozNDo0MloiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRl
+        ZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQyWiIsICJ1bml0X3R5cGVfaWQiOiAi
+        cnBtIiwgInVuaXRfaWQiOiAiZTJhM2RmNTgtOTFkNi00NjNjLTk1ZTItZWFk
+        NmRhM2EwODA5IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzQwMjMyZGI2MDc3
+        YTc5NjcyODMifX1d
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:00 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:43 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1560,21 +1110,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '177'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:00 GMT
+      - Fri, 30 Aug 2019 14:34:43 GMT
       Server:
       - Apache
       Content-Length:
@@ -1587,10 +1137,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:00 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:43 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1599,2156 +1149,158 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '60'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:00 GMT
+      - Fri, 30 Aug 2019 14:34:43 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '5435'
+      - '1313'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
         W3sibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
-        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzFiLzJmMDAzOTY0YmI2NDIxZGU3
-        NDI3N2RiMTljOWNhOGQzMzNhYmE5NjM5MzkxMGM3ODBlNTcwMGRjOGE4M2Ez
-        IiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
-        OiBbImR1Y2stMDowLjYtMS5ub2FyY2giXSwgImNoZWNrc3VtIjogIjZiZDlk
-        OTA5YzkyNzA1NzFiODExZTUwMjcwOWVhN2I1NjE1MGQ0NGEyYjRiMzRjZmQy
-        NWU1MmE4MWM1YmZjZTciLCAiX2xhc3RfdXBkYXRlZCI6IDE1NjUwMzIwOTYs
-        ICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2ZpbGVzIjog
-        eyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNrIDAuNiBt
-        b2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3
-        MDQyNDQyMDUsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQi
-        OiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVu
-        ZGVuY2llcyI6IFtdLCAiX2lkIjogIjA5NzQ2YTlhLTUwMjYtNGVmMi1hNWM1
-        LWM1YjA4MTcwZjQ0YSIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNjcmlwdGlv
-        biI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC42IHBhY2thZ2UifSwgInVw
-        ZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjU5WiIs
-        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICIwOTc0
-        NmE5YS01MDI2LTRlZjItYTVjNS1jNWIwODE3MGY0NGEiLCAiX2lkIjogeyIk
-        b2lkIjogIjVkNDg3ZjdmYWIzNmNlM2ZlNTFkZjVjMCJ9fSwgeyJtZXRhZGF0
+        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kL2VhL2E4NzIwM2FhNzFhY2QwOWVk
+        NGM4NzBlMDg3NTQ5ZGEyYTVkMmNhYzdjYjllZWQ3ZTdiMDYzYmY5ZjQ5N2E5
+        IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICIwLjcxIiwgImFydGlm
+        YWN0cyI6IFsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCAiY2hlY2tzdW0i
+        OiAiODNmNmFmZjMyNjE0ODU3ZTk5MDk4NzZhNGZiN2E5NWQ1OTE5NWZkOThi
+        OWEyN2EwNjRhOTQyZWNiYzRmNDY4MiIsICJfbGFzdF91cGRhdGVkIjogMTU2
+        NzE3NTY2MSwgIl9jb250ZW50X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAicHJv
+        ZmlsZXMiOiB7ImRlZmF1bHQiOiBbIndhbHJ1cyJdLCAiZmxpcHBlciI6IFsi
+        d2FscnVzIl19LCAic3VtbWFyeSI6ICJXYWxydXMgMC43MSBtb2R1bGUiLCAi
+        ZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3MDcxNDQyMDMs
+        ICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQiOiAiYzBmZmVl
+        NDIiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVuZGVuY2llcyI6
+        IFtdLCAiX2lkIjogIjBiZWU4ZTBjLWFlYWEtNGE4MS04YWZmLWQxODNjMDQ4
+        NTIxNyIsICJhcmNoIjogIng4Nl82NCIsICJkZXNjcmlwdGlvbiI6ICJBIG1v
+        ZHVsZSBmb3IgdGhlIHdhbHJ1cyAwLjcxIHBhY2thZ2UifSwgInVwZGF0ZWQi
+        OiAiMjAxOS0wOC0zMFQxNDozNDo0MloiLCAicmVwb19pZCI6ICJGZWRvcmFf
+        MTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQyWiIsICJ1bml0
+        X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICIwYmVlOGUwYy1h
+        ZWFhLTRhODEtOGFmZi1kMTgzYzA0ODUyMTciLCAiX2lkIjogeyIkb2lkIjog
+        IjVkNjkzNDAyMzJkYjYwNzdhNzk2NzJmNiJ9fSwgeyJtZXRhZGF0YSI6IHsi
+        X3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQvdW5pdHMv
+        bW9kdWxlbWQvNDEvOWMyNmNhMDMyMmYwNDU4YWI3NGY1ODc2ZTI5YTM2NmY4
+        MGMyYjQ5MDIwZjY2M2FiYjlmZjRiYmRjYmQ2Y2MiLCAibmFtZSI6ICJ3YWxy
+        dXMiLCAic3RyZWFtIjogIjUuMjEiLCAiYXJ0aWZhY3RzIjogWyJ3YWxydXMt
+        MDo1LjIxLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICJmYzBjYjk1MGU1M2M1
+        ZWE5OWIwM2JjYWM0MjcyNWM2MDI5NWYxNDhhYWFkZTFhN2NlNmM3ZDgwMjhh
+        MDczYjU5IiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTY3MTc1NjYxLCAiX2NvbnRl
+        bnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxlcyI6IHsiZGVmYXVs
+        dCI6IFsid2FscnVzIl19LCAic3VtbWFyeSI6ICJXYWxydXMgNS4yMSBtb2R1
+        bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3MDQx
+        NDQyMDMsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQiOiAi
+        ZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVuZGVu
+        Y2llcyI6IFtdLCAiX2lkIjogIjM0YTk5YzA1LWJmMjgtNDQ5ZC1hN2FhLTU4
+        MDY1ZmY4ODRiOCIsICJhcmNoIjogIng4Nl82NCIsICJkZXNjcmlwdGlvbiI6
+        ICJBIG1vZHVsZSBmb3IgdGhlIHdhbHJ1cyA1LjIxIHBhY2thZ2UifSwgInVw
+        ZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDo0MloiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQyWiIs
+        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICIzNGE5
+        OWMwNS1iZjI4LTQ0OWQtYTdhYS01ODA2NWZmODg0YjgiLCAiX2lkIjogeyIk
+        b2lkIjogIjVkNjkzNDAyMzJkYjYwNzdhNzk2NzJlZCJ9fSwgeyJtZXRhZGF0
         YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQv
         dW5pdHMvbW9kdWxlbWQvMDQvZjU1ODZlZTE0ZGU0ZTM1YzY3YWIwOGQyNmNi
         N2EwNWU3ZmZmMGRlMDdkY2VhYjY2MTMzYTU4MjBjMzgyY2UiLCAibmFtZSI6
         ICJkdWNrIiwgInN0cmVhbSI6ICIwIiwgImFydGlmYWN0cyI6IFsiZHVjay0w
         OjAuNy0xLm5vYXJjaCJdLCAiY2hlY2tzdW0iOiAiZGQ2MjFjMDU4Y2RlMWU2
         NzU3OGZkYzE3MTMzMjQ1YTY1MTc5NmFmYzA4NzNkODU2Yjc5MGE3ZjcwMjgy
-        NTAyMSIsICJfbGFzdF91cGRhdGVkIjogMTU2NTAzMjA5NiwgIl9jb250ZW50
+        NTAyMSIsICJfbGFzdF91cGRhdGVkIjogMTU2NzE3NTY2MSwgIl9jb250ZW50
         X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAicHJvZmlsZXMiOiB7ImRlZmF1bHQi
         OiBbImR1Y2siXX0sICJzdW1tYXJ5IjogIkR1Y2sgMC43IG1vZHVsZSIsICJk
         b3dubG9hZGVkIjogdHJ1ZSwgInZlcnNpb24iOiAyMDE4MDczMDIzMzEwMiwg
         InB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiY29udGV4dCI6ICJkZWFkYmVl
         ZiIsICJfbnMiOiAidW5pdHNfbW9kdWxlbWQiLCAiZGVwZW5kZW5jaWVzIjog
-        W10sICJfaWQiOiAiMWRiNjRjYWItMGE1ZS00YmQ4LWJmNTItNDFiMDdkY2Nk
-        NTM2IiwgImFyY2giOiAibm9hcmNoIiwgImRlc2NyaXB0aW9uIjogIkEgbW9k
+        W10sICJfaWQiOiAiNzNkYTgxYTAtMDVjZi00NTljLWIzMDEtMjBmMDI1ZDJj
+        MDU0IiwgImFyY2giOiAibm9hcmNoIiwgImRlc2NyaXB0aW9uIjogIkEgbW9k
         dWxlIGZvciB0aGUgZHVjayAwLjcgcGFja2FnZSJ9LCAidXBkYXRlZCI6ICIy
-        MDE5LTA4LTA1VDE5OjExOjU5WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
-        ICJjcmVhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6NTlaIiwgInVuaXRfdHlw
-        ZV9pZCI6ICJtb2R1bGVtZCIsICJ1bml0X2lkIjogIjFkYjY0Y2FiLTBhNWUt
-        NGJkOC1iZjUyLTQxYjA3ZGNjZDUzNiIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0
-        ODdmN2ZhYjM2Y2UzZmU1MWRmNWI0In19LCB7Im1ldGFkYXRhIjogeyJfc3Rv
-        cmFnZV9wYXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0cy9tb2R1
-        bGVtZC9lYS9hODcyMDNhYTcxYWNkMDllZDRjODcwZTA4NzU0OWRhMmE1ZDJj
-        YWM3Y2I5ZWVkN2U3YjA2M2JmOWY0OTdhOSIsICJuYW1lIjogIndhbHJ1cyIs
-        ICJzdHJlYW0iOiAiMC43MSIsICJhcnRpZmFjdHMiOiBbIndhbHJ1cy0wOjAu
-        NzEtMS5ub2FyY2giXSwgImNoZWNrc3VtIjogIjgzZjZhZmYzMjYxNDg1N2U5
-        OTA5ODc2YTRmYjdhOTVkNTkxOTVmZDk4YjlhMjdhMDY0YTk0MmVjYmM0ZjQ2
-        ODIiLCAiX2xhc3RfdXBkYXRlZCI6IDE1NjUwMzIwOTYsICJfY29udGVudF90
-        eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2ZpbGVzIjogeyJkZWZhdWx0Ijog
-        WyJ3YWxydXMiXSwgImZsaXBwZXIiOiBbIndhbHJ1cyJdfSwgInN1bW1hcnki
-        OiAiV2FscnVzIDAuNzEgbW9kdWxlIiwgImRvd25sb2FkZWQiOiB0cnVlLCAi
-        dmVyc2lvbiI6IDIwMTgwNzA3MTQ0MjAzLCAicHVscF91c2VyX21ldGFkYXRh
-        Ijoge30sICJjb250ZXh0IjogImMwZmZlZTQyIiwgIl9ucyI6ICJ1bml0c19t
-        b2R1bGVtZCIsICJkZXBlbmRlbmNpZXMiOiBbXSwgIl9pZCI6ICIyYjM0YWY5
-        Ni1jMTRkLTQwY2EtYjA4Ni1kZDg2MDk2MThlOWIiLCAiYXJjaCI6ICJ4ODZf
-        NjQiLCAiZGVzY3JpcHRpb24iOiAiQSBtb2R1bGUgZm9yIHRoZSB3YWxydXMg
-        MC43MSBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6
-        NTlaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAx
-        OS0wOC0wNVQxOToxMTo1OVoiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1k
-        IiwgInVuaXRfaWQiOiAiMmIzNGFmOTYtYzE0ZC00MGNhLWIwODYtZGQ4NjA5
-        NjE4ZTliIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y3ZmFiMzZjZTNmZTUx
-        ZGY1ZDcifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zh
-        ci9saWIvcHVscC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzQxLzljMjZjYTAz
-        MjJmMDQ1OGFiNzRmNTg3NmUyOWEzNjZmODBjMmI0OTAyMGY2NjNhYmI5ZmY0
-        YmJkY2JkNmNjIiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICI1LjIx
-        IiwgImFydGlmYWN0cyI6IFsid2FscnVzLTA6NS4yMS0xLm5vYXJjaCJdLCAi
-        Y2hlY2tzdW0iOiAiZmMwY2I5NTBlNTNjNWVhOTliMDNiY2FjNDI3MjVjNjAy
-        OTVmMTQ4YWFhZGUxYTdjZTZjN2Q4MDI4YTA3M2I1OSIsICJfbGFzdF91cGRh
-        dGVkIjogMTU2NTAzMjA5NiwgIl9jb250ZW50X3R5cGVfaWQiOiAibW9kdWxl
-        bWQiLCAicHJvZmlsZXMiOiB7ImRlZmF1bHQiOiBbIndhbHJ1cyJdfSwgInN1
-        bW1hcnkiOiAiV2FscnVzIDUuMjEgbW9kdWxlIiwgImRvd25sb2FkZWQiOiB0
-        cnVlLCAidmVyc2lvbiI6IDIwMTgwNzA0MTQ0MjAzLCAicHVscF91c2VyX21l
-        dGFkYXRhIjoge30sICJjb250ZXh0IjogImRlYWRiZWVmIiwgIl9ucyI6ICJ1
-        bml0c19tb2R1bGVtZCIsICJkZXBlbmRlbmNpZXMiOiBbXSwgIl9pZCI6ICJi
-        MWViZDJlOC0xNDg3LTQxNjctYTdhNi1kYTM2N2ExODFlY2IiLCAiYXJjaCI6
-        ICJ4ODZfNjQiLCAiZGVzY3JpcHRpb24iOiAiQSBtb2R1bGUgZm9yIHRoZSB3
-        YWxydXMgNS4yMSBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMDVU
-        MTk6MTE6NTlaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQi
-        OiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAidW5pdF90eXBlX2lkIjogIm1v
-        ZHVsZW1kIiwgInVuaXRfaWQiOiAiYjFlYmQyZTgtMTQ4Ny00MTY3LWE3YTYt
-        ZGEzNjdhMTgxZWNiIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y3ZmFiMzZj
-        ZTNmZTUxZGY1YzkifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgi
-        OiAiL3Zhci9saWIvcHVscC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzkwLzY2
-        ZjZiNDNiMWI0ZGYwOWY4YTY4Nzk3YTA3YTg0ZmQzZjU1ZTQ3NGY3ZDM5OTNl
-        ZjJhOGRjNzQxOGQxMDAxIiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAic3RyZWFt
-        IjogIjAiLCAiYXJ0aWZhY3RzIjogWyJrYW5nYXJvby0wOjAuMi0xLm5vYXJj
-        aCJdLCAiY2hlY2tzdW0iOiAiZTgyMGUwOGMwNWFhNzM2Y2U1MzAwNjZjNjg4
-        Mjg4YmY1NzQ2MDk4MjY3YzI4MjQyNzllMzZjOWE3MmU2YjljZSIsICJfbGFz
-        dF91cGRhdGVkIjogMTU2NTAzMjA5NiwgIl9jb250ZW50X3R5cGVfaWQiOiAi
-        bW9kdWxlbWQiLCAicHJvZmlsZXMiOiB7ImRlZmF1bHQiOiBbImthbmdhcm9v
-        Il19LCAic3VtbWFyeSI6ICJLYW5nYXJvbyAwLjIgbW9kdWxlIiwgImRvd25s
-        b2FkZWQiOiB0cnVlLCAidmVyc2lvbiI6IDIwMTgwNzA0MTExNzE5LCAicHVs
-        cF91c2VyX21ldGFkYXRhIjoge30sICJjb250ZXh0IjogImRlYWRiZWVmIiwg
-        Il9ucyI6ICJ1bml0c19tb2R1bGVtZCIsICJkZXBlbmRlbmNpZXMiOiBbXSwg
-        Il9pZCI6ICJjYjk0NDA0NC05NWYxLTQ0OTktYjgwNy01ZTgzZTc4NzMyMTYi
-        LCAiYXJjaCI6ICJub2FyY2giLCAiZGVzY3JpcHRpb24iOiAiQSBtb2R1bGUg
-        Zm9yIHRoZSBrYW5nYXJvbyAwLjIgcGFja2FnZSJ9LCAidXBkYXRlZCI6ICIy
-        MDE5LTA4LTA1VDE5OjExOjU5WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
-        ICJjcmVhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6NTlaIiwgInVuaXRfdHlw
-        ZV9pZCI6ICJtb2R1bGVtZCIsICJ1bml0X2lkIjogImNiOTQ0MDQ0LTk1ZjEt
-        NDQ5OS1iODA3LTVlODNlNzg3MzIxNiIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0
-        ODdmN2ZhYjM2Y2UzZmU1MWRmNWE5In19LCB7Im1ldGFkYXRhIjogeyJfc3Rv
+        MDE5LTA4LTMwVDE0OjM0OjQyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIs
+        ICJjcmVhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDJaIiwgInVuaXRfdHlw
+        ZV9pZCI6ICJtb2R1bGVtZCIsICJ1bml0X2lkIjogIjczZGE4MWEwLTA1Y2Yt
+        NDU5Yy1iMzAxLTIwZjAyNWQyYzA1NCIsICJfaWQiOiB7IiRvaWQiOiAiNWQ2
+        OTM0MDIzMmRiNjA3N2E3OTY3MmQ5In19LCB7Im1ldGFkYXRhIjogeyJfc3Rv
         cmFnZV9wYXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0cy9tb2R1
         bGVtZC83OC82ODcyN2JjYzJhOWQ5YTYwM2JlMWJkNDA3ZjQ3ZWQ4N2I5NmIx
         MmVkNmNkNTU1NmJjZGNlYTkxZGE5ODBlMCIsICJuYW1lIjogImthbmdhcm9v
         IiwgInN0cmVhbSI6ICIwIiwgImFydGlmYWN0cyI6IFsia2FuZ2Fyb28tMDow
         LjMtMS5ub2FyY2giXSwgImNoZWNrc3VtIjogIjA5MDBkZDBmYWE2N2Y5Mzg2
         NzdjNGJhYWNmMDA1ZWM5ZDI0ODI3YWZhMjExY2I0MTU3ZWQ4NmQzNWNjODNm
-        ZGUiLCAiX2xhc3RfdXBkYXRlZCI6IDE1NjUwMzIwOTYsICJfY29udGVudF90
+        ZGUiLCAiX2xhc3RfdXBkYXRlZCI6IDE1NjcxNzU2NjEsICJfY29udGVudF90
         eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2ZpbGVzIjogeyJkZWZhdWx0Ijog
         WyJrYW5nYXJvbyJdfSwgInN1bW1hcnkiOiAiS2FuZ2Fyb28gMC4zIG1vZHVs
         ZSIsICJkb3dubG9hZGVkIjogdHJ1ZSwgInZlcnNpb24iOiAyMDE4MDczMDIy
         MzQwNywgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiY29udGV4dCI6ICJk
         ZWFkYmVlZiIsICJfbnMiOiAidW5pdHNfbW9kdWxlbWQiLCAiZGVwZW5kZW5j
-        aWVzIjogW10sICJfaWQiOiAiZDE2MTBkODYtY2IzOS00NTFkLWE4MjUtZGIw
-        NmViZGJhMzkxIiwgImFyY2giOiAibm9hcmNoIiwgImRlc2NyaXB0aW9uIjog
+        aWVzIjogW10sICJfaWQiOiAiNzk1YWM0ZmEtNGQ4Yi00YjFjLThlZDktNmNk
+        ZmNkYTkyNmY2IiwgImFyY2giOiAibm9hcmNoIiwgImRlc2NyaXB0aW9uIjog
         IkEgbW9kdWxlIGZvciB0aGUga2FuZ2Fyb28gMC4zIHBhY2thZ2UifSwgInVw
-        ZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAicmVwb19pZCI6ICJG
-        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjExOjU5WiIs
-        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICJkMTYx
-        MGQ4Ni1jYjM5LTQ1MWQtYTgyNS1kYjA2ZWJkYmEzOTEiLCAiX2lkIjogeyIk
-        b2lkIjogIjVkNDg3ZjdmYWIzNmNlM2ZlNTFkZjU5ZSJ9fV0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:00 GMT
-- request:
-    method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJtb2R1bGVtZCJdLCJsaW1pdCI6
-        MjAwMCwic2tpcCI6MjAwMH19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '63'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:00 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '2'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: 'W10=
-
-'
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImxpbWl0Ijoy
-        MDAwLCJza2lwIjowfX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '59'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:01 GMT
-      Server:
-      - Apache
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '9105'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAx
-        IiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjog
-        W10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDowMDAx
-        IiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6
-        ICIiLCAidGl0bGUiOiAiRW1wdHkgZXJyYXRhIiwgIl9ucyI6ICJ1bml0c19l
-        cnJhdHVtIiwgInZlcnNpb24iOiAiMSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjog
-        ZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3QiOiBbXSwgInN0
-        YXR1cyI6ICJzdGFibGUiLCAidXBkYXRlZCI6ICIiLCAiZGVzY3JpcHRpb24i
-        OiAiRW1wdHkgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTY1MDMyMzIw
-        LCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6ICIi
-        LCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIi
-        LCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICIwMDVmZTMzMy1mMTM5LTQ2Zjct
-        ODM0ZC1jYjk4OWYyN2Y5ZWEifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0wNVQx
-        OToxMjowMFoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6
-        ICIyMDE5LTA4LTA1VDE5OjEyOjAwWiIsICJ1bml0X3R5cGVfaWQiOiAiZXJy
-        YXR1bSIsICJ1bml0X2lkIjogIjAwNWZlMzMzLWYxMzktNDZmNy04MzRkLWNi
-        OTg5ZjI3ZjllYSIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmODBhYjM2Y2Uz
-        ZmU1MWRmNjE1In19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMC0w
-        MS0wMSAwMTowMTowMSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAi
-        cmVmZXJlbmNlcyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJf
-        Y29udGVudF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1S
-        SEVBLTIwMTA6MDAwMiIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20i
-        LCAic2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIk9uZSBwYWNrYWdlIGVycmF0
-        YSIsICJfbnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAi
-        cmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIs
-        ICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3
-        dy5mZWRvcmFwcm9qZWN0Lm9yZyIsICJuYW1lIjogImVsZXBoYW50IiwgInN1
-        bSI6IG51bGwsICJmaWxlbmFtZSI6ICJlbGVwaGFudC0wLjMtMC44Lm5vYXJj
-        aC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxl
-        YXNlIjogIjAuOCIsICJhcmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiY29s
-        bGVjdGlvbi0wIiwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6ICJzdGFibGUi
-        LCAidXBkYXRlZCI6ICIiLCAiZGVzY3JpcHRpb24iOiAiT25lIHBhY2thZ2Ug
-        ZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTY1MDMyMzIwLCAicmVzdGFy
-        dF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRz
-        IjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIiLCAicmVsZWFz
-        ZSI6ICIxIiwgIl9pZCI6ICIxZWRlYzQyMy0yMmZiLTRjMjItODgzNy0zYzFj
-        NDMwYWQ5ZTkifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjowMFoi
-        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4
-        LTA1VDE5OjEyOjAwWiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJ1
-        bml0X2lkIjogIjFlZGVjNDIzLTIyZmItNGMyMi04ODM3LTNjMWM0MzBhZDll
-        OSIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmODBhYjM2Y2UzZmU1MWRmNjRl
-        In19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMC0wMS0wMSAwMTow
-        MTowMSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVmZXJlbmNl
-        cyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90
-        eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6
-        OTkxNDMiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNldmVy
-        aXR5IjogIiIsICJ0aXRsZSI6ICJBcm1hZGlsbG8iLCAiX25zIjogInVuaXRz
-        X2VycmF0dW0iLCAidmVyc2lvbiI6ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQi
-        OiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFt7InBh
-        Y2thZ2VzIjogW3sic3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5v
-        cmciLCAibmFtZSI6ICJhcm1hZGlsbG8iLCAic3VtIjogbnVsbCwgImZpbGVu
-        YW1lIjogImFybWFkaWxsby0yLjEtMS5ub2FyY2gucnBtIiwgImVwb2NoIjog
-        IjAiLCAidmVyc2lvbiI6ICIyLjEiLCAicmVsZWFzZSI6ICIxIiwgImFyY2gi
-        OiAibm9hcmNoIn1dLCAibmFtZSI6ICJjb2xsZWN0aW9uLTAiLCAic2hvcnQi
-        OiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIsICJ1cGRhdGVkIjogIiIsICJk
-        ZXNjcmlwdGlvbiI6ICJBcm1hZGlsbG8iLCAiX2xhc3RfdXBkYXRlZCI6IDE1
-        NjUwMzIzMjAsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNv
-        dW50IjogIiIsICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1t
-        YXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjcwYjYwNjk3LTY3
-        MWQtNGY1OS1hNWJhLTA3MTE1ZjEwMTI0OCJ9LCAidXBkYXRlZCI6ICIyMDE5
-        LTA4LTA1VDE5OjEyOjAwWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJj
-        cmVhdGVkIjogIjIwMTktMDgtMDVUMTk6MTI6MDBaIiwgInVuaXRfdHlwZV9p
-        ZCI6ICJlcnJhdHVtIiwgInVuaXRfaWQiOiAiNzBiNjA2OTctNjcxZC00ZjU5
-        LWE1YmEtMDcxMTVmMTAxMjQ4IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y4
-        MGFiMzZjZTNmZTUxZGY2NmQifX0sIHsibWV0YWRhdGEiOiB7Imlzc3VlZCI6
-        ICIyMDEwLTExLTEwIDAwOjAwOjAwIiwgInJlbG9naW5fc3VnZ2VzdGVkIjog
-        ZmFsc2UsICJyZWZlcmVuY2VzIjogW3siaHJlZiI6ICJodHRwczovL3Jobi5y
-        ZWRoYXQuY29tL2VycmF0YS9SSFNBLTIwMTAtMDg1OC5odG1sIiwgInR5cGUi
-        OiAic2VsZiIsICJpZCI6IG51bGwsICJ0aXRsZSI6ICJSSFNBLTIwMTA6MDg1
-        OCJ9LCB7ImhyZWYiOiAiaHR0cHM6Ly9idWd6aWxsYS5yZWRoYXQuY29tL2J1
-        Z3ppbGxhL3Nob3dfYnVnLmNnaT9pZD02Mjc4ODIiLCAidHlwZSI6ICJidWd6
-        aWxsYSIsICJpZCI6ICI2Mjc4ODIiLCAidGl0bGUiOiAiQ1ZFLTIwMTAtMDQw
-        NSBiemlwMjogaW50ZWdlciBvdmVyZmxvdyBmbGF3IGluIEJaMl9kZWNvbXBy
-        ZXNzIn0sIHsiaHJlZiI6ICJodHRwczovL3d3dy5yZWRoYXQuY29tL3NlY3Vy
-        aXR5L2RhdGEvY3ZlL0NWRS0yMDEwLTA0MDUuaHRtbCIsICJ0eXBlIjogImN2
-        ZSIsICJpZCI6ICJDVkUtMjAxMC0wNDA1IiwgInRpdGxlIjogIkNWRS0yMDEw
-        LTA0MDUifSwgeyJocmVmIjogImh0dHA6Ly93d3cucmVkaGF0LmNvbS9zZWN1
-        cml0eS91cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCAidHlw
-        ZSI6ICJvdGhlciIsICJpZCI6IG51bGwsICJ0aXRsZSI6IG51bGx9XSwgInB1
-        bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJl
-        cnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCAiZnJv
-        bSI6ICJzZWN1cml0eUByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIkltcG9y
-        dGFudCIsICJ0aXRsZSI6ICJJbXBvcnRhbnQ6IGJ6aXAyIHNlY3VyaXR5IHVw
-        ZGF0ZSIsICJfbnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjMi
-        LCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0
-        eSIsICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiYnppcDIt
-        MS4wLjUtNy5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwi
-        LCAic3VtIjogWyJzaGEyNTYiLCAiZWE2N2M2NjRkYTFmZjk2YTZkYzk0ZDMz
-        MDA5YjczZDhmYWIzMWI1OTgyNDE4M2ZiNDVlOWJhMmViZjgyZDU4MyJdLCAi
-        ZmlsZW5hbWUiOiAiYnppcDItZGV2ZWwtMS4wLjUtNy5lbDZfMC5pNjg2LnJw
-        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFz
-        ZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlw
-        Mi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJz
-        IiwgInN1bSI6IFsic2hhMjU2IiwgImM5ZjA2NGE2ODYyNTczZmI5ZjJhNmFm
-        ZjdjMzYyMWYxOTQwYjQ5MmRmMmVkZmMyZWJiZGMwYjgzMDVmNTExNDciXSwg
-        ImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC5pNjg2LnJw
-        bSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFz
-        ZSI6ICI3LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlw
-        Mi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMiIsICJz
-        dW0iOiBbInNoYTI1NiIsICJiOGEzZjcyYmMyYjBkODliYTczNzA5OWFjOThi
-        ZjhkMmFmNGJlYTAyZDMxODg0YzAyZGI5N2Y3ZjY2YzNkNWMyIl0sICJmaWxl
-        bmFtZSI6ICJiemlwMi0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0iLCAiZXBv
-        Y2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5l
-        bDZfMCIsICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6ICJiemlwMi0xLjAu
-        NS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1kZXZlbCIsICJz
-        dW0iOiBbInNoYTI1NiIsICI3ZjYzMTI0ZTQ2NTViN2M5MmQyM2VjNGMzODIy
-        NmY1ZDM3NDY1Njg4NTNkZmY3NTBmYzg1ZTA1OGU3NGI1Y2Y2Il0sICJmaWxl
-        bmFtZSI6ICJiemlwMi1kZXZlbC0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0i
-        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2Ui
-        OiAiNy5lbDZfMCIsICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6ICJiemlw
-        Mi0xLjAuNS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJz
-        IiwgInN1bSI6IFsic2hhMjU2IiwgIjgwMmY0Mzk5ZGJkZDAxNDc2ZTI1NGMz
-        YjMyYzQwYWZmNTljZjVkMjNhNDVmYTQ4OGM2OTE3Y2U4OTA0ZDZiNGQiXSwg
-        ImZpbGVuYW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC54ODZfNjQu
-        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxl
-        YXNlIjogIjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifV0sICJuYW1lIjog
-        ImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAiZmlu
-        YWwiLCAidXBkYXRlZCI6ICIyMDEwLTExLTEwIDAwOjAwOjAwIiwgImRlc2Ny
-        aXB0aW9uIjogImJ6aXAyIGlzIGEgZnJlZWx5IGF2YWlsYWJsZSwgaGlnaC1x
-        dWFsaXR5IGRhdGEgY29tcHJlc3Nvci4gSXQgcHJvdmlkZXMgYm90aFxubGli
-        YnoyIGxpYnJhcnkgbXVzdCBiZSByZXN0YXJ0ZWQgZm9yIHRoZSB1cGRhdGUg
-        dG8gdGFrZSBlZmZlY3QuIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTY1MDMyMzIw
-        LCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6ICIi
-        LCAicmlnaHRzIjogIkNvcHlyaWdodCAyMDEwIFJlZCBIYXQgSW5jIiwgInNv
-        bHV0aW9uIjogIkJlZm9yZSBhcHBseWluZyB0aGlzIHVwZGF0ZSwgbWFrZSBz
-        dXJlIGFsbCBwcmV2aW91c2x5LXJlbGVhc2VkIGVycmF0YVxucmVsZXZhbnQg
-        dG8geW91ciBzeXN0ZW0gaGF2ZSBiZWVuIGFwcGxpZWQuXG5cblRoaXMgdXBk
-        YXRlIGlzIGF2YWlsYWJsZSB2aWEgdGhlIFJlZCBIYXQgTmV0d29yay4gRGV0
-        YWlscyBvbiBob3cgdG9cbnVzZSB0aGUgUmVkIEhhdCBOZXR3b3JrIHRvIGFw
-        cGx5IHRoaXMgdXBkYXRlIGFyZSBhdmFpbGFibGUgYXRcbmh0dHA6Ly9rYmFz
-        ZS5yZWRoYXQuY29tL2ZhcS9kb2NzL0RPQy0xMTI1OSIsICJzdW1tYXJ5Ijog
-        IlVwZGF0ZWQgYnppcDIgcGFja2FnZXMgdGhhdCBmaXggb25lIHNlY3VyaXR5
-        IGlzc3VlIiwgInJlbGVhc2UiOiAiIiwgIl9pZCI6ICJjZTJiNzRjNi1hZWU1
-        LTQxYTYtODZmNi01ZTQ0MTFmZWJiNGIifSwgInVwZGF0ZWQiOiAiMjAxOS0w
-        OC0wNVQxOToxMjowMFoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3Jl
-        YXRlZCI6ICIyMDE5LTA4LTA1VDE5OjEyOjAwWiIsICJ1bml0X3R5cGVfaWQi
-        OiAiZXJyYXR1bSIsICJ1bml0X2lkIjogImNlMmI3NGM2LWFlZTUtNDFhNi04
-        NmY2LTVlNDQxMWZlYmI0YiIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmODBh
-        YjM2Y2UzZmU1MWRmNjM0In19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAi
-        MjAxOC0wMS0yNyAxNjowODowOSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZh
-        bHNlLCAicmVmZXJlbmNlcyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjog
-        e30sICJfY29udGVudF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiS0FU
-        RUxMTy1SSEVBLTIwMTI6MDA1OSIsICJmcm9tIjogImVycmF0YUByZWRoYXQu
-        Y29tIiwgInNldmVyaXR5IjogIiIsICJ0aXRsZSI6ICJEdWNrX0thbmdhcm9v
-        X0VycmF0dW0iLCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAidmVyc2lvbiI6
-        ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAiZW5o
-        YW5jZW1lbnQiLCAicGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjog
-        Imh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJkdWNr
-        IiwgInN1bSI6IG51bGwsICJmaWxlbmFtZSI6ICJkdWNrLTAuNy0xLm5vYXJj
-        aC5ycG0iLCAiZXBvY2giOiBudWxsLCAidmVyc2lvbiI6ICIwLjciLCAicmVs
-        ZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJjb2xs
-        ZWN0aW9uLTAiLCAibW9kdWxlIjogeyJjb250ZXh0IjogImRlYWRiZWVmIiwg
-        InZlcnNpb24iOiAiMjAxODA3MzAyMzMxMDIiLCAiYXJjaCI6ICJub2FyY2gi
-        LCAibmFtZSI6ICJkdWNrIiwgInN0cmVhbSI6ICIwIn0sICJzaG9ydCI6ICIi
-        fSwgeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRwOi8vd3d3LmZlZG9yYXBy
-        b2plY3Qub3JnIiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAic3VtIjogbnVsbCwg
-        ImZpbGVuYW1lIjogImthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCAiZXBv
-        Y2giOiBudWxsLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIxIiwg
-        ImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJjb2xsZWN0aW9uLTEiLCAi
-        bW9kdWxlIjogeyJjb250ZXh0IjogImRlYWRiZWVmIiwgInZlcnNpb24iOiAi
-        MjAxODA3MzAyMjM0MDciLCAiYXJjaCI6ICJub2FyY2giLCAibmFtZSI6ICJr
-        YW5nYXJvbyIsICJzdHJlYW0iOiAiMCJ9LCAic2hvcnQiOiAiIn1dLCAic3Rh
-        dHVzIjogInN0YWJsZSIsICJ1cGRhdGVkIjogIjIwMTgtMDctMjAgMDY6MDA6
-        MDEgVVRDIiwgImRlc2NyaXB0aW9uIjogIkR1Y2tfS2FuZ2Fyb19FcnJhdHVt
-        IGRlc2NyaXB0aW9uIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTY1MDMyMzIwLCAi
-        cmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6ICIiLCAi
-        cmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIiLCAi
-        cmVsZWFzZSI6ICIxIiwgIl9pZCI6ICJmZTUxOTZjNi04YjNkLTRlZDItOTc0
-        Ni0zZDQ1Yjg5MWY0NjcifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOTox
-        MjowMFoiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIy
-        MDE5LTA4LTA1VDE5OjEyOjAwWiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1
-        bSIsICJ1bml0X2lkIjogImZlNTE5NmM2LThiM2QtNGVkMi05NzQ2LTNkNDVi
-        ODkxZjQ2NyIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmODBhYjM2Y2UzZmU1
-        MWRmNmFjIn19LCB7Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMi0wMS0w
-        MSAwMTowMTowMSIsICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVm
-        ZXJlbmNlcyI6IFtdLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29u
-        dGVudF90eXBlX2lkIjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1SSEVB
-        LTIwMTA6MDExMSIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20iLCAi
-        c2V2ZXJpdHkiOiAiIiwgInRpdGxlIjogIkR1cGxpY2F0ZWQgcGFja2FnZSBl
-        cnJhdGEiLCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAidmVyc2lvbiI6ICIx
-        IiwgInJlYm9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJp
-        dHkiLCAicGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogImh0dHA6
-        Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJlbGVwaGFudCIs
-        ICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5u
-        b2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAi
-        cmVsZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifSwgeyJzcmMiOiAi
-        aHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIsICJuYW1lIjogImxpb24i
-        LCAic3VtIjogbnVsbCwgImZpbGVuYW1lIjogImxpb24tMC4zLTAuOC5ub2Fy
-        Y2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVs
-        ZWFzZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogImNv
-        bGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxl
-        IiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjogIkR1cGxpY2F0ZSBP
-        bmUgcGFja2FnZSBlcnJhdGEiLCAiX2xhc3RfdXBkYXRlZCI6IDE1NjUwMzIz
-        MjAsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50Ijog
-        IiIsICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5Ijog
-        IiIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImZmOTVmZWM1LWFmNDMtNGVl
-        OC1hZTkzLTZhOGViNDdkM2JhYSJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTA1
-        VDE5OjEyOjAwWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
-        IjogIjIwMTktMDgtMDVUMTk6MTI6MDBaIiwgInVuaXRfdHlwZV9pZCI6ICJl
-        cnJhdHVtIiwgInVuaXRfaWQiOiAiZmY5NWZlYzUtYWY0My00ZWU4LWFlOTMt
-        NmE4ZWI0N2QzYmFhIiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y4MGFiMzZj
-        ZTNmZTUxZGY2ODcifX1d
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImxpbWl0Ijoy
-        MDAwLCJza2lwIjoyMDAwfX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '62'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:01 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '2'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: 'W10=
-
-'
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwYWNrYWdlX2dyb3VwIl0sImxp
-        bWl0IjoyMDAwLCJza2lwIjowfX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '65'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:01 GMT
-      Server:
-      - Apache
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1486'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Im1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJw
-        ZW5ndWluIl0sICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImJp
-        cmQiLCAidXNlcl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAi
-        X25zIjogInVuaXRzX3BhY2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6
-        IDE1NjUwMzIwOTYsICJvcHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0
-        cmFuc2xhdGVkX25hbWUiOiB7fSwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24i
-        OiB7fSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNr
-        YWdlX25hbWVzIjogW10sICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2Vf
-        Z3JvdXAiLCAiaWQiOiAiYmlyZCIsICJfaWQiOiAiYTVlMDM1NjctMTkxOS00
-        NTc3LWFlNWEtNGUxYTgwNGFhYjJhIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0
-        LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQi
-        OiAiMjAxOS0wOC0wNVQxOToxMjowMFoiLCAicmVwb19pZCI6ICJGZWRvcmFf
-        MTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjEyOjAwWiIsICJ1bml0
-        X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0X2lkIjogImE1ZTAz
-        NTY3LTE5MTktNDU3Ny1hZTVhLTRlMWE4MDRhYWIyYSIsICJfaWQiOiB7IiRv
-        aWQiOiAiNWQ0ODdmODBhYjM2Y2UzZmU1MWRmNmJjIn19LCB7Im1ldGFkYXRh
-        IjogeyJtYW5kYXRvcnlfcGFja2FnZV9uYW1lcyI6IFsiZWxlcGhhbnQsZ2ly
-        YWZmZSxjaGVldGFoLGxpb24sbW9ua2V5LHBlbmd1aW4sc3F1aXJyZWwsd2Fs
-        cnVzIiwgInBlbmd1aW4iXSwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5h
-        bWUiOiAibWFtbWFsIiwgInVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0
-        IjogdHJ1ZSwgIl9ucyI6ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0
-        X3VwZGF0ZWQiOiAxNTY1MDMyMDk2LCAib3B0aW9uYWxfcGFja2FnZV9uYW1l
-        cyI6IFtdLCAidHJhbnNsYXRlZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rl
-        c2NyaXB0aW9uIjoge30sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRl
-        ZmF1bHRfcGFja2FnZV9uYW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6
-        ICJwYWNrYWdlX2dyb3VwIiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiZDA0
-        ZDRmZjgtYjU3ZS00ZTU2LTgwODUtOTliMzU1NTgyYmQzIiwgImRpc3BsYXlf
-        b3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtd
-        fSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjowMFoiLCAicmVwb19p
-        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjEy
-        OjAwWiIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0
-        X2lkIjogImQwNGQ0ZmY4LWI1N2UtNGU1Ni04MDg1LTk5YjM1NTU4MmJkMyIs
-        ICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmODBhYjM2Y2UzZmU1MWRmNmM5In19
-        XQ==
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwYWNrYWdlX2dyb3VwIl0sImxp
-        bWl0IjoyMDAwLCJza2lwIjoyMDAwfX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '68'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:01 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '2'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: 'W10=
-
-'
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJ5dW1fcmVwb19tZXRhZGF0YV9m
-        aWxlIl0sImxpbWl0IjoyMDAwLCJza2lwIjowfX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '74'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:01 GMT
-      Server:
-      - Apache
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1656'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
-        cC9jb250ZW50L3VuaXRzL3l1bV9yZXBvX21ldGFkYXRhX2ZpbGUvYjQvNWYz
-        YTU5ZWY0MTllODNiMzBkZDA1ZjIyYTUxZWExZWZlMzA1N2RiNmE3NDc0MDBh
-        ZTMxOGQ2NTc3NzJiMWYvMGQxZWI3Mzg2N2M0NTliODZkMTU4Y2RhZDI2NjAw
-        MmU0NTg4MTQwNTFlMzU1Mjk5NzA1M2QzNTY3MTQ0YTdlMi1wcm9kdWN0aWQu
-        Z3oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiZGF0YV90eXBlIjogInBy
-        b2R1Y3RpZCIsICJjaGVja3N1bSI6ICIwZDFlYjczODY3YzQ1OWI4NmQxNThj
-        ZGFkMjY2MDAyZTQ1ODgxNDA1MWUzNTUyOTk3MDUzZDM1NjcxNDRhN2UyIiwg
-        Il9sYXN0X3VwZGF0ZWQiOiAxNTY1MDMyMzE5LCAiX2NvbnRlbnRfdHlwZV9p
-        ZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIiwgImRvd25sb2FkZWQiOiB0
-        cnVlLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfbnMiOiAidW5pdHNf
-        eXVtX3JlcG9fbWV0YWRhdGFfZmlsZSIsICJjaGVja3N1bV90eXBlIjogInNo
-        YTI1NiIsICJfaWQiOiAiNDRjNGE3NTYtYzkzNi00NmJjLTg3MGUtMmYxNTI4
-        OTY5ZWVjIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6NTlaIiwg
-        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0w
-        NVQxOToxMTo1OVoiLCAidW5pdF90eXBlX2lkIjogInl1bV9yZXBvX21ldGFk
-        YXRhX2ZpbGUiLCAidW5pdF9pZCI6ICI0NGM0YTc1Ni1jOTM2LTQ2YmMtODcw
-        ZS0yZjE1Mjg5NjllZWMiLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3ZjdmYWIz
-        NmNlM2ZlNTFkZjQ4NCJ9fSwgeyJtZXRhZGF0YSI6IHsiX3N0b3JhZ2VfcGF0
-        aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQvdW5pdHMveXVtX3JlcG9fbWV0
-        YWRhdGFfZmlsZS85ZS9iNjY2MGRlZjEzM2U1Yjg2N2JiZWEwODM2MTNhNjVj
-        NDk4ZDU4YWYwMWMwMGFmNTkyNTllODk4ZWYwOTFiMS81NjljMGFjMzI0MzJh
-        MjEzMDg2NzkzYTcwNTAyMjI4YTJiZTk5NWJjNTEzNDgwMWZlMTU4MmM0MDhm
-        OGQ5NzFiLXN3aWR0YWdzLnhtbC5neiIsICJyZXBvX2lkIjogIkZlZG9yYV8x
-        NyIsICJkYXRhX3R5cGUiOiAic3dpZHRhZ3MiLCAiY2hlY2tzdW0iOiAiNTY5
-        YzBhYzMyNDMyYTIxMzA4Njc5M2E3MDUwMjIyOGEyYmU5OTViYzUxMzQ4MDFm
-        ZTE1ODJjNDA4ZjhkOTcxYiIsICJfbGFzdF91cGRhdGVkIjogMTU2NTAzMjMx
-        OSwgIl9jb250ZW50X3R5cGVfaWQiOiAieXVtX3JlcG9fbWV0YWRhdGFfZmls
-        ZSIsICJkb3dubG9hZGVkIjogdHJ1ZSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6
-        IHt9LCAiX25zIjogInVuaXRzX3l1bV9yZXBvX21ldGFkYXRhX2ZpbGUiLCAi
-        Y2hlY2tzdW1fdHlwZSI6ICJzaGEyNTYiLCAiX2lkIjogImZhZjdjOWRlLTc0
-        NzktNDkxMi1hMGEzLTY0MTUzYWUyZGNkYyJ9LCAidXBkYXRlZCI6ICIyMDE5
-        LTA4LTA1VDE5OjExOjU5WiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJj
-        cmVhdGVkIjogIjIwMTktMDgtMDVUMTk6MTE6NTlaIiwgInVuaXRfdHlwZV9p
-        ZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIiwgInVuaXRfaWQiOiAiZmFm
-        N2M5ZGUtNzQ3OS00OTEyLWEwYTMtNjQxNTNhZTJkY2RjIiwgIl9pZCI6IHsi
-        JG9pZCI6ICI1ZDQ4N2Y3ZmFiMzZjZTNmZTUxZGY0N2QifX1d
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJ5dW1fcmVwb19tZXRhZGF0YV9m
-        aWxlIl0sImxpbWl0IjoyMDAwLCJza2lwIjoyMDAwfX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '77'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:01 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '2'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: 'W10=
-
-'
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJzcnBtIl0sImxpbWl0IjoyMDAw
-        LCJza2lwIjowLCJmaWVsZHMiOnsidW5pdCI6WyJuYW1lIiwidmVyc2lvbiIs
-        InJlbGVhc2UiLCJhcmNoIiwiZXBvY2giLCJzdW1tYXJ5IiwiY2hlY2tzdW0i
-        LCJmaWxlbmFtZSJdfX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '150'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:01 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '2'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: 'W10=
-
-'
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkaXN0cmlidXRpb24iXX19
-
-'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '42'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:01 GMT
-      Server:
-      - Apache
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1198'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7ImZpbGVzIjogW3sicmVsYXRpdmVwYXRoIjogImlt
-        YWdlcy90ZXN0Mi5pbWciLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiIsICJj
-        aGVja3N1bSI6ICJlM2IwYzQ0Mjk4ZmMxYzE0OWFmYmY0Yzg5OTZmYjkyNDI3
-        YWU0MWU0NjQ5YjkzNGNhNDk1OTkxYjc4NTJiODU1In0sIHsicmVsYXRpdmVw
-        YXRoIjogImVtcHR5LmlzbyIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2Iiwg
-        ImNoZWNrc3VtIjogImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0
-        MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifSwgeyJyZWxhdGl2
-        ZXBhdGgiOiAiaW1hZ2VzL3Rlc3QxLmltZyIsICJjaGVja3N1bXR5cGUiOiAi
-        c2hhMjU2IiwgImNoZWNrc3VtIjogImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRj
-        ODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifV0s
-        ICJfc3RvcmFnZV9wYXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0
-        cy9kaXN0cmlidXRpb24vOWIvODMxMjU2YTEyNDcxOGJmMzkxNjZiNTY0ZDhl
-        Njg5OTU0ZmYwYThmMGY0NzliYTI0Y2ZhMjYzNTAxMDliYzUiLCAiZmFtaWx5
-        IjogIlRlc3QgRmFtaWx5IiwgImRvd25sb2FkZWQiOiBmYWxzZSwgInRpbWVz
-        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTU2NTAz
-        MjMxOSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
-        cmlhbnQiOiAiVGVzdFZhcmlhbnQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHkt
-        VGVzdFZhcmlhbnQtMTYteDg2XzY0IiwgInZlcnNpb24iOiAiMTYiLCAidmVy
-        c2lvbl9zb3J0X2luZGV4IjogIjAyLTE2IiwgInB1bHBfdXNlcl9tZXRhZGF0
-        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogIjQwOGE5Njg4LTY2
-        ZmQtNDU1Ni05ZTU3LTMxOWI2ZDk2Y2Y2YiIsICJhcmNoIjogIng4Nl82NCIs
-        ICJfbnMiOiAidW5pdHNfZGlzdHJpYnV0aW9uIn0sICJ1cGRhdGVkIjogIjIw
-        MTktMDgtMDVUMTk6MTE6NTlaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
-        ImNyZWF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMTo1OVoiLCAidW5pdF90eXBl
-        X2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogIjQwOGE5Njg4LTY2
-        ZmQtNDU1Ni05ZTU3LTMxOWI2ZDk2Y2Y2YiIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWQ0ODdmN2ZhYjM2Y2UzZmU1MWRmNThmIn19XQ==
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbInJwbSJdLCJmaWx0ZXJzIjp7InVuaXQiOnsiZmlsZW5hbWUi
-        OnsiJGluIjpbImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSJdfX19LCJm
-        aWVsZHMiOnsidW5pdCI6WyJuYW1lIiwiZXBvY2giLCJ2ZXJzaW9uIiwicmVs
-        ZWFzZSIsImFyY2giLCJjaGVja3N1bXR5cGUiLCJjaGVja3N1bSJdfX0sIm92
-        ZXJyaWRlX2NvbmZpZyI6e319
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '243'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:01 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzYwZjU0NmVhLWJlYWItNGI4Zi1hNDgyLTgzNzZjOWY1NGI4Yi8iLCAi
-        dGFza19pZCI6ICI2MGY1NDZlYS1iZWFiLTRiOGYtYTQ4Mi04Mzc2YzlmNTRi
-        OGIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbInJwbSJdLCJmaWx0ZXJzIjp7InVuaXQiOnsiZmlsZW5hbWUi
-        OnsiJGluIjpbIndhbHJ1cy0wLjcxLTEubm9hcmNoLnJwbSIsImthbmdhcm9v
-        LTAuMy0xLm5vYXJjaC5ycG0iLCJrYW5nYXJvby0wLjItMS5ub2FyY2gucnBt
-        IiwiZHVjay0wLjctMS5ub2FyY2gucnBtIiwid2FscnVzLTUuMjEtMS5ub2Fy
-        Y2gucnBtIiwiZHVjay0wLjYtMS5ub2FyY2gucnBtIl19fX19fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '262'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:01 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzAzZjk3N2FjLTkxYjctNDE3My05N2I3LTFhN2NkYjdhNTlhMy8iLCAi
-        dGFza19pZCI6ICIwM2Y5NzdhYy05MWI3LTQxNzMtOTdiNy0xYTdjZGI3YTU5
-        YTMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbInNycG0iXSwiZmlsdGVycyI6e319fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '76'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:01 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzUxMmZhZjVkLWI5YmItNDU5Ny1iYzVmLWYzZDkxZjZiZTIwMS8iLCAi
-        dGFza19pZCI6ICI1MTJmYWY1ZC1iOWJiLTQ1OTctYmM1Zi1mM2Q5MWY2YmUy
-        MDEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbImVycmF0dW0iXSwiZmlsdGVycyI6e319fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '79'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:01 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzdmNTM3MjVkLWFmNWUtNGI4NS04NmNkLWU4YzhkNTcyODE4NS8iLCAi
-        dGFza19pZCI6ICI3ZjUzNzI1ZC1hZjVlLTRiODUtODZjZC1lOGM4ZDU3Mjgx
-        ODUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbInBhY2thZ2VfZ3JvdXAiXSwiZmlsdGVycyI6e319fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '85'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:01 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2VjMWZiNzk3LWY3ZDgtNDJjNS1hYmZlLTlkYmJkZTMzYWZiYi8iLCAi
-        dGFza19pZCI6ICJlYzFmYjc5Ny1mN2Q4LTQyYzUtYWJmZS05ZGJiZGUzM2Fm
-        YmIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiXSwiZmlsdGVycyI6
-        e319fQ==
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '94'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:01 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzI4YTVmOGNkLWRkN2QtNDFjOC05NzVmLTAyMjg5MTJjMjNlNS8iLCAi
-        dGFza19pZCI6ICIyOGE1ZjhjZC1kZDdkLTQxYzgtOTc1Zi0wMjI4OTEyYzIz
-        ZTUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbImRpc3RyaWJ1dGlvbiJdLCJmaWx0ZXJzIjp7fX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '84'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:01 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzNmOTFhMjVlLTE5ZGQtNDkwMC1hNThhLWNiMTViMDE5NTg2YS8iLCAi
-        dGFza19pZCI6ICIzZjkxYTI1ZS0xOWRkLTQ5MDAtYTU4YS1jYjE1YjAxOTU4
-        NmEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbIm1vZHVsZW1kIl0sImZpbHRlcnMiOnt9fX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '80'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:01 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzBiODNmNTA1LWJiYjAtNGQ5NC1hNzdkLTEzNjg1YTI1ZGRjZi8iLCAi
-        dGFza19pZCI6ICIwYjgzZjUwNS1iYmIwLTRkOTQtYTc3ZC0xMzY4NWEyNWRk
-        Y2YifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
-        cGVfaWRzIjpbIm1vZHVsZW1kX2RlZmF1bHRzIl0sImZpbHRlcnMiOnt9fX0=
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '89'
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:01 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '172'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2M5ZDBjY2JiLTVlZWQtNDY2My05YmExLTMwZWEwMDgzZWMzOS8iLCAi
-        dGFza19pZCI6ICJjOWQwY2NiYi01ZWVkLTQ2NjMtOWJhMS0zMGVhMDA4M2Vj
-        MzkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/60f546ea-beab-4b8f-a482-8376c9f54b8b/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:01 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"d44fdeebc9167669954fec953e60268b-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1050'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy82MGY1NDZl
-        YS1iZWFiLTRiOGYtYTQ4Mi04Mzc2YzlmNTRiOGIvIiwgInRhc2tfaWQiOiAi
-        NjBmNTQ2ZWEtYmVhYi00YjhmLWE0ODItODM3NmM5ZjU0YjhiIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjAxWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjAx
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJzaWdu
-        aW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJlbGVwaGFu
-        dCIsICJjaGVja3N1bSI6ICIzZTFjNzBjZDFiNDIxMzI4YWNhZjYzOTdjYjNk
-        MTYxNDUzMDZiYjk1ZjY1ZDFiMDk1ZmMzMTM3MmEwYTcwMWYzIiwgImVwb2No
-        IjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAi
-        YXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAi
-        dHlwZV9pZCI6ICJycG0ifV0sICJ1bml0c19mYWlsZWRfc2lnbmF0dXJlX2Zp
-        bHRlciI6IFtdfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
-        ZDQ4N2Y4MWFiMzZjZTNmZTUxZGY4Y2YifSwgImlkIjogIjVkNDg3ZjgxYWIz
-        NmNlM2ZlNTFkZjhjZiJ9
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/03f977ac-91b7-4173-97b7-1a7cdb7a59a3/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:01 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"d0eccc6e1d6eee3b1ab14fa9e414b7a0-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '2273'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8wM2Y5Nzdh
-        Yy05MWI3LTQxNzMtOTdiNy0xYTdjZGI3YTU5YTMvIiwgInRhc2tfaWQiOiAi
-        MDNmOTc3YWMtOTFiNy00MTczLTk3YjctMWE3Y2RiN2E1OWEzIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjAxWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjAx
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJzaWdu
-        aW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJrYW5nYXJv
-        byIsICJjaGVja3N1bSI6ICI4MzNhZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3
-        ZDNkZjJkODM0MWE4OWIwYzVhOWJmNjEwZGQ2MTAzY2U0Y2M4IiwgImVwb2No
-        IjogIjAiLCAidmVyc2lvbiI6ICIwLjIiLCAicmVsZWFzZSI6ICIxIiwgImFy
-        Y2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5
-        cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9r
-        ZXkiOiB7Im5hbWUiOiAid2FscnVzIiwgImNoZWNrc3VtIjogIjc0NTMzZmJk
-        NGY5YWRhOWUwMmE2MzYxY2JiZjAxNGI4ZmY4OGRmZjhkNjk3ODVlYzQ4Yjc3
-        ZTAxODk4ZTdjMzEiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjUuMjEi
-        LCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3Vt
-        dHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmlu
-        Z19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAid2FscnVzIiwg
-        ImNoZWNrc3VtIjogIjUxNmEyMmNjYzBjYmUzZWNiMmNiZWUxYzYyNmEzOWI5
-        MTc2N2RiZjBmODE1YWZkYTdiNzMzYWE1NjUyMzE0MmMiLCAiZXBvY2giOiAi
-        MCIsICJ2ZXJzaW9uIjogIjAuNzEiLCAicmVsZWFzZSI6ICIxIiwgImFyY2gi
-        OiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVf
-        aWQiOiAicnBtIn0sIHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXki
-        OiB7Im5hbWUiOiAiZHVjayIsICJjaGVja3N1bSI6ICI1YmQzNjNiODYwYWQ2
-        NzgzMjE3Y2JjYTNiYmMzZWYyNjBmOThkMTQwZmZiMTIxYmY0YzIwOGUzZjY2
-        YzI0NzEyIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjciLCAicmVs
-        ZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6
-        ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19rZXki
-        OiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAia2FuZ2Fyb28iLCAiY2hl
-        Y2tzdW0iOiAiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5MjAy
-        ZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsICJlcG9jaCI6ICIwIiwg
-        InZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5v
-        YXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjog
-        InJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJu
-        YW1lIjogImR1Y2siLCAiY2hlY2tzdW0iOiAiOTZmMzc4Nzc1MThhMWZlNmVh
-        MmUxN2Y0Y2UxZmM4MWI0MDkwODA0M2JjYmVkNzY3NDRiM2Q3ZDM4YTc3NGJj
-        NyIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC42IiwgInJlbGVhc2Ui
-        OiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hh
-        MjU2In0sICJ0eXBlX2lkIjogInJwbSJ9XSwgInVuaXRzX2ZhaWxlZF9zaWdu
-        YXR1cmVfZmlsdGVyIjogW119LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIk
-        b2lkIjogIjVkNDg3ZjgxYWIzNmNlM2ZlNTFkZjhkZSJ9LCAiaWQiOiAiNWQ0
-        ODdmODFhYjM2Y2UzZmU1MWRmOGRlIn0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/512faf5d-b9bb-4597-bc5f-f3d91f6be201/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:01 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"8b96a0769738f1cd0c8770f7499130c6-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '803'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81MTJmYWY1
-        ZC1iOWJiLTQ1OTctYmM1Zi1mM2Q5MWY2YmUyMDEvIiwgInRhc2tfaWQiOiAi
-        NTEyZmFmNWQtYjliYi00NTk3LWJjNWYtZjNkOTFmNmJlMjAxIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjAxWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjAx
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbXSwgInVu
-        aXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW119LCAiZXJyb3IiOiBu
-        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3ZjgxYWIzNmNlM2ZlNTFkZjhm
-        YyJ9LCAiaWQiOiAiNWQ0ODdmODFhYjM2Y2UzZmU1MWRmOGZjIn0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/7f53725d-af5e-4b85-86cd-e8c8d5728185/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:01 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"ee888d4dcc5f22ec248b33e993f926a9-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1222'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy83ZjUzNzI1
-        ZC1hZjVlLTRiODUtODZjZC1lOGM4ZDU3MjgxODUvIiwgInRhc2tfaWQiOiAi
-        N2Y1MzcyNWQtYWY1ZS00Yjg1LTg2Y2QtZThjOGQ1NzI4MTg1IiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjAxWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjAx
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJ1bml0
-        X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTI6MDA1OSJ9LCAidHlw
-        ZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7ImlkIjogIktBVEVM
-        TE8tUkhTQS0yMDEwOjA4NTgifSwgInR5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7
-        InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDowMTExIn0s
-        ICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1bml0X2tleSI6IHsiaWQiOiAi
-        S0FURUxMTy1SSEVBLTIwMTA6MDAwMiJ9LCAidHlwZV9pZCI6ICJlcnJhdHVt
-        In0sIHsidW5pdF9rZXkiOiB7ImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjk5
-        MTQzIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1bml0X2tleSI6IHsi
-        aWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSJ9LCAidHlwZV9pZCI6ICJl
-        cnJhdHVtIn1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBb
-        XX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmODFh
-        YjM2Y2UzZmU1MWRmOTE0In0sICJpZCI6ICI1ZDQ4N2Y4MWFiMzZjZTNmZTUx
-        ZGY5MTQifQ==
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/ec1fb797-f7d8-42c5-abfe-9dbbde33afbb/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:01 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"3d45a05181ffec74f85cdb81497f2012-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1127'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9lYzFmYjc5
-        Ny1mN2Q4LTQyYzUtYWJmZS05ZGJiZGUzM2FmYmIvIiwgInRhc2tfaWQiOiAi
-        ZWMxZmI3OTctZjdkOC00MmM1LWFiZmUtOWRiYmRlMzNhZmJiIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjAxWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjAx
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJ1bml0
-        X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImlkIjogImJpcmQifSwg
-        InR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9LCB7InVuaXRfa2V5IjogeyJy
-        ZXBvX2lkIjogIjNfdmlldzEiLCAiaWQiOiAibWFtbWFsIn0sICJ0eXBlX2lk
-        IjogInBhY2thZ2VfZ3JvdXAifV0sICJ1bml0c19mYWlsZWRfc2lnbmF0dXJl
-        X2ZpbHRlciI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lkIjogIkZlZG9yYV8x
-        NyIsICJpZCI6ICJiaXJkIn0sICJ0eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAi
-        fSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiaWQi
-        OiAibWFtbWFsIn0sICJ0eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAifV19LCAi
-        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3ZjgxYWIzNmNl
-        M2ZlNTFkZjkyZCJ9LCAiaWQiOiAiNWQ0ODdmODFhYjM2Y2UzZmU1MWRmOTJk
-        In0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:01 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/28a5f8cd-dd7d-41c8-975f-0228912c23e5/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:02 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"d6960e633b21673c1d7f149eed42cd96-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1205'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8yOGE1Zjhj
-        ZC1kZDdkLTQxYzgtOTc1Zi0wMjI4OTEyYzIzZTUvIiwgInRhc2tfaWQiOiAi
-        MjhhNWY4Y2QtZGQ3ZC00MWM4LTk3NWYtMDIyODkxMmMyM2U1IiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjAxWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjAx
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJ1bml0
-        X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgImRhdGFfdHlwZSI6ICJw
-        cm9kdWN0aWQifSwgInR5cGVfaWQiOiAieXVtX3JlcG9fbWV0YWRhdGFfZmls
-        ZSJ9LCB7InVuaXRfa2V5IjogeyJyZXBvX2lkIjogIjNfdmlldzEiLCAiZGF0
-        YV90eXBlIjogInN3aWR0YWdzIn0sICJ0eXBlX2lkIjogInl1bV9yZXBvX21l
-        dGFkYXRhX2ZpbGUifV0sICJ1bml0c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRl
-        ciI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJk
-        YXRhX3R5cGUiOiAic3dpZHRhZ3MifSwgInR5cGVfaWQiOiAieXVtX3JlcG9f
-        bWV0YWRhdGFfZmlsZSJ9LCB7InVuaXRfa2V5IjogeyJyZXBvX2lkIjogIkZl
-        ZG9yYV8xNyIsICJkYXRhX3R5cGUiOiAicHJvZHVjdGlkIn0sICJ0eXBlX2lk
-        IjogInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUifV19LCAiZXJyb3IiOiBudWxs
-        LCAiX2lkIjogeyIkb2lkIjogIjVkNDg3ZjgxYWIzNmNlM2ZlNTFkZjk0NCJ9
-        LCAiaWQiOiAiNWQ0ODdmODFhYjM2Y2UzZmU1MWRmOTQ0In0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:02 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/3f91a25e-19dd-4900-a58a-cb15b019586a/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:02 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"4cfdbc4ae4c890a388ded49c1811de9d-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '976'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8zZjkxYTI1
-        ZS0xOWRkLTQ5MDAtYTU4YS1jYjE1YjAxOTU4NmEvIiwgInRhc2tfaWQiOiAi
-        M2Y5MWEyNWUtMTlkZC00OTAwLWE1OGEtY2IxNWIwMTk1ODZhIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjAxWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjAx
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJ1bml0
-        X2tleSI6IHsidmFyaWFudCI6ICJUZXN0VmFyaWFudCIsICJ2ZXJzaW9uIjog
-        IjE2IiwgImFyY2giOiAieDg2XzY0IiwgImlkIjogImtzLVRlc3QgRmFtaWx5
-        LVRlc3RWYXJpYW50LTE2LXg4Nl82NCIsICJmYW1pbHkiOiAiVGVzdCBGYW1p
-        bHkifSwgInR5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIn1dLCAidW5pdHNfZmFp
-        bGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJf
-        aWQiOiB7IiRvaWQiOiAiNWQ0ODdmODFhYjM2Y2UzZmU1MWRmOTY1In0sICJp
-        ZCI6ICI1ZDQ4N2Y4MWFiMzZjZTNmZTUxZGY5NjUifQ==
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:02 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/0b83f505-bbb0-4d94-a77d-13685a25ddcf/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:03 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"3a3219a1822f08c0ca83eebdce43c506-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '3119'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8wYjgzZjUw
-        NS1iYmIwLTRkOTQtYTc3ZC0xMzY4NWEyNWRkY2YvIiwgInRhc2tfaWQiOiAi
-        MGI4M2Y1MDUtYmJiMC00ZDk0LWE3N2QtMTM2ODVhMjVkZGNmIiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjAxWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjAx
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJ1bml0
-        X2tleSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJzaW9uIjogMjAx
-        ODA3MDQyNDQyMDUsICJhcmNoIjogIm5vYXJjaCIsICJuYW1lIjogImR1Y2si
-        LCAic3RyZWFtIjogIjAifSwgInR5cGVfaWQiOiAibW9kdWxlbWQifSwgeyJ1
-        bml0X2tleSI6IHsiY29udGV4dCI6ICJjMGZmZWU0MiIsICJ2ZXJzaW9uIjog
-        MjAxODA3MDcxNDQyMDMsICJhcmNoIjogIng4Nl82NCIsICJuYW1lIjogIndh
-        bHJ1cyIsICJzdHJlYW0iOiAiMC43MSJ9LCAidHlwZV9pZCI6ICJtb2R1bGVt
-        ZCJ9LCB7InVuaXRfa2V5IjogeyJjb250ZXh0IjogImRlYWRiZWVmIiwgInZl
-        cnNpb24iOiAyMDE4MDczMDIzMzEwMiwgImFyY2giOiAibm9hcmNoIiwgIm5h
-        bWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCJ9LCAidHlwZV9pZCI6ICJtb2R1
-        bGVtZCJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJu
-        YW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6ICI1MTZhMjJjY2MwY2JlM2Vj
-        YjJjYmVlMWM2MjZhMzliOTE3NjdkYmYwZjgxNWFmZGE3YjczM2FhNTY1MjMx
-        NDJjIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjcxIiwgInJlbGVh
-        c2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAi
-        c2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5Ijog
-        bnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogImR1Y2siLCAiY2hlY2tzdW0i
-        OiAiNWJkMzYzYjg2MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZm
-        YjEyMWJmNGMyMDhlM2Y2NmMyNDcxMiIsICJlcG9jaCI6ICIwIiwgInZlcnNp
-        b24iOiAiMC43IiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIs
-        ICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9
-        LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjog
-        Imthbmdhcm9vIiwgImNoZWNrc3VtIjogIjg2NWE0Yzg5NDg1YmRkOTcyM2Ez
-        YzQwNzI4MGMxNDFlOTIwMmYwMjRlN2RiMzhjYmEzZDA5N2MzZjI1NmIyZmQi
-        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjog
-        IjEiLCAiYXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1
-        NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwgeyJ1bml0X2tleSI6IHsiY29udGV4
-        dCI6ICJkZWFkYmVlZiIsICJ2ZXJzaW9uIjogMjAxODA3MDQxMTE3MTksICJh
-        cmNoIjogIm5vYXJjaCIsICJuYW1lIjogImthbmdhcm9vIiwgInN0cmVhbSI6
-        ICIwIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0sIHsic2lnbmluZ19rZXki
-        OiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAia2FuZ2Fyb28iLCAiY2hl
-        Y2tzdW0iOiAiODMzYWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgz
-        NDFhODliMGM1YTliZjYxMGRkNjEwM2NlNGNjOCIsICJlcG9jaCI6ICIwIiwg
-        InZlcnNpb24iOiAiMC4yIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5v
-        YXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjog
-        InJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJu
-        YW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6ICI3NDUzM2ZiZDRmOWFkYTll
-        MDJhNjM2MWNiYmYwMTRiOGZmODhkZmY4ZDY5Nzg1ZWM0OGI3N2UwMTg5OGU3
-        YzMxIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICI1LjIxIiwgInJlbGVh
-        c2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAi
-        c2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InVuaXRfa2V5IjogeyJj
-        b250ZXh0IjogImRlYWRiZWVmIiwgInZlcnNpb24iOiAyMDE4MDczMDIyMzQw
-        NywgImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAic3Ry
-        ZWFtIjogIjAifSwgInR5cGVfaWQiOiAibW9kdWxlbWQifSwgeyJ1bml0X2tl
-        eSI6IHsiY29udGV4dCI6ICJkZWFkYmVlZiIsICJ2ZXJzaW9uIjogMjAxODA3
-        MDQxNDQyMDMsICJhcmNoIjogIng4Nl82NCIsICJuYW1lIjogIndhbHJ1cyIs
-        ICJzdHJlYW0iOiAiNS4yMSJ9LCAidHlwZV9pZCI6ICJtb2R1bGVtZCJ9LCB7
-        InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjogImR1
-        Y2siLCAiY2hlY2tzdW0iOiAiOTZmMzc4Nzc1MThhMWZlNmVhMmUxN2Y0Y2Ux
-        ZmM4MWI0MDkwODA0M2JjYmVkNzY3NDRiM2Q3ZDM4YTc3NGJjNyIsICJlcG9j
-        aCI6ICIwIiwgInZlcnNpb24iOiAiMC42IiwgInJlbGVhc2UiOiAiMSIsICJh
-        cmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0
-        eXBlX2lkIjogInJwbSJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmls
-        dGVyIjogW119LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVk
-        NDg3ZjgxYWIzNmNlM2ZlNTFkZjk3OSJ9LCAiaWQiOiAiNWQ0ODdmODFhYjM2
-        Y2UzZmU1MWRmOTc5In0=
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:03 GMT
-- request:
-    method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/c9d0ccbb-5eed-4663-9ba1-30ea0083ec39/
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:03 GMT
-      Server:
-      - Apache
-      Etag:
-      - '"b5e0b25b84b39024260044c32c5e25b7-gzip"'
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '1333'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
-        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
-        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9jOWQwY2Ni
-        Yi01ZWVkLTQ2NjMtOWJhMS0zMGVhMDA4M2VjMzkvIiwgInRhc2tfaWQiOiAi
-        YzlkMGNjYmItNWVlZC00NjYzLTliYTEtMzBlYTAwODNlYzM5IiwgInRhZ3Mi
-        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
-        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
-        c2hfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjAxWiIsICJfbnMiOiAidGFz
-        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjAx
-        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
-        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
-        dXJjZV93b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEy
-        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
-        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxl
-        LmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwiOiBbeyJ1bml0
-        X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgIm5hbWUiOiAia2FuZ2Fy
-        b28ifSwgInR5cGVfaWQiOiAibW9kdWxlbWRfZGVmYXVsdHMifSwgeyJ1bml0
-        X2tleSI6IHsicmVwb19pZCI6ICIzX3ZpZXcxIiwgIm5hbWUiOiAid2FscnVz
-        In0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2RlZmF1bHRzIn0sIHsidW5pdF9r
-        ZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIsICJuYW1lIjogImR1Y2sifSwg
-        InR5cGVfaWQiOiAibW9kdWxlbWRfZGVmYXVsdHMifV0sICJ1bml0c19mYWls
-        ZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFt7InVuaXRfa2V5IjogeyJyZXBvX2lk
-        IjogIkZlZG9yYV8xNyIsICJuYW1lIjogImthbmdhcm9vIn0sICJ0eXBlX2lk
-        IjogIm1vZHVsZW1kX2RlZmF1bHRzIn0sIHsidW5pdF9rZXkiOiB7InJlcG9f
-        aWQiOiAiRmVkb3JhXzE3IiwgIm5hbWUiOiAiZHVjayJ9LCAidHlwZV9pZCI6
-        ICJtb2R1bGVtZF9kZWZhdWx0cyJ9LCB7InVuaXRfa2V5IjogeyJyZXBvX2lk
-        IjogIkZlZG9yYV8xNyIsICJuYW1lIjogIndhbHJ1cyJ9LCAidHlwZV9pZCI6
-        ICJtb2R1bGVtZF9kZWZhdWx0cyJ9XX0sICJlcnJvciI6IG51bGwsICJfaWQi
-        OiB7IiRvaWQiOiAiNWQ0ODdmODFhYjM2Y2UzZmU1MWRmOTk2In0sICJpZCI6
-        ICI1ZDQ4N2Y4MWFiMzZjZTNmZTUxZGY5OTYifQ==
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:03 GMT
-- request:
-    method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwibGltaXQiOjIwMDAs
-        InNraXAiOjAsImZpZWxkcyI6eyJ1bml0IjpbIm5hbWUiLCJ2ZXJzaW9uIiwi
-        cmVsZWFzZSIsImFyY2giLCJlcG9jaCIsInN1bW1hcnkiLCJzb3VyY2VycG0i
-        LCJjaGVja3N1bSIsImZpbGVuYW1lIiwiaXNfbW9kdWxhciJdfX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '174'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:04 GMT
-      Server:
-      - Apache
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '4240'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJ3YWxydXMtMC43MS0xLnNy
-        Yy5ycG0iLCAibmFtZSI6ICJ3YWxydXMiLCAiY2hlY2tzdW0iOiAiNTE2YTIy
-        Y2NjMGNiZTNlY2IyY2JlZTFjNjI2YTM5YjkxNzY3ZGJmMGY4MTVhZmRhN2I3
-        MzNhYTU2NTIzMTQyYyIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBv
-        ZiB3YWxydXMiLCAiZmlsZW5hbWUiOiAid2FscnVzLTAuNzEtMS5ub2FyY2gu
-        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjcxIiwgImlzX21v
-        ZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVs
-        ZWFzZSI6ICIxIiwgIl9pZCI6ICIwNzI2MDI4ZC1kM2EwLTQxYzYtYTNjMi1i
-        ODIxM2Q0ODA1NzMiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAi
-        MjAxOS0wOC0wNVQxOToxMjowMVoiLCAicmVwb19pZCI6ICIzX3ZpZXcxIiwg
-        ImNyZWF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjowMVoiLCAidW5pdF90eXBl
-        X2lkIjogInJwbSIsICJ1bml0X2lkIjogIjA3MjYwMjhkLWQzYTAtNDFjNi1h
-        M2MyLWI4MjEzZDQ4MDU3MyIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmODFh
-        YjM2Y2UzZmU1MWRmOTQxIn19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0i
-        OiAia2FuZ2Fyb28tMC4zLTEuc3JjLnJwbSIsICJuYW1lIjogImthbmdhcm9v
-        IiwgImNoZWNrc3VtIjogIjg2NWE0Yzg5NDg1YmRkOTcyM2EzYzQwNzI4MGMx
-        NDFlOTIwMmYwMjRlN2RiMzhjYmEzZDA5N2MzZjI1NmIyZmQiLCAic3VtbWFy
-        eSI6ICJob3AgbGlrZSBhIGthbmdhcm9vIGluIEF1c3RyYWxpYSIsICJmaWxl
-        bmFtZSI6ICJrYW5nYXJvby0wLjMtMS5ub2FyY2gucnBtIiwgImVwb2NoIjog
-        IjAiLCAidmVyc2lvbiI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IHRydWUsICJf
-        Y29udGVudF90eXBlX2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lk
-        IjogIjJkNDkxZTgzLTUwYzQtNGMyNS05ODA1LTM3M2YyNzBkNWUyMSIsICJh
-        cmNoIjogIm5vYXJjaCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjEy
-        OjAxWiIsICJyZXBvX2lkIjogIjNfdmlldzEiLCAiY3JlYXRlZCI6ICIyMDE5
-        LTA4LTA1VDE5OjEyOjAxWiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVu
-        aXRfaWQiOiAiMmQ0OTFlODMtNTBjNC00YzI1LTk4MDUtMzczZjI3MGQ1ZTIx
-        IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y4MWFiMzZjZTNmZTUxZGY5NGEi
-        fX0sIHsibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJlbGVwaGFudC0wLjMt
-        MC44LnNyYy5ycG0iLCAibmFtZSI6ICJlbGVwaGFudCIsICJjaGVja3N1bSI6
-        ICIzZTFjNzBjZDFiNDIxMzI4YWNhZjYzOTdjYjNkMTYxNDUzMDZiYjk1ZjY1
-        ZDFiMDk1ZmMzMTM3MmEwYTcwMWYzIiwgInN1bW1hcnkiOiAiQSBkdW1teSBw
-        YWNrYWdlIG9mIGVsZXBoYW50IiwgImZpbGVuYW1lIjogImVsZXBoYW50LTAu
-        My0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAi
-        MC4zIiwgImlzX21vZHVsYXIiOiBmYWxzZSwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAicnBtIiwgInJlbGVhc2UiOiAiMC44IiwgIl9pZCI6ICIyZjAwZTcxMC0y
-        YmQ2LTRmNGQtODhlNS04NWNjZDBlZjhjYzAiLCAiYXJjaCI6ICJub2FyY2gi
-        fSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjowMVoiLCAicmVwb19p
-        ZCI6ICIzX3ZpZXcxIiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjow
-        MVoiLCAidW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjJmMDBl
-        NzEwLTJiZDYtNGY0ZC04OGU1LTg1Y2NkMGVmOGNjMCIsICJfaWQiOiB7IiRv
-        aWQiOiAiNWQ0ODdmODFhYjM2Y2UzZmU1MWRmOGYxIn19LCB7Im1ldGFkYXRh
-        IjogeyJzb3VyY2VycG0iOiAia2FuZ2Fyb28tMC4yLTEuc3JjLnJwbSIsICJu
-        YW1lIjogImthbmdhcm9vIiwgImNoZWNrc3VtIjogIjgzM2FmNTk0YmMwYmEz
-        MTI1NjA0NWVkMWZiMTdkM2RmMmQ4MzQxYTg5YjBjNWE5YmY2MTBkZDYxMDNj
-        ZTRjYzgiLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Yga2FuZ2Fy
-        b28iLCAiZmlsZW5hbWUiOiAia2FuZ2Fyb28tMC4yLTEubm9hcmNoLnJwbSIs
-        ICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4yIiwgImlzX21vZHVsYXIi
-        OiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6
-        ICIxIiwgIl9pZCI6ICIzOTEwZTg5Ny04ZWQ0LTRjMTItOTI5Ny1lYjAwYzJl
-        YTFmNzAiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAxOS0w
-        OC0wNVQxOToxMjowMVoiLCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImNyZWF0
-        ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjowMVoiLCAidW5pdF90eXBlX2lkIjog
-        InJwbSIsICJ1bml0X2lkIjogIjM5MTBlODk3LThlZDQtNGMxMi05Mjk3LWVi
-        MDBjMmVhMWY3MCIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmODFhYjM2Y2Uz
-        ZmU1MWRmOTM2In19LCB7Im1ldGFkYXRhIjogeyJzb3VyY2VycG0iOiAiZHVj
-        ay0wLjctMS5zcmMucnBtIiwgIm5hbWUiOiAiZHVjayIsICJjaGVja3N1bSI6
-        ICI1YmQzNjNiODYwYWQ2NzgzMjE3Y2JjYTNiYmMzZWYyNjBmOThkMTQwZmZi
-        MTIxYmY0YzIwOGUzZjY2YzI0NzEyIiwgInN1bW1hcnkiOiAiUXVhY2sgbGlr
-        ZSBhIGR1Y2sgYXQgdGhlIHBhcmsuIiwgImZpbGVuYW1lIjogImR1Y2stMC43
-        LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC43
-        IiwgImlzX21vZHVsYXIiOiB0cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJy
-        cG0iLCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICI0ZGViMTcxYi1kNDkwLTQw
-        OGMtOWE0Yy1hNzc0NzU4ZGYyMzMiLCAiYXJjaCI6ICJub2FyY2gifSwgInVw
-        ZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjowMVoiLCAicmVwb19pZCI6ICIz
-        X3ZpZXcxIiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjowMVoiLCAi
-        dW5pdF90eXBlX2lkIjogInJwbSIsICJ1bml0X2lkIjogIjRkZWIxNzFiLWQ0
-        OTAtNDA4Yy05YTRjLWE3NzQ3NThkZjIzMyIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWQ0ODdmODFhYjM2Y2UzZmU1MWRmOTQ2In19LCB7Im1ldGFkYXRhIjogeyJz
-        b3VyY2VycG0iOiAid2FscnVzLTUuMjEtMS5zcmMucnBtIiwgIm5hbWUiOiAi
-        d2FscnVzIiwgImNoZWNrc3VtIjogIjc0NTMzZmJkNGY5YWRhOWUwMmE2MzYx
-        Y2JiZjAxNGI4ZmY4OGRmZjhkNjk3ODVlYzQ4Yjc3ZTAxODk4ZTdjMzEiLCAi
-        c3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2Ygd2FscnVzIiwgImZpbGVu
-        YW1lIjogIndhbHJ1cy01LjIxLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6ICIw
-        IiwgInZlcnNpb24iOiAiNS4yMSIsICJpc19tb2R1bGFyIjogdHJ1ZSwgIl9j
-        b250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMSIsICJfaWQi
-        OiAiYTY0NjI0MDctZDRiMy00YjgwLWEyZGMtNzExMTg3MTFlYmEwIiwgImFy
-        Y2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMDVUMTk6MTI6
-        MDFaIiwgInJlcG9faWQiOiAiM192aWV3MSIsICJjcmVhdGVkIjogIjIwMTkt
-        MDgtMDVUMTk6MTI6MDFaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5p
-        dF9pZCI6ICJhNjQ2MjQwNy1kNGIzLTRiODAtYTJkYy03MTExODcxMWViYTAi
-        LCAiX2lkIjogeyIkb2lkIjogIjVkNDg3ZjgxYWIzNmNlM2ZlNTFkZjkzYSJ9
-        fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImR1Y2stMC42LTEuc3Jj
-        LnJwbSIsICJuYW1lIjogImR1Y2siLCAiY2hlY2tzdW0iOiAiOTZmMzc4Nzc1
-        MThhMWZlNmVhMmUxN2Y0Y2UxZmM4MWI0MDkwODA0M2JjYmVkNzY3NDRiM2Q3
-        ZDM4YTc3NGJjNyIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiBk
-        dWNrIiwgImZpbGVuYW1lIjogImR1Y2stMC42LTEubm9hcmNoLnJwbSIsICJl
-        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC42IiwgImlzX21vZHVsYXIiOiB0
-        cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIx
-        IiwgIl9pZCI6ICJjZTA5MzcyYS1hMWEwLTRhZWItYmYyYy1mNjBhMGExZmFk
-        OTUiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0w
-        NVQxOToxMjowMVoiLCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImNyZWF0ZWQi
-        OiAiMjAxOS0wOC0wNVQxOToxMjowMVoiLCAidW5pdF90eXBlX2lkIjogInJw
-        bSIsICJ1bml0X2lkIjogImNlMDkzNzJhLWExYTAtNGFlYi1iZjJjLWY2MGEw
-        YTFmYWQ5NSIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmODFhYjM2Y2UzZmU1
-        MWRmOTRlIn19XQ==
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:04 GMT
-- request:
-    method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwibGltaXQiOjIwMDAs
-        InNraXAiOjIwMDAsImZpZWxkcyI6eyJ1bml0IjpbIm5hbWUiLCJ2ZXJzaW9u
-        IiwicmVsZWFzZSIsImFyY2giLCJlcG9jaCIsInN1bW1hcnkiLCJzb3VyY2Vy
-        cG0iLCJjaGVja3N1bSIsImZpbGVuYW1lIiwiaXNfbW9kdWxhciJdfX19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '177'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:04 GMT
-      Server:
-      - Apache
-      Content-Length:
-      - '2'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      base64_string: 'W10=
-
-'
-    http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:04 GMT
-- request:
-    method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/search/units/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJtb2R1bGVtZCJdLCJsaW1pdCI6
-        MjAwMCwic2tpcCI6MH19
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '60'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 05 Aug 2019 19:12:04 GMT
-      Server:
-      - Apache
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '5423'
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        W3sibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
+        ZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDo0MloiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQyWiIs
+        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICI3OTVh
+        YzRmYS00ZDhiLTRiMWMtOGVkOS02Y2RmY2RhOTI2ZjYiLCAiX2lkIjogeyIk
+        b2lkIjogIjVkNjkzNDAyMzJkYjYwNzdhNzk2NzJjNCJ9fSwgeyJtZXRhZGF0
+        YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQv
+        dW5pdHMvbW9kdWxlbWQvOTAvNjZmNmI0M2IxYjRkZjA5ZjhhNjg3OTdhMDdh
+        ODRmZDNmNTVlNDc0ZjdkMzk5M2VmMmE4ZGM3NDE4ZDEwMDEiLCAibmFtZSI6
+        ICJrYW5nYXJvbyIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMiOiBbImth
+        bmdhcm9vLTA6MC4yLTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICJlODIwZTA4
+        YzA1YWE3MzZjZTUzMDA2NmM2ODgyODhiZjU3NDYwOTgyNjdjMjgyNDI3OWUz
+        NmM5YTcyZTZiOWNlIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTY3MTc1NjYxLCAi
+        X2NvbnRlbnRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxlcyI6IHsi
+        ZGVmYXVsdCI6IFsia2FuZ2Fyb28iXX0sICJzdW1tYXJ5IjogIkthbmdhcm9v
+        IDAuMiBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjog
+        MjAxODA3MDQxMTE3MTksICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNv
+        bnRleHQiOiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwg
+        ImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogIjlhNjM4YWNhLTdiZjQtNDE4
+        MS1iMGEzLTM4ZTAwMGFlYTgxNCIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNj
+        cmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIGthbmdhcm9vIDAuMiBwYWNr
+        YWdlIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDJaIiwgInJl
+        cG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0zMFQx
+        NDozNDo0MloiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInVuaXRf
+        aWQiOiAiOWE2MzhhY2EtN2JmNC00MTgxLWIwYTMtMzhlMDAwYWVhODE0Iiwg
+        Il9pZCI6IHsiJG9pZCI6ICI1ZDY5MzQwMjMyZGI2MDc3YTc5NjcyY2QifX0s
+        IHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
         cC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzFiLzJmMDAzOTY0YmI2NDIxZGU3
         NDI3N2RiMTljOWNhOGQzMzNhYmE5NjM5MzkxMGM3ODBlNTcwMGRjOGE4M2Ez
         IiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMi
         OiBbImR1Y2stMDowLjYtMS5ub2FyY2giXSwgImNoZWNrc3VtIjogIjZiZDlk
         OTA5YzkyNzA1NzFiODExZTUwMjcwOWVhN2I1NjE1MGQ0NGEyYjRiMzRjZmQy
-        NWU1MmE4MWM1YmZjZTciLCAiX2xhc3RfdXBkYXRlZCI6IDE1NjUwMzIwOTYs
+        NWU1MmE4MWM1YmZjZTciLCAiX2xhc3RfdXBkYXRlZCI6IDE1NjcxNzU2NjEs
         ICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2ZpbGVzIjog
         eyJkZWZhdWx0IjogWyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNrIDAuNiBt
         b2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3
         MDQyNDQyMDUsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQi
         OiAiZGVhZGJlZWYiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVu
-        ZGVuY2llcyI6IFtdLCAiX2lkIjogIjA5NzQ2YTlhLTUwMjYtNGVmMi1hNWM1
-        LWM1YjA4MTcwZjQ0YSIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNjcmlwdGlv
+        ZGVuY2llcyI6IFtdLCAiX2lkIjogImVjMmQ2NWZmLTAyZGItNDg0MS04MzVl
+        LTkzMGI3ZjcxYTMzNiIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNjcmlwdGlv
         biI6ICJBIG1vZHVsZSBmb3IgdGhlIGR1Y2sgMC42IHBhY2thZ2UifSwgInVw
-        ZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjowMVoiLCAicmVwb19pZCI6ICIz
-        X3ZpZXcxIiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjowMVoiLCAi
-        dW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInVuaXRfaWQiOiAiMDk3NDZh
-        OWEtNTAyNi00ZWYyLWE1YzUtYzViMDgxNzBmNDRhIiwgIl9pZCI6IHsiJG9p
-        ZCI6ICI1ZDQ4N2Y4MWFiMzZjZTNmZTUxZGZhOWQifX0sIHsibWV0YWRhdGEi
-        OiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVscC9jb250ZW50L3Vu
-        aXRzL21vZHVsZW1kLzA0L2Y1NTg2ZWUxNGRlNGUzNWM2N2FiMDhkMjZjYjdh
-        MDVlN2ZmZjBkZTA3ZGNlYWI2NjEzM2E1ODIwYzM4MmNlIiwgIm5hbWUiOiAi
-        ZHVjayIsICJzdHJlYW0iOiAiMCIsICJhcnRpZmFjdHMiOiBbImR1Y2stMDow
-        LjctMS5ub2FyY2giXSwgImNoZWNrc3VtIjogImRkNjIxYzA1OGNkZTFlNjc1
-        NzhmZGMxNzEzMzI0NWE2NTE3OTZhZmMwODczZDg1NmI3OTBhN2Y3MDI4MjUw
-        MjEiLCAiX2xhc3RfdXBkYXRlZCI6IDE1NjUwMzIwOTYsICJfY29udGVudF90
-        eXBlX2lkIjogIm1vZHVsZW1kIiwgInByb2ZpbGVzIjogeyJkZWZhdWx0Ijog
-        WyJkdWNrIl19LCAic3VtbWFyeSI6ICJEdWNrIDAuNyBtb2R1bGUiLCAiZG93
-        bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3MzAyMzMxMDIsICJw
-        dWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQiOiAiZGVhZGJlZWYi
-        LCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVuZGVuY2llcyI6IFtd
-        LCAiX2lkIjogIjFkYjY0Y2FiLTBhNWUtNGJkOC1iZjUyLTQxYjA3ZGNjZDUz
-        NiIsICJhcmNoIjogIm5vYXJjaCIsICJkZXNjcmlwdGlvbiI6ICJBIG1vZHVs
-        ZSBmb3IgdGhlIGR1Y2sgMC43IHBhY2thZ2UifSwgInVwZGF0ZWQiOiAiMjAx
-        OS0wOC0wNVQxOToxMjowMVoiLCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImNy
-        ZWF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjowMVoiLCAidW5pdF90eXBlX2lk
-        IjogIm1vZHVsZW1kIiwgInVuaXRfaWQiOiAiMWRiNjRjYWItMGE1ZS00YmQ4
-        LWJmNTItNDFiMDdkY2NkNTM2IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y4
-        MWFiMzZjZTNmZTUxZGZhYTMifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdl
-        X3BhdGgiOiAiL3Zhci9saWIvcHVscC9jb250ZW50L3VuaXRzL21vZHVsZW1k
-        L2VhL2E4NzIwM2FhNzFhY2QwOWVkNGM4NzBlMDg3NTQ5ZGEyYTVkMmNhYzdj
-        YjllZWQ3ZTdiMDYzYmY5ZjQ5N2E5IiwgIm5hbWUiOiAid2FscnVzIiwgInN0
-        cmVhbSI6ICIwLjcxIiwgImFydGlmYWN0cyI6IFsid2FscnVzLTA6MC43MS0x
-        Lm5vYXJjaCJdLCAiY2hlY2tzdW0iOiAiODNmNmFmZjMyNjE0ODU3ZTk5MDk4
-        NzZhNGZiN2E5NWQ1OTE5NWZkOThiOWEyN2EwNjRhOTQyZWNiYzRmNDY4MiIs
-        ICJfbGFzdF91cGRhdGVkIjogMTU2NTAzMjA5NiwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAibW9kdWxlbWQiLCAicHJvZmlsZXMiOiB7ImRlZmF1bHQiOiBbIndh
-        bHJ1cyJdLCAiZmxpcHBlciI6IFsid2FscnVzIl19LCAic3VtbWFyeSI6ICJX
-        YWxydXMgMC43MSBtb2R1bGUiLCAiZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJz
-        aW9uIjogMjAxODA3MDcxNDQyMDMsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7
-        fSwgImNvbnRleHQiOiAiYzBmZmVlNDIiLCAiX25zIjogInVuaXRzX21vZHVs
-        ZW1kIiwgImRlcGVuZGVuY2llcyI6IFtdLCAiX2lkIjogIjJiMzRhZjk2LWMx
-        NGQtNDBjYS1iMDg2LWRkODYwOTYxOGU5YiIsICJhcmNoIjogIng4Nl82NCIs
-        ICJkZXNjcmlwdGlvbiI6ICJBIG1vZHVsZSBmb3IgdGhlIHdhbHJ1cyAwLjcx
-        IHBhY2thZ2UifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjowMVoi
-        LCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0w
-        NVQxOToxMjowMVoiLCAidW5pdF90eXBlX2lkIjogIm1vZHVsZW1kIiwgInVu
-        aXRfaWQiOiAiMmIzNGFmOTYtYzE0ZC00MGNhLWIwODYtZGQ4NjA5NjE4ZTli
-        IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y4MWFiMzZjZTNmZTUxZGZhYTAi
-        fX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIv
-        cHVscC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzQxLzljMjZjYTAzMjJmMDQ1
-        OGFiNzRmNTg3NmUyOWEzNjZmODBjMmI0OTAyMGY2NjNhYmI5ZmY0YmJkY2Jk
-        NmNjIiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICI1LjIxIiwgImFy
-        dGlmYWN0cyI6IFsid2FscnVzLTA6NS4yMS0xLm5vYXJjaCJdLCAiY2hlY2tz
-        dW0iOiAiZmMwY2I5NTBlNTNjNWVhOTliMDNiY2FjNDI3MjVjNjAyOTVmMTQ4
-        YWFhZGUxYTdjZTZjN2Q4MDI4YTA3M2I1OSIsICJfbGFzdF91cGRhdGVkIjog
-        MTU2NTAzMjA5NiwgIl9jb250ZW50X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAi
-        cHJvZmlsZXMiOiB7ImRlZmF1bHQiOiBbIndhbHJ1cyJdfSwgInN1bW1hcnki
-        OiAiV2FscnVzIDUuMjEgbW9kdWxlIiwgImRvd25sb2FkZWQiOiB0cnVlLCAi
-        dmVyc2lvbiI6IDIwMTgwNzA0MTQ0MjAzLCAicHVscF91c2VyX21ldGFkYXRh
-        Ijoge30sICJjb250ZXh0IjogImRlYWRiZWVmIiwgIl9ucyI6ICJ1bml0c19t
-        b2R1bGVtZCIsICJkZXBlbmRlbmNpZXMiOiBbXSwgIl9pZCI6ICJiMWViZDJl
-        OC0xNDg3LTQxNjctYTdhNi1kYTM2N2ExODFlY2IiLCAiYXJjaCI6ICJ4ODZf
-        NjQiLCAiZGVzY3JpcHRpb24iOiAiQSBtb2R1bGUgZm9yIHRoZSB3YWxydXMg
-        NS4yMSBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMDVUMTk6MTI6
-        MDFaIiwgInJlcG9faWQiOiAiM192aWV3MSIsICJjcmVhdGVkIjogIjIwMTkt
-        MDgtMDVUMTk6MTI6MDFaIiwgInVuaXRfdHlwZV9pZCI6ICJtb2R1bGVtZCIs
-        ICJ1bml0X2lkIjogImIxZWJkMmU4LTE0ODctNDE2Ny1hN2E2LWRhMzY3YTE4
-        MWVjYiIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmODFhYjM2Y2UzZmU1MWRm
-        YWFjIn19LCB7Im1ldGFkYXRhIjogeyJfc3RvcmFnZV9wYXRoIjogIi92YXIv
-        bGliL3B1bHAvY29udGVudC91bml0cy9tb2R1bGVtZC85MC82NmY2YjQzYjFi
-        NGRmMDlmOGE2ODc5N2EwN2E4NGZkM2Y1NWU0NzRmN2QzOTkzZWYyYThkYzc0
-        MThkMTAwMSIsICJuYW1lIjogImthbmdhcm9vIiwgInN0cmVhbSI6ICIwIiwg
-        ImFydGlmYWN0cyI6IFsia2FuZ2Fyb28tMDowLjItMS5ub2FyY2giXSwgImNo
-        ZWNrc3VtIjogImU4MjBlMDhjMDVhYTczNmNlNTMwMDY2YzY4ODI4OGJmNTc0
-        NjA5ODI2N2MyODI0Mjc5ZTM2YzlhNzJlNmI5Y2UiLCAiX2xhc3RfdXBkYXRl
-        ZCI6IDE1NjUwMzIwOTYsICJfY29udGVudF90eXBlX2lkIjogIm1vZHVsZW1k
-        IiwgInByb2ZpbGVzIjogeyJkZWZhdWx0IjogWyJrYW5nYXJvbyJdfSwgInN1
-        bW1hcnkiOiAiS2FuZ2Fyb28gMC4yIG1vZHVsZSIsICJkb3dubG9hZGVkIjog
-        dHJ1ZSwgInZlcnNpb24iOiAyMDE4MDcwNDExMTcxOSwgInB1bHBfdXNlcl9t
-        ZXRhZGF0YSI6IHt9LCAiY29udGV4dCI6ICJkZWFkYmVlZiIsICJfbnMiOiAi
-        dW5pdHNfbW9kdWxlbWQiLCAiZGVwZW5kZW5jaWVzIjogW10sICJfaWQiOiAi
-        Y2I5NDQwNDQtOTVmMS00NDk5LWI4MDctNWU4M2U3ODczMjE2IiwgImFyY2gi
-        OiAibm9hcmNoIiwgImRlc2NyaXB0aW9uIjogIkEgbW9kdWxlIGZvciB0aGUg
-        a2FuZ2Fyb28gMC4yIHBhY2thZ2UifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0w
-        NVQxOToxMjowMVoiLCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImNyZWF0ZWQi
-        OiAiMjAxOS0wOC0wNVQxOToxMjowMVoiLCAidW5pdF90eXBlX2lkIjogIm1v
-        ZHVsZW1kIiwgInVuaXRfaWQiOiAiY2I5NDQwNDQtOTVmMS00NDk5LWI4MDct
-        NWU4M2U3ODczMjE2IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y4MWFiMzZj
-        ZTNmZTUxZGZhYTYifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgi
-        OiAiL3Zhci9saWIvcHVscC9jb250ZW50L3VuaXRzL21vZHVsZW1kLzc4LzY4
-        NzI3YmNjMmE5ZDlhNjAzYmUxYmQ0MDdmNDdlZDg3Yjk2YjEyZWQ2Y2Q1NTU2
-        YmNkY2VhOTFkYTk4MGUwIiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAic3RyZWFt
-        IjogIjAiLCAiYXJ0aWZhY3RzIjogWyJrYW5nYXJvby0wOjAuMy0xLm5vYXJj
-        aCJdLCAiY2hlY2tzdW0iOiAiMDkwMGRkMGZhYTY3ZjkzODY3N2M0YmFhY2Yw
-        MDVlYzlkMjQ4MjdhZmEyMTFjYjQxNTdlZDg2ZDM1Y2M4M2ZkZSIsICJfbGFz
-        dF91cGRhdGVkIjogMTU2NTAzMjA5NiwgIl9jb250ZW50X3R5cGVfaWQiOiAi
-        bW9kdWxlbWQiLCAicHJvZmlsZXMiOiB7ImRlZmF1bHQiOiBbImthbmdhcm9v
-        Il19LCAic3VtbWFyeSI6ICJLYW5nYXJvbyAwLjMgbW9kdWxlIiwgImRvd25s
-        b2FkZWQiOiB0cnVlLCAidmVyc2lvbiI6IDIwMTgwNzMwMjIzNDA3LCAicHVs
-        cF91c2VyX21ldGFkYXRhIjoge30sICJjb250ZXh0IjogImRlYWRiZWVmIiwg
-        Il9ucyI6ICJ1bml0c19tb2R1bGVtZCIsICJkZXBlbmRlbmNpZXMiOiBbXSwg
-        Il9pZCI6ICJkMTYxMGQ4Ni1jYjM5LTQ1MWQtYTgyNS1kYjA2ZWJkYmEzOTEi
-        LCAiYXJjaCI6ICJub2FyY2giLCAiZGVzY3JpcHRpb24iOiAiQSBtb2R1bGUg
-        Zm9yIHRoZSBrYW5nYXJvbyAwLjMgcGFja2FnZSJ9LCAidXBkYXRlZCI6ICIy
-        MDE5LTA4LTA1VDE5OjEyOjAxWiIsICJyZXBvX2lkIjogIjNfdmlldzEiLCAi
-        Y3JlYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjEyOjAxWiIsICJ1bml0X3R5cGVf
-        aWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICJkMTYxMGQ4Ni1jYjM5LTQ1
-        MWQtYTgyNS1kYjA2ZWJkYmEzOTEiLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3
-        ZjgxYWIzNmNlM2ZlNTFkZmFhOSJ9fV0=
+        ZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDo0MloiLCAicmVwb19pZCI6ICJG
+        ZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQyWiIs
+        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICJlYzJk
+        NjVmZi0wMmRiLTQ4NDEtODM1ZS05MzBiN2Y3MWEzMzYiLCAiX2lkIjogeyIk
+        b2lkIjogIjVkNjkzNDAyMzJkYjYwNzdhNzk2NzJlNCJ9fV0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:04 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:43 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3757,21 +1309,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '63'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:04 GMT
+      - Fri, 30 Aug 2019 14:34:43 GMT
       Server:
       - Apache
       Content-Length:
@@ -3784,10 +1336,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:04 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:43 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -3796,172 +1348,182 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '59'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:04 GMT
+      - Fri, 30 Aug 2019 14:34:43 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '9093'
+      - '1947'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAx
+        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTExLTEwIDAwOjAwOjAw
         IiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjog
-        W10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDowMDAx
-        IiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6
-        ICIiLCAidGl0bGUiOiAiRW1wdHkgZXJyYXRhIiwgIl9ucyI6ICJ1bml0c19l
-        cnJhdHVtIiwgInZlcnNpb24iOiAiMSIsICJyZWJvb3Rfc3VnZ2VzdGVkIjog
-        ZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3QiOiBbXSwgInN0
-        YXR1cyI6ICJzdGFibGUiLCAidXBkYXRlZCI6ICIiLCAiZGVzY3JpcHRpb24i
-        OiAiRW1wdHkgZXJyYXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTY1MDMyMzIw
-        LCAicmVzdGFydF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6ICIi
-        LCAicmlnaHRzIjogIiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIi
-        LCAicmVsZWFzZSI6ICIxIiwgIl9pZCI6ICIwMDVmZTMzMy1mMTM5LTQ2Zjct
-        ODM0ZC1jYjk4OWYyN2Y5ZWEifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0wNVQx
-        OToxMjowMVoiLCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImNyZWF0ZWQiOiAi
-        MjAxOS0wOC0wNVQxOToxMjowMVoiLCAidW5pdF90eXBlX2lkIjogImVycmF0
-        dW0iLCAidW5pdF9pZCI6ICIwMDVmZTMzMy1mMTM5LTQ2ZjctODM0ZC1jYjk4
-        OWYyN2Y5ZWEiLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3ZjgxYWIzNmNlM2Zl
-        NTFkZjljMSJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTAtMDEt
-        MDEgMDE6MDE6MDEiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJl
-        ZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2Nv
-        bnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhF
-        QS0yMDEwOjAwMDIiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwg
-        InNldmVyaXR5IjogIiIsICJ0aXRsZSI6ICJPbmUgcGFja2FnZSBlcnJhdGEi
-        LCAiX25zIjogInVuaXRzX2VycmF0dW0iLCAidmVyc2lvbiI6ICIxIiwgInJl
-        Ym9vdF9zdWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAi
-        cGtnbGlzdCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogImh0dHA6Ly93d3cu
-        ZmVkb3JhcHJvamVjdC5vcmciLCAibmFtZSI6ICJlbGVwaGFudCIsICJzdW0i
-        OiBudWxsLCAiZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gu
-        cnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFz
-        ZSI6ICIwLjgiLCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxl
-        Y3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwg
-        InVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjogIk9uZSBwYWNrYWdlIGVy
-        cmF0YSIsICJfbGFzdF91cGRhdGVkIjogMTU2NTAzMjMyMCwgInJlc3RhcnRf
-        c3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6
-        ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVhc2Ui
-        OiAiMSIsICJfaWQiOiAiMWVkZWM0MjMtMjJmYi00YzIyLTg4MzctM2MxYzQz
-        MGFkOWU5In0sICJ1cGRhdGVkIjogIjIwMTktMDgtMDVUMTk6MTI6MDFaIiwg
-        InJlcG9faWQiOiAiM192aWV3MSIsICJjcmVhdGVkIjogIjIwMTktMDgtMDVU
-        MTk6MTI6MDFaIiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVuaXRf
-        aWQiOiAiMWVkZWM0MjMtMjJmYi00YzIyLTg4MzctM2MxYzQzMGFkOWU5Iiwg
-        Il9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y4MWFiMzZjZTNmZTUxZGY5YmEifX0s
-        IHsibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAx
-        IiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjog
-        W10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDo5OTE0
-        MyIsICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJpdHki
-        OiAiIiwgInRpdGxlIjogIkFybWFkaWxsbyIsICJfbnMiOiAidW5pdHNfZXJy
-        YXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZh
-        bHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFja2Fn
-        ZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIs
-        ICJuYW1lIjogImFybWFkaWxsbyIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUi
-        OiAiYXJtYWRpbGxvLTIuMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIs
-        ICJ2ZXJzaW9uIjogIjIuMSIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJu
-        b2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIi
-        fV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2Ny
-        aXB0aW9uIjogIkFybWFkaWxsbyIsICJfbGFzdF91cGRhdGVkIjogMTU2NTAz
-        MjMyMCwgInJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQi
-        OiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnki
-        OiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQiOiAiNzBiNjA2OTctNjcxZC00
-        ZjU5LWE1YmEtMDcxMTVmMTAxMjQ4In0sICJ1cGRhdGVkIjogIjIwMTktMDgt
-        MDVUMTk6MTI6MDFaIiwgInJlcG9faWQiOiAiM192aWV3MSIsICJjcmVhdGVk
-        IjogIjIwMTktMDgtMDVUMTk6MTI6MDFaIiwgInVuaXRfdHlwZV9pZCI6ICJl
-        cnJhdHVtIiwgInVuaXRfaWQiOiAiNzBiNjA2OTctNjcxZC00ZjU5LWE1YmEt
-        MDcxMTVmMTAxMjQ4IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y4MWFiMzZj
-        ZTNmZTUxZGY5YmUifX0sIHsibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEw
-        LTExLTEwIDAwOjAwOjAwIiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2Us
-        ICJyZWZlcmVuY2VzIjogW3siaHJlZiI6ICJodHRwczovL3Jobi5yZWRoYXQu
-        Y29tL2VycmF0YS9SSFNBLTIwMTAtMDg1OC5odG1sIiwgInR5cGUiOiAic2Vs
-        ZiIsICJpZCI6IG51bGwsICJ0aXRsZSI6ICJSSFNBLTIwMTA6MDg1OCJ9LCB7
-        ImhyZWYiOiAiaHR0cHM6Ly9idWd6aWxsYS5yZWRoYXQuY29tL2J1Z3ppbGxh
-        L3Nob3dfYnVnLmNnaT9pZD02Mjc4ODIiLCAidHlwZSI6ICJidWd6aWxsYSIs
-        ICJpZCI6ICI2Mjc4ODIiLCAidGl0bGUiOiAiQ1ZFLTIwMTAtMDQwNSBiemlw
-        MjogaW50ZWdlciBvdmVyZmxvdyBmbGF3IGluIEJaMl9kZWNvbXByZXNzIn0s
-        IHsiaHJlZiI6ICJodHRwczovL3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5L2Rh
-        dGEvY3ZlL0NWRS0yMDEwLTA0MDUuaHRtbCIsICJ0eXBlIjogImN2ZSIsICJp
-        ZCI6ICJDVkUtMjAxMC0wNDA1IiwgInRpdGxlIjogIkNWRS0yMDEwLTA0MDUi
-        fSwgeyJocmVmIjogImh0dHA6Ly93d3cucmVkaGF0LmNvbS9zZWN1cml0eS91
-        cGRhdGVzL2NsYXNzaWZpY2F0aW9uLyNpbXBvcnRhbnQiLCAidHlwZSI6ICJv
-        dGhlciIsICJpZCI6IG51bGwsICJ0aXRsZSI6IG51bGx9XSwgInB1bHBfdXNl
-        cl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVt
-        IiwgImlkIjogIktBVEVMTE8tUkhTQS0yMDEwOjA4NTgiLCAiZnJvbSI6ICJz
-        ZWN1cml0eUByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIkltcG9ydGFudCIs
-        ICJ0aXRsZSI6ICJJbXBvcnRhbnQ6IGJ6aXAyIHNlY3VyaXR5IHVwZGF0ZSIs
-        ICJfbnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjMiLCAicmVi
-        b290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJw
-        a2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiYnppcDItMS4wLjUt
-        Ny5lbDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwiLCAic3Vt
-        IjogWyJzaGEyNTYiLCAiZWE2N2M2NjRkYTFmZjk2YTZkYzk0ZDMzMDA5Yjcz
-        ZDhmYWIzMWI1OTgyNDE4M2ZiNDVlOWJhMmViZjgyZDU4MyJdLCAiZmlsZW5h
-        bWUiOiAiYnppcDItZGV2ZWwtMS4wLjUtNy5lbDZfMC5pNjg2LnJwbSIsICJl
-        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3
-        LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlwMi0xLjAu
-        NS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJzIiwgInN1
-        bSI6IFsic2hhMjU2IiwgImM5ZjA2NGE2ODYyNTczZmI5ZjJhNmFmZjdjMzYy
-        MWYxOTQwYjQ5MmRmMmVkZmMyZWJiZGMwYjgzMDVmNTExNDciXSwgImZpbGVu
-        YW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC5pNjg2LnJwbSIsICJl
-        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3
-        LmVsNl8wIiwgImFyY2giOiAiaTY4NiJ9LCB7InNyYyI6ICJiemlwMi0xLjAu
-        NS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMiIsICJzdW0iOiBb
-        InNoYTI1NiIsICJiOGEzZjcyYmMyYjBkODliYTczNzA5OWFjOThiZjhkMmFm
-        NGJlYTAyZDMxODg0YzAyZGI5N2Y3ZjY2YzNkNWMyIl0sICJmaWxlbmFtZSI6
-        ICJiemlwMi0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0iLCAiZXBvY2giOiAi
-        MCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIs
-        ICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6ICJiemlwMi0xLjAuNS03LmVs
-        Nl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1kZXZlbCIsICJzdW0iOiBb
-        InNoYTI1NiIsICI3ZjYzMTI0ZTQ2NTViN2M5MmQyM2VjNGMzODIyNmY1ZDM3
-        NDY1Njg4NTNkZmY3NTBmYzg1ZTA1OGU3NGI1Y2Y2Il0sICJmaWxlbmFtZSI6
-        ICJiemlwMi1kZXZlbC0xLjAuNS03LmVsNl8wLng4Nl82NC5ycG0iLCAiZXBv
-        Y2giOiAiMCIsICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5l
-        bDZfMCIsICJhcmNoIjogIng4Nl82NCJ9LCB7InNyYyI6ICJiemlwMi0xLjAu
-        NS03LmVsNl8wLnNyYy5ycG0iLCAibmFtZSI6ICJiemlwMi1saWJzIiwgInN1
-        bSI6IFsic2hhMjU2IiwgIjgwMmY0Mzk5ZGJkZDAxNDc2ZTI1NGMzYjMyYzQw
-        YWZmNTljZjVkMjNhNDVmYTQ4OGM2OTE3Y2U4OTA0ZDZiNGQiXSwgImZpbGVu
-        YW1lIjogImJ6aXAyLWxpYnMtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwg
-        ImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjog
-        IjcuZWw2XzAiLCAiYXJjaCI6ICJ4ODZfNjQifV0sICJuYW1lIjogImNvbGxl
-        Y3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAiZmluYWwiLCAi
-        dXBkYXRlZCI6ICIyMDEwLTExLTEwIDAwOjAwOjAwIiwgImRlc2NyaXB0aW9u
-        IjogImJ6aXAyIGlzIGEgZnJlZWx5IGF2YWlsYWJsZSwgaGlnaC1xdWFsaXR5
-        IGRhdGEgY29tcHJlc3Nvci4gSXQgcHJvdmlkZXMgYm90aFxubGliYnoyIGxp
-        YnJhcnkgbXVzdCBiZSByZXN0YXJ0ZWQgZm9yIHRoZSB1cGRhdGUgdG8gdGFr
-        ZSBlZmZlY3QuIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTY1MDMyMzIwLCAicmVz
-        dGFydF9zdWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6ICIiLCAicmln
-        aHRzIjogIkNvcHlyaWdodCAyMDEwIFJlZCBIYXQgSW5jIiwgInNvbHV0aW9u
-        IjogIkJlZm9yZSBhcHBseWluZyB0aGlzIHVwZGF0ZSwgbWFrZSBzdXJlIGFs
-        bCBwcmV2aW91c2x5LXJlbGVhc2VkIGVycmF0YVxucmVsZXZhbnQgdG8geW91
-        ciBzeXN0ZW0gaGF2ZSBiZWVuIGFwcGxpZWQuXG5cblRoaXMgdXBkYXRlIGlz
-        IGF2YWlsYWJsZSB2aWEgdGhlIFJlZCBIYXQgTmV0d29yay4gRGV0YWlscyBv
-        biBob3cgdG9cbnVzZSB0aGUgUmVkIEhhdCBOZXR3b3JrIHRvIGFwcGx5IHRo
-        aXMgdXBkYXRlIGFyZSBhdmFpbGFibGUgYXRcbmh0dHA6Ly9rYmFzZS5yZWRo
-        YXQuY29tL2ZhcS9kb2NzL0RPQy0xMTI1OSIsICJzdW1tYXJ5IjogIlVwZGF0
-        ZWQgYnppcDIgcGFja2FnZXMgdGhhdCBmaXggb25lIHNlY3VyaXR5IGlzc3Vl
-        IiwgInJlbGVhc2UiOiAiIiwgIl9pZCI6ICJjZTJiNzRjNi1hZWU1LTQxYTYt
-        ODZmNi01ZTQ0MTFmZWJiNGIifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0wNVQx
-        OToxMjowMVoiLCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImNyZWF0ZWQiOiAi
-        MjAxOS0wOC0wNVQxOToxMjowMVoiLCAidW5pdF90eXBlX2lkIjogImVycmF0
-        dW0iLCAidW5pdF9pZCI6ICJjZTJiNzRjNi1hZWU1LTQxYTYtODZmNi01ZTQ0
-        MTFmZWJiNGIiLCAiX2lkIjogeyIkb2lkIjogIjVkNDg3ZjgxYWIzNmNlM2Zl
-        NTFkZjliNCJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTgtMDEt
+        W3siaHJlZiI6ICJodHRwczovL3Jobi5yZWRoYXQuY29tL2VycmF0YS9SSFNB
+        LTIwMTAtMDg1OC5odG1sIiwgInR5cGUiOiAic2VsZiIsICJpZCI6IG51bGws
+        ICJ0aXRsZSI6ICJSSFNBLTIwMTA6MDg1OCJ9LCB7ImhyZWYiOiAiaHR0cHM6
+        Ly9idWd6aWxsYS5yZWRoYXQuY29tL2J1Z3ppbGxhL3Nob3dfYnVnLmNnaT9p
+        ZD02Mjc4ODIiLCAidHlwZSI6ICJidWd6aWxsYSIsICJpZCI6ICI2Mjc4ODIi
+        LCAidGl0bGUiOiAiQ1ZFLTIwMTAtMDQwNSBiemlwMjogaW50ZWdlciBvdmVy
+        ZmxvdyBmbGF3IGluIEJaMl9kZWNvbXByZXNzIn0sIHsiaHJlZiI6ICJodHRw
+        czovL3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5L2RhdGEvY3ZlL0NWRS0yMDEw
+        LTA0MDUuaHRtbCIsICJ0eXBlIjogImN2ZSIsICJpZCI6ICJDVkUtMjAxMC0w
+        NDA1IiwgInRpdGxlIjogIkNWRS0yMDEwLTA0MDUifSwgeyJocmVmIjogImh0
+        dHA6Ly93d3cucmVkaGF0LmNvbS9zZWN1cml0eS91cGRhdGVzL2NsYXNzaWZp
+        Y2F0aW9uLyNpbXBvcnRhbnQiLCAidHlwZSI6ICJvdGhlciIsICJpZCI6IG51
+        bGwsICJ0aXRsZSI6IG51bGx9XSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9
+        LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVM
+        TE8tUkhTQS0yMDEwOjA4NTgiLCAiZnJvbSI6ICJzZWN1cml0eUByZWRoYXQu
+        Y29tIiwgInNldmVyaXR5IjogIkltcG9ydGFudCIsICJ0aXRsZSI6ICJJbXBv
+        cnRhbnQ6IGJ6aXAyIHNlY3VyaXR5IHVwZGF0ZSIsICJfbnMiOiAidW5pdHNf
+        ZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjMiLCAicmVib290X3N1Z2dlc3RlZCI6
+        IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFj
+        a2FnZXMiOiBbeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBt
+        IiwgIm5hbWUiOiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1NiIsICI4
+        MDJmNDM5OWRiZGQwMTQ3NmUyNTRjM2IzMmM0MGFmZjU5Y2Y1ZDIzYTQ1ZmE0
+        ODhjNjkxN2NlODkwNGQ2YjRkIl0sICJmaWxlbmFtZSI6ICJiemlwMi1saWJz
+        LTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6ICIwIiwgInZl
+        cnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2gi
+        OiAieDg2XzY0In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3Jj
+        LnJwbSIsICJuYW1lIjogImJ6aXAyLWRldmVsIiwgInN1bSI6IFsic2hhMjU2
+        IiwgImVhNjdjNjY0ZGExZmY5NmE2ZGM5NGQzMzAwOWI3M2Q4ZmFiMzFiNTk4
+        MjQxODNmYjQ1ZTliYTJlYmY4MmQ1ODMiXSwgImZpbGVuYW1lIjogImJ6aXAy
+        LWRldmVsLTEuMC41LTcuZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
+        cmNoIjogImk2ODYifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5z
+        cmMucnBtIiwgIm5hbWUiOiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1
+        NiIsICJjOWYwNjRhNjg2MjU3M2ZiOWYyYTZhZmY3YzM2MjFmMTk0MGI0OTJk
+        ZjJlZGZjMmViYmRjMGI4MzA1ZjUxMTQ3Il0sICJmaWxlbmFtZSI6ICJiemlw
+        Mi1saWJzLTEuMC41LTcuZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
+        cmNoIjogImk2ODYifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5z
+        cmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwiLCAic3VtIjogWyJzaGEy
+        NTYiLCAiN2Y2MzEyNGU0NjU1YjdjOTJkMjNlYzRjMzgyMjZmNWQzNzQ2NTY4
+        ODUzZGZmNzUwZmM4NWUwNThlNzRiNWNmNiJdLCAiZmlsZW5hbWUiOiAiYnpp
+        cDItZGV2ZWwtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjog
+        IjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAi
+        LCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5l
+        bDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDIiLCAic3VtIjogWyJzaGEy
+        NTYiLCAiYjhhM2Y3MmJjMmIwZDg5YmE3MzcwOTlhYzk4YmY4ZDJhZjRiZWEw
+        MmQzMTg4NGMwMmRiOTdmN2Y2NmMzZDVjMiJdLCAiZmlsZW5hbWUiOiAiYnpp
+        cDItMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjogIjAiLCAi
+        dmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJj
+        aCI6ICJ4ODZfNjQifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9y
+        dCI6ICIifV0sICJzdGF0dXMiOiAiZmluYWwiLCAidXBkYXRlZCI6ICIyMDEw
+        LTExLTEwIDAwOjAwOjAwIiwgImRlc2NyaXB0aW9uIjogImJ6aXAyIGlzIGEg
+        ZnJlZWx5IGF2YWlsYWJsZSwgaGlnaC1xdWFsaXR5IGRhdGEgY29tcHJlc3Nv
+        ci4gSXQgcHJvdmlkZXMgYm90aFxubGliYnoyIGxpYnJhcnkgbXVzdCBiZSBy
+        ZXN0YXJ0ZWQgZm9yIHRoZSB1cGRhdGUgdG8gdGFrZSBlZmZlY3QuIiwgIl9s
+        YXN0X3VwZGF0ZWQiOiAxNTY3MTc1NjgyLCAicmVzdGFydF9zdWdnZXN0ZWQi
+        OiBmYWxzZSwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIkNvcHlyaWdo
+        dCAyMDEwIFJlZCBIYXQgSW5jIiwgInNvbHV0aW9uIjogIkJlZm9yZSBhcHBs
+        eWluZyB0aGlzIHVwZGF0ZSwgbWFrZSBzdXJlIGFsbCBwcmV2aW91c2x5LXJl
+        bGVhc2VkIGVycmF0YVxucmVsZXZhbnQgdG8geW91ciBzeXN0ZW0gaGF2ZSBi
+        ZWVuIGFwcGxpZWQuXG5cblRoaXMgdXBkYXRlIGlzIGF2YWlsYWJsZSB2aWEg
+        dGhlIFJlZCBIYXQgTmV0d29yay4gRGV0YWlscyBvbiBob3cgdG9cbnVzZSB0
+        aGUgUmVkIEhhdCBOZXR3b3JrIHRvIGFwcGx5IHRoaXMgdXBkYXRlIGFyZSBh
+        dmFpbGFibGUgYXRcbmh0dHA6Ly9rYmFzZS5yZWRoYXQuY29tL2ZhcS9kb2Nz
+        L0RPQy0xMTI1OSIsICJzdW1tYXJ5IjogIlVwZGF0ZWQgYnppcDIgcGFja2Fn
+        ZXMgdGhhdCBmaXggb25lIHNlY3VyaXR5IGlzc3VlIiwgInJlbGVhc2UiOiAi
+        IiwgIl9pZCI6ICI0YmM2ZGRiNy1hNGU1LTRkYTUtODM0YS00OTVhYWI2ODZh
+        NDgifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDo0MloiLCAicmVw
+        b19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTMwVDE0
+        OjM0OjQyWiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJ1bml0X2lk
+        IjogIjRiYzZkZGI3LWE0ZTUtNGRhNS04MzRhLTQ5NWFhYjY4NmE0OCIsICJf
+        aWQiOiB7IiRvaWQiOiAiNWQ2OTM0MDIzMmRiNjA3N2E3OTY3MzRlIn19LCB7
+        Im1ldGFkYXRhIjogeyJpc3N1ZWQiOiAiMjAxMi0wMS0wMSAwMTowMTowMSIs
+        ICJyZWxvZ2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVmZXJlbmNlcyI6IFtd
+        LCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lk
+        IjogImVycmF0dW0iLCAiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6MDExMSIs
+        ICJmcm9tIjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAi
+        IiwgInRpdGxlIjogIkR1cGxpY2F0ZWQgcGFja2FnZSBlcnJhdGEiLCAiX25z
+        IjogInVuaXRzX2VycmF0dW0iLCAidmVyc2lvbiI6ICIxIiwgInJlYm9vdF9z
+        dWdnZXN0ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlz
+        dCI6IFt7InBhY2thZ2VzIjogW3sic3JjIjogImh0dHA6Ly93d3cuZmVkb3Jh
+        cHJvamVjdC5vcmciLCAibmFtZSI6ICJsaW9uIiwgInN1bSI6IG51bGwsICJm
+        aWxlbmFtZSI6ICJsaW9uLTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9jaCI6
+        ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44IiwgImFy
+        Y2giOiAibm9hcmNoIn0sIHsic3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJv
+        amVjdC5vcmciLCAibmFtZSI6ICJlbGVwaGFudCIsICJzdW0iOiBudWxsLCAi
+        ZmlsZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVw
+        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgi
+        LCAiYXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIs
+        ICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQi
+        OiAiIiwgImRlc2NyaXB0aW9uIjogIkR1cGxpY2F0ZSBPbmUgcGFja2FnZSBl
+        cnJhdGEiLCAiX2xhc3RfdXBkYXRlZCI6IDE1NjcxNzU2ODIsICJyZXN0YXJ0
+        X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMi
+        OiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNl
+        IjogIjEiLCAiX2lkIjogIjUyYmE2NTI1LWU5NTktNGNjZC04YWNiLWY1MjQ5
+        OTdiNjM1YiJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQyWiIs
+        ICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTktMDgt
+        MzBUMTQ6MzQ6NDJaIiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVu
+        aXRfaWQiOiAiNTJiYTY1MjUtZTk1OS00Y2NkLThhY2ItZjUyNDk5N2I2MzVi
+        IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzQwMjMyZGI2MDc3YTc5NjczOWMi
+        fX0sIHsibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAx
+        OjAxIiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2Vz
+        IjogW10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5
+        cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDow
+        MDAyIiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNvbSIsICJzZXZlcml0
+        eSI6ICIiLCAidGl0bGUiOiAiT25lIHBhY2thZ2UgZXJyYXRhIiwgIl9ucyI6
+        ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMSIsICJyZWJvb3Rfc3Vn
+        Z2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3Qi
+        OiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRwOi8vd3d3LmZlZG9yYXBy
+        b2plY3Qub3JnIiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAic3VtIjogbnVsbCwg
+        ImZpbGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsICJl
+        cG9jaCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44
+        IiwgImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJjb2xsZWN0aW9uLTAi
+        LCAic2hvcnQiOiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIsICJ1cGRhdGVk
+        IjogIiIsICJkZXNjcmlwdGlvbiI6ICJPbmUgcGFja2FnZSBlcnJhdGEiLCAi
+        X2xhc3RfdXBkYXRlZCI6IDE1NjcxNzU2ODIsICJyZXN0YXJ0X3N1Z2dlc3Rl
+        ZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMiOiAiIiwgInNv
+        bHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAi
+        X2lkIjogIjZkMmNhYTMzLTczNjYtNDUzMi05ZjNkLWVhYjgzNzAyZTJhMCJ9
+        LCAidXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQyWiIsICJyZXBvX2lk
+        IjogIkZlZG9yYV8xNyIsICJjcmVhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6
+        NDJaIiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVuaXRfaWQiOiAi
+        NmQyY2FhMzMtNzM2Ni00NTMyLTlmM2QtZWFiODM3MDJlMmEwIiwgIl9pZCI6
+        IHsiJG9pZCI6ICI1ZDY5MzQwMjMyZGI2MDc3YTc5NjczNjgifX0sIHsibWV0
+        YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAxIiwgInJl
+        bG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjogW10sICJw
+        dWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAi
+        ZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDo5OTE0MyIsICJm
+        cm9tIjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwg
+        InRpdGxlIjogIkFybWFkaWxsbyIsICJfbnMiOiAidW5pdHNfZXJyYXR1bSIs
+        ICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAi
+        dHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBb
+        eyJzcmMiOiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIsICJuYW1l
+        IjogImFybWFkaWxsbyIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiYXJt
+        YWRpbGxvLTIuMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJz
+        aW9uIjogIjIuMSIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2gi
+        fV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJz
+        dGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9u
+        IjogIkFybWFkaWxsbyIsICJfbGFzdF91cGRhdGVkIjogMTU2NzE3NTY4Miwg
+        InJlc3RhcnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwg
+        InJpZ2h0cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwg
+        InJlbGVhc2UiOiAiMSIsICJfaWQiOiAiYjFiNzQ3NTAtMGYxMC00M2M0LTgy
+        YmMtMTk1ZjE3NjAxOTBkIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6
+        MzQ6NDJaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAi
+        MjAxOS0wOC0zMFQxNDozNDo0MloiLCAidW5pdF90eXBlX2lkIjogImVycmF0
+        dW0iLCAidW5pdF9pZCI6ICJiMWI3NDc1MC0wZjEwLTQzYzQtODJiYy0xOTVm
+        MTc2MDE5MGQiLCAiX2lkIjogeyIkb2lkIjogIjVkNjkzNDAyMzJkYjYwNzdh
+        Nzk2NzM4MiJ9fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTgtMDEt
         MjcgMTY6MDg6MDkiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJl
         ZmVyZW5jZXMiOiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2Nv
         bnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhF
@@ -3987,49 +1549,39 @@ http_interactions:
         LCAic3RyZWFtIjogIjAifSwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6ICJz
         dGFibGUiLCAidXBkYXRlZCI6ICIyMDE4LTA3LTIwIDA2OjAwOjAxIFVUQyIs
         ICJkZXNjcmlwdGlvbiI6ICJEdWNrX0thbmdhcm9fRXJyYXR1bSBkZXNjcmlw
-        dGlvbiIsICJfbGFzdF91cGRhdGVkIjogMTU2NTAzMjMyMCwgInJlc3RhcnRf
+        dGlvbiIsICJfbGFzdF91cGRhdGVkIjogMTU2NzE3NTY4MiwgInJlc3RhcnRf
         c3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6
         ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVhc2Ui
-        OiAiMSIsICJfaWQiOiAiZmU1MTk2YzYtOGIzZC00ZWQyLTk3NDYtM2Q0NWI4
-        OTFmNDY3In0sICJ1cGRhdGVkIjogIjIwMTktMDgtMDVUMTk6MTI6MDFaIiwg
-        InJlcG9faWQiOiAiM192aWV3MSIsICJjcmVhdGVkIjogIjIwMTktMDgtMDVU
-        MTk6MTI6MDFaIiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVuaXRf
-        aWQiOiAiZmU1MTk2YzYtOGIzZC00ZWQyLTk3NDYtM2Q0NWI4OTFmNDY3Iiwg
-        Il9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y4MWFiMzZjZTNmZTUxZGY5YWYifX0s
-        IHsibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEyLTAxLTAxIDAxOjAxOjAx
-        IiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjog
-        W10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVf
-        aWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDowMTEx
-        IiwgImZyb20iOiAibHphcCtwdWJAcmVkaGF0LmNvbSIsICJzZXZlcml0eSI6
-        ICIiLCAidGl0bGUiOiAiRHVwbGljYXRlZCBwYWNrYWdlIGVycmF0YSIsICJf
-        bnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290
-        X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2ds
-        aXN0IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRv
-        cmFwcm9qZWN0Lm9yZyIsICJuYW1lIjogImVsZXBoYW50IiwgInN1bSI6IG51
-        bGwsICJmaWxlbmFtZSI6ICJlbGVwaGFudC0wLjMtMC44Lm5vYXJjaC5ycG0i
-        LCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjog
-        IjAuOCIsICJhcmNoIjogIm5vYXJjaCJ9LCB7InNyYyI6ICJodHRwOi8vd3d3
-        LmZlZG9yYXByb2plY3Qub3JnIiwgIm5hbWUiOiAibGlvbiIsICJzdW0iOiBu
-        dWxsLCAiZmlsZW5hbWUiOiAibGlvbi0wLjMtMC44Lm5vYXJjaC5ycG0iLCAi
-        ZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAu
-        OCIsICJhcmNoIjogIm5vYXJjaCJ9XSwgIm5hbWUiOiAiY29sbGVjdGlvbi0w
-        IiwgInNob3J0IjogIiJ9XSwgInN0YXR1cyI6ICJzdGFibGUiLCAidXBkYXRl
-        ZCI6ICIiLCAiZGVzY3JpcHRpb24iOiAiRHVwbGljYXRlIE9uZSBwYWNrYWdl
-        IGVycmF0YSIsICJfbGFzdF91cGRhdGVkIjogMTU2NTAzMjMyMCwgInJlc3Rh
-        cnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0
-        cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVh
-        c2UiOiAiMSIsICJfaWQiOiAiZmY5NWZlYzUtYWY0My00ZWU4LWFlOTMtNmE4
-        ZWI0N2QzYmFhIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMDVUMTk6MTI6MDFa
-        IiwgInJlcG9faWQiOiAiM192aWV3MSIsICJjcmVhdGVkIjogIjIwMTktMDgt
-        MDVUMTk6MTI6MDFaIiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVu
-        aXRfaWQiOiAiZmY5NWZlYzUtYWY0My00ZWU4LWFlOTMtNmE4ZWI0N2QzYmFh
-        IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y4MWFiMzZjZTNmZTUxZGY5Yjci
-        fX1d
+        OiAiMSIsICJfaWQiOiAiYzY4ZDEzOTUtZGZiNS00MjdhLWI0OWQtOTFhZmM4
+        NGVmYjVkIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDJaIiwg
+        InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0z
+        MFQxNDozNDo0MloiLCAidW5pdF90eXBlX2lkIjogImVycmF0dW0iLCAidW5p
+        dF9pZCI6ICJjNjhkMTM5NS1kZmI1LTQyN2EtYjQ5ZC05MWFmYzg0ZWZiNWQi
+        LCAiX2lkIjogeyIkb2lkIjogIjVkNjkzNDAyMzJkYjYwNzdhNzk2NzNiNyJ9
+        fSwgeyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTAtMDEtMDEgMDE6MDE6
+        MDEiLCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMi
+        OiBbXSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlw
+        ZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjAw
+        MDEiLCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5
+        IjogIiIsICJ0aXRsZSI6ICJFbXB0eSBlcnJhdGEiLCAiX25zIjogInVuaXRz
+        X2VycmF0dW0iLCAidmVyc2lvbiI6ICIxIiwgInJlYm9vdF9zdWdnZXN0ZWQi
+        OiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFtdLCAi
+        c3RhdHVzIjogInN0YWJsZSIsICJ1cGRhdGVkIjogIiIsICJkZXNjcmlwdGlv
+        biI6ICJFbXB0eSBlcnJhdGEiLCAiX2xhc3RfdXBkYXRlZCI6IDE1NjcxNzU2
+        ODIsICJyZXN0YXJ0X3N1Z2dlc3RlZCI6IGZhbHNlLCAicHVzaGNvdW50Ijog
+        IiIsICJyaWdodHMiOiAiIiwgInNvbHV0aW9uIjogIiIsICJzdW1tYXJ5Ijog
+        IiIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImRjODM2NDUyLWJmYjItNDRi
+        MS05YThlLWIzYmU5YTc1ZTczNSJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTMw
+        VDE0OjM0OjQyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJjcmVhdGVk
+        IjogIjIwMTktMDgtMzBUMTQ6MzQ6NDJaIiwgInVuaXRfdHlwZV9pZCI6ICJl
+        cnJhdHVtIiwgInVuaXRfaWQiOiAiZGM4MzY0NTItYmZiMi00NGIxLTlhOGUt
+        YjNiZTlhNzVlNzM1IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzQwMjMyZGI2
+        MDc3YTc5NjczMzMifX1d
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:04 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:43 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -4038,21 +1590,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '62'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:04 GMT
+      - Fri, 30 Aug 2019 14:34:43 GMT
       Server:
       - Apache
       Content-Length:
@@ -4065,10 +1617,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:04 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:43 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -4077,70 +1629,71 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '65'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:04 GMT
+      - Fri, 30 Aug 2019 14:34:43 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1478'
+      - '444'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
         W3sibWV0YWRhdGEiOiB7Im1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJw
-        ZW5ndWluIl0sICJyZXBvX2lkIjogIjNfdmlldzEiLCAibmFtZSI6ICJiaXJk
-        IiwgInVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9u
-        cyI6ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0X3VwZGF0ZWQiOiAx
-        NTY1MDMyMzIxLCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdLCAidHJh
-        bnNsYXRlZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rlc2NyaXB0aW9uIjog
-        e30sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRlZmF1bHRfcGFja2Fn
-        ZV9uYW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNrYWdlX2dy
-        b3VwIiwgImlkIjogImJpcmQiLCAiX2lkIjogIjI2OWM2MmFkLTk5ZGQtNGI1
-        NC1hYmUxLTNiMjY5ZWY2N2VlNiIsICJkaXNwbGF5X29yZGVyIjogMTAyNCwg
-        ImNvbmRpdGlvbmFsX3BhY2thZ2VfbmFtZXMiOiBbXX0sICJ1cGRhdGVkIjog
-        IjIwMTktMDgtMDVUMTk6MTI6MDFaIiwgInJlcG9faWQiOiAiM192aWV3MSIs
-        ICJjcmVhdGVkIjogIjIwMTktMDgtMDVUMTk6MTI6MDFaIiwgInVuaXRfdHlw
-        ZV9pZCI6ICJwYWNrYWdlX2dyb3VwIiwgInVuaXRfaWQiOiAiMjY5YzYyYWQt
-        OTlkZC00YjU0LWFiZTEtM2IyNjllZjY3ZWU2IiwgIl9pZCI6IHsiJG9pZCI6
-        ICI1ZDQ4N2Y4MWFiMzZjZTNmZTUxZGZhMDAifX0sIHsibWV0YWRhdGEiOiB7
-        Im1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJlbGVwaGFudCxnaXJhZmZl
-        LGNoZWV0YWgsbGlvbixtb25rZXkscGVuZ3VpbixzcXVpcnJlbCx3YWxydXMi
-        LCAicGVuZ3VpbiJdLCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgIm5hbWUiOiAi
-        bWFtbWFsIiwgInVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1
-        ZSwgIl9ucyI6ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0X3VwZGF0
-        ZWQiOiAxNTY1MDMyMzIxLCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtd
-        LCAidHJhbnNsYXRlZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rlc2NyaXB0
-        aW9uIjoge30sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRlZmF1bHRf
-        cGFja2FnZV9uYW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNr
-        YWdlX2dyb3VwIiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiODQyMmViNWUt
-        MjJhZi00ZTVjLTlkMzktNWM2NDhhMmQ0MmQzIiwgImRpc3BsYXlfb3JkZXIi
-        OiAxMDI0LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVw
-        ZGF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjowMVoiLCAicmVwb19pZCI6ICIz
-        X3ZpZXcxIiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0wNVQxOToxMjowMVoiLCAi
-        dW5pdF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAidW5pdF9pZCI6ICI4
-        NDIyZWI1ZS0yMmFmLTRlNWMtOWQzOS01YzY0OGEyZDQyZDMiLCAiX2lkIjog
-        eyIkb2lkIjogIjVkNDg3ZjgxYWIzNmNlM2ZlNTFkZmExOSJ9fV0=
+        ZW5ndWluIl0sICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJuYW1lIjogImJp
+        cmQiLCAidXNlcl92aXNpYmxlIjogdHJ1ZSwgImRlZmF1bHQiOiB0cnVlLCAi
+        X25zIjogInVuaXRzX3BhY2thZ2VfZ3JvdXAiLCAiX2xhc3RfdXBkYXRlZCI6
+        IDE1NjcxNzU2NjEsICJvcHRpb25hbF9wYWNrYWdlX25hbWVzIjogW10sICJ0
+        cmFuc2xhdGVkX25hbWUiOiB7fSwgInRyYW5zbGF0ZWRfZGVzY3JpcHRpb24i
+        OiB7fSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiZGVmYXVsdF9wYWNr
+        YWdlX25hbWVzIjogW10sICJfY29udGVudF90eXBlX2lkIjogInBhY2thZ2Vf
+        Z3JvdXAiLCAiaWQiOiAiYmlyZCIsICJfaWQiOiAiNGUxZjFmOWQtZGYzOS00
+        NWYxLWEyMmQtYjdlODY0ZTZmMGFhIiwgImRpc3BsYXlfb3JkZXIiOiAxMDI0
+        LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVwZGF0ZWQi
+        OiAiMjAxOS0wOC0zMFQxNDozNDo0MloiLCAicmVwb19pZCI6ICJGZWRvcmFf
+        MTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQyWiIsICJ1bml0
+        X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0X2lkIjogIjRlMWYx
+        ZjlkLWRmMzktNDVmMS1hMjJkLWI3ZTg2NGU2ZjBhYSIsICJfaWQiOiB7IiRv
+        aWQiOiAiNWQ2OTM0MDIzMmRiNjA3N2E3OTY3M2NiIn19LCB7Im1ldGFkYXRh
+        IjogeyJtYW5kYXRvcnlfcGFja2FnZV9uYW1lcyI6IFsiZWxlcGhhbnQsZ2ly
+        YWZmZSxjaGVldGFoLGxpb24sbW9ua2V5LHBlbmd1aW4sc3F1aXJyZWwsd2Fs
+        cnVzIiwgInBlbmd1aW4iXSwgInJlcG9faWQiOiAiRmVkb3JhXzE3IiwgIm5h
+        bWUiOiAibWFtbWFsIiwgInVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0
+        IjogdHJ1ZSwgIl9ucyI6ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0
+        X3VwZGF0ZWQiOiAxNTY3MTc1NjYxLCAib3B0aW9uYWxfcGFja2FnZV9uYW1l
+        cyI6IFtdLCAidHJhbnNsYXRlZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rl
+        c2NyaXB0aW9uIjoge30sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRl
+        ZmF1bHRfcGFja2FnZV9uYW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6
+        ICJwYWNrYWdlX2dyb3VwIiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiY2Fl
+        MGFiMmUtMjljZC00YjEzLWFlZjEtZjUxYWQzOWNiMThlIiwgImRpc3BsYXlf
+        b3JkZXIiOiAxMDI0LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtd
+        fSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDo0MloiLCAicmVwb19p
+        ZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0
+        OjQyWiIsICJ1bml0X3R5cGVfaWQiOiAicGFja2FnZV9ncm91cCIsICJ1bml0
+        X2lkIjogImNhZTBhYjJlLTI5Y2QtNGIxMy1hZWYxLWY1MWFkMzljYjE4ZSIs
+        ICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTM0MDIzMmRiNjA3N2E3OTY3M2Q3In19
+        XQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:04 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:43 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -4149,21 +1702,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '68'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:04 GMT
+      - Fri, 30 Aug 2019 14:34:43 GMT
       Server:
       - Apache
       Content-Length:
@@ -4176,10 +1729,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:04 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:43 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -4188,74 +1741,74 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '74'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:04 GMT
+      - Fri, 30 Aug 2019 14:34:43 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1648'
+      - '550'
       Content-Type:
       - application/json; charset=utf-8
     body:
       encoding: ASCII-8BIT
       base64_string: |
         W3sibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
-        cC9jb250ZW50L3VuaXRzL3l1bV9yZXBvX21ldGFkYXRhX2ZpbGUvYzAvMTcw
-        N2Q5YzhlOTkyNGIzOGQwNjYwMDlmODg1ODVkMjNhOGQxM2NiOTg3NjQxODFi
-        OTdjN2MyNDJiNDc3MDQvMGQxZWI3Mzg2N2M0NTliODZkMTU4Y2RhZDI2NjAw
-        MmU0NTg4MTQwNTFlMzU1Mjk5NzA1M2QzNTY3MTQ0YTdlMi1wcm9kdWN0aWQu
-        Z3oiLCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImRhdGFfdHlwZSI6ICJwcm9k
-        dWN0aWQiLCAiY2hlY2tzdW0iOiAiMGQxZWI3Mzg2N2M0NTliODZkMTU4Y2Rh
-        ZDI2NjAwMmU0NTg4MTQwNTFlMzU1Mjk5NzA1M2QzNTY3MTQ0YTdlMiIsICJf
-        bGFzdF91cGRhdGVkIjogMTU2NTAzMjMyMSwgIl9jb250ZW50X3R5cGVfaWQi
-        OiAieXVtX3JlcG9fbWV0YWRhdGFfZmlsZSIsICJkb3dubG9hZGVkIjogdHJ1
-        ZSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX25zIjogInVuaXRzX3l1
-        bV9yZXBvX21ldGFkYXRhX2ZpbGUiLCAiY2hlY2tzdW1fdHlwZSI6ICJzaGEy
-        NTYiLCAiX2lkIjogIjViNGE0ZDVmLTY0YzAtNGQyNC1hOTgwLTAzNjc2YjUy
-        ZjliYSJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTA1VDE5OjEyOjAxWiIsICJy
-        ZXBvX2lkIjogIjNfdmlldzEiLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTA1VDE5
-        OjEyOjAxWiIsICJ1bml0X3R5cGVfaWQiOiAieXVtX3JlcG9fbWV0YWRhdGFf
-        ZmlsZSIsICJ1bml0X2lkIjogIjViNGE0ZDVmLTY0YzAtNGQyNC1hOTgwLTAz
-        Njc2YjUyZjliYSIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmODFhYjM2Y2Uz
-        ZmU1MWRmYTViIn19LCB7Im1ldGFkYXRhIjogeyJfc3RvcmFnZV9wYXRoIjog
-        Ii92YXIvbGliL3B1bHAvY29udGVudC91bml0cy95dW1fcmVwb19tZXRhZGF0
-        YV9maWxlLzhhLzgxOTI0ODUzYThhNGU2NjgzZjU2MmEyM2ZhMzUyYjdlNzlm
-        YmYwZmE1MjQ3ZmU5MTBmYjgxODJhY2RhODgwLzU2OWMwYWMzMjQzMmEyMTMw
-        ODY3OTNhNzA1MDIyMjhhMmJlOTk1YmM1MTM0ODAxZmUxNTgyYzQwOGY4ZDk3
-        MWItc3dpZHRhZ3MueG1sLmd6IiwgInJlcG9faWQiOiAiM192aWV3MSIsICJk
-        YXRhX3R5cGUiOiAic3dpZHRhZ3MiLCAiY2hlY2tzdW0iOiAiNTY5YzBhYzMy
-        NDMyYTIxMzA4Njc5M2E3MDUwMjIyOGEyYmU5OTViYzUxMzQ4MDFmZTE1ODJj
-        NDA4ZjhkOTcxYiIsICJfbGFzdF91cGRhdGVkIjogMTU2NTAzMjMyMSwgIl9j
-        b250ZW50X3R5cGVfaWQiOiAieXVtX3JlcG9fbWV0YWRhdGFfZmlsZSIsICJk
-        b3dubG9hZGVkIjogdHJ1ZSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAi
-        X25zIjogInVuaXRzX3l1bV9yZXBvX21ldGFkYXRhX2ZpbGUiLCAiY2hlY2tz
-        dW1fdHlwZSI6ICJzaGEyNTYiLCAiX2lkIjogImQ4NDYxM2VmLThiNzUtNDA5
-        NC1iNmY2LTNmOGNmNzRmY2VjYSJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTA1
-        VDE5OjEyOjAxWiIsICJyZXBvX2lkIjogIjNfdmlldzEiLCAiY3JlYXRlZCI6
-        ICIyMDE5LTA4LTA1VDE5OjEyOjAxWiIsICJ1bml0X3R5cGVfaWQiOiAieXVt
-        X3JlcG9fbWV0YWRhdGFfZmlsZSIsICJ1bml0X2lkIjogImQ4NDYxM2VmLThi
-        NzUtNDA5NC1iNmY2LTNmOGNmNzRmY2VjYSIsICJfaWQiOiB7IiRvaWQiOiAi
-        NWQ0ODdmODFhYjM2Y2UzZmU1MWRmYTRkIn19XQ==
+        cC9jb250ZW50L3VuaXRzL3l1bV9yZXBvX21ldGFkYXRhX2ZpbGUvOWUvYjY2
+        NjBkZWYxMzNlNWI4NjdiYmVhMDgzNjEzYTY1YzQ5OGQ1OGFmMDFjMDBhZjU5
+        MjU5ZTg5OGVmMDkxYjEvNTY5YzBhYzMyNDMyYTIxMzA4Njc5M2E3MDUwMjIy
+        OGEyYmU5OTViYzUxMzQ4MDFmZTE1ODJjNDA4ZjhkOTcxYi1zd2lkdGFncy54
+        bWwuZ3oiLCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiZGF0YV90eXBlIjog
+        InN3aWR0YWdzIiwgImNoZWNrc3VtIjogIjU2OWMwYWMzMjQzMmEyMTMwODY3
+        OTNhNzA1MDIyMjhhMmJlOTk1YmM1MTM0ODAxZmUxNTgyYzQwOGY4ZDk3MWIi
+        LCAiX2xhc3RfdXBkYXRlZCI6IDE1NjcxNzU2ODIsICJfY29udGVudF90eXBl
+        X2lkIjogInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiLCAiZG93bmxvYWRlZCI6
+        IHRydWUsICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9ucyI6ICJ1bml0
+        c195dW1fcmVwb19tZXRhZGF0YV9maWxlIiwgImNoZWNrc3VtX3R5cGUiOiAi
+        c2hhMjU2IiwgIl9pZCI6ICJiNWQyZDIxZi02MGM1LTQ2ZWEtODFhYi1kOTg2
+        ZjY5NDQ5NzYifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDo0Mloi
+        LCAicmVwb19pZCI6ICJGZWRvcmFfMTciLCAiY3JlYXRlZCI6ICIyMDE5LTA4
+        LTMwVDE0OjM0OjQyWiIsICJ1bml0X3R5cGVfaWQiOiAieXVtX3JlcG9fbWV0
+        YWRhdGFfZmlsZSIsICJ1bml0X2lkIjogImI1ZDJkMjFmLTYwYzUtNDZlYS04
+        MWFiLWQ5ODZmNjk0NDk3NiIsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTM0MDIz
+        MmRiNjA3N2E3OTY3MWJmIn19LCB7Im1ldGFkYXRhIjogeyJfc3RvcmFnZV9w
+        YXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0cy95dW1fcmVwb19t
+        ZXRhZGF0YV9maWxlL2I0LzVmM2E1OWVmNDE5ZTgzYjMwZGQwNWYyMmE1MWVh
+        MWVmZTMwNTdkYjZhNzQ3NDAwYWUzMThkNjU3NzcyYjFmLzBkMWViNzM4Njdj
+        NDU5Yjg2ZDE1OGNkYWQyNjYwMDJlNDU4ODE0MDUxZTM1NTI5OTcwNTNkMzU2
+        NzE0NGE3ZTItcHJvZHVjdGlkLmd6IiwgInJlcG9faWQiOiAiRmVkb3JhXzE3
+        IiwgImRhdGFfdHlwZSI6ICJwcm9kdWN0aWQiLCAiY2hlY2tzdW0iOiAiMGQx
+        ZWI3Mzg2N2M0NTliODZkMTU4Y2RhZDI2NjAwMmU0NTg4MTQwNTFlMzU1Mjk5
+        NzA1M2QzNTY3MTQ0YTdlMiIsICJfbGFzdF91cGRhdGVkIjogMTU2NzE3NTY4
+        MiwgIl9jb250ZW50X3R5cGVfaWQiOiAieXVtX3JlcG9fbWV0YWRhdGFfZmls
+        ZSIsICJkb3dubG9hZGVkIjogdHJ1ZSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6
+        IHt9LCAiX25zIjogInVuaXRzX3l1bV9yZXBvX21ldGFkYXRhX2ZpbGUiLCAi
+        Y2hlY2tzdW1fdHlwZSI6ICJzaGEyNTYiLCAiX2lkIjogImM5ZDYzMDhmLTY2
+        NzQtNDhkNC1hMDVhLTZkMWViN2VjMWE2NCJ9LCAidXBkYXRlZCI6ICIyMDE5
+        LTA4LTMwVDE0OjM0OjQyWiIsICJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJj
+        cmVhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDJaIiwgInVuaXRfdHlwZV9p
+        ZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIiwgInVuaXRfaWQiOiAiYzlk
+        NjMwOGYtNjY3NC00OGQ0LWEwNWEtNmQxZWI3ZWMxYTY0IiwgIl9pZCI6IHsi
+        JG9pZCI6ICI1ZDY5MzQwMjMyZGI2MDc3YTc5NjcxYzcifX1d
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:04 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:43 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -4264,21 +1817,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '77'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:04 GMT
+      - Fri, 30 Aug 2019 14:34:43 GMT
       Server:
       - Apache
       Content-Length:
@@ -4291,10 +1844,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:04 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:43 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: |
@@ -4305,21 +1858,21 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '150'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:04 GMT
+      - Fri, 30 Aug 2019 14:34:43 GMT
       Server:
       - Apache
       Content-Length:
@@ -4332,10 +1885,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:04 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:43 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/search/units/
     body:
       encoding: UTF-8
       base64_string: 'eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkaXN0cmlidXRpb24iXX19
@@ -4344,27 +1897,27 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
       - '42'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:04 GMT
+      - Fri, 30 Aug 2019 14:34:43 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1196'
+      - '534'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -4384,50 +1937,51 @@ http_interactions:
         cy9kaXN0cmlidXRpb24vOWIvODMxMjU2YTEyNDcxOGJmMzkxNjZiNTY0ZDhl
         Njg5OTU0ZmYwYThmMGY0NzliYTI0Y2ZhMjYzNTAxMDliYzUiLCAiZmFtaWx5
         IjogIlRlc3QgRmFtaWx5IiwgImRvd25sb2FkZWQiOiBmYWxzZSwgInRpbWVz
-        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTU2NTAz
-        MjMxOSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
+        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTU2NzE3
+        NTY4MiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
         cmlhbnQiOiAiVGVzdFZhcmlhbnQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHkt
         VGVzdFZhcmlhbnQtMTYteDg2XzY0IiwgInZlcnNpb24iOiAiMTYiLCAidmVy
         c2lvbl9zb3J0X2luZGV4IjogIjAyLTE2IiwgInB1bHBfdXNlcl9tZXRhZGF0
-        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogIjQwOGE5Njg4LTY2
-        ZmQtNDU1Ni05ZTU3LTMxOWI2ZDk2Y2Y2YiIsICJhcmNoIjogIng4Nl82NCIs
+        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogImU0NWRmNzI1LWJj
+        ZWMtNGM3Mi05NDQ3LTAyZjczMTM1Nzc4YyIsICJhcmNoIjogIng4Nl82NCIs
         ICJfbnMiOiAidW5pdHNfZGlzdHJpYnV0aW9uIn0sICJ1cGRhdGVkIjogIjIw
-        MTktMDgtMDVUMTk6MTI6MDFaIiwgInJlcG9faWQiOiAiM192aWV3MSIsICJj
-        cmVhdGVkIjogIjIwMTktMDgtMDVUMTk6MTI6MDFaIiwgInVuaXRfdHlwZV9p
-        ZCI6ICJkaXN0cmlidXRpb24iLCAidW5pdF9pZCI6ICI0MDhhOTY4OC02NmZk
-        LTQ1NTYtOWU1Ny0zMTliNmQ5NmNmNmIiLCAiX2lkIjogeyIkb2lkIjogIjVk
-        NDg3ZjgxYWIzNmNlM2ZlNTFkZmE4MSJ9fV0=
+        MTktMDgtMzBUMTQ6MzQ6NDJaIiwgInJlcG9faWQiOiAiRmVkb3JhXzE3Iiwg
+        ImNyZWF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDo0MloiLCAidW5pdF90eXBl
+        X2lkIjogImRpc3RyaWJ1dGlvbiIsICJ1bml0X2lkIjogImU0NWRmNzI1LWJj
+        ZWMtNGM3Mi05NDQ3LTAyZjczMTM1Nzc4YyIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWQ2OTM0MDIzMmRiNjA3N2E3OTY3MmI4In19XQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:04 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:43 GMT
 - request:
     method: post
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/actions/unassociate/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImZpbHRlcnMi
-        OnsidW5pdCI6eyJpZCI6eyIkaW4iOlsiS0FURUxMTy1SSEVBLTIwMTA6MDAw
-        MSIsIktBVEVMTE8tUkhFQS0yMDEwOjk5MTQzIiwiS0FURUxMTy1SSFNBLTIw
-        MTA6MDg1OCIsIktBVEVMTE8tUkhFQS0yMDEwOjAxMTEiXX19fSwiZmllbGRz
-        Ijp7InVuaXQiOlsiZXJyYXRhX2lkIl19fX0=
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInJwbSJdLCJmaWx0ZXJzIjp7InVuaXQiOnsiZmlsZW5hbWUi
+        OnsiJGluIjpbImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSJdfX19LCJm
+        aWVsZHMiOnsidW5pdCI6WyJuYW1lIiwiZXBvY2giLCJ2ZXJzaW9uIiwicmVs
+        ZWFzZSIsImFyY2giLCJjaGVja3N1bXR5cGUiLCJjaGVja3N1bSJdfX0sIm92
+        ZXJyaWRlX2NvbmZpZyI6e319
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
       Content-Length:
-      - '206'
+      - '243'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:04 GMT
+      - Fri, 30 Aug 2019 14:34:44 GMT
       Server:
       - Apache
       Content-Length:
@@ -4438,41 +1992,2142 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2RiZmY4YmI5LTBiYTItNGI0Ni05OWY1LWM1ZDYyMzJiNmQ1Ni8iLCAi
-        dGFza19pZCI6ICJkYmZmOGJiOS0wYmEyLTRiNDYtOTlmNS1jNWQ2MjMyYjZk
-        NTYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzL2Y4YWE0MTE5LTZhNjEtNDRlZC1iMDA4LTIxYzY3ZDhiZDNlYi8iLCAi
+        dGFza19pZCI6ICJmOGFhNDExOS02YTYxLTQ0ZWQtYjAwOC0yMWM2N2Q4YmQz
+        ZWIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:04 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:44 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInJwbSJdLCJmaWx0ZXJzIjp7InVuaXQiOnsiZmlsZW5hbWUi
+        OnsiJGluIjpbImthbmdhcm9vLTAuMi0xLm5vYXJjaC5ycG0iLCJrYW5nYXJv
+        by0wLjMtMS5ub2FyY2gucnBtIiwiZHVjay0wLjYtMS5ub2FyY2gucnBtIiwi
+        ZHVjay0wLjctMS5ub2FyY2gucnBtIiwid2FscnVzLTUuMjEtMS5ub2FyY2gu
+        cnBtIiwid2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIl19fX19fQ==
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '262'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:44 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzk1NWVhM2Q3LTRkZGUtNDIzYS05ZjQ3LTk4MTE2OGVkYmFlMy8iLCAi
+        dGFza19pZCI6ICI5NTVlYTNkNy00ZGRlLTQyM2EtOWY0Ny05ODExNjhlZGJh
+        ZTMifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:44 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInNycG0iXSwiZmlsdGVycyI6e319fQ==
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '76'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:44 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzViZWI3MWNjLThhZjgtNGEwMi1hZTg1LTRkNjY4MjczNzA3Mi8iLCAi
+        dGFza19pZCI6ICI1YmViNzFjYy04YWY4LTRhMDItYWU4NS00ZDY2ODI3Mzcw
+        NzIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:44 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbImVycmF0dW0iXSwiZmlsdGVycyI6e319fQ==
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '79'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:44 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzg5NjRmOGZlLWYxMmItNDg0Yi1iMGQzLTc5MzFhZDIxMGY4Yi8iLCAi
+        dGFza19pZCI6ICI4OTY0ZjhmZS1mMTJiLTQ4NGItYjBkMy03OTMxYWQyMTBm
+        OGIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:44 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInBhY2thZ2VfZ3JvdXAiXSwiZmlsdGVycyI6e319fQ==
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '85'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:44 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzExMmQwOGE5LTVkZGYtNDEyYi1iMTA2LTIwNGQ1OGUyNzBjNS8iLCAi
+        dGFza19pZCI6ICIxMTJkMDhhOS01ZGRmLTQxMmItYjEwNi0yMDRkNThlMjcw
+        YzUifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:44 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInBhY2thZ2VfZW52aXJvbm1lbnQiXSwiZmlsdGVycyI6e319
+        fQ==
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '91'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:44 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2UwYTY3YmNkLWM3ZGYtNGFiYS1hZDczLWZlZGRiMzljMGE3Ny8iLCAi
+        dGFza19pZCI6ICJlMGE2N2JjZC1jN2RmLTRhYmEtYWQ3My1mZWRkYjM5YzBh
+        NzcifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:44 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbInl1bV9yZXBvX21ldGFkYXRhX2ZpbGUiXSwiZmlsdGVycyI6
+        e319fQ==
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '94'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:44 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzL2IxNTcwOWVmLTM0YjEtNDgxNS05ZWQ3LTE0MTQzYzJmOTY4NC8iLCAi
+        dGFza19pZCI6ICJiMTU3MDllZi0zNGIxLTQ4MTUtOWVkNy0xNDE0M2MyZjk2
+        ODQifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:44 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbImRpc3RyaWJ1dGlvbiJdLCJmaWx0ZXJzIjp7fX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '84'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:44 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzVkYmZhODhkLWNlMzUtNDNkZi1hZjNkLWRkMWYxMzQyNjdlOS8iLCAi
+        dGFza19pZCI6ICI1ZGJmYTg4ZC1jZTM1LTQzZGYtYWYzZC1kZDFmMTM0MjY3
+        ZTkifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:44 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbIm1vZHVsZW1kIl0sImZpbHRlcnMiOnt9fX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '80'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:44 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzEyODRmYzkxLTk3MzctNGE1YS05YjBjLWNiMDRlNDUzNjM0Mi8iLCAi
+        dGFza19pZCI6ICIxMjg0ZmM5MS05NzM3LTRhNWEtOWIwYy1jYjA0ZTQ1MzYz
+        NDIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:44 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/associate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzb3VyY2VfcmVwb19pZCI6IkZlZG9yYV8xNyIsImNyaXRlcmlhIjp7InR5
+        cGVfaWRzIjpbIm1vZHVsZW1kX2RlZmF1bHRzIl0sImZpbHRlcnMiOnt9fX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '89'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:44 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzBjOTNlY2I2LWUyYjktNDBmMS05YTFkLTQxOWMzOTJmOTIyMS8iLCAi
+        dGFza19pZCI6ICIwYzkzZWNiNi1lMmI5LTQwZjEtOWExZC00MTljMzkyZjky
+        MjEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:44 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/dbff8bb9-0ba2-4b46-99f5-c5d6232b6d56/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/f8aa4119-6a61-44ed-b008-21c67d8bd3eb/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:05 GMT
+      - Fri, 30 Aug 2019 14:34:44 GMT
       Server:
       - Apache
       Etag:
-      - '"3b6f035bed91012f1102ce65cfce1939-gzip"'
+      - '"9669aa3bce427e98e9477dbc412b64aa-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '1022'
+      - '563'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9mOGFhNDEx
+        OS02YTYxLTQ0ZWQtYjAwOC0yMWM2N2Q4YmQzZWIvIiwgInRhc2tfaWQiOiAi
+        ZjhhYTQxMTktNmE2MS00NGVkLWIwMDgtMjFjNjdkOGJkM2ViIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InNpZ25pbmdfa2V5IjogbnVs
+        bCwgInVuaXRfa2V5IjogeyJuYW1lIjogImVsZXBoYW50IiwgImNoZWNrc3Vt
+        IjogIjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJiOTVm
+        NjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCAiZXBvY2giOiAiMCIsICJ2ZXJz
+        aW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJhcmNoIjogIm5vYXJj
+        aCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJw
+        bSJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW119LCAi
+        ZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNjkzNDA0MzJkYjYw
+        NzdhNzk2N2Q5YyJ9LCAiaWQiOiAiNWQ2OTM0MDQzMmRiNjA3N2E3OTY3ZDlj
+        In0=
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:44 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/955ea3d7-4dde-423a-9f47-981168edbae3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:44 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"9122d9ba38ed1affba20844253560335-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '824'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy85NTVlYTNk
+        Ny00ZGRlLTQyM2EtOWY0Ny05ODExNjhlZGJhZTMvIiwgInRhc2tfaWQiOiAi
+        OTU1ZWEzZDctNGRkZS00MjNhLTlmNDctOTgxMTY4ZWRiYWUzIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InNpZ25pbmdfa2V5IjogbnVs
+        bCwgInVuaXRfa2V5IjogeyJuYW1lIjogIndhbHJ1cyIsICJjaGVja3N1bSI6
+        ICI1MTZhMjJjY2MwY2JlM2VjYjJjYmVlMWM2MjZhMzliOTE3NjdkYmYwZjgx
+        NWFmZGE3YjczM2FhNTY1MjMxNDJjIiwgImVwb2NoIjogIjAiLCAidmVyc2lv
+        biI6ICIwLjcxIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjogIm5vYXJjaCIs
+        ICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lkIjogInJwbSJ9
+        LCB7InNpZ25pbmdfa2V5IjogbnVsbCwgInVuaXRfa2V5IjogeyJuYW1lIjog
+        IndhbHJ1cyIsICJjaGVja3N1bSI6ICI3NDUzM2ZiZDRmOWFkYTllMDJhNjM2
+        MWNiYmYwMTRiOGZmODhkZmY4ZDY5Nzg1ZWM0OGI3N2UwMTg5OGU3YzMxIiwg
+        ImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICI1LjIxIiwgInJlbGVhc2UiOiAi
+        MSIsICJhcmNoIjogIm5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2
+        In0sICJ0eXBlX2lkIjogInJwbSJ9LCB7InNpZ25pbmdfa2V5IjogbnVsbCwg
+        InVuaXRfa2V5IjogeyJuYW1lIjogImthbmdhcm9vIiwgImNoZWNrc3VtIjog
+        IjgzM2FmNTk0YmMwYmEzMTI1NjA0NWVkMWZiMTdkM2RmMmQ4MzQxYTg5YjBj
+        NWE5YmY2MTBkZDYxMDNjZTRjYzgiLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9u
+        IjogIjAuMiIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2giLCAi
+        Y2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAidHlwZV9pZCI6ICJycG0ifSwg
+        eyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0X2tleSI6IHsibmFtZSI6ICJk
+        dWNrIiwgImNoZWNrc3VtIjogIjViZDM2M2I4NjBhZDY3ODMyMTdjYmNhM2Ji
+        YzNlZjI2MGY5OGQxNDBmZmIxMjFiZjRjMjA4ZTNmNjZjMjQ3MTIiLCAiZXBv
+        Y2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuNyIsICJyZWxlYXNlIjogIjEiLCAi
+        YXJjaCI6ICJub2FyY2giLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiJ9LCAi
+        dHlwZV9pZCI6ICJycG0ifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0
+        X2tleSI6IHsibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVja3N1bSI6ICI4NjVh
+        NGM4OTQ4NWJkZDk3MjNhM2M0MDcyODBjMTQxZTkyMDJmMDI0ZTdkYjM4Y2Jh
+        M2QwOTdjM2YyNTZiMmZkIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIw
+        LjMiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNr
+        c3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2ln
+        bmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiZHVjayIs
+        ICJjaGVja3N1bSI6ICI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgx
+        YjQwOTA4MDQzYmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3IiwgImVwb2NoIjog
+        IjAiLCAidmVyc2lvbiI6ICIwLjYiLCAicmVsZWFzZSI6ICIxIiwgImFyY2gi
+        OiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVf
+        aWQiOiAicnBtIn1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIi
+        OiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTM0
+        MDQzMmRiNjA3N2E3OTY3ZGFiIn0sICJpZCI6ICI1ZDY5MzQwNDMyZGI2MDc3
+        YTc5NjdkYWIifQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:44 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/5beb71cc-8af8-4a02-ae85-4d6682737072/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:44 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"8c7f4183fab0b05ff0b92710f9e09dc3-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '433'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81YmViNzFj
+        Yy04YWY4LTRhMDItYWU4NS00ZDY2ODI3MzcwNzIvIiwgInRhc2tfaWQiOiAi
+        NWJlYjcxY2MtOGFmOC00YTAyLWFlODUtNGQ2NjgyNzM3MDcyIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNfZmFpbGVkX3Np
+        Z25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNWQ2OTM0MDQzMmRiNjA3N2E3OTY3ZGQzIn0sICJpZCI6ICI1
+        ZDY5MzQwNDMyZGI2MDc3YTc5NjdkZDMifQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:44 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/8964f8fe-f12b-484b-b0d3-7931ad210f8b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:44 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"175ef71017fde4ef2cfa8deb4bd08ea1-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '516'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy84OTY0Zjhm
+        ZS1mMTJiLTQ4NGItYjBkMy03OTMxYWQyMTBmOGIvIiwgInRhc2tfaWQiOiAi
+        ODk2NGY4ZmUtZjEyYi00ODRiLWIwZDMtNzkzMWFkMjEwZjhiIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJpZCI6
+        ICJLQVRFTExPLVJIU0EtMjAxMDowODU4In0sICJ0eXBlX2lkIjogImVycmF0
+        dW0ifSwgeyJ1bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTI6
+        MDA1OSJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7
+        ImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjAxMTEifSwgInR5cGVfaWQiOiAi
+        ZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEt
+        MjAxMDowMDAyIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifSwgeyJ1bml0X2tl
+        eSI6IHsiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6OTkxNDMifSwgInR5cGVf
+        aWQiOiAiZXJyYXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExP
+        LVJIRUEtMjAxMDowMDAxIn0sICJ0eXBlX2lkIjogImVycmF0dW0ifV0sICJ1
+        bml0c19mYWlsZWRfc2lnbmF0dXJlX2ZpbHRlciI6IFtdfSwgImVycm9yIjog
+        bnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzQwNDMyZGI2MDc3YTc5Njdk
+        ZTMifSwgImlkIjogIjVkNjkzNDA0MzJkYjYwNzdhNzk2N2RlMyJ9
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:44 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/112d08a9-5ddf-412b-b106-204d58e270c5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:44 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"e179748f08c633d3fe0cd1ecf36de690-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '491'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8xMTJkMDhh
+        OS01ZGRmLTQxMmItYjEwNi0yMDRkNThlMjcwYzUvIiwgInRhc2tfaWQiOiAi
+        MTEyZDA4YTktNWRkZi00MTJiLWIxMDYtMjA0ZDU4ZTI3MGM1IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBv
+        X2lkIjogIjNfdmlldzEiLCAiaWQiOiAiYmlyZCJ9LCAidHlwZV9pZCI6ICJw
+        YWNrYWdlX2dyb3VwIn0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiM192
+        aWV3MSIsICJpZCI6ICJtYW1tYWwifSwgInR5cGVfaWQiOiAicGFja2FnZV9n
+        cm91cCJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW3si
+        dW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImlkIjogImJp
+        cmQifSwgInR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9LCB7InVuaXRfa2V5
+        IjogeyJyZXBvX2lkIjogIkZlZG9yYV8xNyIsICJpZCI6ICJtYW1tYWwifSwg
+        InR5cGVfaWQiOiAicGFja2FnZV9ncm91cCJ9XX0sICJlcnJvciI6IG51bGws
+        ICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTM0MDQzMmRiNjA3N2E3OTY3ZTBlIn0s
+        ICJpZCI6ICI1ZDY5MzQwNDMyZGI2MDc3YTc5NjdlMGUifQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:44 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/e0a67bcd-c7df-4aba-ad73-feddb39c0a77/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:44 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"6e886f6327c3f17fd2bef667d22bfa43-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '432'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9lMGE2N2Jj
+        ZC1jN2RmLTRhYmEtYWQ3My1mZWRkYjM5YzBhNzcvIiwgInRhc2tfaWQiOiAi
+        ZTBhNjdiY2QtYzdkZi00YWJhLWFkNzMtZmVkZGIzOWMwYTc3IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFtdLCAidW5pdHNfZmFpbGVkX3Np
+        Z25hdHVyZV9maWx0ZXIiOiBbXX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNWQ2OTM0MDQzMmRiNjA3N2E3OTY3ZTJhIn0sICJpZCI6ICI1
+        ZDY5MzQwNDMyZGI2MDc3YTc5NjdlMmEifQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:45 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/b15709ef-34b1-4815-9ed7-14143c2f9684/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:45 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"948e2287108335614d23e33da67efee4-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '500'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy9iMTU3MDll
+        Zi0zNGIxLTQ4MTUtOWVkNy0xNDE0M2MyZjk2ODQvIiwgInRhc2tfaWQiOiAi
+        YjE1NzA5ZWYtMzRiMS00ODE1LTllZDctMTQxNDNjMmY5Njg0IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBv
+        X2lkIjogIjNfdmlldzEiLCAiZGF0YV90eXBlIjogInByb2R1Y3RpZCJ9LCAi
+        dHlwZV9pZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIn0sIHsidW5pdF9r
+        ZXkiOiB7InJlcG9faWQiOiAiM192aWV3MSIsICJkYXRhX3R5cGUiOiAic3dp
+        ZHRhZ3MifSwgInR5cGVfaWQiOiAieXVtX3JlcG9fbWV0YWRhdGFfZmlsZSJ9
+        XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVfZmlsdGVyIjogW3sidW5pdF9r
+        ZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImRhdGFfdHlwZSI6ICJz
+        d2lkdGFncyJ9LCAidHlwZV9pZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxl
+        In0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3IiwgImRh
+        dGFfdHlwZSI6ICJwcm9kdWN0aWQifSwgInR5cGVfaWQiOiAieXVtX3JlcG9f
+        bWV0YWRhdGFfZmlsZSJ9XX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRv
+        aWQiOiAiNWQ2OTM0MDQzMmRiNjA3N2E3OTY3ZTRjIn0sICJpZCI6ICI1ZDY5
+        MzQwNDMyZGI2MDc3YTc5NjdlNGMifQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:45 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/5dbfa88d-ce35-43df-af3d-dd1f134267e9/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:46 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"662788f1ea6610fb2e3ef59f87576a92-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '516'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy81ZGJmYTg4
+        ZC1jZTM1LTQzZGYtYWYzZC1kZDFmMTM0MjY3ZTkvIiwgInRhc2tfaWQiOiAi
+        NWRiZmE4OGQtY2UzNS00M2RmLWFmM2QtZGQxZjEzNDI2N2U5IiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJ2YXJp
+        YW50IjogIlRlc3RWYXJpYW50IiwgInZlcnNpb24iOiAiMTYiLCAiYXJjaCI6
+        ICJ4ODZfNjQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHktVGVzdFZhcmlhbnQt
+        MTYteDg2XzY0IiwgImZhbWlseSI6ICJUZXN0IEZhbWlseSJ9LCAidHlwZV9p
+        ZCI6ICJkaXN0cmlidXRpb24ifV0sICJ1bml0c19mYWlsZWRfc2lnbmF0dXJl
+        X2ZpbHRlciI6IFtdfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6
+        ICI1ZDY5MzQwNDMyZGI2MDc3YTc5NjdlNTkifSwgImlkIjogIjVkNjkzNDA0
+        MzJkYjYwNzdhNzk2N2U1OSJ9
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:46 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/1284fc91-9737-4a5a-9b0c-cb04e4536342/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:46 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"b7c95f92b269c5cd57c5c2a3b1580b58-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '961'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8xMjg0ZmM5
+        MS05NzM3LTRhNWEtOWIwYy1jYjA0ZTQ1MzYzNDIvIiwgInRhc2tfaWQiOiAi
+        MTI4NGZjOTEtOTczNy00YTVhLTliMGMtY2IwNGU0NTM2MzQyIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJjb250
+        ZXh0IjogImRlYWRiZWVmIiwgInZlcnNpb24iOiAyMDE4MDcwNDI0NDIwNSwg
+        ImFyY2giOiAibm9hcmNoIiwgIm5hbWUiOiAiZHVjayIsICJzdHJlYW0iOiAi
+        MCJ9LCAidHlwZV9pZCI6ICJtb2R1bGVtZCJ9LCB7InVuaXRfa2V5IjogeyJj
+        b250ZXh0IjogImMwZmZlZTQyIiwgInZlcnNpb24iOiAyMDE4MDcwNzE0NDIw
+        MywgImFyY2giOiAieDg2XzY0IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVh
+        bSI6ICIwLjcxIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0sIHsidW5pdF9r
+        ZXkiOiB7ImNvbnRleHQiOiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6IDIwMTgw
+        NzMwMjMzMTAyLCAiYXJjaCI6ICJub2FyY2giLCAibmFtZSI6ICJkdWNrIiwg
+        InN0cmVhbSI6ICIwIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0sIHsic2ln
+        bmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAid2FscnVz
+        IiwgImNoZWNrc3VtIjogIjUxNmEyMmNjYzBjYmUzZWNiMmNiZWUxYzYyNmEz
+        OWI5MTc2N2RiZjBmODE1YWZkYTdiNzMzYWE1NjUyMzE0MmMiLCAiZXBvY2gi
+        OiAiMCIsICJ2ZXJzaW9uIjogIjAuNzEiLCAicmVsZWFzZSI6ICIxIiwgImFy
+        Y2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5
+        cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19rZXkiOiBudWxsLCAidW5pdF9r
+        ZXkiOiB7Im5hbWUiOiAiZHVjayIsICJjaGVja3N1bSI6ICI1YmQzNjNiODYw
+        YWQ2NzgzMjE3Y2JjYTNiYmMzZWYyNjBmOThkMTQwZmZiMTIxYmY0YzIwOGUz
+        ZjY2YzI0NzEyIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjciLCAi
+        cmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlw
+        ZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2lnbmluZ19r
+        ZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAia2FuZ2Fyb28iLCAi
+        Y2hlY2tzdW0iOiAiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3MjgwYzE0MWU5
+        MjAyZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsICJlcG9jaCI6ICIw
+        IiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMSIsICJhcmNoIjog
+        Im5vYXJjaCIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2In0sICJ0eXBlX2lk
+        IjogInJwbSJ9LCB7InVuaXRfa2V5IjogeyJjb250ZXh0IjogImRlYWRiZWVm
+        IiwgInZlcnNpb24iOiAyMDE4MDcwNDExMTcxOSwgImFyY2giOiAibm9hcmNo
+        IiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAic3RyZWFtIjogIjAifSwgInR5cGVf
+        aWQiOiAibW9kdWxlbWQifSwgeyJzaWduaW5nX2tleSI6IG51bGwsICJ1bml0
+        X2tleSI6IHsibmFtZSI6ICJrYW5nYXJvbyIsICJjaGVja3N1bSI6ICI4MzNh
+        ZjU5NGJjMGJhMzEyNTYwNDVlZDFmYjE3ZDNkZjJkODM0MWE4OWIwYzVhOWJm
+        NjEwZGQ2MTAzY2U0Y2M4IiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIw
+        LjIiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNoIiwgImNoZWNr
+        c3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBtIn0sIHsic2ln
+        bmluZ19rZXkiOiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAid2FscnVz
+        IiwgImNoZWNrc3VtIjogIjc0NTMzZmJkNGY5YWRhOWUwMmE2MzYxY2JiZjAx
+        NGI4ZmY4OGRmZjhkNjk3ODVlYzQ4Yjc3ZTAxODk4ZTdjMzEiLCAiZXBvY2gi
+        OiAiMCIsICJ2ZXJzaW9uIjogIjUuMjEiLCAicmVsZWFzZSI6ICIxIiwgImFy
+        Y2giOiAibm9hcmNoIiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5
+        cGVfaWQiOiAicnBtIn0sIHsidW5pdF9rZXkiOiB7ImNvbnRleHQiOiAiZGVh
+        ZGJlZWYiLCAidmVyc2lvbiI6IDIwMTgwNzMwMjIzNDA3LCAiYXJjaCI6ICJu
+        b2FyY2giLCAibmFtZSI6ICJrYW5nYXJvbyIsICJzdHJlYW0iOiAiMCJ9LCAi
+        dHlwZV9pZCI6ICJtb2R1bGVtZCJ9LCB7InVuaXRfa2V5IjogeyJjb250ZXh0
+        IjogImRlYWRiZWVmIiwgInZlcnNpb24iOiAyMDE4MDcwNDE0NDIwMywgImFy
+        Y2giOiAieDg2XzY0IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICI1
+        LjIxIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kIn0sIHsic2lnbmluZ19rZXki
+        OiBudWxsLCAidW5pdF9rZXkiOiB7Im5hbWUiOiAiZHVjayIsICJjaGVja3N1
+        bSI6ICI5NmYzNzg3NzUxOGExZmU2ZWEyZTE3ZjRjZTFmYzgxYjQwOTA4MDQz
+        YmNiZWQ3Njc0NGIzZDdkMzhhNzc0YmM3IiwgImVwb2NoIjogIjAiLCAidmVy
+        c2lvbiI6ICIwLjYiLCAicmVsZWFzZSI6ICIxIiwgImFyY2giOiAibm9hcmNo
+        IiwgImNoZWNrc3VtdHlwZSI6ICJzaGEyNTYifSwgInR5cGVfaWQiOiAicnBt
+        In1dLCAidW5pdHNfZmFpbGVkX3NpZ25hdHVyZV9maWx0ZXIiOiBbXX0sICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTM0MDQzMmRiNjA3
+        N2E3OTY3ZTZhIn0sICJpZCI6ICI1ZDY5MzQwNDMyZGI2MDc3YTc5NjdlNmEi
+        fQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:46 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/0c93ecb6-e2b9-40f1-9a1d-419c392f9221/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:47 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"5b358696df8d8b9cf2ac1341750c32be-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '507'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi5hc3NvY2lhdGVfZnJv
+        bV9yZXBvIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi90YXNrcy8wYzkzZWNi
+        Ni1lMmI5LTQwZjEtOWExZC00MTljMzkyZjkyMjEvIiwgInRhc2tfaWQiOiAi
+        MGM5M2VjYjYtZTJiOS00MGYxLTlhMWQtNDE5YzM5MmY5MjIxIiwgInRhZ3Mi
+        OiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcxIiwgInB1bHA6cmVwb3NpdG9y
+        eTpGZWRvcmFfMTciLCAicHVscDphY3Rpb246YXNzb2NpYXRlIl0sICJmaW5p
+        c2hfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0WiIsICJfbnMiOiAidGFz
+        a19zdGF0dXMiLCAic3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0
+        WiIsICJ0cmFjZWJhY2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAi
+        cHJvZ3Jlc3NfcmVwb3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNv
+        dXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xv
+        LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3Jr
+        ZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3
+        LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3Vs
+        dCI6IHsidW5pdHNfc3VjY2Vzc2Z1bCI6IFt7InVuaXRfa2V5IjogeyJyZXBv
+        X2lkIjogIjNfdmlldzEiLCAibmFtZSI6ICJrYW5nYXJvbyJ9LCAidHlwZV9p
+        ZCI6ICJtb2R1bGVtZF9kZWZhdWx0cyJ9LCB7InVuaXRfa2V5IjogeyJyZXBv
+        X2lkIjogIjNfdmlldzEiLCAibmFtZSI6ICJ3YWxydXMifSwgInR5cGVfaWQi
+        OiAibW9kdWxlbWRfZGVmYXVsdHMifSwgeyJ1bml0X2tleSI6IHsicmVwb19p
+        ZCI6ICIzX3ZpZXcxIiwgIm5hbWUiOiAiZHVjayJ9LCAidHlwZV9pZCI6ICJt
+        b2R1bGVtZF9kZWZhdWx0cyJ9XSwgInVuaXRzX2ZhaWxlZF9zaWduYXR1cmVf
+        ZmlsdGVyIjogW3sidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3
+        IiwgIm5hbWUiOiAia2FuZ2Fyb28ifSwgInR5cGVfaWQiOiAibW9kdWxlbWRf
+        ZGVmYXVsdHMifSwgeyJ1bml0X2tleSI6IHsicmVwb19pZCI6ICJGZWRvcmFf
+        MTciLCAibmFtZSI6ICJkdWNrIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2Rl
+        ZmF1bHRzIn0sIHsidW5pdF9rZXkiOiB7InJlcG9faWQiOiAiRmVkb3JhXzE3
+        IiwgIm5hbWUiOiAid2FscnVzIn0sICJ0eXBlX2lkIjogIm1vZHVsZW1kX2Rl
+        ZmF1bHRzIn1dfSwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1
+        ZDY5MzQwNDMyZGI2MDc3YTc5NjdlOTAifSwgImlkIjogIjVkNjkzNDA0MzJk
+        YjYwNzdhNzk2N2U5MCJ9
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:47 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwibGltaXQiOjIwMDAs
+        InNraXAiOjAsImZpZWxkcyI6eyJ1bml0IjpbIm5hbWUiLCJ2ZXJzaW9uIiwi
+        cmVsZWFzZSIsImFyY2giLCJlcG9jaCIsInN1bW1hcnkiLCJzb3VyY2VycG0i
+        LCJjaGVja3N1bSIsImZpbGVuYW1lIiwiaXNfbW9kdWxhciJdfX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '174'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:47 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '989'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJrYW5nYXJvby0wLjItMS5z
+        cmMucnBtIiwgIm5hbWUiOiAia2FuZ2Fyb28iLCAiY2hlY2tzdW0iOiAiODMz
+        YWY1OTRiYzBiYTMxMjU2MDQ1ZWQxZmIxN2QzZGYyZDgzNDFhODliMGM1YTli
+        ZjYxMGRkNjEwM2NlNGNjOCIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2Fn
+        ZSBvZiBrYW5nYXJvbyIsICJmaWxlbmFtZSI6ICJrYW5nYXJvby0wLjItMS5u
+        b2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjIiLCAi
+        aXNfbW9kdWxhciI6IHRydWUsICJfY29udGVudF90eXBlX2lkIjogInJwbSIs
+        ICJyZWxlYXNlIjogIjEiLCAiX2lkIjogIjA0YjM3ZTdhLTE4ZDgtNDJiZi1i
+        N2FhLWFjOTY3MzRmODE4NyIsICJhcmNoIjogIm5vYXJjaCJ9LCAidXBkYXRl
+        ZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0WiIsICJyZXBvX2lkIjogIjNfdmll
+        dzEiLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0WiIsICJ1bml0
+        X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiMDRiMzdlN2EtMThkOC00
+        MmJmLWI3YWEtYWM5NjczNGY4MTg3IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5
+        MzQwNDMyZGI2MDc3YTc5NjdkZmUifX0sIHsibWV0YWRhdGEiOiB7InNvdXJj
+        ZXJwbSI6ICJrYW5nYXJvby0wLjMtMS5zcmMucnBtIiwgIm5hbWUiOiAia2Fu
+        Z2Fyb28iLCAiY2hlY2tzdW0iOiAiODY1YTRjODk0ODViZGQ5NzIzYTNjNDA3
+        MjgwYzE0MWU5MjAyZjAyNGU3ZGIzOGNiYTNkMDk3YzNmMjU2YjJmZCIsICJz
+        dW1tYXJ5IjogImhvcCBsaWtlIGEga2FuZ2Fyb28gaW4gQXVzdHJhbGlhIiwg
+        ImZpbGVuYW1lIjogImthbmdhcm9vLTAuMy0xLm5vYXJjaC5ycG0iLCAiZXBv
+        Y2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuMyIsICJpc19tb2R1bGFyIjogdHJ1
+        ZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMSIs
+        ICJfaWQiOiAiODU1MWJkYzktNjEzZi00ZGIyLWE4ZGUtZTk5M2Y5OWJkNmU1
+        IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMzBU
+        MTQ6MzQ6NDRaIiwgInJlcG9faWQiOiAiM192aWV3MSIsICJjcmVhdGVkIjog
+        IjIwMTktMDgtMzBUMTQ6MzQ6NDRaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0i
+        LCAidW5pdF9pZCI6ICI4NTUxYmRjOS02MTNmLTRkYjItYThkZS1lOTkzZjk5
+        YmQ2ZTUiLCAiX2lkIjogeyIkb2lkIjogIjVkNjkzNDA0MzJkYjYwNzdhNzk2
+        N2UwNyJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImVsZXBoYW50
+        LTAuMy0wLjguc3JjLnJwbSIsICJuYW1lIjogImVsZXBoYW50IiwgImNoZWNr
+        c3VtIjogIjNlMWM3MGNkMWI0MjEzMjhhY2FmNjM5N2NiM2QxNjE0NTMwNmJi
+        OTVmNjVkMWIwOTVmYzMxMzcyYTBhNzAxZjMiLCAic3VtbWFyeSI6ICJBIGR1
+        bW15IHBhY2thZ2Ugb2YgZWxlcGhhbnQiLCAiZmlsZW5hbWUiOiAiZWxlcGhh
+        bnQtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2NoIjogIjAiLCAidmVyc2lv
+        biI6ICIwLjMiLCAiaXNfbW9kdWxhciI6IGZhbHNlLCAiX2NvbnRlbnRfdHlw
+        ZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIwLjgiLCAiX2lkIjogIjk0NDE4
+        NzFlLTIxNDYtNDRhNC04NTQ0LWUzOTAyY2RhNjZlYiIsICJhcmNoIjogIm5v
+        YXJjaCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0WiIsICJy
+        ZXBvX2lkIjogIjNfdmlldzEiLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTMwVDE0
+        OjM0OjQ0WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAi
+        OTQ0MTg3MWUtMjE0Ni00NGE0LTg1NDQtZTM5MDJjZGE2NmViIiwgIl9pZCI6
+        IHsiJG9pZCI6ICI1ZDY5MzQwNDMyZGI2MDc3YTc5NjdkYmMifX0sIHsibWV0
+        YWRhdGEiOiB7InNvdXJjZXJwbSI6ICJkdWNrLTAuNi0xLnNyYy5ycG0iLCAi
+        bmFtZSI6ICJkdWNrIiwgImNoZWNrc3VtIjogIjk2ZjM3ODc3NTE4YTFmZTZl
+        YTJlMTdmNGNlMWZjODFiNDA5MDgwNDNiY2JlZDc2NzQ0YjNkN2QzOGE3NzRi
+        YzciLCAic3VtbWFyeSI6ICJBIGR1bW15IHBhY2thZ2Ugb2YgZHVjayIsICJm
+        aWxlbmFtZSI6ICJkdWNrLTAuNi0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjAuNiIsICJpc19tb2R1bGFyIjogdHJ1ZSwgIl9j
+        b250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVhc2UiOiAiMSIsICJfaWQi
+        OiAiOTUyZmQ5NDEtYjhhMS00YTRmLWIyNGMtNDdjYjE0M2YyZmIyIiwgImFy
+        Y2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6
+        NDRaIiwgInJlcG9faWQiOiAiM192aWV3MSIsICJjcmVhdGVkIjogIjIwMTkt
+        MDgtMzBUMTQ6MzQ6NDRaIiwgInVuaXRfdHlwZV9pZCI6ICJycG0iLCAidW5p
+        dF9pZCI6ICI5NTJmZDk0MS1iOGExLTRhNGYtYjI0Yy00N2NiMTQzZjJmYjIi
+        LCAiX2lkIjogeyIkb2lkIjogIjVkNjkzNDA0MzJkYjYwNzdhNzk2N2UwYiJ9
+        fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjogImR1Y2stMC43LTEuc3Jj
+        LnJwbSIsICJuYW1lIjogImR1Y2siLCAiY2hlY2tzdW0iOiAiNWJkMzYzYjg2
+        MGFkNjc4MzIxN2NiY2EzYmJjM2VmMjYwZjk4ZDE0MGZmYjEyMWJmNGMyMDhl
+        M2Y2NmMyNDcxMiIsICJzdW1tYXJ5IjogIlF1YWNrIGxpa2UgYSBkdWNrIGF0
+        IHRoZSBwYXJrLiIsICJmaWxlbmFtZSI6ICJkdWNrLTAuNy0xLm5vYXJjaC5y
+        cG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjogIjAuNyIsICJpc19tb2R1
+        bGFyIjogdHJ1ZSwgIl9jb250ZW50X3R5cGVfaWQiOiAicnBtIiwgInJlbGVh
+        c2UiOiAiMSIsICJfaWQiOiAiYTE4ZGY2MjktYTU1YS00MzJjLWJkNzEtNmI0
+        ZTFhMTZkN2I2IiwgImFyY2giOiAibm9hcmNoIn0sICJ1cGRhdGVkIjogIjIw
+        MTktMDgtMzBUMTQ6MzQ6NDRaIiwgInJlcG9faWQiOiAiM192aWV3MSIsICJj
+        cmVhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDRaIiwgInVuaXRfdHlwZV9p
+        ZCI6ICJycG0iLCAidW5pdF9pZCI6ICJhMThkZjYyOS1hNTVhLTQzMmMtYmQ3
+        MS02YjRlMWExNmQ3YjYiLCAiX2lkIjogeyIkb2lkIjogIjVkNjkzNDA0MzJk
+        YjYwNzdhNzk2N2UwMiJ9fSwgeyJtZXRhZGF0YSI6IHsic291cmNlcnBtIjog
+        IndhbHJ1cy01LjIxLTEuc3JjLnJwbSIsICJuYW1lIjogIndhbHJ1cyIsICJj
+        aGVja3N1bSI6ICI3NDUzM2ZiZDRmOWFkYTllMDJhNjM2MWNiYmYwMTRiOGZm
+        ODhkZmY4ZDY5Nzg1ZWM0OGI3N2UwMTg5OGU3YzMxIiwgInN1bW1hcnkiOiAi
+        QSBkdW1teSBwYWNrYWdlIG9mIHdhbHJ1cyIsICJmaWxlbmFtZSI6ICJ3YWxy
+        dXMtNS4yMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9u
+        IjogIjUuMjEiLCAiaXNfbW9kdWxhciI6IHRydWUsICJfY29udGVudF90eXBl
+        X2lkIjogInJwbSIsICJyZWxlYXNlIjogIjEiLCAiX2lkIjogImJhNzcxZGY4
+        LTNlZmQtNDkyYi05MWE0LTYyYTJmOThkMDI4YSIsICJhcmNoIjogIm5vYXJj
+        aCJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0WiIsICJyZXBv
+        X2lkIjogIjNfdmlldzEiLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0
+        OjQ0WiIsICJ1bml0X3R5cGVfaWQiOiAicnBtIiwgInVuaXRfaWQiOiAiYmE3
+        NzFkZjgtM2VmZC00OTJiLTkxYTQtNjJhMmY5OGQwMjhhIiwgIl9pZCI6IHsi
+        JG9pZCI6ICI1ZDY5MzQwNDMyZGI2MDc3YTc5NjdkZmIifX0sIHsibWV0YWRh
+        dGEiOiB7InNvdXJjZXJwbSI6ICJ3YWxydXMtMC43MS0xLnNyYy5ycG0iLCAi
+        bmFtZSI6ICJ3YWxydXMiLCAiY2hlY2tzdW0iOiAiNTE2YTIyY2NjMGNiZTNl
+        Y2IyY2JlZTFjNjI2YTM5YjkxNzY3ZGJmMGY4MTVhZmRhN2I3MzNhYTU2NTIz
+        MTQyYyIsICJzdW1tYXJ5IjogIkEgZHVtbXkgcGFja2FnZSBvZiB3YWxydXMi
+        LCAiZmlsZW5hbWUiOiAid2FscnVzLTAuNzEtMS5ub2FyY2gucnBtIiwgImVw
+        b2NoIjogIjAiLCAidmVyc2lvbiI6ICIwLjcxIiwgImlzX21vZHVsYXIiOiB0
+        cnVlLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJycG0iLCAicmVsZWFzZSI6ICIx
+        IiwgIl9pZCI6ICJkN2QyNDQ0MC1hZjk3LTQ4NWMtOGY1Yy00N2UwNGIyODEw
+        YWQiLCAiYXJjaCI6ICJub2FyY2gifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0z
+        MFQxNDozNDo0NFoiLCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImNyZWF0ZWQi
+        OiAiMjAxOS0wOC0zMFQxNDozNDo0NFoiLCAidW5pdF90eXBlX2lkIjogInJw
+        bSIsICJ1bml0X2lkIjogImQ3ZDI0NDQwLWFmOTctNDg1Yy04ZjVjLTQ3ZTA0
+        YjI4MTBhZCIsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTM0MDQzMmRiNjA3N2E3
+        OTY3ZGY3In19XQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:47 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJycG0iXSwibGltaXQiOjIwMDAs
+        InNraXAiOjIwMDAsImZpZWxkcyI6eyJ1bml0IjpbIm5hbWUiLCJ2ZXJzaW9u
+        IiwicmVsZWFzZSIsImFyY2giLCJlcG9jaCIsInN1bW1hcnkiLCJzb3VyY2Vy
+        cG0iLCJjaGVja3N1bSIsImZpbGVuYW1lIiwiaXNfbW9kdWxhciJdfX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '177'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:47 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:47 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJtb2R1bGVtZCJdLCJsaW1pdCI6
+        MjAwMCwic2tpcCI6MH19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '60'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:47 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1308'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
+        cC9jb250ZW50L3VuaXRzL21vZHVsZW1kL2VhL2E4NzIwM2FhNzFhY2QwOWVk
+        NGM4NzBlMDg3NTQ5ZGEyYTVkMmNhYzdjYjllZWQ3ZTdiMDYzYmY5ZjQ5N2E5
+        IiwgIm5hbWUiOiAid2FscnVzIiwgInN0cmVhbSI6ICIwLjcxIiwgImFydGlm
+        YWN0cyI6IFsid2FscnVzLTA6MC43MS0xLm5vYXJjaCJdLCAiY2hlY2tzdW0i
+        OiAiODNmNmFmZjMyNjE0ODU3ZTk5MDk4NzZhNGZiN2E5NWQ1OTE5NWZkOThi
+        OWEyN2EwNjRhOTQyZWNiYzRmNDY4MiIsICJfbGFzdF91cGRhdGVkIjogMTU2
+        NzE3NTY2MSwgIl9jb250ZW50X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAicHJv
+        ZmlsZXMiOiB7ImRlZmF1bHQiOiBbIndhbHJ1cyJdLCAiZmxpcHBlciI6IFsi
+        d2FscnVzIl19LCAic3VtbWFyeSI6ICJXYWxydXMgMC43MSBtb2R1bGUiLCAi
+        ZG93bmxvYWRlZCI6IHRydWUsICJ2ZXJzaW9uIjogMjAxODA3MDcxNDQyMDMs
+        ICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImNvbnRleHQiOiAiYzBmZmVl
+        NDIiLCAiX25zIjogInVuaXRzX21vZHVsZW1kIiwgImRlcGVuZGVuY2llcyI6
+        IFtdLCAiX2lkIjogIjBiZWU4ZTBjLWFlYWEtNGE4MS04YWZmLWQxODNjMDQ4
+        NTIxNyIsICJhcmNoIjogIng4Nl82NCIsICJkZXNjcmlwdGlvbiI6ICJBIG1v
+        ZHVsZSBmb3IgdGhlIHdhbHJ1cyAwLjcxIHBhY2thZ2UifSwgInVwZGF0ZWQi
+        OiAiMjAxOS0wOC0zMFQxNDozNDo0NFoiLCAicmVwb19pZCI6ICIzX3ZpZXcx
+        IiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDo0NFoiLCAidW5pdF90
+        eXBlX2lkIjogIm1vZHVsZW1kIiwgInVuaXRfaWQiOiAiMGJlZThlMGMtYWVh
+        YS00YTgxLThhZmYtZDE4M2MwNDg1MjE3IiwgIl9pZCI6IHsiJG9pZCI6ICI1
+        ZDY5MzQwNDMyZGI2MDc3YTc5NjdmOTQifX0sIHsibWV0YWRhdGEiOiB7Il9z
+        dG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVscC9jb250ZW50L3VuaXRzL21v
+        ZHVsZW1kLzQxLzljMjZjYTAzMjJmMDQ1OGFiNzRmNTg3NmUyOWEzNjZmODBj
+        MmI0OTAyMGY2NjNhYmI5ZmY0YmJkY2JkNmNjIiwgIm5hbWUiOiAid2FscnVz
+        IiwgInN0cmVhbSI6ICI1LjIxIiwgImFydGlmYWN0cyI6IFsid2FscnVzLTA6
+        NS4yMS0xLm5vYXJjaCJdLCAiY2hlY2tzdW0iOiAiZmMwY2I5NTBlNTNjNWVh
+        OTliMDNiY2FjNDI3MjVjNjAyOTVmMTQ4YWFhZGUxYTdjZTZjN2Q4MDI4YTA3
+        M2I1OSIsICJfbGFzdF91cGRhdGVkIjogMTU2NzE3NTY2MSwgIl9jb250ZW50
+        X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAicHJvZmlsZXMiOiB7ImRlZmF1bHQi
+        OiBbIndhbHJ1cyJdfSwgInN1bW1hcnkiOiAiV2FscnVzIDUuMjEgbW9kdWxl
+        IiwgImRvd25sb2FkZWQiOiB0cnVlLCAidmVyc2lvbiI6IDIwMTgwNzA0MTQ0
+        MjAzLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJjb250ZXh0IjogImRl
+        YWRiZWVmIiwgIl9ucyI6ICJ1bml0c19tb2R1bGVtZCIsICJkZXBlbmRlbmNp
+        ZXMiOiBbXSwgIl9pZCI6ICIzNGE5OWMwNS1iZjI4LTQ0OWQtYTdhYS01ODA2
+        NWZmODg0YjgiLCAiYXJjaCI6ICJ4ODZfNjQiLCAiZGVzY3JpcHRpb24iOiAi
+        QSBtb2R1bGUgZm9yIHRoZSB3YWxydXMgNS4yMSBwYWNrYWdlIn0sICJ1cGRh
+        dGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDRaIiwgInJlcG9faWQiOiAiM192
+        aWV3MSIsICJjcmVhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDRaIiwgInVu
+        aXRfdHlwZV9pZCI6ICJtb2R1bGVtZCIsICJ1bml0X2lkIjogIjM0YTk5YzA1
+        LWJmMjgtNDQ5ZC1hN2FhLTU4MDY1ZmY4ODRiOCIsICJfaWQiOiB7IiRvaWQi
+        OiAiNWQ2OTM0MDQzMmRiNjA3N2E3OTY3ZmEwIn19LCB7Im1ldGFkYXRhIjog
+        eyJfc3RvcmFnZV9wYXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0
+        cy9tb2R1bGVtZC8wNC9mNTU4NmVlMTRkZTRlMzVjNjdhYjA4ZDI2Y2I3YTA1
+        ZTdmZmYwZGUwN2RjZWFiNjYxMzNhNTgyMGMzODJjZSIsICJuYW1lIjogImR1
+        Y2siLCAic3RyZWFtIjogIjAiLCAiYXJ0aWZhY3RzIjogWyJkdWNrLTA6MC43
+        LTEubm9hcmNoIl0sICJjaGVja3N1bSI6ICJkZDYyMWMwNThjZGUxZTY3NTc4
+        ZmRjMTcxMzMyNDVhNjUxNzk2YWZjMDg3M2Q4NTZiNzkwYTdmNzAyODI1MDIx
+        IiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTY3MTc1NjYxLCAiX2NvbnRlbnRfdHlw
+        ZV9pZCI6ICJtb2R1bGVtZCIsICJwcm9maWxlcyI6IHsiZGVmYXVsdCI6IFsi
+        ZHVjayJdfSwgInN1bW1hcnkiOiAiRHVjayAwLjcgbW9kdWxlIiwgImRvd25s
+        b2FkZWQiOiB0cnVlLCAidmVyc2lvbiI6IDIwMTgwNzMwMjMzMTAyLCAicHVs
+        cF91c2VyX21ldGFkYXRhIjoge30sICJjb250ZXh0IjogImRlYWRiZWVmIiwg
+        Il9ucyI6ICJ1bml0c19tb2R1bGVtZCIsICJkZXBlbmRlbmNpZXMiOiBbXSwg
+        Il9pZCI6ICI3M2RhODFhMC0wNWNmLTQ1OWMtYjMwMS0yMGYwMjVkMmMwNTQi
+        LCAiYXJjaCI6ICJub2FyY2giLCAiZGVzY3JpcHRpb24iOiAiQSBtb2R1bGUg
+        Zm9yIHRoZSBkdWNrIDAuNyBwYWNrYWdlIn0sICJ1cGRhdGVkIjogIjIwMTkt
+        MDgtMzBUMTQ6MzQ6NDRaIiwgInJlcG9faWQiOiAiM192aWV3MSIsICJjcmVh
+        dGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDRaIiwgInVuaXRfdHlwZV9pZCI6
+        ICJtb2R1bGVtZCIsICJ1bml0X2lkIjogIjczZGE4MWEwLTA1Y2YtNDU5Yy1i
+        MzAxLTIwZjAyNWQyYzA1NCIsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTM0MDQz
+        MmRiNjA3N2E3OTY3Zjk3In19LCB7Im1ldGFkYXRhIjogeyJfc3RvcmFnZV9w
+        YXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0cy9tb2R1bGVtZC83
+        OC82ODcyN2JjYzJhOWQ5YTYwM2JlMWJkNDA3ZjQ3ZWQ4N2I5NmIxMmVkNmNk
+        NTU1NmJjZGNlYTkxZGE5ODBlMCIsICJuYW1lIjogImthbmdhcm9vIiwgInN0
+        cmVhbSI6ICIwIiwgImFydGlmYWN0cyI6IFsia2FuZ2Fyb28tMDowLjMtMS5u
+        b2FyY2giXSwgImNoZWNrc3VtIjogIjA5MDBkZDBmYWE2N2Y5Mzg2NzdjNGJh
+        YWNmMDA1ZWM5ZDI0ODI3YWZhMjExY2I0MTU3ZWQ4NmQzNWNjODNmZGUiLCAi
+        X2xhc3RfdXBkYXRlZCI6IDE1NjcxNzU2NjEsICJfY29udGVudF90eXBlX2lk
+        IjogIm1vZHVsZW1kIiwgInByb2ZpbGVzIjogeyJkZWZhdWx0IjogWyJrYW5n
+        YXJvbyJdfSwgInN1bW1hcnkiOiAiS2FuZ2Fyb28gMC4zIG1vZHVsZSIsICJk
+        b3dubG9hZGVkIjogdHJ1ZSwgInZlcnNpb24iOiAyMDE4MDczMDIyMzQwNywg
+        InB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiY29udGV4dCI6ICJkZWFkYmVl
+        ZiIsICJfbnMiOiAidW5pdHNfbW9kdWxlbWQiLCAiZGVwZW5kZW5jaWVzIjog
+        W10sICJfaWQiOiAiNzk1YWM0ZmEtNGQ4Yi00YjFjLThlZDktNmNkZmNkYTky
+        NmY2IiwgImFyY2giOiAibm9hcmNoIiwgImRlc2NyaXB0aW9uIjogIkEgbW9k
+        dWxlIGZvciB0aGUga2FuZ2Fyb28gMC4zIHBhY2thZ2UifSwgInVwZGF0ZWQi
+        OiAiMjAxOS0wOC0zMFQxNDozNDo0NFoiLCAicmVwb19pZCI6ICIzX3ZpZXcx
+        IiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDo0NFoiLCAidW5pdF90
+        eXBlX2lkIjogIm1vZHVsZW1kIiwgInVuaXRfaWQiOiAiNzk1YWM0ZmEtNGQ4
+        Yi00YjFjLThlZDktNmNkZmNkYTkyNmY2IiwgIl9pZCI6IHsiJG9pZCI6ICI1
+        ZDY5MzQwNDMyZGI2MDc3YTc5NjdmOWQifX0sIHsibWV0YWRhdGEiOiB7Il9z
+        dG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVscC9jb250ZW50L3VuaXRzL21v
+        ZHVsZW1kLzkwLzY2ZjZiNDNiMWI0ZGYwOWY4YTY4Nzk3YTA3YTg0ZmQzZjU1
+        ZTQ3NGY3ZDM5OTNlZjJhOGRjNzQxOGQxMDAxIiwgIm5hbWUiOiAia2FuZ2Fy
+        b28iLCAic3RyZWFtIjogIjAiLCAiYXJ0aWZhY3RzIjogWyJrYW5nYXJvby0w
+        OjAuMi0xLm5vYXJjaCJdLCAiY2hlY2tzdW0iOiAiZTgyMGUwOGMwNWFhNzM2
+        Y2U1MzAwNjZjNjg4Mjg4YmY1NzQ2MDk4MjY3YzI4MjQyNzllMzZjOWE3MmU2
+        YjljZSIsICJfbGFzdF91cGRhdGVkIjogMTU2NzE3NTY2MSwgIl9jb250ZW50
+        X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAicHJvZmlsZXMiOiB7ImRlZmF1bHQi
+        OiBbImthbmdhcm9vIl19LCAic3VtbWFyeSI6ICJLYW5nYXJvbyAwLjIgbW9k
+        dWxlIiwgImRvd25sb2FkZWQiOiB0cnVlLCAidmVyc2lvbiI6IDIwMTgwNzA0
+        MTExNzE5LCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJjb250ZXh0Ijog
+        ImRlYWRiZWVmIiwgIl9ucyI6ICJ1bml0c19tb2R1bGVtZCIsICJkZXBlbmRl
+        bmNpZXMiOiBbXSwgIl9pZCI6ICI5YTYzOGFjYS03YmY0LTQxODEtYjBhMy0z
+        OGUwMDBhZWE4MTQiLCAiYXJjaCI6ICJub2FyY2giLCAiZGVzY3JpcHRpb24i
+        OiAiQSBtb2R1bGUgZm9yIHRoZSBrYW5nYXJvbyAwLjIgcGFja2FnZSJ9LCAi
+        dXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0WiIsICJyZXBvX2lkIjog
+        IjNfdmlldzEiLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0WiIs
+        ICJ1bml0X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICI5YTYz
+        OGFjYS03YmY0LTQxODEtYjBhMy0zOGUwMDBhZWE4MTQiLCAiX2lkIjogeyIk
+        b2lkIjogIjVkNjkzNDA0MzJkYjYwNzdhNzk2N2Y5YSJ9fSwgeyJtZXRhZGF0
+        YSI6IHsiX3N0b3JhZ2VfcGF0aCI6ICIvdmFyL2xpYi9wdWxwL2NvbnRlbnQv
+        dW5pdHMvbW9kdWxlbWQvMWIvMmYwMDM5NjRiYjY0MjFkZTc0Mjc3ZGIxOWM5
+        Y2E4ZDMzM2FiYTk2MzkzOTEwYzc4MGU1NzAwZGM4YTgzYTMiLCAibmFtZSI6
+        ICJkdWNrIiwgInN0cmVhbSI6ICIwIiwgImFydGlmYWN0cyI6IFsiZHVjay0w
+        OjAuNi0xLm5vYXJjaCJdLCAiY2hlY2tzdW0iOiAiNmJkOWQ5MDljOTI3MDU3
+        MWI4MTFlNTAyNzA5ZWE3YjU2MTUwZDQ0YTJiNGIzNGNmZDI1ZTUyYTgxYzVi
+        ZmNlNyIsICJfbGFzdF91cGRhdGVkIjogMTU2NzE3NTY2MSwgIl9jb250ZW50
+        X3R5cGVfaWQiOiAibW9kdWxlbWQiLCAicHJvZmlsZXMiOiB7ImRlZmF1bHQi
+        OiBbImR1Y2siXX0sICJzdW1tYXJ5IjogIkR1Y2sgMC42IG1vZHVsZSIsICJk
+        b3dubG9hZGVkIjogdHJ1ZSwgInZlcnNpb24iOiAyMDE4MDcwNDI0NDIwNSwg
+        InB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiY29udGV4dCI6ICJkZWFkYmVl
+        ZiIsICJfbnMiOiAidW5pdHNfbW9kdWxlbWQiLCAiZGVwZW5kZW5jaWVzIjog
+        W10sICJfaWQiOiAiZWMyZDY1ZmYtMDJkYi00ODQxLTgzNWUtOTMwYjdmNzFh
+        MzM2IiwgImFyY2giOiAibm9hcmNoIiwgImRlc2NyaXB0aW9uIjogIkEgbW9k
+        dWxlIGZvciB0aGUgZHVjayAwLjYgcGFja2FnZSJ9LCAidXBkYXRlZCI6ICIy
+        MDE5LTA4LTMwVDE0OjM0OjQ0WiIsICJyZXBvX2lkIjogIjNfdmlldzEiLCAi
+        Y3JlYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0WiIsICJ1bml0X3R5cGVf
+        aWQiOiAibW9kdWxlbWQiLCAidW5pdF9pZCI6ICJlYzJkNjVmZi0wMmRiLTQ4
+        NDEtODM1ZS05MzBiN2Y3MWEzMzYiLCAiX2lkIjogeyIkb2lkIjogIjVkNjkz
+        NDA0MzJkYjYwNzdhNzk2N2Y5MSJ9fV0=
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:47 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJtb2R1bGVtZCJdLCJsaW1pdCI6
+        MjAwMCwic2tpcCI6MjAwMH19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '63'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:47 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:47 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImxpbWl0Ijoy
+        MDAwLCJza2lwIjowfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '59'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:47 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '1945'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDEwLTExLTEwIDAwOjAwOjAw
+        IiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjog
+        W3siaHJlZiI6ICJodHRwczovL3Jobi5yZWRoYXQuY29tL2VycmF0YS9SSFNB
+        LTIwMTAtMDg1OC5odG1sIiwgInR5cGUiOiAic2VsZiIsICJpZCI6IG51bGws
+        ICJ0aXRsZSI6ICJSSFNBLTIwMTA6MDg1OCJ9LCB7ImhyZWYiOiAiaHR0cHM6
+        Ly9idWd6aWxsYS5yZWRoYXQuY29tL2J1Z3ppbGxhL3Nob3dfYnVnLmNnaT9p
+        ZD02Mjc4ODIiLCAidHlwZSI6ICJidWd6aWxsYSIsICJpZCI6ICI2Mjc4ODIi
+        LCAidGl0bGUiOiAiQ1ZFLTIwMTAtMDQwNSBiemlwMjogaW50ZWdlciBvdmVy
+        ZmxvdyBmbGF3IGluIEJaMl9kZWNvbXByZXNzIn0sIHsiaHJlZiI6ICJodHRw
+        czovL3d3dy5yZWRoYXQuY29tL3NlY3VyaXR5L2RhdGEvY3ZlL0NWRS0yMDEw
+        LTA0MDUuaHRtbCIsICJ0eXBlIjogImN2ZSIsICJpZCI6ICJDVkUtMjAxMC0w
+        NDA1IiwgInRpdGxlIjogIkNWRS0yMDEwLTA0MDUifSwgeyJocmVmIjogImh0
+        dHA6Ly93d3cucmVkaGF0LmNvbS9zZWN1cml0eS91cGRhdGVzL2NsYXNzaWZp
+        Y2F0aW9uLyNpbXBvcnRhbnQiLCAidHlwZSI6ICJvdGhlciIsICJpZCI6IG51
+        bGwsICJ0aXRsZSI6IG51bGx9XSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9
+        LCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVM
+        TE8tUkhTQS0yMDEwOjA4NTgiLCAiZnJvbSI6ICJzZWN1cml0eUByZWRoYXQu
+        Y29tIiwgInNldmVyaXR5IjogIkltcG9ydGFudCIsICJ0aXRsZSI6ICJJbXBv
+        cnRhbnQ6IGJ6aXAyIHNlY3VyaXR5IHVwZGF0ZSIsICJfbnMiOiAidW5pdHNf
+        ZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjMiLCAicmVib290X3N1Z2dlc3RlZCI6
+        IGZhbHNlLCAidHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFj
+        a2FnZXMiOiBbeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5zcmMucnBt
+        IiwgIm5hbWUiOiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1NiIsICI4
+        MDJmNDM5OWRiZGQwMTQ3NmUyNTRjM2IzMmM0MGFmZjU5Y2Y1ZDIzYTQ1ZmE0
+        ODhjNjkxN2NlODkwNGQ2YjRkIl0sICJmaWxlbmFtZSI6ICJiemlwMi1saWJz
+        LTEuMC41LTcuZWw2XzAueDg2XzY0LnJwbSIsICJlcG9jaCI6ICIwIiwgInZl
+        cnNpb24iOiAiMS4wLjUiLCAicmVsZWFzZSI6ICI3LmVsNl8wIiwgImFyY2gi
+        OiAieDg2XzY0In0sIHsic3JjIjogImJ6aXAyLTEuMC41LTcuZWw2XzAuc3Jj
+        LnJwbSIsICJuYW1lIjogImJ6aXAyLWRldmVsIiwgInN1bSI6IFsic2hhMjU2
+        IiwgImVhNjdjNjY0ZGExZmY5NmE2ZGM5NGQzMzAwOWI3M2Q4ZmFiMzFiNTk4
+        MjQxODNmYjQ1ZTliYTJlYmY4MmQ1ODMiXSwgImZpbGVuYW1lIjogImJ6aXAy
+        LWRldmVsLTEuMC41LTcuZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
+        cmNoIjogImk2ODYifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5z
+        cmMucnBtIiwgIm5hbWUiOiAiYnppcDItbGlicyIsICJzdW0iOiBbInNoYTI1
+        NiIsICJjOWYwNjRhNjg2MjU3M2ZiOWYyYTZhZmY3YzM2MjFmMTk0MGI0OTJk
+        ZjJlZGZjMmViYmRjMGI4MzA1ZjUxMTQ3Il0sICJmaWxlbmFtZSI6ICJiemlw
+        Mi1saWJzLTEuMC41LTcuZWw2XzAuaTY4Ni5ycG0iLCAiZXBvY2giOiAiMCIs
+        ICJ2ZXJzaW9uIjogIjEuMC41IiwgInJlbGVhc2UiOiAiNy5lbDZfMCIsICJh
+        cmNoIjogImk2ODYifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5lbDZfMC5z
+        cmMucnBtIiwgIm5hbWUiOiAiYnppcDItZGV2ZWwiLCAic3VtIjogWyJzaGEy
+        NTYiLCAiN2Y2MzEyNGU0NjU1YjdjOTJkMjNlYzRjMzgyMjZmNWQzNzQ2NTY4
+        ODUzZGZmNzUwZmM4NWUwNThlNzRiNWNmNiJdLCAiZmlsZW5hbWUiOiAiYnpp
+        cDItZGV2ZWwtMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjog
+        IjAiLCAidmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAi
+        LCAiYXJjaCI6ICJ4ODZfNjQifSwgeyJzcmMiOiAiYnppcDItMS4wLjUtNy5l
+        bDZfMC5zcmMucnBtIiwgIm5hbWUiOiAiYnppcDIiLCAic3VtIjogWyJzaGEy
+        NTYiLCAiYjhhM2Y3MmJjMmIwZDg5YmE3MzcwOTlhYzk4YmY4ZDJhZjRiZWEw
+        MmQzMTg4NGMwMmRiOTdmN2Y2NmMzZDVjMiJdLCAiZmlsZW5hbWUiOiAiYnpp
+        cDItMS4wLjUtNy5lbDZfMC54ODZfNjQucnBtIiwgImVwb2NoIjogIjAiLCAi
+        dmVyc2lvbiI6ICIxLjAuNSIsICJyZWxlYXNlIjogIjcuZWw2XzAiLCAiYXJj
+        aCI6ICJ4ODZfNjQifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9y
+        dCI6ICIifV0sICJzdGF0dXMiOiAiZmluYWwiLCAidXBkYXRlZCI6ICIyMDEw
+        LTExLTEwIDAwOjAwOjAwIiwgImRlc2NyaXB0aW9uIjogImJ6aXAyIGlzIGEg
+        ZnJlZWx5IGF2YWlsYWJsZSwgaGlnaC1xdWFsaXR5IGRhdGEgY29tcHJlc3Nv
+        ci4gSXQgcHJvdmlkZXMgYm90aFxubGliYnoyIGxpYnJhcnkgbXVzdCBiZSBy
+        ZXN0YXJ0ZWQgZm9yIHRoZSB1cGRhdGUgdG8gdGFrZSBlZmZlY3QuIiwgIl9s
+        YXN0X3VwZGF0ZWQiOiAxNTY3MTc1NjgyLCAicmVzdGFydF9zdWdnZXN0ZWQi
+        OiBmYWxzZSwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjogIkNvcHlyaWdo
+        dCAyMDEwIFJlZCBIYXQgSW5jIiwgInNvbHV0aW9uIjogIkJlZm9yZSBhcHBs
+        eWluZyB0aGlzIHVwZGF0ZSwgbWFrZSBzdXJlIGFsbCBwcmV2aW91c2x5LXJl
+        bGVhc2VkIGVycmF0YVxucmVsZXZhbnQgdG8geW91ciBzeXN0ZW0gaGF2ZSBi
+        ZWVuIGFwcGxpZWQuXG5cblRoaXMgdXBkYXRlIGlzIGF2YWlsYWJsZSB2aWEg
+        dGhlIFJlZCBIYXQgTmV0d29yay4gRGV0YWlscyBvbiBob3cgdG9cbnVzZSB0
+        aGUgUmVkIEhhdCBOZXR3b3JrIHRvIGFwcGx5IHRoaXMgdXBkYXRlIGFyZSBh
+        dmFpbGFibGUgYXRcbmh0dHA6Ly9rYmFzZS5yZWRoYXQuY29tL2ZhcS9kb2Nz
+        L0RPQy0xMTI1OSIsICJzdW1tYXJ5IjogIlVwZGF0ZWQgYnppcDIgcGFja2Fn
+        ZXMgdGhhdCBmaXggb25lIHNlY3VyaXR5IGlzc3VlIiwgInJlbGVhc2UiOiAi
+        IiwgIl9pZCI6ICI0YmM2ZGRiNy1hNGU1LTRkYTUtODM0YS00OTVhYWI2ODZh
+        NDgifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDo0NFoiLCAicmVw
+        b19pZCI6ICIzX3ZpZXcxIiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0zMFQxNDoz
+        NDo0NFoiLCAidW5pdF90eXBlX2lkIjogImVycmF0dW0iLCAidW5pdF9pZCI6
+        ICI0YmM2ZGRiNy1hNGU1LTRkYTUtODM0YS00OTVhYWI2ODZhNDgiLCAiX2lk
+        IjogeyIkb2lkIjogIjVkNjkzNDA0MzJkYjYwNzdhNzk2N2U2ZiJ9fSwgeyJt
+        ZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTItMDEtMDEgMDE6MDE6MDEiLCAi
+        cmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMiOiBbXSwg
+        InB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9pZCI6
+        ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjAxMTEiLCAi
+        ZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5IjogIiIs
+        ICJ0aXRsZSI6ICJEdXBsaWNhdGVkIHBhY2thZ2UgZXJyYXRhIiwgIl9ucyI6
+        ICJ1bml0c19lcnJhdHVtIiwgInZlcnNpb24iOiAiMSIsICJyZWJvb3Rfc3Vn
+        Z2VzdGVkIjogZmFsc2UsICJ0eXBlIjogInNlY3VyaXR5IiwgInBrZ2xpc3Qi
+        OiBbeyJwYWNrYWdlcyI6IFt7InNyYyI6ICJodHRwOi8vd3d3LmZlZG9yYXBy
+        b2plY3Qub3JnIiwgIm5hbWUiOiAibGlvbiIsICJzdW0iOiBudWxsLCAiZmls
+        ZW5hbWUiOiAibGlvbi0wLjMtMC44Lm5vYXJjaC5ycG0iLCAiZXBvY2giOiAi
+        MCIsICJ2ZXJzaW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjAuOCIsICJhcmNo
+        IjogIm5vYXJjaCJ9LCB7InNyYyI6ICJodHRwOi8vd3d3LmZlZG9yYXByb2pl
+        Y3Qub3JnIiwgIm5hbWUiOiAiZWxlcGhhbnQiLCAic3VtIjogbnVsbCwgImZp
+        bGVuYW1lIjogImVsZXBoYW50LTAuMy0wLjgubm9hcmNoLnJwbSIsICJlcG9j
+        aCI6ICIwIiwgInZlcnNpb24iOiAiMC4zIiwgInJlbGVhc2UiOiAiMC44Iiwg
+        ImFyY2giOiAibm9hcmNoIn1dLCAibmFtZSI6ICJjb2xsZWN0aW9uLTAiLCAi
+        c2hvcnQiOiAiIn1dLCAic3RhdHVzIjogInN0YWJsZSIsICJ1cGRhdGVkIjog
+        IiIsICJkZXNjcmlwdGlvbiI6ICJEdXBsaWNhdGUgT25lIHBhY2thZ2UgZXJy
+        YXRhIiwgIl9sYXN0X3VwZGF0ZWQiOiAxNTY3MTc1NjgyLCAicmVzdGFydF9z
+        dWdnZXN0ZWQiOiBmYWxzZSwgInB1c2hjb3VudCI6ICIiLCAicmlnaHRzIjog
+        IiIsICJzb2x1dGlvbiI6ICIiLCAic3VtbWFyeSI6ICIiLCAicmVsZWFzZSI6
+        ICIxIiwgIl9pZCI6ICI1MmJhNjUyNS1lOTU5LTRjY2QtOGFjYi1mNTI0OTk3
+        YjYzNWIifSwgInVwZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDo0NFoiLCAi
+        cmVwb19pZCI6ICIzX3ZpZXcxIiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0zMFQx
+        NDozNDo0NFoiLCAidW5pdF90eXBlX2lkIjogImVycmF0dW0iLCAidW5pdF9p
+        ZCI6ICI1MmJhNjUyNS1lOTU5LTRjY2QtOGFjYi1mNTI0OTk3YjYzNWIiLCAi
+        X2lkIjogeyIkb2lkIjogIjVkNjkzNDA0MzJkYjYwNzdhNzk2N2U3NiJ9fSwg
+        eyJtZXRhZGF0YSI6IHsiaXNzdWVkIjogIjIwMTAtMDEtMDEgMDE6MDE6MDEi
+        LCAicmVsb2dpbl9zdWdnZXN0ZWQiOiBmYWxzZSwgInJlZmVyZW5jZXMiOiBb
+        XSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAiX2NvbnRlbnRfdHlwZV9p
+        ZCI6ICJlcnJhdHVtIiwgImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjAwMDIi
+        LCAiZnJvbSI6ICJsemFwK3B1YkByZWRoYXQuY29tIiwgInNldmVyaXR5Ijog
+        IiIsICJ0aXRsZSI6ICJPbmUgcGFja2FnZSBlcnJhdGEiLCAiX25zIjogInVu
+        aXRzX2VycmF0dW0iLCAidmVyc2lvbiI6ICIxIiwgInJlYm9vdF9zdWdnZXN0
+        ZWQiOiBmYWxzZSwgInR5cGUiOiAic2VjdXJpdHkiLCAicGtnbGlzdCI6IFt7
+        InBhY2thZ2VzIjogW3sic3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVj
+        dC5vcmciLCAibmFtZSI6ICJlbGVwaGFudCIsICJzdW0iOiBudWxsLCAiZmls
+        ZW5hbWUiOiAiZWxlcGhhbnQtMC4zLTAuOC5ub2FyY2gucnBtIiwgImVwb2No
+        IjogIjAiLCAidmVyc2lvbiI6ICIwLjMiLCAicmVsZWFzZSI6ICIwLjgiLCAi
+        YXJjaCI6ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJz
+        aG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwgInVwZGF0ZWQiOiAi
+        IiwgImRlc2NyaXB0aW9uIjogIk9uZSBwYWNrYWdlIGVycmF0YSIsICJfbGFz
+        dF91cGRhdGVkIjogMTU2NzE3NTY4MiwgInJlc3RhcnRfc3VnZ2VzdGVkIjog
+        ZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0cyI6ICIiLCAic29sdXRp
+        b24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVhc2UiOiAiMSIsICJfaWQi
+        OiAiNmQyY2FhMzMtNzM2Ni00NTMyLTlmM2QtZWFiODM3MDJlMmEwIn0sICJ1
+        cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDRaIiwgInJlcG9faWQiOiAi
+        M192aWV3MSIsICJjcmVhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDRaIiwg
+        InVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVuaXRfaWQiOiAiNmQyY2Fh
+        MzMtNzM2Ni00NTMyLTlmM2QtZWFiODM3MDJlMmEwIiwgIl9pZCI6IHsiJG9p
+        ZCI6ICI1ZDY5MzQwNDMyZGI2MDc3YTc5NjdlN2EifX0sIHsibWV0YWRhdGEi
+        OiB7Imlzc3VlZCI6ICIyMDEwLTAxLTAxIDAxOjAxOjAxIiwgInJlbG9naW5f
+        c3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2VzIjogW10sICJwdWxwX3Vz
+        ZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5cGVfaWQiOiAiZXJyYXR1
+        bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDo5OTE0MyIsICJmcm9tIjog
+        Imx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRpdGxl
+        IjogIkFybWFkaWxsbyIsICJfbnMiOiAidW5pdHNfZXJyYXR1bSIsICJ2ZXJz
+        aW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6
+        ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW3sicGFja2FnZXMiOiBbeyJzcmMi
+        OiAiaHR0cDovL3d3dy5mZWRvcmFwcm9qZWN0Lm9yZyIsICJuYW1lIjogImFy
+        bWFkaWxsbyIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAiYXJtYWRpbGxv
+        LTIuMS0xLm5vYXJjaC5ycG0iLCAiZXBvY2giOiAiMCIsICJ2ZXJzaW9uIjog
+        IjIuMSIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2gifV0sICJu
+        YW1lIjogImNvbGxlY3Rpb24tMCIsICJzaG9ydCI6ICIifV0sICJzdGF0dXMi
+        OiAic3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjogIkFy
+        bWFkaWxsbyIsICJfbGFzdF91cGRhdGVkIjogMTU2NzE3NTY4MiwgInJlc3Rh
+        cnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0
+        cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVh
+        c2UiOiAiMSIsICJfaWQiOiAiYjFiNzQ3NTAtMGYxMC00M2M0LTgyYmMtMTk1
+        ZjE3NjAxOTBkIn0sICJ1cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDRa
+        IiwgInJlcG9faWQiOiAiM192aWV3MSIsICJjcmVhdGVkIjogIjIwMTktMDgt
+        MzBUMTQ6MzQ6NDRaIiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVu
+        aXRfaWQiOiAiYjFiNzQ3NTAtMGYxMC00M2M0LTgyYmMtMTk1ZjE3NjAxOTBk
+        IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzQwNDMyZGI2MDc3YTc5NjdlODAi
+        fX0sIHsibWV0YWRhdGEiOiB7Imlzc3VlZCI6ICIyMDE4LTAxLTI3IDE2OjA4
+        OjA5IiwgInJlbG9naW5fc3VnZ2VzdGVkIjogZmFsc2UsICJyZWZlcmVuY2Vz
+        IjogW10sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgIl9jb250ZW50X3R5
+        cGVfaWQiOiAiZXJyYXR1bSIsICJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMjow
+        MDU5IiwgImZyb20iOiAiZXJyYXRhQHJlZGhhdC5jb20iLCAic2V2ZXJpdHki
+        OiAiIiwgInRpdGxlIjogIkR1Y2tfS2FuZ2Fyb29fRXJyYXR1bSIsICJfbnMi
+        OiAidW5pdHNfZXJyYXR1bSIsICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1
+        Z2dlc3RlZCI6IGZhbHNlLCAidHlwZSI6ICJlbmhhbmNlbWVudCIsICJwa2ds
+        aXN0IjogW3sicGFja2FnZXMiOiBbeyJzcmMiOiAiaHR0cDovL3d3dy5mZWRv
+        cmFwcm9qZWN0Lm9yZyIsICJuYW1lIjogImR1Y2siLCAic3VtIjogbnVsbCwg
+        ImZpbGVuYW1lIjogImR1Y2stMC43LTEubm9hcmNoLnJwbSIsICJlcG9jaCI6
+        IG51bGwsICJ2ZXJzaW9uIjogIjAuNyIsICJyZWxlYXNlIjogIjEiLCAiYXJj
+        aCI6ICJub2FyY2gifV0sICJuYW1lIjogImNvbGxlY3Rpb24tMCIsICJtb2R1
+        bGUiOiB7ImNvbnRleHQiOiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6ICIyMDE4
+        MDczMDIzMzEwMiIsICJhcmNoIjogIm5vYXJjaCIsICJuYW1lIjogImR1Y2si
+        LCAic3RyZWFtIjogIjAifSwgInNob3J0IjogIiJ9LCB7InBhY2thZ2VzIjog
+        W3sic3JjIjogImh0dHA6Ly93d3cuZmVkb3JhcHJvamVjdC5vcmciLCAibmFt
+        ZSI6ICJrYW5nYXJvbyIsICJzdW0iOiBudWxsLCAiZmlsZW5hbWUiOiAia2Fu
+        Z2Fyb28tMC4zLTEubm9hcmNoLnJwbSIsICJlcG9jaCI6IG51bGwsICJ2ZXJz
+        aW9uIjogIjAuMyIsICJyZWxlYXNlIjogIjEiLCAiYXJjaCI6ICJub2FyY2gi
+        fV0sICJuYW1lIjogImNvbGxlY3Rpb24tMSIsICJtb2R1bGUiOiB7ImNvbnRl
+        eHQiOiAiZGVhZGJlZWYiLCAidmVyc2lvbiI6ICIyMDE4MDczMDIyMzQwNyIs
+        ICJhcmNoIjogIm5vYXJjaCIsICJuYW1lIjogImthbmdhcm9vIiwgInN0cmVh
+        bSI6ICIwIn0sICJzaG9ydCI6ICIifV0sICJzdGF0dXMiOiAic3RhYmxlIiwg
+        InVwZGF0ZWQiOiAiMjAxOC0wNy0yMCAwNjowMDowMSBVVEMiLCAiZGVzY3Jp
+        cHRpb24iOiAiRHVja19LYW5nYXJvX0VycmF0dW0gZGVzY3JpcHRpb24iLCAi
+        X2xhc3RfdXBkYXRlZCI6IDE1NjcxNzU2ODIsICJyZXN0YXJ0X3N1Z2dlc3Rl
+        ZCI6IGZhbHNlLCAicHVzaGNvdW50IjogIiIsICJyaWdodHMiOiAiIiwgInNv
+        bHV0aW9uIjogIiIsICJzdW1tYXJ5IjogIiIsICJyZWxlYXNlIjogIjEiLCAi
+        X2lkIjogImM2OGQxMzk1LWRmYjUtNDI3YS1iNDlkLTkxYWZjODRlZmI1ZCJ9
+        LCAidXBkYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0WiIsICJyZXBvX2lk
+        IjogIjNfdmlldzEiLCAiY3JlYXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQ0
+        WiIsICJ1bml0X3R5cGVfaWQiOiAiZXJyYXR1bSIsICJ1bml0X2lkIjogImM2
+        OGQxMzk1LWRmYjUtNDI3YS1iNDlkLTkxYWZjODRlZmI1ZCIsICJfaWQiOiB7
+        IiRvaWQiOiAiNWQ2OTM0MDQzMmRiNjA3N2E3OTY3ZTczIn19LCB7Im1ldGFk
+        YXRhIjogeyJpc3N1ZWQiOiAiMjAxMC0wMS0wMSAwMTowMTowMSIsICJyZWxv
+        Z2luX3N1Z2dlc3RlZCI6IGZhbHNlLCAicmVmZXJlbmNlcyI6IFtdLCAicHVs
+        cF91c2VyX21ldGFkYXRhIjoge30sICJfY29udGVudF90eXBlX2lkIjogImVy
+        cmF0dW0iLCAiaWQiOiAiS0FURUxMTy1SSEVBLTIwMTA6MDAwMSIsICJmcm9t
+        IjogImx6YXArcHViQHJlZGhhdC5jb20iLCAic2V2ZXJpdHkiOiAiIiwgInRp
+        dGxlIjogIkVtcHR5IGVycmF0YSIsICJfbnMiOiAidW5pdHNfZXJyYXR1bSIs
+        ICJ2ZXJzaW9uIjogIjEiLCAicmVib290X3N1Z2dlc3RlZCI6IGZhbHNlLCAi
+        dHlwZSI6ICJzZWN1cml0eSIsICJwa2dsaXN0IjogW10sICJzdGF0dXMiOiAi
+        c3RhYmxlIiwgInVwZGF0ZWQiOiAiIiwgImRlc2NyaXB0aW9uIjogIkVtcHR5
+        IGVycmF0YSIsICJfbGFzdF91cGRhdGVkIjogMTU2NzE3NTY4MiwgInJlc3Rh
+        cnRfc3VnZ2VzdGVkIjogZmFsc2UsICJwdXNoY291bnQiOiAiIiwgInJpZ2h0
+        cyI6ICIiLCAic29sdXRpb24iOiAiIiwgInN1bW1hcnkiOiAiIiwgInJlbGVh
+        c2UiOiAiMSIsICJfaWQiOiAiZGM4MzY0NTItYmZiMi00NGIxLTlhOGUtYjNi
+        ZTlhNzVlNzM1In0sICJ1cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDRa
+        IiwgInJlcG9faWQiOiAiM192aWV3MSIsICJjcmVhdGVkIjogIjIwMTktMDgt
+        MzBUMTQ6MzQ6NDRaIiwgInVuaXRfdHlwZV9pZCI6ICJlcnJhdHVtIiwgInVu
+        aXRfaWQiOiAiZGM4MzY0NTItYmZiMi00NGIxLTlhOGUtYjNiZTlhNzVlNzM1
+        IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzQwNDMyZGI2MDc3YTc5NjdlODYi
+        fX1d
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:47 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImxpbWl0Ijoy
+        MDAwLCJza2lwIjoyMDAwfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '62'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:47 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:47 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwYWNrYWdlX2dyb3VwIl0sImxp
+        bWl0IjoyMDAwLCJza2lwIjowfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '65'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:47 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '442'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Im1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJw
+        ZW5ndWluIl0sICJyZXBvX2lkIjogIjNfdmlldzEiLCAibmFtZSI6ICJiaXJk
+        IiwgInVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1ZSwgIl9u
+        cyI6ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0X3VwZGF0ZWQiOiAx
+        NTY3MTc1Njg0LCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdLCAidHJh
+        bnNsYXRlZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rlc2NyaXB0aW9uIjog
+        e30sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRlZmF1bHRfcGFja2Fn
+        ZV9uYW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNrYWdlX2dy
+        b3VwIiwgImlkIjogImJpcmQiLCAiX2lkIjogIjRiNWU5YjM3LTcyZDUtNGM0
+        NC1hMTc4LWYxMmZiMzY1ZDJkNyIsICJkaXNwbGF5X29yZGVyIjogMTAyNCwg
+        ImNvbmRpdGlvbmFsX3BhY2thZ2VfbmFtZXMiOiBbXX0sICJ1cGRhdGVkIjog
+        IjIwMTktMDgtMzBUMTQ6MzQ6NDRaIiwgInJlcG9faWQiOiAiM192aWV3MSIs
+        ICJjcmVhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDRaIiwgInVuaXRfdHlw
+        ZV9pZCI6ICJwYWNrYWdlX2dyb3VwIiwgInVuaXRfaWQiOiAiNGI1ZTliMzct
+        NzJkNS00YzQ0LWExNzgtZjEyZmIzNjVkMmQ3IiwgIl9pZCI6IHsiJG9pZCI6
+        ICI1ZDY5MzQwNDMyZGI2MDc3YTc5NjdlZGEifX0sIHsibWV0YWRhdGEiOiB7
+        Im1hbmRhdG9yeV9wYWNrYWdlX25hbWVzIjogWyJlbGVwaGFudCxnaXJhZmZl
+        LGNoZWV0YWgsbGlvbixtb25rZXkscGVuZ3VpbixzcXVpcnJlbCx3YWxydXMi
+        LCAicGVuZ3VpbiJdLCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgIm5hbWUiOiAi
+        bWFtbWFsIiwgInVzZXJfdmlzaWJsZSI6IHRydWUsICJkZWZhdWx0IjogdHJ1
+        ZSwgIl9ucyI6ICJ1bml0c19wYWNrYWdlX2dyb3VwIiwgIl9sYXN0X3VwZGF0
+        ZWQiOiAxNTY3MTc1Njg0LCAib3B0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtd
+        LCAidHJhbnNsYXRlZF9uYW1lIjoge30sICJ0cmFuc2xhdGVkX2Rlc2NyaXB0
+        aW9uIjoge30sICJwdWxwX3VzZXJfbWV0YWRhdGEiOiB7fSwgImRlZmF1bHRf
+        cGFja2FnZV9uYW1lcyI6IFtdLCAiX2NvbnRlbnRfdHlwZV9pZCI6ICJwYWNr
+        YWdlX2dyb3VwIiwgImlkIjogIm1hbW1hbCIsICJfaWQiOiAiOGY5ODFmNWMt
+        YTViZi00NGMzLWExOTMtN2IyYTQyMjQ3ZjFlIiwgImRpc3BsYXlfb3JkZXIi
+        OiAxMDI0LCAiY29uZGl0aW9uYWxfcGFja2FnZV9uYW1lcyI6IFtdfSwgInVw
+        ZGF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDo0NFoiLCAicmVwb19pZCI6ICIz
+        X3ZpZXcxIiwgImNyZWF0ZWQiOiAiMjAxOS0wOC0zMFQxNDozNDo0NFoiLCAi
+        dW5pdF90eXBlX2lkIjogInBhY2thZ2VfZ3JvdXAiLCAidW5pdF9pZCI6ICI4
+        Zjk4MWY1Yy1hNWJmLTQ0YzMtYTE5My03YjJhNDIyNDdmMWUiLCAiX2lkIjog
+        eyIkb2lkIjogIjVkNjkzNDA0MzJkYjYwNzdhNzk2N2VmNiJ9fV0=
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:47 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJwYWNrYWdlX2dyb3VwIl0sImxp
+        bWl0IjoyMDAwLCJza2lwIjoyMDAwfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '68'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:47 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:47 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJ5dW1fcmVwb19tZXRhZGF0YV9m
+        aWxlIl0sImxpbWl0IjoyMDAwLCJza2lwIjowfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '74'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:47 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '548'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgiOiAiL3Zhci9saWIvcHVs
+        cC9jb250ZW50L3VuaXRzL3l1bV9yZXBvX21ldGFkYXRhX2ZpbGUvOGEvODE5
+        MjQ4NTNhOGE0ZTY2ODNmNTYyYTIzZmEzNTJiN2U3OWZiZjBmYTUyNDdmZTkx
+        MGZiODE4MmFjZGE4ODAvNTY5YzBhYzMyNDMyYTIxMzA4Njc5M2E3MDUwMjIy
+        OGEyYmU5OTViYzUxMzQ4MDFmZTE1ODJjNDA4ZjhkOTcxYi1zd2lkdGFncy54
+        bWwuZ3oiLCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImRhdGFfdHlwZSI6ICJz
+        d2lkdGFncyIsICJjaGVja3N1bSI6ICI1NjljMGFjMzI0MzJhMjEzMDg2Nzkz
+        YTcwNTAyMjI4YTJiZTk5NWJjNTEzNDgwMWZlMTU4MmM0MDhmOGQ5NzFiIiwg
+        Il9sYXN0X3VwZGF0ZWQiOiAxNTY3MTc1Njg0LCAiX2NvbnRlbnRfdHlwZV9p
+        ZCI6ICJ5dW1fcmVwb19tZXRhZGF0YV9maWxlIiwgImRvd25sb2FkZWQiOiB0
+        cnVlLCAicHVscF91c2VyX21ldGFkYXRhIjoge30sICJfbnMiOiAidW5pdHNf
+        eXVtX3JlcG9fbWV0YWRhdGFfZmlsZSIsICJjaGVja3N1bV90eXBlIjogInNo
+        YTI1NiIsICJfaWQiOiAiNGEwYTIwMjAtNWU1ZS00OTNjLWI1NGYtY2FiZTQ2
+        YmJkZGM0In0sICJ1cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDRaIiwg
+        InJlcG9faWQiOiAiM192aWV3MSIsICJjcmVhdGVkIjogIjIwMTktMDgtMzBU
+        MTQ6MzQ6NDRaIiwgInVuaXRfdHlwZV9pZCI6ICJ5dW1fcmVwb19tZXRhZGF0
+        YV9maWxlIiwgInVuaXRfaWQiOiAiNGEwYTIwMjAtNWU1ZS00OTNjLWI1NGYt
+        Y2FiZTQ2YmJkZGM0IiwgIl9pZCI6IHsiJG9pZCI6ICI1ZDY5MzQwNDMyZGI2
+        MDc3YTc5NjdmNGQifX0sIHsibWV0YWRhdGEiOiB7Il9zdG9yYWdlX3BhdGgi
+        OiAiL3Zhci9saWIvcHVscC9jb250ZW50L3VuaXRzL3l1bV9yZXBvX21ldGFk
+        YXRhX2ZpbGUvYzAvMTcwN2Q5YzhlOTkyNGIzOGQwNjYwMDlmODg1ODVkMjNh
+        OGQxM2NiOTg3NjQxODFiOTdjN2MyNDJiNDc3MDQvMGQxZWI3Mzg2N2M0NTli
+        ODZkMTU4Y2RhZDI2NjAwMmU0NTg4MTQwNTFlMzU1Mjk5NzA1M2QzNTY3MTQ0
+        YTdlMi1wcm9kdWN0aWQuZ3oiLCAicmVwb19pZCI6ICIzX3ZpZXcxIiwgImRh
+        dGFfdHlwZSI6ICJwcm9kdWN0aWQiLCAiY2hlY2tzdW0iOiAiMGQxZWI3Mzg2
+        N2M0NTliODZkMTU4Y2RhZDI2NjAwMmU0NTg4MTQwNTFlMzU1Mjk5NzA1M2Qz
+        NTY3MTQ0YTdlMiIsICJfbGFzdF91cGRhdGVkIjogMTU2NzE3NTY4NCwgIl9j
+        b250ZW50X3R5cGVfaWQiOiAieXVtX3JlcG9fbWV0YWRhdGFfZmlsZSIsICJk
+        b3dubG9hZGVkIjogdHJ1ZSwgInB1bHBfdXNlcl9tZXRhZGF0YSI6IHt9LCAi
+        X25zIjogInVuaXRzX3l1bV9yZXBvX21ldGFkYXRhX2ZpbGUiLCAiY2hlY2tz
+        dW1fdHlwZSI6ICJzaGEyNTYiLCAiX2lkIjogImJkOGU3MmVlLTA1NTYtNGRh
+        Ni1hYjM3LTRhNTIwZGRmNzE2YiJ9LCAidXBkYXRlZCI6ICIyMDE5LTA4LTMw
+        VDE0OjM0OjQ0WiIsICJyZXBvX2lkIjogIjNfdmlldzEiLCAiY3JlYXRlZCI6
+        ICIyMDE5LTA4LTMwVDE0OjM0OjQ0WiIsICJ1bml0X3R5cGVfaWQiOiAieXVt
+        X3JlcG9fbWV0YWRhdGFfZmlsZSIsICJ1bml0X2lkIjogImJkOGU3MmVlLTA1
+        NTYtNGRhNi1hYjM3LTRhNTIwZGRmNzE2YiIsICJfaWQiOiB7IiRvaWQiOiAi
+        NWQ2OTM0MDQzMmRiNjA3N2E3OTY3ZjU5In19XQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:48 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJ5dW1fcmVwb19tZXRhZGF0YV9m
+        aWxlIl0sImxpbWl0IjoyMDAwLCJza2lwIjoyMDAwfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '77'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:48 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:48 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJzcnBtIl0sImxpbWl0IjoyMDAw
+        LCJza2lwIjowLCJmaWVsZHMiOnsidW5pdCI6WyJuYW1lIiwidmVyc2lvbiIs
+        InJlbGVhc2UiLCJhcmNoIiwiZXBvY2giLCJzdW1tYXJ5IiwiY2hlY2tzdW0i
+        LCJmaWxlbmFtZSJdfX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '150'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:48 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:48 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJkaXN0cmlidXRpb24iXX19
+
+'
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '42'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:48 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '533'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7ImZpbGVzIjogW3sicmVsYXRpdmVwYXRoIjogImlt
+        YWdlcy90ZXN0Mi5pbWciLCAiY2hlY2tzdW10eXBlIjogInNoYTI1NiIsICJj
+        aGVja3N1bSI6ICJlM2IwYzQ0Mjk4ZmMxYzE0OWFmYmY0Yzg5OTZmYjkyNDI3
+        YWU0MWU0NjQ5YjkzNGNhNDk1OTkxYjc4NTJiODU1In0sIHsicmVsYXRpdmVw
+        YXRoIjogImVtcHR5LmlzbyIsICJjaGVja3N1bXR5cGUiOiAic2hhMjU2Iiwg
+        ImNoZWNrc3VtIjogImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0
+        MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifSwgeyJyZWxhdGl2
+        ZXBhdGgiOiAiaW1hZ2VzL3Rlc3QxLmltZyIsICJjaGVja3N1bXR5cGUiOiAi
+        c2hhMjU2IiwgImNoZWNrc3VtIjogImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRj
+        ODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifV0s
+        ICJfc3RvcmFnZV9wYXRoIjogIi92YXIvbGliL3B1bHAvY29udGVudC91bml0
+        cy9kaXN0cmlidXRpb24vOWIvODMxMjU2YTEyNDcxOGJmMzkxNjZiNTY0ZDhl
+        Njg5OTU0ZmYwYThmMGY0NzliYTI0Y2ZhMjYzNTAxMDliYzUiLCAiZmFtaWx5
+        IjogIlRlc3QgRmFtaWx5IiwgImRvd25sb2FkZWQiOiBmYWxzZSwgInRpbWVz
+        dGFtcCI6IDEzMjMxMTIxNTMuMDksICJfbGFzdF91cGRhdGVkIjogMTU2NzE3
+        NTY4MiwgIl9jb250ZW50X3R5cGVfaWQiOiAiZGlzdHJpYnV0aW9uIiwgInZh
+        cmlhbnQiOiAiVGVzdFZhcmlhbnQiLCAiaWQiOiAia3MtVGVzdCBGYW1pbHkt
+        VGVzdFZhcmlhbnQtMTYteDg2XzY0IiwgInZlcnNpb24iOiAiMTYiLCAidmVy
+        c2lvbl9zb3J0X2luZGV4IjogIjAyLTE2IiwgInB1bHBfdXNlcl9tZXRhZGF0
+        YSI6IHt9LCAicGFja2FnZWRpciI6ICIiLCAiX2lkIjogImU0NWRmNzI1LWJj
+        ZWMtNGM3Mi05NDQ3LTAyZjczMTM1Nzc4YyIsICJhcmNoIjogIng4Nl82NCIs
+        ICJfbnMiOiAidW5pdHNfZGlzdHJpYnV0aW9uIn0sICJ1cGRhdGVkIjogIjIw
+        MTktMDgtMzBUMTQ6MzQ6NDRaIiwgInJlcG9faWQiOiAiM192aWV3MSIsICJj
+        cmVhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDRaIiwgInVuaXRfdHlwZV9p
+        ZCI6ICJkaXN0cmlidXRpb24iLCAidW5pdF9pZCI6ICJlNDVkZjcyNS1iY2Vj
+        LTRjNzItOTQ0Ny0wMmY3MzEzNTc3OGMiLCAiX2lkIjogeyIkb2lkIjogIjVk
+        NjkzNDA0MzJkYjYwNzdhNzk2N2Y3NSJ9fV0=
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:48 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/actions/unassociate/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJlcnJhdHVtIl0sImZpbHRlcnMi
+        OnsidW5pdCI6eyJpZCI6eyIkaW4iOlsiS0FURUxMTy1SSFNBLTIwMTA6MDg1
+        OCIsIktBVEVMTE8tUkhFQS0yMDEwOjAxMTEiLCJLQVRFTExPLVJIRUEtMjAx
+        MDo5OTE0MyIsIktBVEVMTE8tUkhFQS0yMDEwOjAwMDEiXX19fSwiZmllbGRz
+        Ijp7InVuaXQiOlsiZXJyYXRhX2lkIl19fX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '206'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:48 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzBjYTNkMjNmLWQ2N2UtNDk4Yy05YzQzLWMxMTJmYzcxZTQ2Yi8iLCAi
+        dGFza19pZCI6ICIwY2EzZDIzZi1kNjdlLTQ5OGMtOWM0My1jMTEyZmM3MWU0
+        NmIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Fri, 30 Aug 2019 14:34:48 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/0ca3d23f-d67e-498c-9c43-c112fc71e46b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 30 Aug 2019 14:34:49 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"6bd28dda18b110ef4657e4521a4aecc4-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '478'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -4480,59 +4135,60 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         Lm1hbmFnZXJzLnJlcG8udW5pdF9hc3NvY2lhdGlvbi51bmFzc29jaWF0ZV9i
-        eV9jcml0ZXJpYSIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvZGJm
-        ZjhiYjktMGJhMi00YjQ2LTk5ZjUtYzVkNjIzMmI2ZDU2LyIsICJ0YXNrX2lk
-        IjogImRiZmY4YmI5LTBiYTItNGI0Ni05OWY1LWM1ZDYyMzJiNmQ1NiIsICJ0
+        eV9jcml0ZXJpYSIsICJfaHJlZiI6ICIvcHVscC9hcGkvdjIvdGFza3MvMGNh
+        M2QyM2YtZDY3ZS00OThjLTljNDMtYzExMmZjNzFlNDZiLyIsICJ0YXNrX2lk
+        IjogIjBjYTNkMjNmLWQ2N2UtNDk4Yy05YzQzLWMxMTJmYzcxZTQ2YiIsICJ0
         YWdzIjogWyJwdWxwOnJlcG9zaXRvcnk6M192aWV3MSIsICJwdWxwOmFjdGlv
-        bjp1bmFzc29jaWF0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAxOS0wOC0wNVQx
-        OToxMjowNFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
-        OiAiMjAxOS0wOC0wNVQxOToxMjowNFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
+        bjp1bmFzc29jaWF0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAxOS0wOC0zMFQx
+        NDozNDo0OFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUi
+        OiAiMjAxOS0wOC0zMFQxNDozNDo0OFoiLCAidHJhY2ViYWNrIjogbnVsbCwg
         InNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAi
-        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwubG9j
-        YWxob3N0LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIs
-        ICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBk
-        ZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20iLCAicmVzdWx0IjogeyJ1bml0
-        c19zdWNjZXNzZnVsIjogW3sidW5pdF9rZXkiOiB7ImlkIjogIktBVEVMTE8t
-        UkhFQS0yMDEwOjAwMDEifSwgInR5cGVfaWQiOiAiZXJyYXR1bSJ9LCB7InVu
-        aXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDo5OTE0MyJ9LCAi
-        dHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7ImlkIjogIktB
-        VEVMTE8tUkhTQS0yMDEwOjA4NTgifSwgInR5cGVfaWQiOiAiZXJyYXR1bSJ9
-        LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEtMjAxMDowMTEx
-        In0sICJ0eXBlX2lkIjogImVycmF0dW0ifV19LCAiZXJyb3IiOiBudWxsLCAi
-        X2lkIjogeyIkb2lkIjogIjVkNDg3Zjg0YWIzNmNlM2ZlNTFkZmI5YyJ9LCAi
-        aWQiOiAiNWQ0ODdmODRhYjM2Y2UzZmU1MWRmYjljIn0=
+        cXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1r
+        YXRlbGxvLWRldmVsLTIuY2Fubm9sby5leGFtcGxlLmNvbS5kcTIiLCAic3Rh
+        dGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVzZXJ2ZWRfcmVz
+        b3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRldmVsLTIuY2Fubm9s
+        by5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiB7InVuaXRzX3N1Y2Nlc3NmdWwi
+        OiBbeyJ1bml0X2tleSI6IHsiaWQiOiAiS0FURUxMTy1SSFNBLTIwMTA6MDg1
+        OCJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXkiOiB7Imlk
+        IjogIktBVEVMTE8tUkhFQS0yMDEwOjAxMTEifSwgInR5cGVfaWQiOiAiZXJy
+        YXR1bSJ9LCB7InVuaXRfa2V5IjogeyJpZCI6ICJLQVRFTExPLVJIRUEtMjAx
+        MDo5OTE0MyJ9LCAidHlwZV9pZCI6ICJlcnJhdHVtIn0sIHsidW5pdF9rZXki
+        OiB7ImlkIjogIktBVEVMTE8tUkhFQS0yMDEwOjAwMDEifSwgInR5cGVfaWQi
+        OiAiZXJyYXR1bSJ9XX0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQi
+        OiAiNWQ2OTM0MDgzMmRiNjA3N2E3OTY4MGE5In0sICJpZCI6ICI1ZDY5MzQw
+        ODMyZGI2MDc3YTc5NjgwYTkifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:05 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:49 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/?details=true
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/?details=true
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:06 GMT
+      - Fri, 30 Aug 2019 14:34:49 GMT
       Server:
       - Apache
       Etag:
-      - '"9aad3cce45218ab40cd8834ee52b3a28-gzip"'
+      - '"9059e10ff91ccc32453035ad3f52f7e2-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '2323'
+      - '627'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -4541,79 +4197,79 @@ http_interactions:
         eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiRmVkb3JhIDE3
         IHg4Nl82NCIsICJkZXNjcmlwdGlvbiI6IG51bGwsICJkaXN0cmlidXRvcnMi
         OiBbeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MTktMDgtMDVUMTk6MTI6MDBaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        MTktMDgtMzBUMTQ6MzQ6NDNaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
         ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvZXhwb3J0X2Rpc3Ry
         aWJ1dG9yLyIsICJsYXN0X292ZXJyaWRlX2NvbmZpZyI6IHt9LCAibGFzdF9w
         dWJsaXNoIjogbnVsbCwgImRpc3RyaWJ1dG9yX3R5cGVfaWQiOiAiZXhwb3J0
         X2Rpc3RyaWJ1dG9yIiwgImF1dG9fcHVibGlzaCI6IGZhbHNlLCAic2NyYXRj
         aHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwgIl9pZCI6
-        IHsiJG9pZCI6ICI1ZDQ4N2Y4MGFjZTIzZjA3YTY3ZTBlOTQifSwgImNvbmZp
+        IHsiJG9pZCI6ICI1ZDY5MzQwMzdhY2NlOTA3ZTU3YTRkYzIifSwgImNvbmZp
         ZyI6IHsiaHR0cCI6IGZhbHNlLCAicmVsYXRpdmVfdXJsIjogIkFDTUVfQ29y
         cG9yYXRpb24vbGlicmFyeS9MaWJyYXJ5Vmlldy9mZWRvcmFfMTdfbGFiZWwi
         LCAiaHR0cHMiOiBmYWxzZX0sICJpZCI6ICJleHBvcnRfZGlzdHJpYnV0b3Ii
         fSwgeyJyZXBvX2lkIjogIjNfdmlldzEiLCAibGFzdF91cGRhdGVkIjogIjIw
-        MTktMDgtMDVUMTk6MTI6MDBaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
+        MTktMDgtMzBUMTQ6MzQ6NDNaIiwgIl9ocmVmIjogIi9wdWxwL2FwaS92Mi9y
         ZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0cmlidXRvcnMvM192aWV3MV9jbG9u
         ZS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7fSwgImxhc3RfcHVibGlz
         aCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lkIjogInl1bV9jbG9uZV9k
         aXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiBmYWxzZSwgInNjcmF0Y2hw
         YWQiOiB7fSwgIl9ucyI6ICJyZXBvX2Rpc3RyaWJ1dG9ycyIsICJfaWQiOiB7
-        IiRvaWQiOiAiNWQ0ODdmODBhY2UyM2YwN2E2N2UwZTkzIn0sICJjb25maWci
+        IiRvaWQiOiAiNWQ2OTM0MDM3YWNjZTkwN2U1N2E0ZGMxIn0sICJjb25maWci
         OiB7ImRlc3RpbmF0aW9uX2Rpc3RyaWJ1dG9yX2lkIjogIjNfdmlldzEifSwg
         ImlkIjogIjNfdmlldzFfY2xvbmUifSwgeyJyZXBvX2lkIjogIjNfdmlldzEi
-        LCAibGFzdF91cGRhdGVkIjogIjIwMTktMDgtMDVUMTk6MTI6MDBaIiwgIl9o
+        LCAibGFzdF91cGRhdGVkIjogIjIwMTktMDgtMzBUMTQ6MzQ6NDNaIiwgIl9o
         cmVmIjogIi9wdWxwL2FwaS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS9kaXN0
         cmlidXRvcnMvM192aWV3MS8iLCAibGFzdF9vdmVycmlkZV9jb25maWciOiB7
         fSwgImxhc3RfcHVibGlzaCI6IG51bGwsICJkaXN0cmlidXRvcl90eXBlX2lk
         IjogInl1bV9kaXN0cmlidXRvciIsICJhdXRvX3B1Ymxpc2giOiB0cnVlLCAi
         c2NyYXRjaHBhZCI6IHt9LCAiX25zIjogInJlcG9fZGlzdHJpYnV0b3JzIiwg
-        Il9pZCI6IHsiJG9pZCI6ICI1ZDQ4N2Y4MGFjZTIzZjA3YTY3ZTBlOTIifSwg
+        Il9pZCI6IHsiJG9pZCI6ICI1ZDY5MzQwMzdhY2NlOTA3ZTU3YTRkYzAifSwg
         ImNvbmZpZyI6IHsicHJvdGVjdGVkIjogdHJ1ZSwgImh0dHAiOiBmYWxzZSwg
         Imh0dHBzIjogdHJ1ZSwgInJlbGF0aXZlX3VybCI6ICJBQ01FX0NvcnBvcmF0
         aW9uL2xpYnJhcnkvTGlicmFyeVZpZXcvZmVkb3JhXzE3X2xhYmVsIn0sICJp
         ZCI6ICIzX3ZpZXcxIn1dLCAibGFzdF91bml0X2FkZGVkIjogIjIwMTktMDgt
-        MDVUMTk6MTI6MDFaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
-        ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6ICIyMDE5LTA4LTA1VDE5OjEy
-        OjA0WiIsICJjb250ZW50X3VuaXRfY291bnRzIjogeyJwYWNrYWdlX2dyb3Vw
+        MzBUMTQ6MzQ6NDRaIiwgIm5vdGVzIjogeyJfcmVwby10eXBlIjogInJwbS1y
+        ZXBvIn0sICJsYXN0X3VuaXRfcmVtb3ZlZCI6ICIyMDE5LTA4LTMwVDE0OjM0
+        OjQ4WiIsICJjb250ZW50X3VuaXRfY291bnRzIjogeyJwYWNrYWdlX2dyb3Vw
         IjogMiwgIm1vZHVsZW1kIjogNiwgIm1vZHVsZW1kX2RlZmF1bHRzIjogMywg
         ImVycmF0dW0iOiAyLCAiZGlzdHJpYnV0aW9uIjogMSwgInJwbSI6IDcsICJ5
         dW1fcmVwb19tZXRhZGF0YV9maWxlIjogMn0sICJfbnMiOiAicmVwb3MiLCAi
         aW1wb3J0ZXJzIjogW3sicmVwb19pZCI6ICIzX3ZpZXcxIiwgImxhc3RfdXBk
-        YXRlZCI6ICIyMDE5LTA4LTA1VDE5OjEyOjAwWiIsICJfaHJlZiI6ICIvcHVs
+        YXRlZCI6ICIyMDE5LTA4LTMwVDE0OjM0OjQzWiIsICJfaHJlZiI6ICIvcHVs
         cC9hcGkvdjIvcmVwb3NpdG9yaWVzLzNfdmlldzEvaW1wb3J0ZXJzL3l1bV9p
         bXBvcnRlci8iLCAiX25zIjogInJlcG9faW1wb3J0ZXJzIiwgImltcG9ydGVy
         X3R5cGVfaWQiOiAieXVtX2ltcG9ydGVyIiwgImxhc3Rfb3ZlcnJpZGVfY29u
         ZmlnIjoge30sICJsYXN0X3N5bmMiOiBudWxsLCAic2NyYXRjaHBhZCI6IG51
-        bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ0ODdmODBhY2UyM2YwN2E2N2UwZTkx
+        bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTM0MDM3YWNjZTkwN2U1N2E0ZGJm
         In0sICJjb25maWciOiB7fSwgImlkIjogInl1bV9pbXBvcnRlciJ9XSwgImxv
-        Y2FsbHlfc3RvcmVkX3VuaXRzIjogMjIsICJfaWQiOiB7IiRvaWQiOiAiNWQ0
-        ODdmODBhY2UyM2YwN2E2N2UwZTkwIn0sICJ0b3RhbF9yZXBvc2l0b3J5X3Vu
+        Y2FsbHlfc3RvcmVkX3VuaXRzIjogMjIsICJfaWQiOiB7IiRvaWQiOiAiNWQ2
+        OTM0MDM3YWNjZTkwN2U1N2E0ZGJlIn0sICJ0b3RhbF9yZXBvc2l0b3J5X3Vu
         aXRzIjogMjMsICJpZCI6ICIzX3ZpZXcxIiwgIl9ocmVmIjogIi9wdWxwL2Fw
         aS92Mi9yZXBvc2l0b3JpZXMvM192aWV3MS8ifQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:06 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:49 GMT
 - request:
     method: delete
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/Fedora_17/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/Fedora_17/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:06 GMT
+      - Fri, 30 Aug 2019 14:34:50 GMT
       Server:
       - Apache
       Content-Length:
@@ -4624,41 +4280,41 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzL2Y1MTE3Y2YwLWQ1M2UtNDZhNS1hODlhLWE2OGQxNTY5ZmZiNi8iLCAi
-        dGFza19pZCI6ICJmNTExN2NmMC1kNTNlLTQ2YTUtYTg5YS1hNjhkMTU2OWZm
-        YjYifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzkzNDEyOGJkLTMzMjYtNGIyYi1iMDU3LTlhNmRlMTE3OGM2YS8iLCAi
+        dGFza19pZCI6ICI5MzQxMjhiZC0zMzI2LTRiMmItYjA1Ny05YTZkZTExNzhj
+        NmEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:06 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:50 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/f5117cf0-d53e-46a5-a89a-a68d1569ffb6/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/934128bd-3326-4b2b-b057-9a6de1178c6a/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:06 GMT
+      - Fri, 30 Aug 2019 14:34:50 GMT
       Server:
       - Apache
       Etag:
-      - '"eba5c877a482bca24e06a1d2e512f1e3-gzip"'
+      - '"534e740444f056c47a0459363ba5bb5f-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '689'
+      - '373'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -4666,44 +4322,45 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy9mNTExN2NmMC1kNTNlLTQ2YTUtYTg5YS1hNjhkMTU2OWZm
-        YjYvIiwgInRhc2tfaWQiOiAiZjUxMTdjZjAtZDUzZS00NmE1LWE4OWEtYTY4
-        ZDE1NjlmZmI2IiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
+        aS92Mi90YXNrcy85MzQxMjhiZC0zMzI2LTRiMmItYjA1Ny05YTZkZTExNzhj
+        NmEvIiwgInRhc2tfaWQiOiAiOTM0MTI4YmQtMzMyNi00YjJiLWIwNTctOWE2
+        ZGUxMTc4YzZhIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpGZWRvcmFf
         MTciLCAicHVscDphY3Rpb246ZGVsZXRlIl0sICJmaW5pc2hfdGltZSI6ICIy
-        MDE5LTA4LTA1VDE5OjEyOjA2WiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
-        c3RhcnRfdGltZSI6ICIyMDE5LTA4LTA1VDE5OjEyOjA2WiIsICJ0cmFjZWJh
+        MDE5LTA4LTMwVDE0OjM0OjUwWiIsICJfbnMiOiAidGFza19zdGF0dXMiLCAi
+        c3RhcnRfdGltZSI6ICIyMDE5LTA4LTMwVDE0OjM0OjUwWiIsICJ0cmFjZWJh
         Y2siOiBudWxsLCAic3Bhd25lZF90YXNrcyI6IFtdLCAicHJvZ3Jlc3NfcmVw
         b3J0Ijoge30sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXIt
-        MEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20uZHEyIiwgInN0YXRlIjog
-        ImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2VydmVkX3Jlc291cmNl
-        X3dvcmtlci0wQGRldmVsLmxvY2FsaG9zdC5leGFtcGxlLmNvbSIsICJyZXN1
-        bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVk
-        NDg3Zjg2YWIzNmNlM2ZlNTFkZmJmNSJ9LCAiaWQiOiAiNWQ0ODdmODZhYjM2
-        Y2UzZmU1MWRmYmY1In0=
+        MkBjZW50b3M3LWthdGVsbG8tZGV2ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29t
+        LmRxMiIsICJzdGF0ZSI6ICJmaW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJy
+        ZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMkBjZW50b3M3LWthdGVsbG8tZGV2
+        ZWwtMi5jYW5ub2xvLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IG51bGwsICJl
+        cnJvciI6IG51bGwsICJfaWQiOiB7IiRvaWQiOiAiNWQ2OTM0MGEzMmRiNjA3
+        N2E3OTY4MGY3In0sICJpZCI6ICI1ZDY5MzQwYTMyZGI2MDc3YTc5NjgwZjci
+        fQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:06 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:50 GMT
 - request:
     method: delete
-    uri: https://devel.localhost.example.com/pulp/api/v2/repositories/3_view1/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/repositories/3_view1/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 202
       message: Accepted
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:06 GMT
+      - Fri, 30 Aug 2019 14:34:50 GMT
       Server:
       - Apache
       Content-Length:
@@ -4714,41 +4371,41 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
-        c2tzLzNhZTk3MWJiLTdmODAtNDVhMS04OTNkLWFkMjZkMDA2MzZmMC8iLCAi
-        dGFza19pZCI6ICIzYWU5NzFiYi03ZjgwLTQ1YTEtODkzZC1hZDI2ZDAwNjM2
-        ZjAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+        c2tzLzhkNjNiNGUxLWEzMzctNDBkOS1iMjU5LWUxZGM1NDQyYzIwMC8iLCAi
+        dGFza19pZCI6ICI4ZDYzYjRlMS1hMzM3LTQwZDktYjI1OS1lMWRjNTQ0MmMy
+        MDAifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:06 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:50 GMT
 - request:
     method: get
-    uri: https://devel.localhost.example.com/pulp/api/v2/tasks/3ae971bb-7f80-45a1-893d-ad26d00636f0/
+    uri: https://centos7-katello-devel-2.cannolo.example.com/pulp/api/v2/tasks/8d63b4e1-a337-40d9-b259-e1dc5442c200/
     body:
       encoding: US-ASCII
       base64_string: ''
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.5p157
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
       Content-Type:
       - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 05 Aug 2019 19:12:06 GMT
+      - Fri, 30 Aug 2019 14:34:50 GMT
       Server:
       - Apache
       Etag:
-      - '"9dce465dedeb22e9b413caf8dbb70bbc-gzip"'
+      - '"58ef46b62ddfeffbb8bc93bed01296b2-gzip"'
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '687'
+      - '370'
       Content-Type:
       - application/json; charset=utf-8
     body:
@@ -4756,20 +4413,20 @@ http_interactions:
       base64_string: |
         eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
         LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
-        aS92Mi90YXNrcy8zYWU5NzFiYi03ZjgwLTQ1YTEtODkzZC1hZDI2ZDAwNjM2
-        ZjAvIiwgInRhc2tfaWQiOiAiM2FlOTcxYmItN2Y4MC00NWExLTg5M2QtYWQy
-        NmQwMDYzNmYwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
+        aS92Mi90YXNrcy84ZDYzYjRlMS1hMzM3LTQwZDktYjI1OS1lMWRjNTQ0MmMy
+        MDAvIiwgInRhc2tfaWQiOiAiOGQ2M2I0ZTEtYTMzNy00MGQ5LWIyNTktZTFk
+        YzU0NDJjMjAwIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTozX3ZpZXcx
         IiwgInB1bHA6YWN0aW9uOmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAx
-        OS0wOC0wNVQxOToxMjowNloiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
-        YXJ0X3RpbWUiOiAiMjAxOS0wOC0wNVQxOToxMjowNloiLCAidHJhY2ViYWNr
+        OS0wOC0zMFQxNDozNDo1MFoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0
+        YXJ0X3RpbWUiOiAiMjAxOS0wOC0zMFQxNDozNDo1MFoiLCAidHJhY2ViYWNr
         IjogbnVsbCwgInNwYXduZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9y
-        dCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBA
-        ZGV2ZWwubG9jYWxob3N0LmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJm
-        aW5pc2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93
-        b3JrZXItMEBkZXZlbC5sb2NhbGhvc3QuZXhhbXBsZS5jb20iLCAicmVzdWx0
-        IjogbnVsbCwgImVycm9yIjogbnVsbCwgIl9pZCI6IHsiJG9pZCI6ICI1ZDQ4
-        N2Y4NmFiMzZjZTNmZTUxZGZjNDMifSwgImlkIjogIjVkNDg3Zjg2YWIzNmNl
-        M2ZlNTFkZmM0MyJ9
+        dCI6IHt9LCAicXVldWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJA
+        Y2VudG9zNy1rYXRlbGxvLWRldmVsLTIuY2Fubm9sby5leGFtcGxlLmNvbS5k
+        cTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2VyX25hbWUiOiAicmVz
+        ZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTJAY2VudG9zNy1rYXRlbGxvLWRldmVs
+        LTIuY2Fubm9sby5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJy
+        b3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkNjkzNDBhMzJkYjYwNzdh
+        Nzk2ODE0NSJ9LCAiaWQiOiAiNWQ2OTM0MGEzMmRiNjA3N2E3OTY4MTQ1In0=
     http_version: 
-  recorded_at: Mon, 05 Aug 2019 19:12:06 GMT
+  recorded_at: Fri, 30 Aug 2019 14:34:50 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Adds support for copying over environment groups in yum repos.

Note that this only copies over the environment groups.  The environment group information is still not kept track of in Katello.  The environment groups don't appear in the UI and are not installable by package actions.  This implementation should be introduced in a following PR.

To test the patch:

1) Sync CentOS 7 repo http://mirror.centos.org/centos/7/os/x86_64/
2) Add that repo to a content view and publish
3) Subscribe a katello client to that content view and enable the synced repo
4) On the client run 
```yum --disablerepo="*" --enablerepo="<your repo id>" grouplist```

You should see environment groups
```
...
Available Environment Groups:
   Minimal Install
   Compute Node
   Infrastructure Server
   File and Print Server
   Basic Web Server
   Virtualization Host
   Server with GUI
   GNOME Desktop
   KDE Plasma Workspaces
   Development and Creative Workstation
...
```

Alternatively, you could check the repodata/<characters>-comps.xml file in your content view's pulp repo for the environments.
