### PR TITLE
Fixes #27783 - CVV status error in default CV

### DIFF
--- a/app/views/foreman/smart_proxies/_content_tab.html.erb
+++ b/app/views/foreman/smart_proxies/_content_tab.html.erb
@@ -28,7 +28,7 @@
     </tr>
     <tr ng-repeat-end ng-repeat="cv in env.content_views" ng-show="isEnvronmentExpanded(env)">
       <td>
-        <a href="/content_views/{{cv.id}}/versions" target="_self">
+        <a href="{{ fetchUrl(cv.default, cv.id) }}" target="_self">
           {{ cv.name }}
         </a>
       </td>

--- a/app/views/katello/api/v2/capsule_content/sync_status.json.rabl
+++ b/app/views/katello/api/v2/capsule_content/sync_status.json.rabl
@@ -35,6 +35,7 @@ child @lifecycle_environments => :lifecycle_environments do
         :name => content_view.name,
         :composite => content_view.composite,
         :last_published => content_view.versions.empty? ? nil : content_view.versions.last.created_at,
+        :default => content_view.default,
         :counts => {
           :content_hosts => content_view.hosts.authorized("view_hosts").count,
           :products => content_view.products.enabled.count

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.controller.js
@@ -63,6 +63,10 @@ angular.module('Bastion.capsule-content').controller('CapsuleContentController',
             }
         }
 
+        $scope.fetchUrl = function (cvIsDefault, cvId) {
+            return cvIsDefault ? '/products' : '/content_views/' + cvId + '/versions';
+        };
+
         function aggregateTasks(tasks) {
             var taskIds = _.map(tasks, function (task) {
                                 return task.id;

--- a/engines/bastion_katello/test/capsules/capsule-content.controller.test.js
+++ b/engines/bastion_katello/test/capsules/capsule-content.controller.test.js
@@ -57,6 +57,18 @@ describe('Controller: CapsuleContentController', function() {
         syncState.set(syncState.DEFAULT);
     }));
 
+    describe('fetchUrl', function() {
+
+        it('returns the correct url if default CV', function() {
+            cvId = 1
+            expect($scope.fetchUrl(true, cvId)).toBe("/products")
+        });
+
+        it('returns the correct url if not default CV', function() {
+            cvId = 2
+            expect($scope.fetchUrl(false, cvId)).toBe("/content_views/2/versions")
+        });
+    });
 
     describe('syncCapsule', function() {
 


### PR DESCRIPTION
The user should not be able to browse to the Default Content View since it isn't meant to be interacted with.  It should only be manually accessed via URL when needed for debugging.