### PR TITLE
Fixes #27714 - Generate bastion config on load

### DIFF
--- a/engines/bastion/lib/bastion.rb
+++ b/engines/bastion/lib/bastion.rb
@@ -24,6 +24,7 @@ module Bastion
     }
 
     Bastion.plugins.each do |_name, plugin|
+      base_config.merge!(plugin[:config_generator].call) if plugin[:config_generator]
       base_config.merge!(plugin[:config]) if plugin[:config]
     end
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages-installed.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages-installed.controller.js
@@ -22,10 +22,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostPackagesInstalled
 
             if (!$scope.working) {
                 $scope.working = true;
-                HostPackage.remove({
-                    id: $scope.host.id,
-                    packages: selected
-                }, $scope.openEventInfo, $scope.errorHandler);
+                $scope.performPackageAction("packageRemove", selected.join(","));
             }
         };
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages.controller.js
@@ -64,6 +64,7 @@ angular.module('Bastion.content-hosts').controller('ContentHostPackagesControlle
 
         $scope.performViaRemoteExecution = function(actionType, term, customize) {
             var terms = term.split(/ *, */);
+            $scope.working = true;
             $scope.packageActionFormValues.package = terms.join(' ');
             $scope.packageActionFormValues.remoteAction = actionType;
             $scope.packageActionFormValues.hostIds = $scope.host.id;

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/content/content-host-packages.controller.js
@@ -63,7 +63,8 @@ angular.module('Bastion.content-hosts').controller('ContentHostPackagesControlle
         };
 
         $scope.performViaRemoteExecution = function(actionType, term, customize) {
-            $scope.packageActionFormValues.package = term;
+            var terms = term.split(/ *, */);
+            $scope.packageActionFormValues.package = terms.join(' ');
             $scope.packageActionFormValues.remoteAction = actionType;
             $scope.packageActionFormValues.hostIds = $scope.host.id;
             $scope.packageActionFormValues.customize = customize;

--- a/engines/bastion_katello/lib/bastion_katello/engine.rb
+++ b/engines/bastion_katello/lib/bastion_katello/engine.rb
@@ -40,13 +40,14 @@ module BastionKatello
           katello_tasks
           select_organization
         ),
-        :config => {
-          'consumerCertRPM' => consumer_cert_rpm,
-          'defaultDownloadPolicy' => !Foreman.in_rake? && db_migrated && Setting['default_download_policy'],
-          'remoteExecutionPresent' => ::Katello.with_remote_execution?,
-          'remoteExecutionByDefault' => ::Katello.with_remote_execution? &&
-                                        db_migrated && Setting['remote_execution_by_default']
-        }
+        :config_generator =>  lambda do
+          { 'consumerCertRPM' => consumer_cert_rpm,
+            'defaultDownloadPolicy' => !Foreman.in_rake? && db_migrated && Setting['default_download_policy'],
+            'remoteExecutionPresent' => ::Katello.with_remote_execution?,
+            'remoteExecutionByDefault' => ::Katello.with_remote_execution? &&
+                                          db_migrated && Setting['remote_execution_by_default']
+          }
+        end
       )
     end
   end

--- a/engines/bastion_katello/test/content-hosts/content/content-host-packages-installed.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content/content-host-packages-installed.controller.test.js
@@ -46,6 +46,7 @@ describe('Controller: ContentHostPackagesInstalledController', function() {
         $scope.$stateParams = {hostId: mockHost.id};
         $scope.openEventInfo = function(){};
         $scope.errorHandler = function(){};
+        $scope.performPackageAction = function(action, name) {};
 
         $controller('ContentHostPackagesInstalledController', {$scope: $scope,
                                                HostPackage: HostPackage,
@@ -57,17 +58,14 @@ describe('Controller: ContentHostPackagesInstalledController', function() {
         expect($scope.table).toBeTruthy();
     });
 
-
     it("performs a selected package removal", function() {
         var mockPackage, mockPackageClone;
         mockPackage = {name: 'foo', version: '3', release: '14', arch: 'noarch'};
-        mockPackageClone = {name: 'foo', version: '3', release: '14', arch: 'noarch'};
-        spyOn($scope.table,  'getSelected').and.returnValue([mockPackage]);
-
-        spyOn(HostPackage, 'remove');
+        mockOtherPackage = {name: 'bar', version: '3', release: '14', arch: 'noarch'};
+        spyOn($scope.table, 'getSelected').and.returnValue([mockPackage, mockOtherPackage]);
+        spyOn($scope, 'performPackageAction');
         $scope.removeSelectedPackages();
-        expect(HostPackage.remove).toHaveBeenCalledWith({id: mockHost.id, packages: ['foo']},
-                                                          jasmine.any(Function), jasmine.any(Function));
+        expect($scope.performPackageAction).toHaveBeenCalledWith("packageRemove", mockPackage['name'] + "," + mockOtherPackage['name']);
         expect($scope.working).toBe(true);
     });
 });

--- a/engines/bastion_katello/test/content-hosts/content/content-host-packages.controller.test.js
+++ b/engines/bastion_katello/test/content-hosts/content/content-host-packages.controller.test.js
@@ -1,5 +1,5 @@
 describe('Controller: ContentHostPackagesController', function() {
-    var $scope, Nutupane, HostPackage, mockHost, mockTask, translate, ContentHost;
+    var $scope, Nutupane, HostPackage, mockHost, mockTask, translate, ContentHost, $timeout;
 
     beforeEach(module('Bastion.content-hosts', 'Bastion.hosts', 'Bastion.test-mocks'));
 
@@ -44,7 +44,7 @@ describe('Controller: ContentHostPackagesController', function() {
         $scope = $rootScope.$new();
         $scope.host = mockHost;
         $scope.$stateParams = {hostId: mockHost.id};
-
+        $timeout = function(data) {};
         $controller('ContentHostPackagesController', {$scope: $scope,
                                                HostPackage: HostPackage,
                                                translate:translate,
@@ -86,6 +86,26 @@ describe('Controller: ContentHostPackagesController', function() {
         $scope.updateAll();
         expect(HostPackage.updateAll).toHaveBeenCalledWith({id: mockHost.id}, jasmine.any(Function),
             jasmine.any(Function));
+        expect($scope.working).toBe(true);
+    });
+
+    it("performs a package install via remoteExecution", function() {
+        $scope.remoteExecutionPresent = true;
+        $scope.remoteExecutionByDefault = true;
+        spyOn(HostPackage, 'install');
+        $scope.performPackageAction('packageInstall', 'foo, bar, baz');
+        expect(HostPackage.install).not.toHaveBeenCalled();
+        expect($scope.packageActionFormValues.package).toEqual('foo bar baz');
+        expect($scope.packageActionFormValues.remoteAction).toEqual('packageInstall');
+        expect($scope.packageActionFormValues.hostIds).toEqual(mockHost.id);
+        expect($scope.working).toBe(true);
+    });
+
+    it("performs a multi package install via katello agent", function() {
+        spyOn(HostPackage, 'install');
+        $scope.performPackageAction('packageInstall', 'foo, bar, baz');
+        expect(HostPackage.install).toHaveBeenCalledWith({id: mockHost.id, packages: ["foo","bar","baz"]},
+                                                          jasmine.any(Function), jasmine.any(Function));
         expect($scope.working).toBe(true);
     });
 });


### PR DESCRIPTION
This commit adds a config generator option to bastion so that it reloads
the configurations on every page load. Prior to this commit the plugins
were returning a static list of config items, which means if some one
changed "remote_execution_by_default" setting, the config would not get
regenerated in the UI.