### PR TITLE
[WIP]Fixes #19712 - Allow single default capsule

### DIFF
--- a/app/lib/katello/validators/smart_proxy_default_capsule_validator.rb
+++ b/app/lib/katello/validators/smart_proxy_default_capsule_validator.rb
@@ -2,7 +2,10 @@ module Katello
   module Validators
     class SmartProxyDefaultCapsuleValidator < ActiveModel::Validator
       def validate(record)
-        record.errors[:base] << _("Only one default capsule is allowed") if (record.has_feature?('Pulp') && !SmartProxy.with_features('Pulp').blank?)
+        if (record.has_feature?('Pulp') && !SmartProxy.with_features('Pulp').blank? &&
+            !(SmartProxy.with_features('Pulp').count == 1 && SmartProxy.with_features('Pulp').include?(record)))
+          record.errors[:base] << _("Only one default capsule is allowed. Please check #{SmartProxy.pulp_master.try(:name)}")
+        end
       end
     end
   end

--- a/app/lib/katello/validators/smart_proxy_default_capsule_validator.rb
+++ b/app/lib/katello/validators/smart_proxy_default_capsule_validator.rb
@@ -1,0 +1,9 @@
+module Katello
+  module Validators
+    class SmartProxyDefaultCapsuleValidator < ActiveModel::Validator
+      def validate(record)
+        record.errors[:base] << _("Only one default capsule is allowed") if (record.has_feature?('Pulp') && SmartProxy.pulp_master && SmartProxy.pulp_master != record)
+      end
+    end
+  end
+end

--- a/app/lib/katello/validators/smart_proxy_default_capsule_validator.rb
+++ b/app/lib/katello/validators/smart_proxy_default_capsule_validator.rb
@@ -2,7 +2,7 @@ module Katello
   module Validators
     class SmartProxyDefaultCapsuleValidator < ActiveModel::Validator
       def validate(record)
-        record.errors[:base] << _("Only one default capsule is allowed") if (record.has_feature?('Pulp') && SmartProxy.pulp_master && SmartProxy.pulp_master != record)
+        record.errors[:base] << _("Only one default capsule is allowed") if (record.has_feature?('Pulp') && !SmartProxy.with_features('Pulp').blank?)
       end
     end
   end

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -32,7 +32,7 @@ module Katello
         before_create :associate_default_locations
         before_create :associate_lifecycle_environments
         before_validation :set_default_download_policy
-
+        validates_with Katello::Validators::SmartProxyDefaultCapsuleValidator, on: :create
         lazy_accessor :pulp_repositories, :initializer => lambda { |_s| pulp_node.extensions.repository.retrieve_all }
 
         has_many :capsule_lifecycle_environments,
@@ -56,8 +56,6 @@ module Katello
           :in => DOWNLOAD_POLICIES,
           :message => _("must be one of the following: %s") % DOWNLOAD_POLICIES.join(', ')
         }
-
-        validates_with Katello::Validators::SmartProxyDefaultCapsuleValidator
 
         scope :with_content, -> { with_features(PULP_FEATURE, PULP_NODE_FEATURE) }
 

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -32,7 +32,7 @@ module Katello
         before_create :associate_default_locations
         before_create :associate_lifecycle_environments
         before_validation :set_default_download_policy
-        validates_with Katello::Validators::SmartProxyDefaultCapsuleValidator, on: :create
+        validates_with Katello::Validators::SmartProxyDefaultCapsuleValidator
         lazy_accessor :pulp_repositories, :initializer => lambda { |_s| pulp_node.extensions.repository.retrieve_all }
 
         has_many :capsule_lifecycle_environments,

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -56,6 +56,9 @@ module Katello
           :in => DOWNLOAD_POLICIES,
           :message => _("must be one of the following: %s") % DOWNLOAD_POLICIES.join(', ')
         }
