### PR TITLE
Fixes #27617 - adds an action to remove unneeded capsule repos

### DIFF
--- a/app/lib/actions/katello/capsule_content/remove_orphans.rb
+++ b/app/lib/actions/katello/capsule_content/remove_orphans.rb
@@ -9,8 +9,11 @@ module Actions
           sequence do
             plan_action(Actions::Katello::CapsuleContent::RemoveUnneededRepos, proxy) unless proxy.pulp_master?
 
-            if proxy.pulp3_enabled? && proxy == SmartProxy.pulp_master
-              plan_action(Actions::Pulp3::Orchestration::Repository::RemoveOrphans, proxy)
+            if proxy.pulp3_enabled?
+              if proxy == SmartProxy.pulp_master
+                plan_action(Actions::Katello::Pulp3::Orchestration::Repository::RemoveOrphans, proxy)
+              end
+              plan_action(Actions::Pulp3::CapsuleContent::RemoveUnneededRepos, proxy)
             end
 
             plan_self(:capsule_id => proxy.id)

--- a/app/lib/actions/pulp3/capsule_content/remove_unneeded_repos.rb
+++ b/app/lib/actions/pulp3/capsule_content/remove_unneeded_repos.rb
@@ -1,0 +1,17 @@
+module Actions
+  module Pulp3
+    module CapsuleContent
+      class RemoveUnneededRepos < Pulp3::AbstractAsyncTask
+        def plan(smart_proxy)
+          plan_self(smart_proxy_id => smart_proxy.id)
+        end
+
+        def invoke_external_task
+          smart_proxy = SmartProxy.unscoped.find(input[:smart_proxy_id])
+          smart_proxy_service = ::Katello::Pulp3::SmartProxyRepository.new(smart_proxy)
+          smart_proxy_service.delete_orphaned_repos
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/smart_proxy_repository.rb
+++ b/app/services/katello/pulp3/smart_proxy_repository.rb
@@ -20,6 +20,16 @@ module Katello
         repo_ids = repos_on_capsule.map(&:name)
         katello_repos.select { |repo| repo_ids.include? repo.pulp_id }
       end
+
+      def orphaned_repos
+        repos_on_capsule = ::Katello::Pulp3::Repository.new(nil, smart_proxy).list({})
+        repo_ids = repos_on_capsule.map(&:name)
+        katello_repos.reject { |repo| repo_ids.include? repo.pulp_id }
+      end
+
+      def delete_orphaned_repos
+        orphaned_repos.map { |repo| ::Katello::Pulp3::Repository.new(repo).delete }.compact
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds an asynchronous action to purge unneeded repositories (and associated data) from pulp3 capsules.

Apparently this will be insufficient for handling yum sub-repos planned as a future pulp3 feature, and additional precautions should be added.