### PR TITLE
Fixes #27878 - hide Registered Through for hypervisor profiles

### DIFF
--- a/app/views/katello/api/v2/subscription_facet/base.json.rabl
+++ b/app/views/katello/api/v2/subscription_facet/base.json.rabl
@@ -1,4 +1,4 @@
-attributes :id, :uuid, :last_checkin, :service_level, :release_version, :autoheal, :registered_at, :registered_through, :purpose_role, :purpose_usage
+attributes :id, :uuid, :last_checkin, :service_level, :release_version, :autoheal, :registered_at, :registered_through, :purpose_role, :purpose_usage, :hypervisor
 
 child :user => :user do
   attributes :id, :login

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/details/views/content-host-info.html
@@ -54,8 +54,8 @@
           </a>
         </dd>
 
-        <dt translate>Registered Through</dt>
-        <dd>{{ host.subscription_facet_attributes.registered_through || "Unknown" | translate}}</dd>
+        <dt ng-show="!host.subscription_facet_attributes.hypervisor || host.subscription_facet_attributes.registered_through" translate>Registered Through</dt>
+        <dd ng-show="!host.subscription_facet_attributes.hypervisor || host.subscription_facet_attributes.registered_through">{{ host.subscription_facet_attributes.registered_through | translate}}</dd>
 
         <dt ng-show="host.subscription_facet_attributes.virtual_host" translate>Virtual Host</dt>
         <dd ng-show="host.subscription_facet_attributes.virtual_host">


### PR DESCRIPTION
hide Registered Through option for hypervisor profiles on the Content Hosts page