### PR TITLE
Fixes #27890 - Adds an action to delete orphan mirror repo versions.

### DIFF
--- a/app/lib/actions/pulp3/orchestration/orphan_cleanup/remove_orphans.rb
+++ b/app/lib/actions/pulp3/orchestration/orphan_cleanup/remove_orphans.rb
@@ -6,8 +6,10 @@ module Actions
           def plan(proxy)
             if proxy.pulp3_enabled?
               sequence do
-                plan_action(Actions::Pulp3::OrphanCleanup::RemoveUnneededRepos, proxy) if proxy.pulp_mirror?
-                plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanRepositoryVersions, proxy) if proxy == SmartProxy.pulp_master
+                if proxy.pulp_mirror?
+                  plan_action(Actions::Pulp3::OrphanCleanup::RemoveUnneededRepos, proxy)
+                end
+                plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanRepositoryVersions, proxy)
               end
             end
           end

--- a/app/lib/actions/pulp3/orphan_cleanup/delete_orphan_repository_versions.rb
+++ b/app/lib/actions/pulp3/orphan_cleanup/delete_orphan_repository_versions.rb
@@ -8,7 +8,11 @@ module Actions
 
         def run
           smart_proxy = SmartProxy.find(input[:smart_proxy_id])
-          output[:pulp_tasks] = ::Katello::Pulp3::Repository.delete_orphan_repository_versions(smart_proxy)
+          if smart_proxy.pulp_mirror?
+            output[:pulp_tasks] = ::Katello::Pulp3::Repository.delete_orphan_repository_versions_for_mirror(smart_proxy)
+          else
+            output[:pulp_tasks] = ::Katello::Pulp3::Repository.delete_orphan_repository_versions(smart_proxy)
+          end
         end
       end
     end

--- a/test/actions/katello/orphan_cleanup/remove_orphans_test.rb
+++ b/test/actions/katello/orphan_cleanup/remove_orphans_test.rb
@@ -46,6 +46,10 @@ module ::Actions::Katello::CapsuleContent
       assert_tree_planned_with(tree, ::Actions::Pulp3::OrphanCleanup::RemoveUnneededRepos) do |input|
         assert_equal smart_proxy.id, input[:smart_proxy_id]
       end
+
+      assert_tree_planned_with(tree, ::Actions::Pulp3::OrphanCleanup::DeleteOrphanRepositoryVersions) do |input|
+        assert_equal smart_proxy.id, input[:smart_proxy_id]
+      end
     end
   end
 

