### PR TITLE
Fixes #27882 - Container CV version has duplicate tag count

### DIFF
--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -298,7 +298,8 @@ module Katello
     end
 
     def docker_tags
-      ::Katello::DockerMetaTag.where(:id => RepositoryDockerMetaTag.where(:repository_id => repositories.docker_type).select(:docker_meta_tag_id))
+      # Don't count tags from non-archived repos; this causes count errors
+      ::Katello::DockerMetaTag.where(:id => RepositoryDockerMetaTag.where(:repository_id => repositories.archived.docker_type).select(:docker_meta_tag_id))
     end
 
     def debs

--- a/test/models/content_view_version_test.rb
+++ b/test/models/content_view_version_test.rb
@@ -105,6 +105,15 @@ module Katello
       end
       DockerMetaTag.import_meta_tags(cvv.repositories.archived.docker_type)
 
+      # simulate another not-archived (env ID not nil) repo existing in the cvv.
+      # this repo should not count towards the cvv docker_tag_count.
+      archived_repo = cvv.repositories.archived.docker_type[0]
+      dup_repo = archived_repo.dup
+      dup_repo.save!
+      dup_repo.update_attributes(:environment_id => ::Katello::KTEnvironment.find_by(:name => "Dev").id)
+      dup_repo.docker_tags = [archived_repo.docker_tags[0]]
+      ::Katello::DockerMetaTag.import_meta_tags([dup_repo])
+
       assert cvv.repositories.archived.docker_type.count > 0
       assert_equal manifest_count, cvv.docker_manifest_count
       assert_equal tag_count, cvv.docker_tag_count


### PR DESCRIPTION
Non-archived repos were erroneously increasing the docker tag count for latest cv versions with docker content. 

To test:
1) Sync a repo with docker content
2) Create a content view with that repo and promote it once
3) Notice that there's double the tags than there should be under the latest CV version's Content
4) Apply this PR
5) Notice that the tag count is now correct