### PR TITLE
Fixes #27875 - Content View missing from Host Collections Add Table

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-add-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/views/host-collection-add-hosts.html
@@ -44,7 +44,7 @@
           </a>
         </td>
         <td bst-table-cell >{{ host.content_facet_attributes.lifecycle_environment.name}}</td>
-        <td bst-table-cell >{{ host.content_facet_attributes.name}}</td>
+        <td bst-table-cell >{{ host.content_facet_attributes.content_view.name}}</td>
       </tr>
 
       </tbody>


### PR DESCRIPTION
Does anyone have an opinion about whether I use `content_view.name` or `content_view_name`?

To test:

1) Ensure there's at least one host registered with Foreman
2) Check Host Collections -> (Some Collection) -> List Hosts -> Add
3) Check that the Content View isn't blank