### PR TITLE
Fixes #27605 - Adding generic first row for grouped subs

### DIFF
--- a/webpack/move_to_foreman/components/common/table/components/TableSelectionCell.js
+++ b/webpack/move_to_foreman/components/common/table/components/TableSelectionCell.js
@@ -5,17 +5,18 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import { noop } from 'foremanReact/common/helpers';
 
 const TableSelectionCell = ({
-  id, before, after, label, checked, onChange, ...props
+  id, before, after, label, checked, hide, onChange, ...props
 }) => (
   <Table.SelectionCell>
     {before}
+    {!hide &&
     <Table.Checkbox
       id={id}
       label={label}
       checked={checked}
       onChange={onChange}
       {...props}
-    />
+    />}
     {after}
   </Table.SelectionCell>
 );
@@ -26,6 +27,7 @@ TableSelectionCell.propTypes = {
   after: PropTypes.node,
   label: PropTypes.string,
   checked: PropTypes.bool,
+  hide: PropTypes.bool,
   onChange: PropTypes.func,
 };
 
@@ -34,6 +36,7 @@ TableSelectionCell.defaultProps = {
   after: null,
   label: __('Select row'),
   checked: false,
+  hide: false,
   onChange: noop,
 };
 

--- a/webpack/move_to_foreman/components/common/table/formatters/EntitlementsInlineEditFormatter.js
+++ b/webpack/move_to_foreman/components/common/table/formatters/EntitlementsInlineEditFormatter.js
@@ -5,12 +5,18 @@ import { Table, FormControl, FormGroup, HelpBlock, Spinner } from 'patternfly-re
 import { validateQuantity } from '../../../../../scenes/Subscriptions/SubscriptionValidations';
 
 const renderValue = (value, additionalData, onActivate) => {
-  const { available, upstream_pool_id: upstreamPoolId } = additionalData.rowData;
-  if (available < 0 || !upstreamPoolId) {
+  const { available, upstream_pool_id: upstreamPoolId, collapsible } = additionalData.rowData;
+
+  if (collapsible) {
+    return (
+      <td>{__('NA')}</td>
+    );
+  } else if (available < 0 || !upstreamPoolId) {
     return (
       <td>{available < 0 ? __('Unlimited') : available}</td>
     );
   }
+
   return (
     <td className="editable">
       <div
@@ -34,6 +40,7 @@ const renderEdit = (hasChanged, onChange, value, additionalData) => {
   const {
     upstreamAvailable, upstreamAvailableLoaded, maxQuantity,
   } = additionalData.rowData;
+
   const className = hasChanged(additionalData)
     ? 'editable editing changed'
     : 'editable editing';

--- a/webpack/move_to_foreman/components/common/table/formatters/collapseableAndSelectionCellFormatter.js
+++ b/webpack/move_to_foreman/components/common/table/formatters/collapseableAndSelectionCellFormatter.js
@@ -4,8 +4,10 @@ import CollapseSubscriptionGroupButton from '../components/CollapseSubscriptionG
 
 export default (collapseableController, selectionController, additionalData) => {
   const shouldShowCollapseButton = collapseableController.isCollapseable(additionalData);
+  const isGenericRow = additionalData.rowData.collapsible;
 
   return selectionCellFormatter(
+    isGenericRow,
     selectionController,
     additionalData,
     shouldShowCollapseButton && (

--- a/webpack/move_to_foreman/components/common/table/formatters/selectionCellFormatter.js
+++ b/webpack/move_to_foreman/components/common/table/formatters/selectionCellFormatter.js
@@ -2,14 +2,17 @@ import React from 'react';
 import TableSelectionCell from '../components/TableSelectionCell';
 
 export default (
+  isGenericRow,
   selectionController,
   additionalData,
   before,
   after,
 ) => (
+
   <TableSelectionCell
     id={`select${additionalData.rowIndex}`}
     checked={selectionController.isSelected(additionalData)}
+    hide={isGenericRow}
     onChange={() => selectionController.selectRow(additionalData)}
     before={before}
     after={after}

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTableHelpers.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTableHelpers.js
@@ -30,18 +30,39 @@ const buildTableRow = (subscription, availableQuantities, updatedQuantity) => {
       quantity: updatedQuantity[subscription.id],
     };
   }
+
   return baseSubscription;
+};
+
+const buildTableCollapseRow = (subscriptionGroup) => {
+  const first = subscriptionGroup.subscriptions[0];
+  const heading = {
+    id: 0,
+    collapsible: true,
+    contract_number: 'NA',
+    start_date: 'NA',
+    end_date: 'NA',
+    consumed: 'NA',
+    product_id: first.product_id,
+    name: first.name,
+    virt_only: first.virt_only,
+    hypervisor: first.hypervisor,
+  };
+  return heading;
 };
 
 const buildTableRowsFromGroup = (subscriptionGroup, availableQuantities, updatedQuantity) => {
   const { open, subscriptions } = subscriptionGroup;
 
-  // build row for each subscription
-  if (open) {
-    return subscriptions.map(subscription =>
-      buildTableRow(subscription, availableQuantities, updatedQuantity));
+  if (subscriptions.length > 1) {
+    const rows = [];
+    rows.push(buildTableCollapseRow(subscriptionGroup));
+    if (open) {
+      subscriptions.forEach(sub =>
+        rows.push(buildTableRow(sub, availableQuantities, updatedQuantity)));
+    }
+    return rows;
   }
-
   // build row only for the first subscription in the group
   const [firstSubscription] = subscriptions;
   return [buildTableRow(firstSubscription, availableQuantities, updatedQuantity)];

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/SubscriptionsTable.fixtures.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/SubscriptionsTable.fixtures.js
@@ -2,7 +2,7 @@ import Immutable from 'seamless-immutable';
 
 const groupedSubscriptions = Immutable({
   RH00001: {
-    open: false,
+    open: true,
     subscriptions: [
       {
         id: 1,
@@ -58,13 +58,37 @@ const groupedSubscriptions = Immutable({
   },
 });
 
-export const subOne = Immutable({
+export const genericRow = Immutable({
+  collapsible: true,
+  consumed: 'NA',
+  contract_number: 'NA',
+  end_date: 'NA',
+  hypervisor: undefined,
+  id: 0,
+  name: 'Alpha',
+  product_id: 'RH00001',
+  start_date: 'NA',
+  virt_only: undefined,
+});
+
+export const subOneRowOne = Immutable({
   consumed: 0,
   id: 1,
   maxQuantity: 60,
   name: 'Alpha',
   product_id: 'RH00001',
   quantity: 10,
+  upstreamAvailable: 50,
+  upstreamAvailableLoaded: true,
+});
+
+export const subOneRowTwo = Immutable({
+  consumed: 5,
+  id: 2,
+  maxQuantity: 65,
+  name: 'Alpha',
+  product_id: 'RH00001',
+  quantity: 15,
   upstreamAvailable: 50,
   upstreamAvailableLoaded: true,
 });
@@ -103,3 +127,4 @@ export const subFour = Immutable({
 });
 
 export default groupedSubscriptions;
+

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/SubscriptionsTableHelpers.test.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/SubscriptionsTableHelpers.test.js
@@ -1,4 +1,4 @@
-import groupedSubscriptions, { subOne, subTwo, subThree, subFour } from './SubscriptionsTable.fixtures';
+import groupedSubscriptions, { genericRow, subOneRowOne, subOneRowTwo, subTwo, subThree, subFour } from './SubscriptionsTable.fixtures';
 import { buildTableRows } from '../SubscriptionsTableHelpers';
 
 describe('Build Table Rows', () => {
@@ -11,7 +11,7 @@ describe('Build Table Rows', () => {
       5: 50,
     };
 
-    const rows = [subOne, subTwo, subThree, subFour];
+    const rows = [genericRow, subOneRowOne, subOneRowTwo, subTwo, subThree, subFour];
 
     expect(buildTableRows(groupedSubscriptions, availableQuantities, {}))
       .toEqual(rows);
@@ -31,8 +31,9 @@ describe('Build Table Rows', () => {
       4: 150,
     };
 
-    const rows = [
-      { ...subOne, entitlementsChanged: true, quantity: 20 },
+    const rows = [genericRow,
+      { ...subOneRowOne, entitlementsChanged: true, quantity: 20 },
+      subOneRowTwo,
       subTwo,
       { ...subThree, entitlementsChanged: true, quantity: 150 },
       subFour,

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/components/Table.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/components/Table.js
@@ -28,10 +28,8 @@ const Table = ({
 
   const groupingController = {
     isCollapseable: ({ rowData }) =>
-      // it is the first subscription in the group
-      rowData.id === groupedSubscriptions[rowData.product_id].subscriptions[0].id &&
       // the group contains more then one subscription
-      groupedSubscriptions[rowData.product_id].subscriptions.length > 1,
+      rowData.collapsible,
     isCollapsed: ({ rowData }) => !groupedSubscriptions[rowData.product_id].open,
     toggle: ({ rowData }) => toggleSubscriptionGroup(rowData.product_id),
   };


### PR DESCRIPTION
This PR is still a work in progess. I would appreciate suggestions. 
This PR is changing the view of the subscriptions with multiple entitlements.

**To test this PR -**
- Create a manifest with a subscription having multiple entitlements in the Red Hat customer portal. 
- Click on manage manifest and import this manifest under the Subscriptions tab.
- When this is viewed in the UI (Content -> Subscriptions), the first row for this subscription must be collapsible having the subscription name and product ID and everything else set to NA. When '>' is clicked it should show all the subscriptions under the generic row  with the same product ID.