### PR TITLE
Fixes #27718 - cannot remove puppet module from cv by uuid

### DIFF
--- a/app/controllers/katello/api/v2/content_view_puppet_modules_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_puppet_modules_controller.rb
@@ -59,7 +59,7 @@ module Katello
     def index_relation
       puppet_modules = ContentViewPuppetModule.where(:content_view_id => @view)
       puppet_modules = puppet_modules.where(:name => params[:name]) if params[:name]
-      puppet_modules = puppet_modules.where(:pulp_id => params[:uuid]) if params[:uuid]
+      puppet_modules = puppet_modules.where(:uuid => params[:uuid]) if params[:uuid]
       puppet_modules = puppet_modules.where(:author => params[:author]) if params[:author]
       puppet_modules
     end

--- a/test/controllers/api/v2/content_view_puppet_modules_controller_test.rb
+++ b/test/controllers/api/v2/content_view_puppet_modules_controller_test.rb
@@ -31,6 +31,14 @@ module Katello
       assert_template 'api/v2/content_view_puppet_modules/index'
     end
 
+    def test_index_with_uuid
+      @cv_puppet_module.uuid = 123
+      get :index, params: { :content_view_id => @content_view.id, :uuid => @cv_puppet_module.uuid }
+
+      assert_response :success
+      assert_template 'api/v2/content_view_puppet_modules/index'
+    end
+
     def test_index_protected
       allowed_perms = [@view_permission]
       denied_perms = [@create_permission, @update_permission, @destroy_permission]


### PR DESCRIPTION
Test steps:
1. Create a repo with a puppet module
2. Sync the repo
3. Create a content view with the puppet module
4. Remove the puppet module using the hammer command: 
`hammer content-view puppet-module remove --content-view-id=<id> --uuid=<uuid>`