### PR TITLE
Fixes #27467 - Rename Status to Default Status

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-repository-sets-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-repository-sets-modal.html
@@ -78,7 +78,7 @@
               <th bst-table-column="repository_name" translate>Repository Name</th>
               <th bst-table-column="product_name" translate>Product Name</th>
               <th bst-table-column="repository_path" translate>Repository Path</th>
-              <th bst-table-column="enabled" translate>Status</th>
+              <th bst-table-column="enabled" translate>Default Status</th>
             </tr>
           </thead>
 


### PR DESCRIPTION
On Content Hosts > Select few content hosts > Selection Action > Manage Repository Sets >

The Status column doesn't reflect the true value of the override flags, instead it displays the default status without overrides. The column name should reflect that and should be called `Default Status` instead.