### PR TITLE
Fixes #27695 - Repo Autocomplete Search

### DIFF
--- a/app/models/katello/ansible_collection.rb
+++ b/app/models/katello/ansible_collection.rb
@@ -3,11 +3,7 @@ module Katello
     include Concerns::PulpDatabaseUnit
 
     self.table_name = 'katello_ansible_collections'
-
     CONTENT_TYPE = 'ansible collection'.freeze
-
-    has_many :repository_ansible_collections, :class_name => "Katello::RepositoryAnsibleCollection", :dependent => :destroy, :inverse_of => :ansible_collection, :foreign_key => :ansible_collection_id
-    has_many :repositories, :through => :repository_ansible_collections, :class_name => "Katello::Repository"
 
     has_many :ansible_collection_tags, :class_name => "Katello::AnsibleCollectionTag", :dependent => :delete_all
     has_many :tags, :through => :ansible_collection_tags
@@ -20,10 +16,6 @@ module Katello
 
     def self.default_sort
       order(:name)
-    end
-
-    def self.repository_association_class
-      RepositoryAnsibleCollection
     end
 
     def self.unit_id_field

--- a/app/models/katello/concerns/search_by_repository_name.rb
+++ b/app/models/katello/concerns/search_by_repository_name.rb
@@ -5,7 +5,10 @@ module Katello
       include ScopedSearchExtensions
 
       included do
-        scoped_search :relation => :repositories, :on => :name, :rename => :repository, :complete_value => true, :ext_method => :search_by_repo_name, :only_explicit => true
+        has_many :root_repositories, through: :repositories, :source => :root, class_name: "Katello::RootRepository"
+        scoped_search :relation => :root_repositories, :on => :name, :rename => :repository,
+                      :complete_value => true,
+                      :ext_method => :search_by_repo_name, :only_explicit => true
       end
 
       module ClassMethods

--- a/app/models/katello/deb.rb
+++ b/app/models/katello/deb.rb
@@ -3,10 +3,6 @@ module Katello
     include Concerns::PulpDatabaseUnit
 
     CONTENT_TYPE = Pulp::Deb::CONTENT_TYPE
-
-    has_many :repositories, :through => :repository_debs, :class_name => "Katello::Repository"
-    has_many :repository_debs, :class_name => "Katello::RepositoryDeb", :dependent => :destroy, :inverse_of => :deb
-
     scoped_search :on => :name, :complete_value => true
     scoped_search :on => :version, :complete_value => true
     scoped_search :on => :architecture, :complete_value => true
@@ -17,10 +13,6 @@ module Katello
 
     def self.default_sort
       order(:name).order(:version).order(:architecture)
-    end
-
-    def self.repository_association_class
-      RepositoryDeb
     end
 
     def self.search_version_range(min = nil, max = nil)

--- a/app/models/katello/docker_manifest.rb
+++ b/app/models/katello/docker_manifest.rb
@@ -2,10 +2,6 @@ module Katello
   class DockerManifest < Katello::Model
     include Concerns::PulpDatabaseUnit
     has_many :docker_tags, :as => :docker_taggable, :class_name => "Katello::DockerTag", :dependent => :destroy
-    has_many :repository_docker_manifests, :class_name => "Katello::RepositoryDockerManifest",
-             :dependent => :destroy, :inverse_of => :docker_manifest
-    has_many :repositories, :through => :repository_docker_manifests, :inverse_of => :docker_manifests
-
     has_many :docker_manifest_list_manifests, :class_name => "Katello::DockerManifestListManifest",
              :dependent => :delete_all, :inverse_of => :docker_manifest
     has_many :docker_manifest_lists, :through => :docker_manifest_list_manifests, :inverse_of => :docker_manifests
@@ -16,10 +12,6 @@ module Katello
     scoped_search :on => :digest, :rename => :digest, :complete_value => true, :only_explicit => true
     scoped_search :on => :schema_version, :rename => :schema_version, :complete_value => true, :only_explicit => true
     scoped_search :relation => :docker_manifest_lists, :on => :digest, :rename => :manifest_list_digest, :complete_value => true, :only_explicit => true
-
-    def self.repository_association_class
-      RepositoryDockerManifest
-    end
 
     def self.default_sort
       order(:schema_version)

