### PR TITLE
Fixes #27400 - pulp3 docker proxy sync

### DIFF
--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -73,7 +73,7 @@ module Katello
       end
 
       def mirror_remote_options
-        common_mirror_remote_options
+        common_mirror_remote_options.merge(url: mirror_remote_feed_url)
       end
 
       def create_mirror_remote
@@ -461,8 +461,7 @@ module Katello
 
       def common_mirror_remote_options
         remote_options = {
-          name: backend_object_name,
-          url: mirror_remote_feed_url
+          name: backend_object_name
         }
         remote_options.merge!(ssl_mirror_remote_options)
       end

--- a/app/services/katello/pulp3/repository/docker.rb
+++ b/app/services/katello/pulp3/repository/docker.rb
@@ -42,6 +42,14 @@ module Katello
           common_remote_options.merge(options)
         end
 
+        def mirror_remote_options
+          docker_options = {
+            url: "https://#{SmartProxy.pulp_master.pulp3_host!.downcase}",
+            upstream_name: repo.container_repository_name
+          }
+          common_mirror_remote_options.merge(docker_options)
+        end
+
         def distribution_options(path)
           {
             base_path: path,


### PR DESCRIPTION
This adds support for smart proxy syncing
docker content with pulp3.  The goal is to use
the katello registry proxy to proxy to the content app.
The mirror proxy will be using a client cert to auth
with the registry proxy.