--- a/test/fixtures/vcr_cassettes/actions/pulp3/remove_orphans/orphans_are_removed.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/remove_orphans/orphans_are_removed.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:24 GMT
+      - Thu, 19 Sep 2019 14:44:58 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -44,7 +44,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:24 GMT
+  recorded_at: Thu, 19 Sep 2019 14:44:58 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
@@ -68,7 +68,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:24 GMT
+      - Thu, 19 Sep 2019 14:44:59 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -89,7 +89,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:24 GMT
+  recorded_at: Thu, 19 Sep 2019 14:44:59 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
@@ -113,7 +113,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:25 GMT
+      - Thu, 19 Sep 2019 14:44:59 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -134,219 +134,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:25 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com:8443/candlepin/owners//uebercert
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Authorization:
-      - OAuth oauth_consumer_key="dNZ8tEDWtwokaUEpig4TxxkzbrEKMeY4", oauth_nonce="Op1eDEr1iK3X41MbHwAvUWhGrHAVhB75yAyuOAG4",
-        oauth_signature="pnowoZ3lZfszM7pkoLPk0pm1Jqg%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1568033005", oauth_version="1.0"
-      Cp-User:
-      - foreman_admin
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - a6447e98-ed25-428b-9f1f-4000d9e88753
-      X-Version:
-      - 2.7.1-1
-      - 2.7.1-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Mon, 09 Sep 2019 12:43:25 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJkaXNwbGF5TWVzc2FnZSI6IlJ1bnRpbWUgRXJyb3IgUkVTVEVBU1kwMDMy
-        MTA6IENvdWxkIG5vdCBmaW5kIHJlc291cmNlIGZvciBmdWxsIHBhdGg6IGh0
-        dHBzOi8vY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUu
-        Y29tOjg0NDMvY2FuZGxlcGluL293bmVycy8vdWViZXJjZXJ0IGF0IG9yZy5q
-        Ym9zcy5yZXN0ZWFzeS5jb3JlLnJlZ2lzdHJ5LlNlZ21lbnROb2RlLm1hdGNo
-        OjEzOSIsInJlcXVlc3RVdWlkIjoiYTY0NDdlOTgtZWQyNS00MjhiLTlmMWYt
-        NDAwMGQ5ZTg4NzUzIn0=
-    http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:25 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com:8443/candlepin/owners//uebercert
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Authorization:
-      - OAuth oauth_consumer_key="dNZ8tEDWtwokaUEpig4TxxkzbrEKMeY4", oauth_nonce="IwtbiggTdnkKz5c8xU1IgTidUGAACOMq6dLePc4nU",
-        oauth_signature="MoHs0hx8sUt13RcEuKjm6d1pMsA%3D", oauth_signature_method="HMAC-SHA1",
-        oauth_timestamp="1568033005", oauth_version="1.0"
-      Cp-User:
-      - foreman_admin
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 7a83b20d-2789-415b-8d42-6969b8de2ae7
-      X-Version:
-      - 2.7.1-1
-      - 2.7.1-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Mon, 09 Sep 2019 12:43:25 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJkaXNwbGF5TWVzc2FnZSI6IlJ1bnRpbWUgRXJyb3IgUkVTVEVBU1kwMDMy
-        MTA6IENvdWxkIG5vdCBmaW5kIHJlc291cmNlIGZvciBmdWxsIHBhdGg6IGh0
-        dHBzOi8vY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUu
-        Y29tOjg0NDMvY2FuZGxlcGluL293bmVycy8vdWViZXJjZXJ0IGF0IG9yZy5q
-        Ym9zcy5yZXN0ZWFzeS5jb3JlLnJlZ2lzdHJ5LlNlZ21lbnROb2RlLm1hdGNo
-        OjEzOSIsInJlcXVlc3RVdWlkIjoiN2E4M2IyMGQtMjc4OS00MTViLThkNDIt
-        Njk2OWI4ZGUyYWU3In0=
-    http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:25 GMT
-- request:
-    method: post
-    uri: https://centos7-katello-devel.jjeffers.example.com:8443/candlepin/owners//uebercert
-    body:
-      encoding: UTF-8
-      base64_string: 'e30=
-
-'
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="dNZ8tEDWtwokaUEpig4TxxkzbrEKMeY4",
-        oauth_nonce="rcwZWlb0Hinj47IHkahrSKaoycbM1jZV9UO55MtPFY", oauth_signature="MwQVIbCvuTJPoQjabXWGuuh3JsE%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1568033005", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-      Content-Length:
-      - '2'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 53dacec6-a101-45f3-82fd-ea1bab1685ab
-      X-Version:
-      - 2.7.1-1
-      - 2.7.1-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Mon, 09 Sep 2019 12:43:25 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJkaXNwbGF5TWVzc2FnZSI6IlJ1bnRpbWUgRXJyb3IgUkVTVEVBU1kwMDMy
-        MTA6IENvdWxkIG5vdCBmaW5kIHJlc291cmNlIGZvciBmdWxsIHBhdGg6IGh0
-        dHBzOi8vY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUu
-        Y29tOjg0NDMvY2FuZGxlcGluL293bmVycy8vdWViZXJjZXJ0IGF0IG9yZy5q
-        Ym9zcy5yZXN0ZWFzeS5jb3JlLnJlZ2lzdHJ5LlNlZ21lbnROb2RlLm1hdGNo
-        OjEzOSIsInJlcXVlc3RVdWlkIjoiNTNkYWNlYzYtYTEwMS00NWYzLTgyZmQt
-        ZWExYmFiMTY4NWFiIn0=
-    http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:25 GMT
-- request:
-    method: post
-    uri: https://centos7-katello-devel.jjeffers.example.com:8443/candlepin/owners//uebercert
-    body:
-      encoding: UTF-8
-      base64_string: 'e30=
-
-'
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
-      Authorization:
-      - OAuth oauth_body_hash="2jmj7l5rSw0yVb%2FvlWAYkK%2FYBwk%3D", oauth_consumer_key="dNZ8tEDWtwokaUEpig4TxxkzbrEKMeY4",
-        oauth_nonce="FMO8pxzsqhRrJaWEZrTgdbiwlh2OM6apaB4KS47EdfY", oauth_signature="gNOPdbU9VIk7%2BY%2BqUxIYWmidRjA%3D",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1568033005", oauth_version="1.0"
-      Accept-Language:
-      - en
-      Content-Type:
-      - application/json
-      Cp-User:
-      - foreman_admin
-      Content-Length:
-      - '2'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Server:
-      - Apache-Coyote/1.1
-      X-Candlepin-Request-Uuid:
-      - 7c2c6248-24a8-42f3-97b7-dab6c89120fd
-      X-Version:
-      - 2.7.1-1
-      - 2.7.1-1
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Date:
-      - Mon, 09 Sep 2019 12:43:25 GMT
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJkaXNwbGF5TWVzc2FnZSI6IlJ1bnRpbWUgRXJyb3IgUkVTVEVBU1kwMDMy
-        MTA6IENvdWxkIG5vdCBmaW5kIHJlc291cmNlIGZvciBmdWxsIHBhdGg6IGh0
-        dHBzOi8vY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJzLmV4YW1wbGUu
-        Y29tOjg0NDMvY2FuZGxlcGluL293bmVycy8vdWViZXJjZXJ0IGF0IG9yZy5q
-        Ym9zcy5yZXN0ZWFzeS5jb3JlLnJlZ2lzdHJ5LlNlZ21lbnROb2RlLm1hdGNo
-        OjEzOSIsInJlcXVlc3RVdWlkIjoiN2MyYzYyNDgtMjRhOC00MmYzLTk3Yjct
-        ZGFiNmM4OTEyMGZkIn0=
-    http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:25 GMT
+  recorded_at: Thu, 19 Sep 2019 14:44:59 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
@@ -370,7 +158,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:25 GMT
+      - Thu, 19 Sep 2019 14:44:59 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -391,7 +179,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:25 GMT
+  recorded_at: Thu, 19 Sep 2019 14:44:59 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
@@ -415,7 +203,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:25 GMT
+      - Thu, 19 Sep 2019 14:44:59 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -436,7 +224,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:25 GMT
+  recorded_at: Thu, 19 Sep 2019 14:44:59 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
@@ -460,7 +248,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:26 GMT
+      - Thu, 19 Sep 2019 14:44:59 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -481,7 +269,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:26 GMT
+  recorded_at: Thu, 19 Sep 2019 14:44:59 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
@@ -505,7 +293,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:26 GMT
+      - Thu, 19 Sep 2019 14:44:59 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -526,7 +314,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:26 GMT
+  recorded_at: Thu, 19 Sep 2019 14:44:59 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
@@ -550,7 +338,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:26 GMT
+      - Thu, 19 Sep 2019 14:44:59 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -571,7 +359,7 @@ http_interactions:
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:26 GMT
+  recorded_at: Thu, 19 Sep 2019 14:44:59 GMT
 - request:
     method: post
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/
@@ -597,13 +385,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:26 GMT
+      - Thu, 19 Sep 2019 14:45:00 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/b698d83f-60db-42a9-b5b9-b7b8f2366a02/"
+      - "/pulp/api/v3/repositories/586ec394-9b23-4e83-baf3-b9afdcf8f7d0/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -617,15 +405,15 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYjY5OGQ4M2Yt
-        NjBkYi00MmE5LWI1YjktYjdiOGYyMzY2YTAyLyIsIl9jcmVhdGVkIjoiMjAx
-        OS0wOS0wOVQxMjo0MzoyNi44OTAxMDhaIiwiX3ZlcnNpb25zX2hyZWYiOiIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2I2OThkODNmLTYwZGItNDJhOS1i
-        NWI5LWI3YjhmMjM2NmEwMi92ZXJzaW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25f
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNTg2ZWMzOTQt
+        OWIyMy00ZTgzLWJhZjMtYjlhZmRjZjhmN2QwLyIsIl9jcmVhdGVkIjoiMjAx
+        OS0wOS0xOVQxNDo0NTowMC4yOTUwNjNaIiwiX3ZlcnNpb25zX2hyZWYiOiIv
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzU4NmVjMzk0LTliMjMtNGU4My1i
+        YWYzLWI5YWZkY2Y4ZjdkMC92ZXJzaW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25f
         aHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmlu
         ZXQtcHVscDNfRmlsZV8xIiwiZGVzY3JpcHRpb24iOm51bGx9
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:26 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:00 GMT
 - request:
     method: post
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/
@@ -653,13 +441,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:27 GMT
+      - Thu, 19 Sep 2019 14:45:00 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/file/file/bfca9403-0ec2-4a3b-b410-6c2936442735/"
+      - "/pulp/api/v3/remotes/file/file/9d4732ff-9f42-494a-a119-a2a81bd03dab/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -673,22 +461,22 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS9iZmNh
-        OTQwMy0wZWMyLTRhM2ItYjQxMC02YzI5MzY0NDI3MzUvIiwiX2NyZWF0ZWQi
-        OiIyMDE5LTA5LTA5VDEyOjQzOjI3LjA4MjMzOFoiLCJfdHlwZSI6ImZpbGUu
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS85ZDQ3
+        MzJmZi05ZjQyLTQ5NGEtYTExOS1hMmE4MWJkMDNkYWIvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTE5VDE0OjQ1OjAwLjUwMDMzNFoiLCJfdHlwZSI6ImZpbGUu
         ZmlsZSIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1
         bHAzX0ZpbGVfMSIsInVybCI6Imh0dHBzOi8vcmVwb3MuZmVkb3JhcGVvcGxl
         Lm9yZy9yZXBvcy9wdWxwL3B1bHAvZml4dHVyZXMvZmlsZTIvL1BVTFBfTUFO
         SUZFU1QiLCJzc2xfY2FfY2VydGlmaWNhdGUiOm51bGwsInNzbF9jbGllbnRf
         Y2VydGlmaWNhdGUiOm51bGwsInNzbF9jbGllbnRfa2V5IjpudWxsLCJzc2xf
         dmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJfbGFzdF91cGRh
-        dGVkIjoiMjAxOS0wOS0wOVQxMjo0MzoyNy4wODIzNjVaIiwiZG93bmxvYWRf
+        dGVkIjoiMjAxOS0wOS0xOVQxNDo0NTowMC41MDAzNTFaIiwiZG93bmxvYWRf
         Y29uY3VycmVuY3kiOjIwLCJwb2xpY3kiOiJpbW1lZGlhdGUifQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:27 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:00 GMT
 - request:
     method: put
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/b698d83f-60db-42a9-b5b9-b7b8f2366a02/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/586ec394-9b23-4e83-baf3-b9afdcf8f7d0/
     body:
       encoding: UTF-8
       base64_string: |
@@ -711,7 +499,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:27 GMT
+      - Thu, 19 Sep 2019 14:45:00 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -729,13 +517,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzY2ZWQ2NDk0LWZlNTEtNGMx
-        MS04Njc2LWM4NjNjZDU1OTFkMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRmMmQ3NmRjLTgyYTMtNDkw
+        NC04NGVlLTgxMjI5ZTU2MmQxZC8ifQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:27 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:00 GMT
 - request:
     method: patch
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/bfca9403-0ec2-4a3b-b410-6c2936442735/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/9d4732ff-9f42-494a-a119-a2a81bd03dab/
     body:
       encoding: UTF-8
       base64_string: |
@@ -762,7 +550,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:27 GMT
+      - Thu, 19 Sep 2019 14:45:01 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -780,18 +568,18 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2UyNmVhOWI1LWUzNDAtNDM4
-        Yy04NGE3LWY5NjAxODk2MmNhYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzgwOGJjNTY3LTdjNDQtNGE0
+        Mi05ODRkLWVhYzE1ODQ4YjY2YS8ifQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:27 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:01 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/bfca9403-0ec2-4a3b-b410-6c2936442735/sync/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/9d4732ff-9f42-494a-a119-a2a81bd03dab/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4
-        ZDgzZi02MGRiLTQyYTktYjViOS1iN2I4ZjIzNjZhMDIvIiwibWlycm9yIjp0
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy81ODZl
+        YzM5NC05YjIzLTRlODMtYmFmMy1iOWFmZGNmOGY3ZDAvIiwibWlycm9yIjp0
         cnVlfQ==
     headers:
       Content-Type:
@@ -810,7 +598,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:28 GMT
+      - Thu, 19 Sep 2019 14:45:01 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -828,13 +616,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2FmZjM5MjE4LTFmNjYtNDU1
-        OS04Zjc2LWZiM2NhODVjMmE5NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFiOWIwZDI3LWVjM2QtNGRk
+        MC1hMzQyLWU4OGMyZDhmY2QwOC8ifQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:28 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:01 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/aff39218-1f66-4559-8f76-fb3ca85c2a95/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/1b9b0d27-ec3d-4dd0-a342-e88c2d8fcd08/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -855,7 +643,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:28 GMT
+      - Thu, 19 Sep 2019 14:45:02 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -869,16 +657,16 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel.jjeffers.example.com
       Content-Length:
-      - '504'
+      - '507'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hZmYzOTIxOC0xZjY2LTQ1
-        NTktOGY3Ni1mYjNjYTg1YzJhOTUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
-        VDEyOjQzOjI4LjA2NDE1NFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8xYjliMGQyNy1lYzNkLTRk
+        ZDAtYTM0Mi1lODhjMmQ4ZmNkMDgvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTE5
+        VDE0OjQ1OjAxLjU5MzM0N1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
         OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
-        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wOS0wOVQxMjo0MzoyOC4xNjMyODda
-        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjQzOjI4LjM2NDEzMloi
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wOS0xOVQxNDo0NTowMS43NTU0Mzda
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA5LTE5VDE0OjQ1OjAyLjM2ODc0NVoi
         LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
         Ii9wdWxwL2FwaS92My93b3JrZXJzL2FmODUzYzcyLTE0NjQtNGY3Yy1hMDM1
         LTQ3MTY2NTNjZWUzOS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
@@ -888,22 +676,22 @@ http_interactions:
         IEFydGlmYWN0cyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
         ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRp
         bmcgQ29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRv
+        bmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2luZyBNZXRh
+        ZGF0YSBMaW5lcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRv
         bmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRp
         bmcgQ29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGws
-        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2luZyBN
-        ZXRhZGF0YSBMaW5lcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMs
-        ImRvbmUiOjMsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6
-        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2I2OThkODNmLTYwZGItNDJh
-        OS1iNWI5LWI3YjhmMjM2NmEwMi92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9y
-        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUv
-        ZmlsZS9iZmNhOTQwMy0wZWMyLTRhM2ItYjQxMC02YzI5MzY0NDI3MzUvIiwi
-        L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4ZDgzZi02MGRiLTQyYTkt
-        YjViOS1iN2I4ZjIzNjZhMDIvIl19
+        ImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6
+        WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzU4NmVjMzk0LTliMjMtNGU4
+        My1iYWYzLWI5YWZkY2Y4ZjdkMC92ZXJzaW9ucy8xLyJdLCJyZXNlcnZlZF9y
+        ZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        NTg2ZWMzOTQtOWIyMy00ZTgzLWJhZjMtYjlhZmRjZjhmN2QwLyIsIi9wdWxw
+        L2FwaS92My9yZW1vdGVzL2ZpbGUvZmlsZS85ZDQ3MzJmZi05ZjQyLTQ5NGEt
+        YTExOS1hMmE4MWJkMDNkYWIvIl19
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:28 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:02 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/b698d83f-60db-42a9-b5b9-b7b8f2366a02/versions/1/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/586ec394-9b23-4e83-baf3-b9afdcf8f7d0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -924,7 +712,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:28 GMT
+      - Thu, 19 Sep 2019 14:45:02 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -938,24 +726,24 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel.jjeffers.example.com
       Content-Length:
-      - '236'
+      - '237'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYjY5OGQ4M2Yt
-        NjBkYi00MmE5LWI1YjktYjdiOGYyMzY2YTAyL3ZlcnNpb25zLzEvIiwiX2Ny
-        ZWF0ZWQiOiIyMDE5LTA5LTA5VDEyOjQzOjI4LjE4OTIzNloiLCJudW1iZXIi
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNTg2ZWMzOTQt
+        OWIyMy00ZTgzLWJhZjMtYjlhZmRjZjhmN2QwL3ZlcnNpb25zLzEvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTE5VDE0OjQ1OjAxLjc5NDY2NFoiLCJudW1iZXIi
         OjEsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
         ZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2Fw
         aS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9h
-        ZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2I2OThkODNmLTYwZGIt
-        NDJhOS1iNWI5LWI3YjhmMjM2NmEwMi92ZXJzaW9ucy8xLyJ9fSwicmVtb3Zl
+        ZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzU4NmVjMzk0LTliMjMt
+        NGU4My1iYWYzLWI5YWZkY2Y4ZjdkMC92ZXJzaW9ucy8xLyJ9fSwicmVtb3Zl
         ZCI6e30sInByZXNlbnQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVm
         IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9y
-        eV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYjY5OGQ4M2Yt
-        NjBkYi00MmE5LWI1YjktYjdiOGYyMzY2YTAyL3ZlcnNpb25zLzEvIn19fX0=
+        eV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNTg2ZWMzOTQt
+        OWIyMy00ZTgzLWJhZjMtYjlhZmRjZjhmN2QwL3ZlcnNpb25zLzEvIn19fX0=
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:28 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:02 GMT
 - request:
     method: post
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/publications/file/file/
@@ -963,7 +751,7 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2I2OThkODNmLTYwZGItNDJhOS1iNWI5LWI3YjhmMjM2NmEwMi92ZXJz
+        aWVzLzU4NmVjMzk0LTliMjMtNGU4My1iYWYzLWI5YWZkY2Y4ZjdkMC92ZXJz
         aW9ucy8xLyIsIm1hbmlmZXN0IjoiUFVMUF9NQU5JRkVTVCJ9
     headers:
       Content-Type:
@@ -982,7 +770,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:28 GMT
+      - Thu, 19 Sep 2019 14:45:02 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -1000,13 +788,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2NlYjRiM2Y0LTE4N2UtNDI5
-        Zi1hYjFkLWM3MGVhZTNhNmRkYy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzFiYWFkNzNhLTVkZTQtNDIy
+        Ni05NTQ2LTE5NWNjYmMzZWNmNy8ifQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:28 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:02 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/ceb4b3f4-187e-429f-ab1d-c70eae3a6ddc/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/1baad73a-5de4-4226-9546-195ccbc3ecf7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1027,7 +815,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:28 GMT
+      - Thu, 19 Sep 2019 14:45:03 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -1045,22 +833,22 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jZWI0YjNmNC0xODdlLTQy
-        OWYtYWIxZC1jNzBlYWUzYTZkZGMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
-        VDEyOjQzOjI4LjgwNjgzMloiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8xYmFhZDczYS01ZGU0LTQy
+        MjYtOTU0Ni0xOTVjY2JjM2VjZjcvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTE5
+        VDE0OjQ1OjAyLjk0NDMxN1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
         OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnB1Ymxpc2hpbmcucHVibGlzaCIsInN0
-        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjQzOjI4LjkyNDUxNFoiLCJmaW5p
-        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6NDM6MjguOTgwNTc2WiIsIm5vbl9m
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTE5VDE0OjQ1OjAzLjA2NjQ0MVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMTlUMTQ6NDU6MDMuMTMwMDc2WiIsIm5vbl9m
         YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
-        YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
-        N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        YXBpL3YzL3dvcmtlcnMvYWY4NTNjNzItMTQ2NC00ZjdjLWEwMzUtNDcxNjY1
+        M2NlZTM5LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
         b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
-        cC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUvZmlsZS9hY2VkMzM0YS1hODAz
-        LTRjNDItYTk4NC1lNzJkZjMzMGFiZDEvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4ZDgz
-        Zi02MGRiLTQyYTktYjViOS1iN2I4ZjIzNjZhMDIvIl19
+        cC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUvZmlsZS8wMzZjYjE1Zi00YTdj
+        LTQwNWUtYWMxYi1hNDliZWUyZjgwY2YvIl0sInJlc2VydmVkX3Jlc291cmNl
+        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy81ODZlYzM5
+        NC05YjIzLTRlODMtYmFmMy1iOWFmZGNmOGY3ZDAvIl19
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:28 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:03 GMT
 - request:
     method: post
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/
@@ -1070,8 +858,8 @@ http_interactions:
         eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
         bHAzX0ZpbGVfMSIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
         bmV0LXB1bHAzX0ZpbGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3Yz