--- a/app/models/katello/docker_manifest_list.rb
+++ b/app/models/katello/docker_manifest_list.rb
@@ -3,10 +3,6 @@ module Katello
     include Concerns::PulpDatabaseUnit
 
     has_many :docker_tags, :as => :docker_taggable, :class_name => "Katello::DockerTag", :dependent => :destroy
-    has_many :repository_docker_manifest_lists, :class_name => "Katello::RepositoryDockerManifestList",
-             :dependent => :destroy, :inverse_of => :docker_manifest_list
-    has_many :repositories, :through => :repository_docker_manifest_lists, :inverse_of => :docker_manifest_lists
-
     has_many :docker_manifest_list_manifests, :class_name => "Katello::DockerManifestListManifest",
              :dependent => :delete_all, :inverse_of => :docker_manifest_list
     has_many :docker_manifests, :through => :docker_manifest_list_manifests, :inverse_of => :docker_manifest_lists
@@ -16,10 +12,6 @@ module Katello
     scoped_search :relation => :docker_tags, :on => :name, :rename => :tag, :complete_value => true
     scoped_search :on => :digest, :rename => :digest, :complete_value => true, :only_explicit => true
     scoped_search :on => :schema_version, :rename => :schema_version, :complete_value => true, :only_explicit => true
-
-    def self.repository_association_class
-      RepositoryDockerManifestList
-    end
 
     def self.default_sort
       order(:schema_version)

--- a/app/models/katello/docker_meta_tag.rb
+++ b/app/models/katello/docker_meta_tag.rb
@@ -4,7 +4,7 @@ module Katello
 
     has_many :repository_docker_meta_tags, :class_name => "Katello::RepositoryDockerMetaTag", :dependent => :delete_all, :inverse_of => :docker_meta_tag
     has_many :repositories, :through => :repository_docker_meta_tags, :inverse_of => :docker_meta_tags
-
+    has_many :root_repositories, through: :repositories, :source => :root, class_name: "Katello::RootRepository"
     belongs_to :schema1, :class_name => "Katello::DockerTag",
                           :inverse_of => :schema1_meta_tag
 
@@ -20,7 +20,7 @@ module Katello
                   :complete_value => true, :only_explicit => true
     scoped_search :on => :digest, :rename => :digest, :complete_value => false,
                   :only_explicit => true, :ext_method => :find_by_digest, :operators => ["="]
-    scoped_search :relation => :repositories, :on => :name, :rename => :repository, :complete_value => true,
+    scoped_search :relation => :root_repositories, :on => :name, :rename => :repository, :complete_value => true,
                   :ext_method => :search_by_repo_name, :only_explicit => true
 
     def self.repository_association_class

--- a/app/models/katello/docker_tag.rb
+++ b/app/models/katello/docker_tag.rb
@@ -6,9 +6,6 @@ module Katello
     CONTENT_TYPE = 'docker_tag'.freeze
 
     belongs_to :docker_taggable, :polymorphic => true, :inverse_of => :docker_tags
-    has_many :repository_docker_tags, :class_name => "Katello::RepositoryDockerTag", :dependent => :delete_all, :inverse_of => :docker_tag
-    has_many :repositories, :through => :repository_docker_tags, :inverse_of => :docker_tags
-
     has_one :schema1_meta_tag, :class_name => "Katello::DockerMetaTag", :foreign_key => "schema1_id",
                                :inverse_of => :schema1, :dependent => :nullify
 
@@ -16,10 +13,6 @@ module Katello
                                :inverse_of => :schema2, :dependent => :nullify
 
     before_destroy :cleanup_meta_tags
-
-    def self.repository_association_class
-      RepositoryDockerTag
-    end
 
     def repository
       repositories.first

--- a/app/models/katello/erratum.rb
+++ b/app/models/katello/erratum.rb
@@ -12,10 +12,6 @@ module Katello
     has_many :content_facet_errata, :class_name => "Katello::ContentFacetErratum", :dependent => :destroy, :inverse_of => :content_facet
     has_many :content_facets, :through => :content_facet_errata, :class_name => "Katello::Host::ContentFacet", :source => :content_facet
     has_many :content_facets_applicable, :through => :content_facet_errata, :class_name => "Katello::Host::ContentFacet", :source => :content_facet
