### PR TITLE
Fixes #27840 - Setting to toggle host profile stealing

### DIFF
--- a/app/models/setting/content.rb
+++ b/app/models/setting/content.rb
@@ -137,6 +137,9 @@ class Setting::Content < Setting
                  N_("If hosts fail to register because of duplicate DMI UUIDs " \
                     "add their comma-separated values here. Subsequent registrations will generate a unique DMI UUID for the affected hosts."),
                  [], N_('Host Duplicate DMI UUIDs')),
+        self.set('host_profile_assume', N_("Allow new Host registrations to assume registered profiles with matching hostname " \
+                    "as long as the registering DMI UUID is not used by another host."),
+                 true, N_('Host Profile Assume')),
         self.set('host_tasks_workers_pool_size', N_("Amount of workers in the pool to handle the execution of host-related tasks. When set to 0, the default queue will be used instead. Restart of the dynflowd/foreman-tasks service is required."),
                  5, N_('Host Tasks Workers Pool Size'))
       ].each { |s| self.create! s.update(:category => "Setting::Content") }

--- a/app/services/katello/registration_manager.rb
+++ b/app/services/katello/registration_manager.rb
@@ -76,7 +76,7 @@ module Katello
           host = hosts.first
 
           if host.name == host_name
-            unless host.subscription_facet.nil? || host.build || host_uuid_overridden
+            unless Setting[:host_profile_assume] || host.subscription_facet.nil? || host.build || host_uuid_overridden
               found_uuid = host.fact_values.where(fact_name_id: dmi_uuid_fact_id).first
               if found_uuid && found_uuid.value != host_uuid
                 registration_error("This host is reporting a DMI UUID that differs from the existing registration.")

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -64,9 +64,16 @@ module Katello
 
         def test_existing_host_mismatch_uuid
           FactValue.create(value: "existing_system_uuid", host: @host, fact_name: @uuid_fact_name)
+          Setting[:host_profile_assume] = false
 
           error = assert_raises(Katello::Errors::RegistrationError) { @klass.validate_hosts(hosts, @org, @host.name, 'different-uuid') }
           assert_match(/DMI UUID that differs/, error.message)
+
+          # if a registering client is matched by hostname to an existing profile
+          # but its UUID has changed *and* is still unique, allow the registration when enabled
+          Setting[:host_profile_assume] = true
+
+          assert @klass.validate_hosts(hosts, @org, @host.name, 'different-uuid')
         end
 
         def test_existing_uuid_and_name


### PR DESCRIPTION
To test:

- register a client to your dev box with this PR checked out
- `subscription-manager clean` on the client and change its DMI UUID:

```
echo '{"dmi.system.uuid": "this-is-made-up1"}' > /etc/rhsm/facts/uuid.facts
```
- re-register the client. it should succeed (crux of this change) as long as the client's DMI UUID is unique across hosts.

To test the reverse: toggle the new Host Profile Assume setting to false. Repeating the test (with a new UUID) will result in a registration error