### PR TITLE
Fixes #27738 - View matching content for CV filter rule

### DIFF
--- a/app/controllers/katello/api/v2/package_groups_controller.rb
+++ b/app/controllers/katello/api/v2/package_groups_controller.rb
@@ -70,6 +70,11 @@ module Katello
       %w(name asc)
     end
 
+    def filter_by_content_view_filter(filter, collection)
+      ids = filter.send("#{singular_resource_name}_rules").pluck(:uuid)
+      filter_by_ids(ids, collection)
+    end
+
     private
 
     def repo_association

--- a/app/controllers/katello/api/v2/packages_controller.rb
+++ b/app/controllers/katello/api/v2/packages_controller.rb
@@ -75,6 +75,22 @@ module Katello
       collection
     end
 
+    def filter_by_content_view_filter(filter, collection)
+      filtered_rpms = []
+      filter.package_rules.each do |rule|
+        filtered_rpms += filter.query_rpms_from_collection(collection, rule).pluck(:id)
+      end
+
+      collection.where(id: filter.applicable_rpms.pluck(:id) & filtered_rpms)
+    end
+
+    def filter_by_content_view_filter_rule(rule, collection)
+      filter = rule.filter
+      filtered_rpms = filter.query_rpms_from_collection(collection, rule).pluck(:id)
+
+      collection.where(id: filter.applicable_rpms.pluck(:id) & filtered_rpms)
+    end
+
     private
 
     def find_host

--- a/app/lib/katello/api/v2/rendering.rb
+++ b/app/lib/katello/api/v2/rendering.rb
@@ -43,8 +43,7 @@ module Katello
 
           render :template => "katello/api/v2/#{resource_name}/#{action}",
                  :status => status,
-                 :locals => { :object_name => options[:object_name],
-                              :root_name => options[:root_name] },
+                 :locals => options.slice(:object_name, :root_name, :locals),
                  :layout => "katello/api/v2/layouts/#{options[:layout]}"
         end
 

--- a/app/models/katello/content_view_package_filter.rb
+++ b/app/models/katello/content_view_package_filter.rb
@@ -36,13 +36,13 @@ module Katello
     def query_rpms(repo, rule)
       query_name = rule.name.tr("*", "%")
       query = Rpm.in_repositories(repo).non_modular.where("#{Rpm.table_name}.name ilike ?", query_name)
-      if rule.architecture
+      if rule.architecture.present?
         query_arch = rule.architecture.tr("*", "%")
         query = query.where("#{Rpm.table_name}.arch ilike ?", query_arch)
       end
-      if !rule.version.blank?
+      if rule.version.present?
         query = query.search_version_equal(rule.version)
-      elsif !rule.min_version.blank? || !rule.max_version.blank?
+      elsif rule.min_version.present? || rule.max_version.present?
         query = query.search_version_range(rule.min_version, rule.max_version)
       end
       query.pluck("#{Rpm.table_name}.filename")