-        L3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvYWNlZDMzNGEtYTgwMy00YzQyLWE5
-        ODQtZTcyZGYzMzBhYmQxLyJ9
+        L3B1YmxpY2F0aW9ucy9maWxlL2ZpbGUvMDM2Y2IxNWYtNGE3Yy00MDVlLWFj
+        MWItYTQ5YmVlMmY4MGNmLyJ9
     headers:
       Content-Type:
       - application/json
@@ -1089,7 +877,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:29 GMT
+      - Thu, 19 Sep 2019 14:45:03 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -1107,13 +895,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2VkZGNhYTkyLWE5NzAtNDE5
-        MC04ZDY1LTYyZWIyNGViOTBlMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q5ZjAzYzMwLTQ2OWUtNGJm
+        NC05ODM3LWRkMGFlNDg0NmI0MS8ifQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:29 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:03 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/eddcaa92-a970-4190-8d65-62eb24eb90e0/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/d9f03c30-469e-4bf4-9837-dd0ae4846b41/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1134,7 +922,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:29 GMT
+      - Thu, 19 Sep 2019 14:45:03 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -1148,28 +936,28 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel.jjeffers.example.com
       Content-Length:
-      - '344'
+      - '347'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9lZGRjYWE5Mi1hOTcwLTQx
-        OTAtOGQ2NS02MmViMjRlYjkwZTAvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
-        VDEyOjQzOjI5LjE4MzM2N1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kOWYwM2MzMC00NjllLTRi
+        ZjQtOTgzNy1kZDBhZTQ4NDZiNDEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTE5
+        VDE0OjQ1OjAzLjM3NjczOFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
         OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsInN0
-        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjQzOjI5LjI5MDg5OVoiLCJmaW5p
-        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6NDM6MjkuNTYwMjM1WiIsIm5vbl9m
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTE5VDE0OjQ1OjAzLjUwODQ3OFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMTlUMTQ6NDU6MDMuNzIyNjA4WiIsIm5vbl9m
         YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
         YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
         N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
         b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
-        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxlL2ZpbGUvMGEyZGQwNDAtZTdk
-        OC00YTlkLWI0YTQtYmQyODIxNDdjMWVmLyJdLCJyZXNlcnZlZF9yZXNvdXJj
+        cC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxlL2ZpbGUvYTkxZjlkMTgtM2Q5
+        Zi00ZjA0LThiY2ItZThlZWNkOTY3YmI5LyJdLCJyZXNlcnZlZF9yZXNvdXJj
         ZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iXX0=
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:29 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:03 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/0a2dd040-e7d8-4a9d-b4a4-bd282147c1ef/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/a91f9d18-3d9f-4f04-8bcb-e8eecd967bb9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1190,7 +978,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:29 GMT
+      - Thu, 19 Sep 2019 14:45:03 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -1204,26 +992,26 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel.jjeffers.example.com
       Content-Length:
-      - '283'
+      - '281'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2ZpbGUvZmls
-        ZS8wYTJkZDA0MC1lN2Q4LTRhOWQtYjRhNC1iZDI4MjE0N2MxZWYvIiwiX2Ny
-        ZWF0ZWQiOiIyMDE5LTA5LTA5VDEyOjQzOjI5LjU0ODIzMFoiLCJiYXNlX3Bh
+        ZS9hOTFmOWQxOC0zZDlmLTRmMDQtOGJjYi1lOGVlY2Q5NjdiYjkvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTE5VDE0OjQ1OjAzLjcwOTQ5NloiLCJiYXNlX3Bh
         dGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1bHAzX0ZpbGVf
         MSIsImJhc2VfdXJsIjoiY2VudG9zNy1rYXRlbGxvLWRldmVsLmpqZWZmZXJz
         LmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9EZWZhdWx0X09yZ2FuaXphdGlv
         bi9saWJyYXJ5L3B1bHAzX0ZpbGVfMSIsImNvbnRlbnRfZ3VhcmQiOm51bGws
         Im5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0Zp
         bGVfMSIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9u
-        cy9maWxlL2ZpbGUvYWNlZDMzNGEtYTgwMy00YzQyLWE5ODQtZTcyZGYzMzBh
-        YmQxLyJ9
+        cy9maWxlL2ZpbGUvMDM2Y2IxNWYtNGE3Yy00MDVlLWFjMWItYTQ5YmVlMmY4
+        MGNmLyJ9
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:29 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:03 GMT
 - request:
     method: put
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/b698d83f-60db-42a9-b5b9-b7b8f2366a02/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/586ec394-9b23-4e83-baf3-b9afdcf8f7d0/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1246,7 +1034,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:30 GMT
+      - Thu, 19 Sep 2019 14:45:04 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -1264,13 +1052,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2MyNDQ2OWU4LThjNGYtNGYw
-        Zi05MDM4LWNlNmRiZjRkMjVkNy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQyNGZmZDgzLTlhZTMtNDM3
+        Mi1hMjNhLWRkNjMyMzMyZmFmNS8ifQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:30 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:04 GMT
 - request:
     method: patch
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/bfca9403-0ec2-4a3b-b410-6c2936442735/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/9d4732ff-9f42-494a-a119-a2a81bd03dab/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1297,7 +1085,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:30 GMT
+      - Thu, 19 Sep 2019 14:45:04 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -1315,18 +1103,18 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2JlY2M4OGU2LTE0ZWUtNDVj
-        Yy1hYzI3LTlhZTVhNDQ5YzRiNS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q4ZWViZjMyLWY1ODAtNDA2
+        ZC1iNjhkLTBmYTFiYzZiMTViMi8ifQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:30 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:04 GMT
 - request:
     method: post
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/bfca9403-0ec2-4a3b-b410-6c2936442735/sync/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/9d4732ff-9f42-494a-a119-a2a81bd03dab/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4
-        ZDgzZi02MGRiLTQyYTktYjViOS1iN2I4ZjIzNjZhMDIvIiwibWlycm9yIjp0
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy81ODZl
+        YzM5NC05YjIzLTRlODMtYmFmMy1iOWFmZGNmOGY3ZDAvIiwibWlycm9yIjp0
         cnVlfQ==
     headers:
       Content-Type:
@@ -1345,7 +1133,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:30 GMT
+      - Thu, 19 Sep 2019 14:45:04 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -1363,13 +1151,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzk1YjJmYWU4LTRiYjMtNDBm
-        MC05MTE4LTZhODI3MmI2M2I3NS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I5NDZkZmNlLTYyMjYtNGU4
+        OS1iYmJmLTM2Zjc5M2IzZWYzMS8ifQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:30 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:04 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/95b2fae8-4bb3-40f0-9118-6a8272b63b75/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/b946dfce-6226-4e89-bbbf-36f793b3ef31/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1390,7 +1178,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:31 GMT
+      - Thu, 19 Sep 2019 14:45:05 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -1408,12 +1196,12 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85NWIyZmFlOC00YmIzLTQw
-        ZjAtOTExOC02YTgyNzJiNjNiNzUvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
-        VDEyOjQzOjMwLjk3NDkwOVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9iOTQ2ZGZjZS02MjI2LTRl
+        ODktYmJiZi0zNmY3OTNiM2VmMzEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTE5
+        VDE0OjQ1OjA0Ljk3NDkyN1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
         OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnN5bmNocm9uaXppbmcuc3luY2hyb25p
-        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wOS0wOVQxMjo0MzozMS4wODA4MzVa
-        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjQzOjMxLjMyMjE0MVoi
+        emUiLCJzdGFydGVkX2F0IjoiMjAxOS0wOS0xOVQxNDo0NTowNS4xNDQxNzRa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTA5LTE5VDE0OjQ1OjA1LjM3NTcyMFoi
         LCJub25fZmF0YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6
         Ii9wdWxwL2FwaS92My93b3JrZXJzL2FmODUzYzcyLTE0NjQtNGY3Yy1hMDM1
         LTQ3MTY2NTNjZWUzOS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3Mi