+
+        validates_with Katello::Validators::SmartProxyDefaultCapsuleValidator
+
         scope :with_content, -> { with_features(PULP_FEATURE, PULP_NODE_FEATURE) }
 
         def self.with_repo(repo)

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -32,7 +32,6 @@ module ::Actions::Katello::Repository
     let(:action_class) { ::Actions::Katello::Repository::UpdateHttpProxyDetails }
 
     it 'plans' do
-      FactoryBot.create(:smart_proxy, :default_smart_proxy)
       plan_action action, repository
       assert_action_planned_with action,
         ::Actions::Pulp::Orchestration::Repository::Refresh,
@@ -45,7 +44,6 @@ module ::Actions::Katello::Repository
     let(:candlepin_action_class) { ::Actions::Candlepin::Environment::AddContentToEnvironment }
 
     before do
-      FactoryBot.create(:smart_proxy, :default_smart_proxy)
       repository.expects(:save!)
       action.expects(:action_subject).with(repository)
       action.execution_plan.stub_planned_action(::Actions::Katello::Product::ContentCreate) do |content_create|
@@ -234,7 +232,6 @@ module ::Actions::Katello::Repository
   end
 
   class UploadFilesTest < TestBase
-    setup { FactoryBot.create(:smart_proxy, :default_smart_proxy) }
     let(:pulp2_action_class) { ::Actions::Pulp::Orchestration::Repository::UploadContent }
     let(:pulp3_action_class) { ::Actions::Pulp3::Orchestration::Repository::UploadContent }
     it 'plans for Pulp' do

--- a/test/helpers/hosts_and_hostgroups_helper_test.rb
+++ b/test/helpers/hosts_and_hostgroups_helper_test.rb
@@ -52,7 +52,6 @@ class HostAndHostGroupsHelperLifecycleEnvironmentTests < HostsAndHostGroupsHelpe
 
   def test_accessible_content_proxies_no_perms
     User.current = FactoryBot.create(:user)
-    FactoryBot.create(:smart_proxy, :features => [FactoryBot.create(:feature, name: 'Pulp')])
     @host.content_facet.content_source = @smart_proxy
 
     assert_equal [@smart_proxy], accessible_content_proxies(@host)

--- a/test/models/concerns/smart_proxy_extensions_test.rb
+++ b/test/models/concerns/smart_proxy_extensions_test.rb
@@ -8,6 +8,7 @@ module Katello
       @library = katello_environments(:library)
       @view = katello_content_views(:library_dev_view)
       @proxy = FactoryBot.build(:smart_proxy, :default_smart_proxy, :url => 'http://fakepath.com/foo')
+      @proxy_2 = FactoryBot.build(:smart_proxy, :default_smart_proxy, :url => 'http://fakepath.com/foo2')
       @proxy_mirror = FactoryBot.build(:smart_proxy, :pulp_mirror, :url => 'http://fakemirrorpath.com/foo')
       ::SmartProxy.any_instance.stubs(:associate_features)
     end
@@ -58,6 +59,13 @@ module Katello
       assert_not_equal Katello::KTEnvironment.all.count, 0
       assert_equal @proxy.lifecycle_environments.all, Katello::KTEnvironment.all
       assert_equal @proxy_mirror.lifecycle_environments.all.count, 0
+    end
+
+    def test_fail_mutiple_pulp_master
+      @proxy.save!
+      @proxy_2.url = "http://fakeduppath.com/foo"
+      error = assert_raises(ActiveRecord::RecordInvalid) { @proxy_2.save! }
+      assert_match(/Only one default capsule is allowed/, error.message)
     end
   end
 end


### PR DESCRIPTION
Add validation to allow only one default capsule.

**To test:**

- Update your default capsule with a new name and a new dummy URL.
- Create a new capsule with the original name and original URL. 
- It should error out with the error message: Only one default capsule is allowed

Create a mirror smart proxy against this instance as an additional test to confirm that we can create a mirror smart proxy.
