### PR TITLE
Fixes #27839 - add missing methods for orphan clean

### DIFF
--- a/app/services/katello/pulp/smart_proxy_repository.rb
+++ b/app/services/katello/pulp/smart_proxy_repository.rb
@@ -61,6 +61,19 @@ module Katello
         @smart_proxy.pulp_repositories.map { |x| x["id"] } - repos_available_to_capsule.map { |x| x.pulp_id }
       end
 
+      def repos_available_to_capsule
+        yum_repos_available_to_capsule + puppet_environments_available_to_capsule
+      end
+
+      def yum_repos_available_to_capsule
+        yum_repos = Katello::Repository.in_environment(@smart_proxy.lifecycle_environments)
+        yum_repos.find_all { |repo| repo.node_syncable? }
+      end
+
+      def puppet_environments_available_to_capsule
+        Katello::ContentViewPuppetEnvironment.in_environment(@smart_proxy.lifecycle_environments)
+      end
+
       def delete_orphaned_repos
         orphaned_repos.map { |repo| self.smart_proxy.pulp_api.extensions.repository.delete(repo) }.compact
       end

--- a/test/services/katello/pulp/smart_proxy_repository_test.rb
+++ b/test/services/katello/pulp/smart_proxy_repository_test.rb
@@ -186,6 +186,14 @@ module Katello
 
           assert_equal expected_repo_ids, repo_ids
         end
+
+        test "orphaned repos" do
+          capsule_content.smart_proxy
+          assert_equal [repo_lib_cv1['id'], repo_lib_cv2['id'], repo_dev_cv2['id']].sort, capsule_content.orphaned_repos.sort
+
+          capsule_content.smart_proxy.lifecycle_environments << katello_environments(:dev)
+          assert_equal [repo_lib_cv1['id'], repo_lib_cv2['id']].sort, capsule_content.orphaned_repos.sort
+        end
       end
     end
   end


### PR DESCRIPTION
a previous commit used a couple of methods that had
been removed, this is adding them back