@@ -1428,17 +1216,17 @@ http_interactions:
         bmUiOjMsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2luZyBNZXRh
         ZGF0YSBMaW5lcyIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjMsImRv
         bmUiOjMsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIv
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2I2OThkODNmLTYwZGItNDJhOS1i
-        NWI5LWI3YjhmMjM2NmEwMi92ZXJzaW9ucy8yLyJdLCJyZXNlcnZlZF9yZXNv
-        dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUvZmls
-        ZS9iZmNhOTQwMy0wZWMyLTRhM2ItYjQxMC02YzI5MzY0NDI3MzUvIiwiL3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4ZDgzZi02MGRiLTQyYTktYjVi
-        OS1iN2I4ZjIzNjZhMDIvIl19
+        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzU4NmVjMzk0LTliMjMtNGU4My1i
+        YWYzLWI5YWZkY2Y4ZjdkMC92ZXJzaW9ucy8yLyJdLCJyZXNlcnZlZF9yZXNv
+        dXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNTg2
+        ZWMzOTQtOWIyMy00ZTgzLWJhZjMtYjlhZmRjZjhmN2QwLyIsIi9wdWxwL2Fw
+        aS92My9yZW1vdGVzL2ZpbGUvZmlsZS85ZDQ3MzJmZi05ZjQyLTQ5NGEtYTEx
+        OS1hMmE4MWJkMDNkYWIvIl19
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:31 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:05 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/b698d83f-60db-42a9-b5b9-b7b8f2366a02/versions/2/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/586ec394-9b23-4e83-baf3-b9afdcf8f7d0/versions/2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1459,7 +1247,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:31 GMT
+      - Thu, 19 Sep 2019 14:45:05 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -1473,28 +1261,28 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel.jjeffers.example.com
       Content-Length:
-      - '239'
+      - '240'
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYjY5OGQ4M2Yt
-        NjBkYi00MmE5LWI1YjktYjdiOGYyMzY2YTAyL3ZlcnNpb25zLzIvIiwiX2Ny
-        ZWF0ZWQiOiIyMDE5LTA5LTA5VDEyOjQzOjMxLjEyNjIzMVoiLCJudW1iZXIi
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNTg2ZWMzOTQt
+        OWIyMy00ZTgzLWJhZjMtYjlhZmRjZjhmN2QwL3ZlcnNpb25zLzIvIiwiX2Ny
+        ZWF0ZWQiOiIyMDE5LTA5LTE5VDE0OjQ1OjA1LjE3MzY3MloiLCJudW1iZXIi
         OjIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
         ZGVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2Fw
         aS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lvbl9h
-        ZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2I2OThkODNmLTYwZGIt
-        NDJhOS1iNWI5LWI3YjhmMjM2NmEwMi92ZXJzaW9ucy8yLyJ9fSwicmVtb3Zl
+        ZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzU4NmVjMzk0LTliMjMt
+        NGU4My1iYWYzLWI5YWZkY2Y4ZjdkMC92ZXJzaW9ucy8yLyJ9fSwicmVtb3Zl
         ZCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkv
         djMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fcmVt
-        b3ZlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2I2OThkODNmLTYwZGIt
-        NDJhOS1iNWI5LWI3YjhmMjM2NmEwMi92ZXJzaW9ucy8yLyJ9fSwicHJlc2Vu
+        b3ZlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzU4NmVjMzk0LTliMjMt
+        NGU4My1iYWYzLWI5YWZkY2Y4ZjdkMC92ZXJzaW9ucy8yLyJ9fSwicHJlc2Vu
         dCI6eyJmaWxlLmZpbGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkv
         djMvY29udGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4ZDgzZi02MGRiLTQyYTktYjVi
-        OS1iN2I4ZjIzNjZhMDIvdmVyc2lvbnMvMi8ifX19fQ==
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy81ODZlYzM5NC05YjIzLTRlODMtYmFm
+        My1iOWFmZGNmOGY3ZDAvdmVyc2lvbnMvMi8ifX19fQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:31 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:05 GMT
 - request:
     method: post
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/publications/file/file/
@@ -1502,7 +1290,7 @@ http_interactions:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2I2OThkODNmLTYwZGItNDJhOS1iNWI5LWI3YjhmMjM2NmEwMi92ZXJz
+        aWVzLzU4NmVjMzk0LTliMjMtNGU4My1iYWYzLWI5YWZkY2Y4ZjdkMC92ZXJz
         aW9ucy8yLyIsIm1hbmlmZXN0IjoiUFVMUF9NQU5JRkVTVCJ9
     headers:
       Content-Type:
@@ -1521,7 +1309,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:31 GMT
+      - Thu, 19 Sep 2019 14:45:05 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -1539,13 +1327,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2I5MzM0ZDlmLWJlYTMtNGFl
-        My04YWNkLTE5NTE1ZDAxNzkxZi8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2E1MjIxYTk3LWI2ZWMtNDQ1
+        OS1iMWY5LThkMmZkYjE4NTBhZC8ifQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:31 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:05 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/b9334d9f-bea3-4ae3-8acd-19515d01791f/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/a5221a97-b6ec-4459-b1f9-8d2fdb1850ad/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1566,7 +1354,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:32 GMT
+      - Thu, 19 Sep 2019 14:45:06 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -1584,30 +1372,30 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9iOTMzNGQ5Zi1iZWEzLTRh
-        ZTMtOGFjZC0xOTUxNWQwMTc5MWYvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
-        VDEyOjQzOjMxLjg5NTEzMFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hNTIyMWE5Ny1iNmVjLTQ0
+        NTktYjFmOS04ZDJmZGIxODUwYWQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTE5
+        VDE0OjQ1OjA1Ljc4OTM4MVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
         OiJwdWxwX2ZpbGUuYXBwLnRhc2tzLnB1Ymxpc2hpbmcucHVibGlzaCIsInN0
-        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjQzOjMxLjk4NTgwNloiLCJmaW5p
-        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6NDM6MzIuMDQzNzAyWiIsIm5vbl9m
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTE5VDE0OjQ1OjA1LjkyNDA2MVoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMTlUMTQ6NDU6MDYuMDA3MzUwWiIsIm5vbl9m
         YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
         YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
         N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
         b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVs
-        cC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUvZmlsZS8xNzEwYzQ4Zi0zOGQz
-        LTQwZDItOTZiZi05NzE5NmEzODRlYmYvIl0sInJlc2VydmVkX3Jlc291cmNl
-        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4ZDgz
-        Zi02MGRiLTQyYTktYjViOS1iN2I4ZjIzNjZhMDIvIl19
+        cC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUvZmlsZS85ZDZhMDE4NS04MTAw
+        LTQ5MDgtYjJlOS1mN2I2YjA1NmVkN2EvIl0sInJlc2VydmVkX3Jlc291cmNl
+        c19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy81ODZlYzM5
+        NC05YjIzLTRlODMtYmFmMy1iOWFmZGNmOGY3ZDAvIl19
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:32 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:06 GMT
 - request:
     method: patch
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/0a2dd040-e7d8-4a9d-b4a4-bd282147c1ef/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/a91f9d18-3d9f-4f04-8bcb-e8eecd967bb9/
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmls
-        ZS9maWxlLzE3MTBjNDhmLTM4ZDMtNDBkMi05NmJmLTk3MTk2YTM4NGViZi8i
+        ZS9maWxlLzlkNmEwMTg1LTgxMDAtNDkwOC1iMmU5LWY3YjZiMDU2ZWQ3YS8i
         fQ==
     headers:
       Content-Type:
@@ -1626,7 +1414,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:32 GMT
+      - Thu, 19 Sep 2019 14:45:06 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -1644,13 +1432,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QyNjQ4YWQ0LWVhNzgtNDFj
-        Yi1hNTFjLTUzYWViMjliZjg2OS8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2ZmNDlhMmYyLWZmOTgtNGU5
+        Zi04YjYzLTEzZTNlMjdkYTBhMS8ifQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:32 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:06 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/d2648ad4-ea78-41cb-a51c-53aeb29bf869/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/ff49a2f2-ff98-4e9f-8b63-13e3e27da0a1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1671,7 +1459,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:32 GMT
+      - Thu, 19 Sep 2019 14:45:06 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -1689,20 +1477,20 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9kMjY0OGFkNC1lYTc4LTQx
-        Y2ItYTUxYy01M2FlYjI5YmY4NjkvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
-        VDEyOjQzOjMyLjI2MjEyN1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9mZjQ5YTJmMi1mZjk4LTRl
+        OWYtOGI2My0xM2UzZTI3ZGEwYTEvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTE5
+        VDE0OjQ1OjA2LjI4NzU4M1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
         OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX3VwZGF0ZSIsInN0
