### PR TITLE
Refs #26245 - Clean up mirror_remote_feed_url handling

### DIFF
--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -420,14 +420,13 @@ module Katello
       end
 
       def mirror_remote_feed_url
-        uri = URI.parse(::SmartProxy.pulp_master.pulp3_url)
-        uri.scheme = 'https'
+        uri = ::SmartProxy.pulp_master.pulp3_uri!
         uri.path = partial_repo_path
         uri.to_s
       end
 
       def partial_repo_path
-        "/api/v3"
+        fail NotImplementedError
       end
 
       def needs_importer_updates?


### PR DESCRIPTION
This reuses the pulp3_uri! method which guarantees there's a URL. It also reuses its scheme. The base partial_repo_path now fails and requires subclasses to return a sensible value.