### PR TITLE
Fixes #27892 - Allow content facet in safe mode

### DIFF
--- a/app/lib/katello/concerns/base_template_scope_extensions.rb
+++ b/app/lib/katello/concerns/base_template_scope_extensions.rb
@@ -6,7 +6,7 @@ module Katello
       module Overrides
         def allowed_helpers
           super + [:errata, :host_subscriptions, :host_applicable_errata_ids, :host_applicable_errata_filtered,
-                   :host_latest_applicable_rpm_version, :load_pools, :load_errata_applications]
+                   :host_latest_applicable_rpm_version, :load_pools, :load_errata_applications, :host_content_facet]
         end
       end
 
@@ -20,6 +20,10 @@ module Katello
 
       def host_subscriptions(host)
         host.subscriptions
+      end
+
+      def host_content_facet(host)
+        host.content_facet
       end
 
       def host_applicable_errata_ids(host)

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -223,6 +223,12 @@ module Katello
         facet_attributes[:content_source_id] ||= hostgroup.inherited_content_source_id
         facet_attributes
       end
+
+      class Jail < ::Safemode::Jail
+        allow :applicable_module_stream_count, :applicable_rpm_count, :content_source, :content_source_id, :content_source_name, :content_view_id,
+              :content_view_name, :errata_counts, :id, :kickstart_repository, :kickstart_repository_id, :kickstart_repository_name,
+              :lifecycle_environment_id, :lifecycle_environment_name, :upgradable_module_stream_count, :upgradable_rpm_count, :uuid
+      end
     end
   end
 end


### PR DESCRIPTION
This change is needed to allow access to content facet attributes in reports.
To test:
Go to Monitor > Report Templates > Create new:
Copy Paste the demo report here: http://pastebin.test.redhat.com/798999 to the editor and save.
Generate a report and you should see the fields in the report.