### PR TITLE
Fixes #27825 - Set autopublish for non-lib puppet

### DIFF
--- a/app/services/katello/pulp/repository/puppet.rb
+++ b/app/services/katello/pulp/repository/puppet.rb
@@ -18,7 +18,7 @@ module Katello
           importer_class.new(config.merge(mirror_importer_connection_options))
         end
 
-        def auto_publish?
+        def puppet_install_auto_publish?
           (smart_proxy.try(:pulp_mirror?) && !@repo.library_instance?) || false
         end
 
@@ -26,7 +26,7 @@ module Katello
           puppet_install_dist = Runcible::Models::PuppetInstallDistributor.new(puppet_install_distributor_path,
                                                                                :subdir => 'modules',
                                                                                :id => repo.pulp_id,
-                                                                               :auto_publish => auto_publish?)
+                                                                               :auto_publish => puppet_install_auto_publish?)
           puppet_dist = Runcible::Models::PuppetDistributor.new(nil, (root.unprotected || false), true,
                                                                 :id => "#{repo.pulp_id}_puppet", :auto_publish => true)
           [puppet_dist, puppet_install_dist]

--- a/app/services/katello/pulp/repository/puppet.rb
+++ b/app/services/katello/pulp/repository/puppet.rb
@@ -18,8 +18,15 @@ module Katello
           importer_class.new(config.merge(mirror_importer_connection_options))
         end
 
+        def auto_publish?
+          (smart_proxy.try(:pulp_mirror?) && !@repo.library_instance?) || false
+        end
+
         def generate_distributors
-          puppet_install_dist = Runcible::Models::PuppetInstallDistributor.new(puppet_install_distributor_path, :subdir => 'modules', :id => repo.pulp_id, :auto_publish => smart_proxy.try(:pulp_mirror?) || false)
+          puppet_install_dist = Runcible::Models::PuppetInstallDistributor.new(puppet_install_distributor_path,
+                                                                               :subdir => 'modules',
+                                                                               :id => repo.pulp_id,
+                                                                               :auto_publish => auto_publish?)
           puppet_dist = Runcible::Models::PuppetDistributor.new(nil, (root.unprotected || false), true,
                                                                 :id => "#{repo.pulp_id}_puppet", :auto_publish => true)
           [puppet_dist, puppet_install_dist]


### PR DESCRIPTION
When creating puppet repos on a capsule

Previously:
puppet_install_dist would have auto_publish to true even for library
repos.

This commit:
puppet_install_dist would have auto_publish to true only for
non-library repos.