### PR TITLE
Fixes #27520 - Allow duplicate content upload

### DIFF
--- a/app/lib/actions/pulp3/orchestration/repository/upload_content.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/upload_content.rb
@@ -5,9 +5,16 @@ module Actions
         class UploadContent < Pulp3::Abstract
           def plan(repository, smart_proxy, file, unit_type_id)
             sequence do
-              upload_action_output = plan_action(Pulp3::Repository::UploadFile, repository, smart_proxy, file[:path]).output
-              artifact_action_output = plan_action(Pulp3::Repository::SaveArtifact, file, repository, upload_action_output[:pulp_tasks], unit_type_id).output
-              action_output = plan_action(Pulp3::Repository::ImportUpload, artifact_action_output[:content_unit_href], repository, smart_proxy).output
+              content_backend_service = SmartProxy.pulp_master.content_service(unit_type_id)
+              content_list = content_backend_service.content_api.list("digest": Digest::SHA256.hexdigest(File.read(file[:path])))
+              if content_list.results.empty?
+                upload_action_output = plan_action(Pulp3::Repository::UploadFile, repository, smart_proxy, file[:path]).output
+                artifact_action_output = plan_action(Pulp3::Repository::SaveArtifact, file, repository, upload_action_output[:pulp_tasks], unit_type_id).output
+                content_unit_href = artifact_action_output[:content_unit_href]
+              else
+                content_unit_href = content_list.results.first._href
+              end
+              action_output = plan_action(Pulp3::Repository::ImportUpload, content_unit_href, repository, smart_proxy).output
               plan_action(Pulp3::Repository::SaveVersion, repository, action_output[:pulp_tasks]).output
             end
           end

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -258,7 +258,9 @@ module ::Actions::Katello::Repository
                                 upload_id: 123)
     end
 
-    it 'plans for Pulp3' do
+    it 'plans for Pulp3 without duplicate' do
+      proxy.stubs(:content_service).returns(stub(:content_api => stub(:list => stub(:results => nil))))
+      #Katello::Pulp3::PulpContentUnit.stubs(:content_api)
       action = create_action pulp3_action_class
       file = File.join(::Katello::Engine.root, "test", "fixtures", "files", "puppet_module.tar.gz")
       action.execution_plan.stub_planned_action(::Actions::Pulp3::Repository::UploadFile) do |content_create|

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -260,7 +260,6 @@ module ::Actions::Katello::Repository
 
     it 'plans for Pulp3 without duplicate' do
       proxy.stubs(:content_service).returns(stub(:content_api => stub(:list => stub(:results => nil))))
-      #Katello::Pulp3::PulpContentUnit.stubs(:content_api)
       action = create_action pulp3_action_class
       file = File.join(::Katello::Engine.root, "test", "fixtures", "files", "puppet_module.tar.gz")
       action.execution_plan.stub_planned_action(::Actions::Pulp3::Repository::UploadFile) do |content_create|
@@ -283,6 +282,22 @@ module ::Actions::Katello::Repository
                                 "file")
       assert_action_planed_with(action, ::Actions::Pulp3::Repository::ImportUpload,
                                 "demo_task/artifact_href", repository_pulp3, proxy)
+      assert_action_planed_with(action, ::Actions::Pulp3::Repository::SaveVersion,
+                                repository_pulp3,
+                                [{href: "demo_task/version_href"}])
+    end
+
+    it 'plans for Pulp3 with duplicate' do
+      proxy.stubs(:content_service).returns(stub(:content_api => stub(:list => stub(:results => [stub(:_href => "demo_content/href")]))))
+      action = create_action pulp3_action_class
+      file = File.join(::Katello::Engine.root, "test", "fixtures", "files", "puppet_module.tar.gz")
+      action.execution_plan.stub_planned_action(::Actions::Pulp3::Repository::ImportUpload) do |import_upload|
+        import_upload.stubs(output: { pulp_tasks: [{href: "demo_task/version_href"}] })
+      end
+
+      plan_action action, repository_pulp3, proxy, {:path => file, :filename => 'puppet_module.tar.gz'}, 'file'
+      assert_action_planed_with(action, ::Actions::Pulp3::Repository::ImportUpload,
+                                "demo_content/href", repository_pulp3, proxy)
       assert_action_planed_with(action, ::Actions::Pulp3::Repository::SaveVersion,
                                 repository_pulp3,
                                 [{href: "demo_task/version_href"}])


### PR DESCRIPTION
**To test:**
1. On a pulp3 box, create 2 file repositories R1 and R2.
2. Upload file F1 to R1
3. Upload file F1 to R2

**Before change:**
Step 3 fails with unique checksum error.
**After change:**
Step 3 should succeed and content should get uploaded to R2.
**PS:**
Uploading same file to R1 twice should also not error out but will not create duplicate content.