-        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjQzOjMyLjM2MDA2NVoiLCJmaW5p
-        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6NDM6MzIuNDU1NjI5WiIsIm5vbl9m
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTE5VDE0OjQ1OjA2LjQzNzkwOFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMTlUMTQ6NDU6MDYuNTk4MTIwWiIsIm5vbl9m
         YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
-        YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
-        N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        YXBpL3YzL3dvcmtlcnMvYWY4NTNjNzItMTQ2NC00ZjdjLWEwMzUtNDcxNjY1
+        M2NlZTM5LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
         b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJl
         c2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2FwaS92My9kaXN0cmlidXRp
         b25zLyJdfQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:32 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:06 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/
@@ -1726,7 +1514,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:32 GMT
+      - Thu, 19 Sep 2019 14:45:07 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -1740,201 +1528,148 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel.jjeffers.example.com
       Content-Length:
-      - '349'
-    body:
-      encoding: ASCII-8BIT
-      base64_string: |
-        eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4
-        ZDgzZi02MGRiLTQyYTktYjViOS1iN2I4ZjIzNjZhMDIvIiwiX2NyZWF0ZWQi
-        OiIyMDE5LTA5LTA5VDEyOjQzOjI2Ljg5MDEwOFoiLCJfdmVyc2lvbnNfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYjY5OGQ4M2YtNjBkYi00
-        MmE5LWI1YjktYjdiOGYyMzY2YTAyL3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVy
-        c2lvbl9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4ZDgz
-        Zi02MGRiLTQyYTktYjViOS1iN2I4ZjIzNjZhMDIvdmVyc2lvbnMvMi8iLCJu
-        YW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxl
-        XzEiLCJkZXNjcmlwdGlvbiI6bnVsbH0seyJfaHJlZiI6Ii9wdWxwL2FwaS92
-        My9yZXBvc2l0b3JpZXMvOTU5Y2YwOWItNzExMy00M2YxLWEwMGEtNGY3ZjRj
-        M2QwNDhiLyIsIl9jcmVhdGVkIjoiMjAxOS0wOS0wNlQxNzo0Mjo0MC40NTUz
-        NTBaIiwiX3ZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzLzk1OWNmMDliLTcxMTMtNDNmMS1hMDBhLTRmN2Y0YzNkMDQ4Yi92ZXJz
-        aW9ucy8iLCJfbGF0ZXN0X3ZlcnNpb25faHJlZiI6bnVsbCwibmFtZSI6IkRl
-        ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRG9ja2VyXzEiLCJk
-        ZXNjcmlwdGlvbiI6bnVsbH0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvYmQ1MDRmOTAtM2UyZC00ZTU1LWEzMjYtNjQ1YTViNTNkYjU2
-        LyIsIl9jcmVhdGVkIjoiMjAxOS0wOS0wNlQxNzo0NDowMy42NTM3NjNaIiwi
-        X3ZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2Jk
-        NTA0ZjkwLTNlMmQtNGU1NS1hMzI2LTY0NWE1YjUzZGI1Ni92ZXJzaW9ucy8i
-        LCJfbGF0ZXN0X3ZlcnNpb25faHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRf
-        T3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMiLCJkZXNjcmlwdGlvbiI6
-        bnVsbH1dfQ==
-    http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:32 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/b698d83f-60db-42a9-b5b9-b7b8f2366a02/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 09 Sep 2019 12:43:33 GMT
-      Server:
-      - gunicorn/19.9.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie,Accept-Encoding
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Via:
-      - 1.1 centos7-katello-devel.jjeffers.example.com
-      Content-Length:
-      - '294'
+      - '306'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4
-        ZDgzZi02MGRiLTQyYTktYjViOS1iN2I4ZjIzNjZhMDIvdmVyc2lvbnMvMi8i
-        LCJfY3JlYXRlZCI6IjIwMTktMDktMDlUMTI6NDM6MzEuMTI2MjMxWiIsIm51
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy8zMGVl
+        YTY4OS1hNGRhLTQyNTUtYjkzYy0wYjRlMTJjNzMyZmIvIiwiX2NyZWF0ZWQi
+        OiIyMDE5LTA5LTE3VDEzOjQ0OjMyLjcxMjg4OFoiLCJfdmVyc2lvbnNfaHJl
+        ZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvMzBlZWE2ODktYTRkYS00
+        MjU1LWI5M2MtMGI0ZTEyYzczMmZiL3ZlcnNpb25zLyIsIl9sYXRlc3RfdmVy
+        c2lvbl9ocmVmIjpudWxsLCJuYW1lIjoiU21hbGxSZXBvLTk5ODQiLCJkZXNj
+        cmlwdGlvbiI6bnVsbH0seyJfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvNTg2ZWMzOTQtOWIyMy00ZTgzLWJhZjMtYjlhZmRjZjhmN2QwLyIs
+        Il9jcmVhdGVkIjoiMjAxOS0wOS0xOVQxNDo0NTowMC4yOTUwNjNaIiwiX3Zl
+        cnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzU4NmVj
+        Mzk0LTliMjMtNGU4My1iYWYzLWI5YWZkY2Y4ZjdkMC92ZXJzaW9ucy8iLCJf
+        bGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvNTg2ZWMzOTQtOWIyMy00ZTgzLWJhZjMtYjlhZmRjZjhmN2QwL3ZlcnNp
+        b25zLzIvIiwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQt
+        cHVscDNfRmlsZV8xIiwiZGVzY3JpcHRpb24iOm51bGx9XX0=
+    http_version: 
+  recorded_at: Thu, 19 Sep 2019 14:45:07 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/30eea689-a4da-4255-b93c-0b4e12c732fb/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 19 Sep 2019 14:45:07 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 19 Sep 2019 14:45:07 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/586ec394-9b23-4e83-baf3-b9afdcf8f7d0/versions/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 19 Sep 2019 14:45:07 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '296'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy81ODZl
+        YzM5NC05YjIzLTRlODMtYmFmMy1iOWFmZGNmOGY3ZDAvdmVyc2lvbnMvMi8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDktMTlUMTQ6NDU6MDUuMTczNjcyWiIsIm51
         bWJlciI6MiwiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250ZW50X3N1bW1hcnki
         OnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVmIjoiL3B1
         bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJz
-        aW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYjY5OGQ4M2Yt
-        NjBkYi00MmE5LWI1YjktYjdiOGYyMzY2YTAyL3ZlcnNpb25zLzIvIn19LCJy
+        aW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNTg2ZWMzOTQt
+        OWIyMy00ZTgzLWJhZjMtYjlhZmRjZjhmN2QwL3ZlcnNpb25zLzIvIn19LCJy
         ZW1vdmVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxw
         L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
-        bl9yZW1vdmVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYjY5OGQ4M2Yt
-        NjBkYi00MmE5LWI1YjktYjdiOGYyMzY2YTAyL3ZlcnNpb25zLzIvIn19LCJw
+        bl9yZW1vdmVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNTg2ZWMzOTQt
+        OWIyMy00ZTgzLWJhZjMtYjlhZmRjZjhmN2QwL3ZlcnNpb25zLzIvIn19LCJw
         cmVzZW50Ijp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxw
         L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
