### PR TITLE
Clean up Pulp3 code

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -147,11 +147,11 @@ module Katello
       def content_pulp3_support?(content_type)
         content_type = content_type.is_a?(String) ? content_type : content_type.model_class::CONTENT_TYPE
         type = Katello::RepositoryTypeManager.find_repository_type content_type
-        type.pulp3_plugin && SmartProxy.pulp_master!.capabilities('Pulp3').try(:include?, type.pulp3_plugin)
+        type.pulp3_plugin && SmartProxy.pulp_master!.capabilities(PULP3_FEATURE).try(:include?, type.pulp3_plugin)
       end
 
       def pulp3_uri!
-        url = self.setting('Pulp3', 'pulp_url')
+        url = self.setting(PULP3_FEATURE, 'pulp_url')
         fail "Cannot determine pulp3 url, check smart proxy configuration" unless url
         URI.parse(url)
       end
@@ -161,7 +161,7 @@ module Katello
       end
 
       def pulp3_url(path = nil)
-        pulp_url = self.setting('Pulp3', 'pulp_url')
+        pulp_url = self.setting(PULP3_FEATURE, 'pulp_url')
         path.blank? ? pulp_url : "#{pulp_url.sub(%r|/$|, '')}/#{path.sub(%r|^/|, '')}"
       end
 

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -117,8 +117,9 @@ module Katello
 
       def pulp3_configuration(config_class)
         config_class.new do |config|
-          config.host = pulp3_host!
-          config.scheme = 'https'
+          uri = pulp3_uri!
+          config.host = uri.host
+          config.scheme = uri.scheme
           config.username = 'admin'
           config.password = 'password'
           config.debugging = true
@@ -149,10 +150,14 @@ module Katello
         type.pulp3_plugin && SmartProxy.pulp_master!.capabilities('Pulp3').try(:include?, type.pulp3_plugin)
       end
 
-      def pulp3_host!
+      def pulp3_uri!
         url = self.setting('Pulp3', 'pulp_url')
         fail "Cannot determine pulp3 url, check smart proxy configuration" unless url
-        URI.parse(url).host
+        URI.parse(url)
+      end
+
+      def pulp3_host!
+        pulp3_uri!.host
       end
 
       def pulp3_url(path = nil)


### PR DESCRIPTION
This applies some best practices of using constants where possible.

It also uses the scheme from the pulp_url setting rather than hardcoding to https making it easier to deploy in development. It still maintains the hardcoded username/password because I'm unsure what the reason behind this is.