-
-    has_many :repository_errata, :class_name => "Katello::RepositoryErratum", :dependent => :destroy, :inverse_of => :erratum
-    has_many :repositories, :through => :repository_errata, :class_name => "Katello::Repository"
-
     has_many :bugzillas, :class_name => "Katello::ErratumBugzilla", :dependent => :destroy, :inverse_of => :erratum
     has_many :cves, :class_name => "Katello::ErratumCve", :dependent => :destroy, :inverse_of => :erratum
     has_many :packages, :class_name => "Katello::ErratumPackage", :dependent => :destroy, :inverse_of => :erratum
@@ -53,10 +49,6 @@ module Katello
     scope :enhancement, -> { of_type(Erratum::ENHANCEMENT) }
     scope :modular, -> { where(:id => Erratum.joins(:packages => :module_stream_errata_packages)) }
     scope :non_modular, -> { where.not(:id => modular) }
-
-    def self.repository_association_class
-      RepositoryErratum
-    end
 
     def self.content_facet_association_class
       ContentFacetErratum

--- a/app/models/katello/file_unit.rb
+++ b/app/models/katello/file_unit.rb
@@ -1,13 +1,9 @@
 module Katello
   class FileUnit < Katello::Model
+    self.table_name = 'katello_files'
     include Concerns::PulpDatabaseUnit
 
-    self.table_name = 'katello_files'
-
     CONTENT_TYPE = 'file'.freeze
-
-    has_many :repository_files, :class_name => "Katello::RepositoryFile", :dependent => :destroy, :inverse_of => :file, :foreign_key => :file_id
-    has_many :repositories, :through => :repository_files, :class_name => "Katello::Repository"
 
     scoped_search :on => :name, :complete_value => true
     scoped_search :on => :path, :complete_value => true
@@ -15,14 +11,6 @@ module Katello
 
     def self.default_sort
       order(:name)
-    end
-
-    def self.repository_association_class
-      RepositoryFile
-    end
-
-    def self.unit_id_field
-      'file_id'
     end
 
     def self.total_for_repositories(repos)

--- a/app/models/katello/module_stream.rb
+++ b/app/models/katello/module_stream.rb
@@ -2,9 +2,6 @@ module Katello
   class ModuleStream < Katello::Model
     include Concerns::PulpDatabaseUnit
     include ScopedSearchExtensions
-    has_many :repository_module_streams, class_name: "Katello::RepositoryModuleStream",
-      dependent: :destroy, inverse_of: :module_stream
-    has_many :repositories, through: :repository_module_streams, class_name: "Katello::Repository"
     has_many :profiles, class_name: "Katello::ModuleProfile", dependent: :destroy, inverse_of: :module_stream
     has_many :artifacts, class_name: "Katello::ModuleStreamArtifact", dependent: :destroy, inverse_of: :module_stream
     has_many :module_stream_errata_packages, class_name: "Katello::ModuleStreamErratumPackage", dependent: :destroy, inverse_of: :module_stream
@@ -36,10 +33,6 @@ module Katello
 
     def self.default_sort
       order(:name)
-    end
-
-    def self.repository_association_class
-      RepositoryModuleStream
     end
 
     def self.content_facet_association_class

--- a/app/models/katello/ostree_branch.rb
+++ b/app/models/katello/ostree_branch.rb
@@ -2,18 +2,11 @@ module Katello
   class OstreeBranch < Katello::Model
     include Concerns::PulpDatabaseUnit
 
-    has_many :repository_ostree_branches, :dependent => :destroy, :class_name => 'Katello::RepositoryOstreeBranch'
-    has_many :repositories, :through => :repository_ostree_branches, :inverse_of => :ostree_branches
-
     scoped_search :on => :name, :complete_value => true
     scoped_search :on => :version, :complete_value => true
     scoped_search :on => :commit, :complete_value => true
     scoped_search :on => :pulp_id, :complete_value => true, :rename => :uuid
 
     CONTENT_TYPE = "ostree".freeze
-
-    def self.repository_association_class
-      RepositoryOstreeBranch
-    end
   end
 end

--- a/app/models/katello/package_group.rb
+++ b/app/models/katello/package_group.rb
@@ -3,17 +3,10 @@ module Katello
     include Concerns::PulpDatabaseUnit
 
     CONTENT_TYPE = "package_group".freeze
