### PR TITLE
Fixes #27849 - delay cp env delete to owner delete

### DIFF
--- a/app/lib/actions/katello/content_view_environment/destroy.rb
+++ b/app/lib/actions/katello/content_view_environment/destroy.rb
@@ -3,7 +3,6 @@ module Actions
     module ContentViewEnvironment
       class Destroy < Actions::Base
         def plan(cv_env, options = {})
-          skip_cp_update = options.fetch(:skip_candlepin_update, false)
           skip_repo_destroy = options.fetch(:skip_repo_destroy, false)
           organization_destroy = options.fetch(:organization_destroy, false)
           content_view = cv_env.content_view
@@ -25,7 +24,7 @@ module Actions
                 plan_action(ContentViewPuppetEnvironment::Destroy, puppet_env) unless organization_destroy
               end
             end
-            plan_action(Candlepin::Environment::Destroy, cp_id: cv_env.cp_id) unless skip_cp_update
+            plan_action(Candlepin::Environment::Destroy, cp_id: cv_env.cp_id) unless organization_destroy
             plan_self(:id => cv_env.id)
           end
         end

--- a/app/lib/actions/katello/organization/destroy.rb
+++ b/app/lib/actions/katello/organization/destroy.rb
@@ -65,7 +65,7 @@ module Actions
         end
 
         def remove_content_view_environment(cv_env)
-          plan_action(ContentViewEnvironment::Destroy, cv_env, :skip_repo_destroy => true, :skip_candlepin_update => true, :organization_destroy => true)
+          plan_action(ContentViewEnvironment::Destroy, cv_env, :skip_repo_destroy => true, :organization_destroy => true)
         end
 
         def remove_content_views(organization)


### PR DESCRIPTION
the candlepin environment was inadvertently being deleted as part
of the content removal.  This commit changes content view removal to
not delete the candlepin environment if the org_delete flag is being passed
in