-        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2I2OThkODNmLTYwZGItNDJh
-        OS1iNWI5LWI3YjhmMjM2NmEwMi92ZXJzaW9ucy8yLyJ9fX19LHsiX2hyZWYi
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2I2OThkODNmLTYwZGItNDJh
-        OS1iNWI5LWI3YjhmMjM2NmEwMi92ZXJzaW9ucy8xLyIsIl9jcmVhdGVkIjoi
-        MjAxOS0wOS0wOVQxMjo0MzoyOC4xODkyMzZaIiwibnVtYmVyIjoxLCJiYXNl
+        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzU4NmVjMzk0LTliMjMtNGU4
+        My1iYWYzLWI5YWZkY2Y4ZjdkMC92ZXJzaW9ucy8yLyJ9fX19LHsiX2hyZWYi
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzU4NmVjMzk0LTliMjMtNGU4
+        My1iYWYzLWI5YWZkY2Y4ZjdkMC92ZXJzaW9ucy8xLyIsIl9jcmVhdGVkIjoi
+        MjAxOS0wOS0xOVQxNDo0NTowMS43OTQ2NjRaIiwibnVtYmVyIjoxLCJiYXNl
         X3ZlcnNpb24iOm51bGwsImNvbnRlbnRfc3VtbWFyeSI6eyJhZGRlZCI6eyJm
         aWxlLmZpbGUiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkvdjMvY29u
         dGVudC9maWxlL2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb25fYWRkZWQ9L3B1
-        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4ZDgzZi02MGRiLTQyYTktYjVi
-        OS1iN2I4ZjIzNjZhMDIvdmVyc2lvbnMvMS8ifX0sInJlbW92ZWQiOnt9LCJw
+        bHAvYXBpL3YzL3JlcG9zaXRvcmllcy81ODZlYzM5NC05YjIzLTRlODMtYmFm
+        My1iOWFmZGNmOGY3ZDAvdmVyc2lvbnMvMS8ifX0sInJlbW92ZWQiOnt9LCJw
         cmVzZW50Ijp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxw
         L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
-        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2I2OThkODNmLTYwZGItNDJh
-        OS1iNWI5LWI3YjhmMjM2NmEwMi92ZXJzaW9ucy8xLyJ9fX19XX0=
+        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzU4NmVjMzk0LTliMjMtNGU4
+        My1iYWYzLWI5YWZkY2Y4ZjdkMC92ZXJzaW9ucy8xLyJ9fX19XX0=
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:33 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/959cf09b-7113-43f1-a00a-4f7f4c3d048b/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 09 Sep 2019 12:43:33 GMT
-      Server:
-      - gunicorn/19.9.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '52'
-      Via:
-      - 1.1 centos7-katello-devel.jjeffers.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:33 GMT
-- request:
-    method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/bd504f90-3e2d-4e55-a326-645a5b53db56/versions/?limit=2000&offset=0
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.0.0rc5.dev01567443997/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic YWRtaW46cGFzc3dvcmQ=
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 09 Sep 2019 12:43:33 GMT
-      Server:
-      - gunicorn/19.9.0
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - SAMEORIGIN
-      Content-Length:
-      - '52'
-      Via:
-      - 1.1 centos7-katello-devel.jjeffers.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-    http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:33 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:07 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/b698d83f-60db-42a9-b5b9-b7b8f2366a02/versions/1/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/586ec394-9b23-4e83-baf3-b9afdcf8f7d0/versions/1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1955,7 +1690,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:33 GMT
+      - Thu, 19 Sep 2019 14:45:07 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -1973,13 +1708,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzYwYWViZTVhLTZmNzQtNGU5
-        Ni04ZTIxLTIyNzI2ZDBjZDM0ZC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzRhNDRiNmVkLWM3N2ItNGRl
+        Yi05MWZiLTIzODQxODQyNDQ5MC8ifQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:33 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:07 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/b698d83f-60db-42a9-b5b9-b7b8f2366a02/versions/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/586ec394-9b23-4e83-baf3-b9afdcf8f7d0/versions/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2000,7 +1735,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:33 GMT
+      - Thu, 19 Sep 2019 14:45:07 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -2014,32 +1749,32 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel.jjeffers.example.com
       Content-Length:
-      - '264'
+      - '267'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iNjk4
-        ZDgzZi02MGRiLTQyYTktYjViOS1iN2I4ZjIzNjZhMDIvdmVyc2lvbnMvMi8i
-        LCJfY3JlYXRlZCI6IjIwMTktMDktMDlUMTI6NDM6MzEuMTI2MjMxWiIsIm51
+        dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy81ODZl
+        YzM5NC05YjIzLTRlODMtYmFmMy1iOWFmZGNmOGY3ZDAvdmVyc2lvbnMvMi8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDktMTlUMTQ6NDU6MDUuMTczNjcyWiIsIm51
         bWJlciI6MiwiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250ZW50X3N1bW1hcnki
         OnsiYWRkZWQiOnsiZmlsZS5maWxlIjp7ImNvdW50IjozLCJocmVmIjoiL3B1
         bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy8/cmVwb3NpdG9yeV92ZXJz
-        aW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYjY5OGQ4M2Yt
-        NjBkYi00MmE5LWI1YjktYjdiOGYyMzY2YTAyL3ZlcnNpb25zLzIvIn19LCJy
+        aW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNTg2ZWMzOTQt
+        OWIyMy00ZTgzLWJhZjMtYjlhZmRjZjhmN2QwL3ZlcnNpb25zLzIvIn19LCJy
         ZW1vdmVkIjp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxw
         L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
-        bl9yZW1vdmVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvYjY5OGQ4M2Yt
-        NjBkYi00MmE5LWI1YjktYjdiOGYyMzY2YTAyL3ZlcnNpb25zLzIvIn19LCJw
+        bl9yZW1vdmVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvNTg2ZWMzOTQt
+        OWIyMy00ZTgzLWJhZjMtYjlhZmRjZjhmN2QwL3ZlcnNpb25zLzIvIn19LCJw
         cmVzZW50Ijp7ImZpbGUuZmlsZSI6eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxw
         L2FwaS92My9jb250ZW50L2ZpbGUvZmlsZXMvP3JlcG9zaXRvcnlfdmVyc2lv
-        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2I2OThkODNmLTYwZGItNDJh
-        OS1iNWI5LWI3YjhmMjM2NmEwMi92ZXJzaW9ucy8yLyJ9fX19XX0=
+        bj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzU4NmVjMzk0LTliMjMtNGU4
+        My1iYWYzLWI5YWZkY2Y4ZjdkMC92ZXJzaW9ucy8yLyJ9fX19XX0=
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:33 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:07 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/bfca9403-0ec2-4a3b-b410-6c2936442735/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/9d4732ff-9f42-494a-a119-a2a81bd03dab/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2060,7 +1795,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:34 GMT
+      - Thu, 19 Sep 2019 14:45:08 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -2078,13 +1813,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2M5MGU1MTM3LWFiM2UtNDUx
-        MS1iMDBlLTdlZGNhY2I4OTMzNC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlhZjEzMzJmLWQyZjYtNDIy
+        Ni04ZmNiLTVlNWQ2YzAyNDdhMy8ifQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:34 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:08 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/c90e5137-ab3e-4511-b00e-7edcacb89334/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/9af1332f-d2f6-4226-8fcb-5e5d6c0247a3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2105,7 +1840,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:34 GMT
+      - Thu, 19 Sep 2019 14:45:08 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -2119,25 +1854,25 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel.jjeffers.example.com
       Content-Length:
-      - '336'
+      - '338'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9jOTBlNTEzNy1hYjNlLTQ1
-        MTEtYjAwZS03ZWRjYWNiODkzMzQvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
-        VDEyOjQzOjM0LjA1MTYxMVoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy85YWYxMzMyZi1kMmY2LTQy
+        MjYtOGZjYi01ZTVkNmMwMjQ3YTMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTE5
+        VDE0OjQ1OjA4LjA4NTcxOFoiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
         OiJwdWxwY29yZS5hcHAudGFza3MuYmFzZS5nZW5lcmFsX2RlbGV0ZSIsInN0
-        YXJ0ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjQzOjM0LjEzODczNloiLCJmaW5p
-        c2hlZF9hdCI6IjIwMTktMDktMDlUMTI6NDM6MzQuMTg1NDgyWiIsIm5vbl9m
+        YXJ0ZWRfYXQiOiIyMDE5LTA5LTE5VDE0OjQ1OjA4LjIzNzUyOFoiLCJmaW5p
+        c2hlZF9hdCI6IjIwMTktMDktMTlUMTQ6NDU6MDguMjc1MDM5WiIsIm5vbl9m
         YXRhbF9lcnJvcnMiOltdLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