-
-    has_many :repository_package_groups, :class_name => "Katello::RepositoryPackageGroup", :dependent => :destroy, :inverse_of => :package_group
-    has_many :repositories, :through => :repository_package_groups, :class_name => "Katello::Repository"
     has_many :roots, :through => :repositories, :class_name => "Katello::RootRepository"
 
     scoped_search :on => :name, :complete_value => true
     scoped_search :on => :pulp_id, :rename => :id, :complete_value => true
-
-    def self.repository_association_class
-      RepositoryPackageGroup
-    end
 
     def repository
       self.repositories.first

--- a/app/models/katello/puppet_module.rb
+++ b/app/models/katello/puppet_module.rb
@@ -7,9 +7,6 @@ module Katello
 
     CONTENT_TYPE = "puppet_module".freeze
 
-    has_many :repository_puppet_modules, :class_name => "Katello::RepositoryPuppetModule", :dependent => :destroy, :inverse_of => :puppet_module
-    has_many :repositories, :through => :repository_puppet_modules, :class_name => "Katello::Repository"
-
     has_many :content_view_puppet_environment_puppet_modules,
              :class_name => "Katello::ContentViewPuppetEnvironmentPuppetModule",
              :dependent => :destroy,
@@ -33,10 +30,6 @@ module Katello
     def self.latest_module(name, author, repositories)
       in_repositories(repositories).where(:name => name, :author => author).
         order(:sortable_version => :desc).first
-    end
-
-    def self.repository_association_class
-      RepositoryPuppetModule
     end
 
     def self.parse_metadata(filepath)

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -52,8 +52,8 @@ module Katello
     has_many :repository_srpms, :class_name => "Katello::RepositorySrpm", :dependent => :delete_all
     has_many :srpms, :through => :repository_srpms
 
-    has_many :repository_files, :class_name => "Katello::RepositoryFile", :dependent => :destroy
-    has_many :files, :through => :repository_files
+    has_many :repository_file_units, :class_name => "Katello::RepositoryFileUnit", :dependent => :destroy
+    has_many :files, :through => :repository_file_units, :source => :file_unit
 
     has_many :repository_puppet_modules, :class_name => "Katello::RepositoryPuppetModule", :dependent => :delete_all
     has_many :puppet_modules, :through => :repository_puppet_modules
@@ -153,14 +153,12 @@ module Katello
     delegate :yum?, :docker?, :puppet?, :deb?, :file?, :ostree?, :ansible_collection?, :to => :root
     delegate :name, :label, :docker_upstream_name, :url, :to => :root
 
-    delegate :name, :created_at, :updated_at, :major, :minor, :gpg_key_id, :gpg_key, :arch, :label, :url, :unprotected,
+    delegate :name, :created_at, :updated_at, :major, :minor, :gpg_key_id, :gpg_key, :content_id, :arch, :label, :url, :unprotected,
              :content_type, :product_id, :checksum_type, :docker_upstream_name, :mirror_on_sync, :"mirror_on_sync?",
              :download_policy, :verify_ssl_on_sync, :"verify_ssl_on_sync?", :upstream_username, :upstream_password,
              :ostree_upstream_sync_policy, :ostree_upstream_sync_depth, :deb_releases, :deb_components, :deb_architectures,
              :ignore_global_proxy, :ssl_ca_cert_id, :ssl_ca_cert, :ssl_client_cert, :ssl_client_cert_id, :ssl_client_key_id,
              :ssl_client_key, :ignorable_content, :description, :docker_tags_whitelist, :ansible_collection_requirements, :http_proxy_policy, :http_proxy_id, :to => :root
-
-    delegate :content_id, to: :root, allow_nil: true
 
     def self.with_type(content_type)
       joins(:root).where("#{RootRepository.table_name}.content_type" => content_type)

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -153,12 +153,14 @@ module Katello
     delegate :yum?, :docker?, :puppet?, :deb?, :file?, :ostree?, :ansible_collection?, :to => :root
     delegate :name, :label, :docker_upstream_name, :url, :to => :root
 