--- a/engines/bastion/app/assets/stylesheets/bastion/overrides.scss
+++ b/engines/bastion/app/assets/stylesheets/bastion/overrides.scss
@@ -77,6 +77,7 @@ html .toolbar-pf.table-view-pf-toolbar-external .toolbar-pf-filter {
 .modal-body {
   overflow-x: hidden;
   overflow-y: scroll;
+  max-height: 75vh; // prevent modal from going below current view causing two scrollbars
 }
 
 // Add some margin to the bottom of the table footer

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filter-rule-matching-package-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/filter-rule-matching-package-modal.controller.js
@@ -1,0 +1,37 @@
+/**
+ * @ngdoc object
+ * @name  Bastion.content-views.controller:FilterRuleMatchingPackageModal
+ *
+ * @requires $scope
+ * @requires $location
+ * @requires $uibModalInstance
+ * @requires filterRuleId
+ * @requires Package
+ * @requires Nutupane
+ * @requires CurrentOrganization
+ *
+ * @description
+ *   A controller for providing matching filter rule modal
+ */
+angular.module('Bastion.content-views').controller('FilterRuleMatchingPackageModal',
+    ['$scope', '$location', '$uibModalInstance', 'filterRuleId', 'Package', 'Nutupane', 'CurrentOrganization',
+        function ($scope, $location, $uibModalInstance, filterRuleId, Package, Nutupane, CurrentOrganization) {
+
+            var nutupane, params = {
+              'organization_id': CurrentOrganization,
+              'content_view_filter_rule_id': filterRuleId,
+              'search': $location.search().search || "",
+              'paged': true
+            };
+
+            nutupane = $scope.nutupane = new Nutupane(Package, params);
+            $scope.nutupane.setSearchKey('filterRule' + filterRuleId + "Packages");
+            $scope.nutupane.setTableName('filterRule' + filterRuleId + "PackagesTable");
+            $scope.table = nutupane.table;
+
+            $scope.cancel = function () {
+                $uibModalInstance.close();
+            };
+        }
+    ]
+);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/package-filter.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/package-filter.controller.js
@@ -11,12 +11,14 @@
  * @requires Rule
  * @requires Package
  * @requires Notification
+ * @requires $uibModal
  *
  * @description
  *   Handles package filter rules for a content view.
  */
 angular.module('Bastion.content-views').controller('PackageFilterController',
-    ['$scope', '$location', 'translate', 'Nutupane', 'CurrentOrganization', 'Filter', 'Rule', 'Package', 'Notification', function ($scope, $location, translate, Nutupane, CurrentOrganization, Filter, Rule, Package, Notification) {
+    ['$scope', '$location', 'translate', 'Nutupane', 'CurrentOrganization', 'Filter', 'Rule', 'Package', 'Notification', '$uibModal',
+     function ($scope, $location, translate, Nutupane, CurrentOrganization, Filter, Rule, Package, Notification, $uibModal) {
         var nutupane, params;
 
         function failure(response) {
@@ -135,6 +137,17 @@ angular.module('Bastion.content-views').controller('PackageFilterController',
             angular.forEach($scope.table.getSelected(), function (rule) {
                 removeRule(rule);
             });
+        };
+
+        $scope.getMatchingContent = function (rule) {
+            $uibModal.open({
+                templateUrl: 'content-views/details/filters/views/filter-rule-matching-package-modal.html',
+                controller: 'FilterRuleMatchingPackageModal',
+                size: 'lg',
+                resolve: {
+                    filterRuleId: rule.id
+                }
+            }).closed.then(function () {});
         };
 
         $scope.fetchAutocompleteName = function (term) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filter-rule-matching-package-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/filter-rule-matching-package-modal.html
@@ -1,0 +1,43 @@
+<div data-extend-template="components/views/bst-modal.html">
+  <h4 data-block="modal-header">Matching Content</h4>
+
+  <div data-block="modal-body">
+    <div data-extend-template="layouts/table-with-header.html">
+      <span data-block="no-rows-message" translate>
+        No RPMs were matched
+      </span>
+
+      <span data-block="no-search-results-message" translate>
+        Your search returned zero RPMs
+      </span>
+
+      <div data-block="table">
+        <table class="table table-striped table-bordered" ng-class="{'table-mask': table.working}">
+          <thead>
+          <tr bst-table-head>
+            <th bst-table-column="name" sortable>{{ "RPM" | translate }}</th>
+            <th bst-table-column="version">{{ "Summary" | translate }}</th>
+          </tr>
+          </thead>
+
+          <tbody>
+          <tr bst-table-row ng-repeat="package in table.rows">
+            <td bst-table-cell>
+              <a ui-sref="package.info({packageId: package.id})" target="_blank">
+                {{ package.nvrea}}
+              </a>
+            </td>
+            <td bst-table-cell>
+              {{ package.summary }}
+            </td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+ </div>
+
+  <div data-block="modal-footer">
+    <button class="btn btn-default" ng-click="cancel()" translate>Close</button>
+  </div>
+</div>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/package-filter-details.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/filters/views/package-filter-details.html
@@ -163,6 +163,10 @@
               <span translate>Edit</span>
             </button>
 
+            <button type="button" class="btn btn-default" ng-click="getMatchingContent(rule)" ng-hide="rule.editMode">
+              <span translate>Show Matching Content</span>
+            </button>
+
             <button bst-save-control
                     on-cancel="restorePrevious(rule); rule.editMode = false"
                     on-save="saveRule(rule)"

--- a/engines/bastion_katello/test/content-views/details/filters/filter-rule-matching-package-modal.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/filter-rule-matching-package-modal.controller.test.js
@@ -1,0 +1,42 @@
+describe('Controller: FilterRuleMatchingPackageModal', function() {
+  var $scope, $uibModalInstance, filterRuleId, Package, Nutupane, rule;
+
+  beforeEach(module('Bastion.content-views'));
+
+  beforeEach(function() {
+      $uibModalInstance = {
+          close: function () {},
+          dismiss: function () {}
+      };
+      filterRuleId = 1;
+      Package = {}
+      Nutupane = function() {
+        this.table = {};
+        this.setSearchKey = function () {}
+        this.setTableName = function () {}
+      }
+      CurrentOrganization = 1;
+  });
+
+  beforeEach(inject(function(_Notification_, $controller, $rootScope, _$q_) {
+      $scope = $rootScope.$new();
+      $controller('FilterRuleMatchingPackageModal', {
+          $scope: $scope,
+          $uibModalInstance: $uibModalInstance,
+          filterRuleId: filterRuleId,
+          Package: Package,
+          Nutupane: Nutupane,
+          CurrentOrganization: CurrentOrganization
+      });
+  }));
+
+  it("provides a function for closing the modal", function () {
+      spyOn($uibModalInstance, 'close');
+      $scope.cancel();
+      expect($uibModalInstance.close).toHaveBeenCalled();
+  });
+
+  it("puts a table object on the $scope", function() {
+    expect($scope.table).toBeDefined();
+  });
+});

--- a/engines/bastion_katello/test/content-views/details/filters/package-filter.controller.test.js
+++ b/engines/bastion_katello/test/content-views/details/filters/package-filter.controller.test.js
@@ -1,5 +1,5 @@
 describe('Controller: PackageFilterController', function() {
-    var $scope, Rule, Package, Notification;
+    var $scope, Rule, Package, Notification, $uibModal;
 
     beforeEach(module('Bastion.content-views', 'Bastion.test-mocks'))
 
@@ -9,6 +9,13 @@ describe('Controller: PackageFilterController', function() {
             $q = $injector.get('$q');
 
         Rule = $injector.get('MockResource').$new();
+
+        Rule.matchingContent = function() {
+          return {
+            $promise: $q.defer().promise,
+          }
+        };
+
         Package = $injector.get('MockResource').$new();
 
         Notification = {
@@ -40,12 +47,23 @@ describe('Controller: PackageFilterController', function() {
             return string;
         };
 
+        $uibModal = {
+            open: function () {
+                return {
+                    closed: {
+                        then: function () {}
+                    }
+                }
+            }
+        };
+
         $controller('PackageFilterController', {
             $scope: $scope,
             translate: translate,
             Rule: Rule,
             Package: Package,
-            Notification: Notification
+            Notification: Notification,
+            $uibModal: $uibModal
         });
 
         $scope.table.getSelected = function () {};
@@ -233,5 +251,18 @@ describe('Controller: PackageFilterController', function() {
         expect(result.length).toBe(2);
         expect(result[0].id).toBe(1);
         expect(result[1].id).toBe(2);
+    });
+
+    it("can show matching content", function () {
+        var result, rule;
+        spyOn($uibModal, 'open').and.callThrough();
+        rule = {};
+
+        $scope.getMatchingContent(rule);
+
+        result = $uibModal.open.calls.argsFor(0)[0];
+
+        expect(result.templateUrl).toContain('content-views/details/filters/views/filter-rule-matching-package-modal.html');
+        expect(result.controller).toBe('FilterRuleMatchingPackageModal');
     });
 });

--- a/test/controllers/api/v2/content_view_filter_rules_controller_test.rb
+++ b/test/controllers/api/v2/content_view_filter_rules_controller_test.rb
@@ -6,8 +6,12 @@ module Katello
   class Api::V2::ContentViewFilterRulesControllerTest < ActionController::TestCase
     def models
       @filter = katello_content_view_filters(:simple_filter)
+      @package_group_filter = katello_content_view_filters(:populated_package_group_filter)
       @rule = katello_content_view_package_filter_rules(:test_package)
       @rule_for_different_filter = katello_content_view_package_filter_rules(:package_rule)
+      @one_package_rule = katello_content_view_package_filter_rules(:one_package_rule)
+      @package_group_rule = katello_content_view_package_group_filter_rules(:package_group_rule)
+      @rpm = katello_rpms(:one)
     end
 
     def permissions
@@ -46,8 +50,8 @@ module Katello
 
       assert_template :layout => 'katello/api/v2/layouts/resource'
       assert_template 'katello/api/v2/common/create'
-      assert_equal @filter.reload.package_rules.second.name, "testpkg"
-      assert_equal @filter.package_rules.second.version, "10.0"
+      assert @filter.reload.package_rules.pluck(:name).include? "testpkg"
+      assert @filter.package_rules.pluck(:version).include? "10.0"
     end
 
     def test_create_with_name_array
@@ -57,8 +61,8 @@ module Katello
 
       assert_template layout: 'katello/api/v2/layouts/collection'
       assert_template 'katello/api/v2/content_view_filter_rules/index'
-      assert_equal @filter.reload.package_rules.sort.map(&:name), %w(package\ def testpkg testpkg2)
-      assert_equal @filter.package_rules.map(&:version), %w(1.0 10.0 10.0)
+      assert_equal @filter.reload.package_rules.sort.map(&:name).uniq.sort, %w(package\ def testpkg testpkg2 one).sort
+      assert_equal @filter.package_rules.map(&:version).compact.sort, ["", "1.0", "10.0", "10.0"].sort
     end
 
     def test_create_protected
@@ -88,6 +92,8 @@ module Katello
 
       assert_response :success
       assert_template 'api/v2/content_view_filter_rules/show'
+      body = JSON.parse(response.body)
+      assert_nil body["matching_content"] # should only show up with the matching_content parameter
     end
 
     def test_mismatched_filter_and_rule

--- a/test/controllers/api/v2/package_groups_controller_test.rb
+++ b/test/controllers/api/v2/package_groups_controller_test.rb
@@ -74,6 +74,17 @@ module Katello
       assert response_ids.length > 0
     end
 
+    def test_index_with_content_view_filter_id
+      get :index, params: { content_view_filter_id: @package_group_filter }
+      body = JSON.parse(response.body, symbolize_names: true)
+      response_uuids = body[:results].map { |result| result[:uuid] }
+      package_group_uuids = @package_group_filter.package_group_rules.map(&:uuid)
+
+      assert_response :success
+      assert body[:results].length > 0
+      assert_equal response_uuids, package_group_uuids
+    end
+
     def test_show
       Pulp::PackageGroup.any_instance.stubs(:backend_data).returns({})
       get :show, params: { :id => @repo.package_groups.first.id }

--- a/test/controllers/api/v2/packages_controller_test.rb
+++ b/test/controllers/api/v2/packages_controller_test.rb
@@ -7,6 +7,8 @@ module Katello
       @version = ContentViewVersion.first
       @rpm = katello_rpms(:one)
       @host = hosts(:one)
+      @simple_filter = katello_content_view_filters(:simple_filter)
+      @one_package_rule = katello_content_view_package_filter_rules(:one_package_rule)
       Pulp::Rpm.any_instance.stubs(:backend_data).returns({})
     end
 
@@ -96,6 +98,24 @@ module Katello
       assert_protected_action(:index, cv_auth_permissions, all_unauth_permissions) do
         get :index, params: { :content_view_version_id => @version.id, :available_for => 'content_view_version' }
       end
+    end
+
+    def test_index_with_content_view_filter_id
+      response = get :index, params: { content_view_filter_id: @simple_filter.id }
+      response_body = JSON.parse(response.body, symbolize_names: true)
+
+      assert_response :success
+      assert response_body[:results].length > 0
+      assert_includes response_body[:results].pluck(:id), @rpm.id
+    end
+
+    def test_index_with_content_view_filter_rule_id
+      response = get :index, params: { content_view_filter_rule_id: @one_package_rule.id }
+      response_body = JSON.parse(response.body, symbolize_names: true)
+
+      assert_response :success
+      assert response_body[:results].length > 0
+      assert_includes response_body[:results].pluck(:id), @rpm.id
     end
 
     def test_autocomplete_name

--- a/test/fixtures/models/katello_content_view_package_filter_rules.yml
+++ b/test/fixtures/models/katello_content_view_package_filter_rules.yml
@@ -11,3 +11,16 @@ test_package:
   content_view_filter_id:  <%= ActiveRecord::FixtureSet.identify(:simple_filter) %>
   created_at:              <%= Time.now %>
   updated_at:              <%= Time.now %>
+
+one_package_rule:
+  name:                    one
+  content_view_filter_id:  <%= ActiveRecord::FixtureSet.identify(:simple_filter) %>
+  created_at:              <%= Time.now %>
+  updated_at:              <%= Time.now %>
+
+one_package_rule_empty_string_arch:
+  name:                    one
+  architecture:            ""
+  content_view_filter_id:  <%= ActiveRecord::FixtureSet.identify(:simple_filter) %>
+  created_at:              <%= Time.now %>
+  updated_at:              <%= Time.now %>

--- a/test/fixtures/models/katello_content_view_package_filter_rules.yml
+++ b/test/fixtures/models/katello_content_view_package_filter_rules.yml
@@ -18,9 +18,10 @@ one_package_rule:
   created_at:              <%= Time.now %>
   updated_at:              <%= Time.now %>
 
-one_package_rule_empty_string_arch:
+one_package_rule_empty_strings:
   name:                    one
   architecture:            ""
+  version:                 ""
   content_view_filter_id:  <%= ActiveRecord::FixtureSet.identify(:simple_filter) %>
   created_at:              <%= Time.now %>
   updated_at:              <%= Time.now %>

--- a/test/models/content_view_package_filter_rule_test.rb
+++ b/test/models/content_view_package_filter_rule_test.rb
@@ -5,6 +5,10 @@ module Katello
     def setup
       User.current = User.find(users(:admin).id)
       @rule = FactoryBot.build(:katello_content_view_package_filter_rule)
+      @one_package_rule = katello_content_view_package_filter_rules(:one_package_rule)
+      @one_package_rule_empty_string = katello_content_view_package_filter_rules(:one_package_rule_empty_string_arch)
+      @filter = katello_content_view_filters(:simple_filter)
+      @fedora = katello_repositories(:fedora_17_x86_64)
     end
 
     def test_create
@@ -74,6 +78,21 @@ module Katello
       assert_raises(ActiveRecord::RecordInvalid) do
         rule_item.save!
       end
+    end
+
+    def test_query_rpms
+      matched_rpms = @filter.query_rpms(@fedora, @one_package_rule)
+      assert matched_rpms.length > 0
+
+      all_applicable_rpms = @filter.applicable_repos.map(&:rpms).flatten.pluck(:filename)
+      matched_rpms.each do |rpm|
+        assert_includes all_applicable_rpms, rpm
+      end
+    end
+
+    def test_rule_with_empty_string_arch_matched
+      matched_rpms = @filter.query_rpms(@fedora, @one_package_rule_empty_string)
+      assert matched_rpms.length > 0
     end
   end
 end

--- a/test/models/content_view_package_filter_rule_test.rb
+++ b/test/models/content_view_package_filter_rule_test.rb
@@ -5,10 +5,6 @@ module Katello
     def setup
       User.current = User.find(users(:admin).id)
       @rule = FactoryBot.build(:katello_content_view_package_filter_rule)
-      @one_package_rule = katello_content_view_package_filter_rules(:one_package_rule)
-      @one_package_rule_empty_string = katello_content_view_package_filter_rules(:one_package_rule_empty_string_arch)
-      @filter = katello_content_view_filters(:simple_filter)
-      @fedora = katello_repositories(:fedora_17_x86_64)
     end
 
     def test_create
@@ -78,21 +74,6 @@ module Katello
       assert_raises(ActiveRecord::RecordInvalid) do
         rule_item.save!
       end
-    end
-
-    def test_query_rpms
-      matched_rpms = @filter.query_rpms(@fedora, @one_package_rule)
-      assert matched_rpms.length > 0
-
-      all_applicable_rpms = @filter.applicable_repos.map(&:rpms).flatten.pluck(:filename)
-      matched_rpms.each do |rpm|
-        assert_includes all_applicable_rpms, rpm
-      end
-    end
-
-    def test_rule_with_empty_string_arch_matched
-      matched_rpms = @filter.query_rpms(@fedora, @one_package_rule_empty_string)
-      assert matched_rpms.length > 0
     end
   end
 end

--- a/test/models/content_view_package_filter_test.rb
+++ b/test/models/content_view_package_filter_test.rb
@@ -1,0 +1,27 @@
+require 'katello_test_helper'
+
+module Katello
+  class ContentViewPackageFilterTest < ActiveSupport::TestCase
+    def setup
+      @one_package_rule = katello_content_view_package_filter_rules(:one_package_rule)
+      @one_package_rule_empty_strings = katello_content_view_package_filter_rules(:one_package_rule_empty_strings)
+      @filter = katello_content_view_filters(:simple_filter)
+      @fedora = katello_repositories(:fedora_17_x86_64)
+    end
+
+    def test_query_rpms
+      matched_rpms = @filter.query_rpms(@fedora, @one_package_rule)
+      assert matched_rpms.length > 0
+
+      all_applicable_rpms = @filter.applicable_repos.map(&:rpms).flatten.pluck(:filename)
+      matched_rpms.each do |rpm|
+        assert_includes all_applicable_rpms, rpm
+      end
+    end
+
+    def test_rule_with_empty_string_arch_matched
+      matched_rpms = @filter.query_rpms(@fedora, @one_package_rule_empty_strings)
+      assert matched_rpms.length > 0
+    end
+  end
+end


### PR DESCRIPTION
Currently, it is difficult to know what packages a content view package filter rule will match until you
publish a Content View. This commit adds the ability to see matching content for a filter rule in the API
and in the UI.