-        YXBpL3YzL3dvcmtlcnMvYWY4NTNjNzItMTQ2NC00ZjdjLWEwMzUtNDcxNjY1
-        M2NlZTM5LyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
+        YXBpL3YzL3dvcmtlcnMvY2I1MTViOTEtZTM3OS00ZDk5LWJhMGEtNDFhNDFj
+        N2E5MmJkLyIsInBhcmVudCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInBy
         b2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291cmNlcyI6W10sInJl
         c2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlbW90
-        ZXMvZmlsZS9maWxlL2JmY2E5NDAzLTBlYzItNGEzYi1iNDEwLTZjMjkzNjQ0
-        MjczNS8iXX0=
+        ZXMvZmlsZS9maWxlLzlkNDczMmZmLTlmNDItNDk0YS1hMTE5LWEyYTgxYmQw
+        M2RhYi8iXX0=
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:34 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:08 GMT
 - request:
     method: get
     uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
@@ -2161,7 +1896,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:34 GMT
+      - Thu, 19 Sep 2019 14:45:08 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -2175,27 +1910,27 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel.jjeffers.example.com
       Content-Length:
-      - '315'
+      - '316'
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7Il9ocmVmIjoiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMvZmls
-        ZS9maWxlLzBhMmRkMDQwLWU3ZDgtNGE5ZC1iNGE0LWJkMjgyMTQ3YzFlZi8i
-        LCJfY3JlYXRlZCI6IjIwMTktMDktMDlUMTI6NDM6MjkuNTQ4MjMwWiIsImJh
+        ZS9maWxlL2E5MWY5ZDE4LTNkOWYtNGYwNC04YmNiLWU4ZWVjZDk2N2JiOS8i
+        LCJfY3JlYXRlZCI6IjIwMTktMDktMTlUMTQ6NDU6MDMuNzA5NDk2WiIsImJh
         c2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVscDNf
         RmlsZV8xIiwiYmFzZV91cmwiOiJjZW50b3M3LWthdGVsbG8tZGV2ZWwuampl
         ZmZlcnMuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3JnYW5p
         emF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xIiwiY29udGVudF9ndWFyZCI6
         bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVs
         cDNfRmlsZV8xIiwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGlj
-        YXRpb25zL2ZpbGUvZmlsZS8xNzEwYzQ4Zi0zOGQzLTQwZDItOTZiZi05NzE5
-        NmEzODRlYmYvIn1dfQ==
+        YXRpb25zL2ZpbGUvZmlsZS85ZDZhMDE4NS04MTAwLTQ5MDgtYjJlOS1mN2I2
+        YjA1NmVkN2EvIn1dfQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:34 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:08 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/0a2dd040-e7d8-4a9d-b4a4-bd282147c1ef/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/a91f9d18-3d9f-4f04-8bcb-e8eecd967bb9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2216,7 +1951,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:34 GMT
+      - Thu, 19 Sep 2019 14:45:08 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -2234,13 +1969,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QwZTdkZDM2LWE5ZDAtNDBi
-        ZS05ODlmLTJiOTlhMmM4MzJkMC8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzcwZmI1NzQyLTkwMDktNDBh
+        MC1hZWE4LTYzZGI4OWI4NGE0NC8ifQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:34 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:08 GMT
 - request:
     method: delete
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/b698d83f-60db-42a9-b5b9-b7b8f2366a02/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/586ec394-9b23-4e83-baf3-b9afdcf8f7d0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2261,7 +1996,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:34 GMT
+      - Thu, 19 Sep 2019 14:45:09 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -2279,13 +2014,13 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EyMjc0OWVhLTljZDctNGEy
-        NC1hMGM5LWIyZmMxNjllZGMyMy8ifQ==
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzJmNmZmODU1LTdhMzItNDYy
+        NS04YTk4LTdiNThhMGEwYWRjMi8ifQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:34 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:09 GMT
 - request:
     method: get
-    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/a22749ea-9cd7-4a24-a0c9-b2fc169edc23/
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/2f6ff855-7a32-4625-8a98-7b58a0a0adc2/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2306,7 +2041,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 09 Sep 2019 12:43:34 GMT
+      - Thu, 19 Sep 2019 14:45:09 GMT
       Server:
       - gunicorn/19.9.0
       Content-Type:
@@ -2320,23 +2055,23 @@ http_interactions:
       Via:
       - 1.1 centos7-katello-devel.jjeffers.example.com
       Content-Length:
-      - '332'
+      - '336'
     body:
       encoding: UTF-8
       base64_string: |
-        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy9hMjI3NDllYS05Y2Q3LTRh
-        MjQtYTBjOS1iMmZjMTY5ZWRjMjMvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTA5
-        VDEyOjQzOjM0Ljc3NjgxM1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
+        eyJfaHJlZiI6Ii9wdWxwL2FwaS92My90YXNrcy8yZjZmZjg1NS03YTMyLTQ2
+        MjUtOGE5OC03YjU4YTBhMGFkYzIvIiwiX2NyZWF0ZWQiOiIyMDE5LTA5LTE5
+        VDE0OjQ1OjA4Ljk5NjA2M1oiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUi
         OiJwdWxwY29yZS5hcHAudGFza3MucmVwb3NpdG9yeS5kZWxldGUiLCJzdGFy
-        dGVkX2F0IjoiMjAxOS0wOS0wOVQxMjo0MzozNC44ODk5MjNaIiwiZmluaXNo
-        ZWRfYXQiOiIyMDE5LTA5LTA5VDEyOjQzOjM0Ljk2MTk0N1oiLCJub25fZmF0
+        dGVkX2F0IjoiMjAxOS0wOS0xOVQxNDo0NTowOS4xMzk3NjBaIiwiZmluaXNo
+        ZWRfYXQiOiIyMDE5LTA5LTE5VDE0OjQ1OjA5LjIxNjk5N1oiLCJub25fZmF0
         YWxfZXJyb3JzIjpbXSwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2Fw
-        aS92My93b3JrZXJzL2FmODUzYzcyLTE0NjQtNGY3Yy1hMDM1LTQ3MTY2NTNj
-        ZWUzOS8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9n
+        aS92My93b3JrZXJzL2NiNTE1YjkxLWUzNzktNGQ5OS1iYTBhLTQxYTQxYzdh
+        OTJiZC8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9n
         cmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNl
         cnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZXBvc2l0
-        b3JpZXMvYjY5OGQ4M2YtNjBkYi00MmE5LWI1YjktYjdiOGYyMzY2YTAyLyJd
+        b3JpZXMvNTg2ZWMzOTQtOWIyMy00ZTgzLWJhZjMtYjlhZmRjZjhmN2QwLyJd
         fQ==
     http_version: 
-  recorded_at: Mon, 09 Sep 2019 12:43:34 GMT
+  recorded_at: Thu, 19 Sep 2019 14:45:09 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
This PR adds an action for pulp3 mirrors that deletes all but the most recent repository version for each proxy repository.

Given a repository added to Katello and a pulp mirror that has been synced 3 times, you might see the following repository versions:
```pulp=# select _id, _created, number, repository_id from core_repositoryversion;
                 _id                  |           _created            | number |            repository_id             
--------------------------------------+-------------------------------+--------+--------------------------------------
 eab0d5f9-15a1-404d-a2a1-f5ecb1aee957 | 2019-09-19 18:16:57.175083+00 |      1 | 4f9118d5-044c-40d1-9d82-1f824c7b252a
 b25513ac-69a6-45b5-9244-f879505fb61e | 2019-09-19 18:18:17.364904+00 |      2 | 4f9118d5-044c-40d1-9d82-1f824c7b252a
 966034e2-7590-4af5-b2df-bffcdf1c679e | 2019-09-19 18:19:56.576712+00 |      3 | 4f9118d5-044c-40d1-9d82-1f824c7b252a
(3 rows)
```
After running the 'katello:delete_orphaned_content' task...
```
pulp=# select _id, _created, number, repository_id from core_repositoryversion;
                 _id                  |           _created            | number |            repository_id             
--------------------------------------+-------------------------------+--------+--------------------------------------
 966034e2-7590-4af5-b2df-bffcdf1c679e | 2019-09-19 18:19:56.576712+00 |      3 | 4f9118d5-044c-40d1-9d82-1f824c7b252a
(1 row)
```
Note that the lone repository version is the "latest" version by number ("3"). Previous versions ("1" and "2") are removed.