-    delegate :name, :created_at, :updated_at, :major, :minor, :gpg_key_id, :gpg_key, :content_id, :arch, :label, :url, :unprotected,
+    delegate :name, :created_at, :updated_at, :major, :minor, :gpg_key_id, :gpg_key, :arch, :label, :url, :unprotected,
              :content_type, :product_id, :checksum_type, :docker_upstream_name, :mirror_on_sync, :"mirror_on_sync?",
              :download_policy, :verify_ssl_on_sync, :"verify_ssl_on_sync?", :upstream_username, :upstream_password,
              :ostree_upstream_sync_policy, :ostree_upstream_sync_depth, :deb_releases, :deb_components, :deb_architectures,
              :ignore_global_proxy, :ssl_ca_cert_id, :ssl_ca_cert, :ssl_client_cert, :ssl_client_cert_id, :ssl_client_key_id,
              :ssl_client_key, :ignorable_content, :description, :docker_tags_whitelist, :ansible_collection_requirements, :http_proxy_policy, :http_proxy_id, :to => :root
+
+    delegate :content_id, to: :root, allow_nil: true
 
     def self.with_type(content_type)
       joins(:root).where("#{RootRepository.table_name}.content_type" => content_type)

--- a/app/models/katello/repository_file.rb
+++ b/app/models/katello/repository_file.rb
@@ -1,7 +1,0 @@
-module Katello
-  class RepositoryFile < Katello::Model
-    # Do not use active record callbacks in this join model.  Direct INSERTs and DELETEs are done
-    belongs_to :repository, :inverse_of => :repository_files, :class_name => 'Katello::Repository'
-    belongs_to :file, :inverse_of => :repository_files, :class_name => 'Katello::FileUnit', :foreign_key => :file_id
-  end
-end

--- a/app/models/katello/repository_file_unit.rb
+++ b/app/models/katello/repository_file_unit.rb
@@ -1,0 +1,7 @@
+module Katello
+  class RepositoryFileUnit < Katello::Model
+    # Do not use active record callbacks in this join model.  Direct INSERTs and DELETEs are done
+    belongs_to :repository, :inverse_of => :repository_file_units, :class_name => 'Katello::Repository'
+    belongs_to :file_unit, :inverse_of => :repository_file_units, :class_name => 'Katello::FileUnit'
+  end
+end

--- a/app/models/katello/rpm.rb
+++ b/app/models/katello/rpm.rb
@@ -3,10 +3,6 @@ module Katello
     include Concerns::PulpDatabaseUnit
 
     CONTENT_TYPE = 'rpm'.freeze
-
-    has_many :repository_rpms, :class_name => "Katello::RepositoryRpm", :dependent => :destroy, :inverse_of => :rpm
-    has_many :repositories, :through => :repository_rpms, :class_name => "Katello::Repository"
-
     has_many :content_facet_applicable_rpms, :class_name => "Katello::ContentFacetApplicableRpm",
              :dependent => :destroy, :inverse_of => :rpm
     has_many :content_facets, :through => :content_facet_applicable_rpms, :class_name => "Katello::Host::ContentFacet"
@@ -29,10 +25,6 @@ module Katello
 
     def self.default_sort
       order(:name).order(:epoch).order(:version_sortable).order(:release_sortable)
-    end
-
-    def self.repository_association_class
-      RepositoryRpm
     end
 
     def self.content_facet_association_class

--- a/app/models/katello/srpm.rb
+++ b/app/models/katello/srpm.rb
@@ -3,18 +3,10 @@ module Katello
     include Concerns::PulpDatabaseUnit
 
     CONTENT_TYPE = 'srpm'.freeze
-
-    has_many :repository_srpms, :class_name => "Katello::RepositorySrpm", :dependent => :destroy, :inverse_of => :srpm
-    has_many :repositories, :through => :repository_srpms, :class_name => "Katello::Repository"
-
     before_save lambda { |rpm| rpm.summary = rpm.summary.truncate(255) unless rpm.summary.blank? }
 
     def self.default_sort
       order(:name).order(:epoch).order(:version_sortable).order(:release_sortable)
-    end
-
-    def self.repository_association_class
-      RepositorySrpm
     end
 
     def self.total_for_repositories(repos)

--- a/app/models/katello/yum_metadata_file.rb
+++ b/app/models/katello/yum_metadata_file.rb
@@ -10,10 +10,6 @@ module Katello
       super(repository)
     end
 
-    def self.many_repository_associations
-      false
-    end
-
     # yum metadata file only has one repo
     def repositories
       [repository]

--- a/db/migrate/20180920214134_create_repository_root.rb
+++ b/db/migrate/20180920214134_create_repository_root.rb
@@ -5,7 +5,7 @@ class CreateRepositoryRoot < ActiveRecord::Migration[5.1]
                      deb_releases deb_components deb_architectures ignore_global_proxy ssl_ca_cert_id
                      ssl_client_cert_id ssl_client_key_id ignorable_content description docker_tags_whitelist).freeze
 
-  REPO_ASSOCIATIONS = %w(RepositoryErratum ContentViewRepository RepositoryRpm RepositorySrpm RepositoryFile RepositoryPuppetModule
+  REPO_ASSOCIATIONS = %w(RepositoryErratum ContentViewRepository RepositoryRpm RepositorySrpm RepositoryFileUnit RepositoryPuppetModule
                          RepositoryDockerManifest RepositoryDockerManifestList DockerTag DockerMetaTag RepositoryOstreeBranch RepositoryDeb
                          ContentFacetRepository RepositoryPackageGroup RepositoryModuleStream).freeze
 

--- a/db/migrate/20190912210927_rename_repository_file_unit.rb
+++ b/db/migrate/20190912210927_rename_repository_file_unit.rb
@@ -1,0 +1,12 @@
+class RenameRepositoryFileUnit < ActiveRecord::Migration[5.2]
+  def change
+    original_name = 'index_katello_repository_files_on_file_id_and_repository_id'
+    shorter_name = 'index_katello_repo_files_file_and_repo'
+
+    if index_exists?(:katello_repository_files, [:file_id, :repository_id], :name => original_name)
+      rename_index :katello_repository_files, original_name, shorter_name
+    end
+    rename_column :katello_repository_files, :file_id, :file_unit_id
+    rename_table :katello_repository_files, :katello_repository_file_units
+  end
+end

--- a/test/actions/pulp3/orchestration/file_sync_test.rb
+++ b/test/actions/pulp3/orchestration/file_sync_test.rb
@@ -56,10 +56,10 @@ module ::Actions::Pulp3
 
       begin
         @repo.reload
-        assert_equal 0, @repo.repository_files.count
+        assert_equal 0, @repo.repository_file_units.count
 
         @repo.index_content
-        assert_equal 250, @repo.repository_files.count
+        assert_equal 250, @repo.repository_file_units.count
       ensure
         SETTINGS[:katello][:pulp][:bulk_load_size] = old_page_size
       end
@@ -70,7 +70,7 @@ module ::Actions::Pulp3
       ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @master, sync_args)
       @repo.reload
       @repo.index_content
-      pre_count_content = ::Katello::RepositoryFile.where(:repository_id => @repo.id).count
+      pre_count_content = ::Katello::RepositoryFileUnit.where(:repository_id => @repo.id).count
       @repo.root.update_attributes(:url => "file:///var/www/test_repos/file2", :mirror_on_sync => false)
 
       ForemanTasks.sync_task(
@@ -81,7 +81,7 @@ module ::Actions::Pulp3
       ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @master, sync_args)
       @repo.reload
       @repo.index_content
-      post_count_content = ::Katello::RepositoryFile.where(:repository_id => @repo.id).count
+      post_count_content = ::Katello::RepositoryFileUnit.where(:repository_id => @repo.id).count
       assert_equal pre_count_content + 3, post_count_content
     end
 
@@ -90,7 +90,7 @@ module ::Actions::Pulp3
       ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @master, sync_args)
       @repo.reload
       @repo.index_content
-      pre_count_content = ::Katello::RepositoryFile.where(:repository_id => @repo.id).count
+      pre_count_content = ::Katello::RepositoryFileUnit.where(:repository_id => @repo.id).count
       @repo.root.update_attributes(:url => "file:///var/www/test_repos/file2")
 
       ForemanTasks.sync_task(
@@ -101,7 +101,7 @@ module ::Actions::Pulp3
       ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @master, sync_args)
       @repo.reload
       @repo.index_content
-      post_count_content = ::Katello::RepositoryFile.where(:repository_id => @repo.id).count
+      post_count_content = ::Katello::RepositoryFileUnit.where(:repository_id => @repo.id).count
       assert_equal pre_count_content, post_count_content
     end
   end

--- a/test/fixtures/models/katello_repository_file_units.yml
+++ b/test/fixtures/models/katello_repository_file_units.yml
@@ -1,15 +1,15 @@
 fedora_one:
-  file_id: <%= ActiveRecord::FixtureSet.identify(:one) %>
+  file_unit_id: <%= ActiveRecord::FixtureSet.identify(:one) %>
   repository_id: <%= ActiveRecord::FixtureSet.identify(:generic_file) %>
 
 fedora_two:
-  file_id: <%= ActiveRecord::FixtureSet.identify(:two) %>
+  file_unit_id: <%= ActiveRecord::FixtureSet.identify(:two) %>
   repository_id: <%= ActiveRecord::FixtureSet.identify(:generic_file) %>
 
 fedora_dev_one:
-  file_id: <%= ActiveRecord::FixtureSet.identify(:one) %>
+  file_unit_id: <%= ActiveRecord::FixtureSet.identify(:one) %>
   repository_id: <%= ActiveRecord::FixtureSet.identify(:generic_file_dev) %>
 
 fedora_dev_two:
-  file_id: <%= ActiveRecord::FixtureSet.identify(:two) %>
+  file_unit_id: <%= ActiveRecord::FixtureSet.identify(:two) %>
   repository_id: <%= ActiveRecord::FixtureSet.identify(:generic_file_dev) %>

--- a/test/models/docker_meta_tag_test.rb
+++ b/test/models/docker_meta_tag_test.rb
@@ -17,6 +17,11 @@ module Katello
       end
     end
 
+    def test_complete_for
+      refute_nil DockerMetaTag.complete_for("repository=")
+      refute_nil DockerMetaTag.search_for("repository='foo'")
+    end
+
     def test_related_tags
       assert_equal 8, @tag_schema1.related_tags.count
       assert_equal 8, @tag_schema2.related_tags.count

--- a/test/models/pulp_database_unit_test.rb
+++ b/test/models/pulp_database_unit_test.rb
@@ -1,0 +1,21 @@
+# encoding: utf-8
+
+require 'katello_test_helper'
+
+module Katello
+  class PulpDatabaseUnitTest < ActiveSupport::TestCase
+    extend ActiveRecord::TestFixtures
+
+    def test_complete_for
+      content_types = ::Katello::RepositoryTypeManager.repository_types.values.map { |t| t.content_types.map(&:model_class) }.flatten.select { |klazz| klazz <= ::Katello::Concerns::PulpDatabaseUnit }
+      content_types.each do |klazz|
+        if klazz.many_repository_associations
+          refute_nil klazz.complete_for("repository="), "asserting #{klazz}"
+          refute_nil klazz.search_for("repository=foo"), "asserting #{klazz}"
+        end
+      end
+
+      assert_empty ::Katello::YumMetadataFile.methods.grep(/complete_for/)
+    end
+  end
+end

--- a/test/services/katello/pulp3/file_unit_test.rb
+++ b/test/services/katello/pulp3/file_unit_test.rb
@@ -25,7 +25,7 @@ module Katello
         @repo.reload
         @repo.index_content
         post_unit_count = Katello::FileUnit.all.count
-        post_unit_repository_count = Katello::RepositoryFile.where(:repository_id => @repo.id).count
+        post_unit_repository_count = Katello::RepositoryFileUnit.where(:repository_id => @repo.id).count
 
         assert_equal post_unit_count, 3
         assert_equal post_unit_repository_count, 3
@@ -39,7 +39,7 @@ module Katello
         ForemanTasks.sync_task(::Actions::Katello::Repository::IndexContent, index_args)
         @repo.reload
         post_unit_count = Katello::FileUnit.all.count
-        post_unit_repository_count = Katello::RepositoryFile.where(:repository_id => @repo.id).count
+        post_unit_repository_count = Katello::RepositoryFileUnit.where(:repository_id => @repo.id).count
 
         assert_equal post_unit_count, 3
         assert_equal post_unit_repository_count, 3


### PR DESCRIPTION
This commit dry's up a bunch of duplicated code for the pulpdatabase
unit types. It also lets the user search/autocomplete by
root_repositories