### PR TITLE
Fixes #27910 - Hammer support to upload duplicate files

### DIFF
--- a/app/controllers/katello/api/v2/content_uploads_controller.rb
+++ b/app/controllers/katello/api/v2/content_uploads_controller.rb
@@ -9,8 +9,12 @@ module Katello
     api :POST, "/repositories/:repository_id/content_uploads", N_("Create an upload request")
     param :repository_id, :number, :required => true, :desc => N_("repository id")
     param :size, :number, :required => true, :desc => N_("Size of file to upload")
+    param :checksum, String, :required => true, :desc => N_("Checksum of file to upload")
+    param :content_type, RepositoryTypeManager.uploadable_content_types.map(&:label), :required => false, :desc => N_("content type ('deb', 'docker_manifest', 'file', 'ostree', 'puppet_module', 'rpm', 'srpm')")
     def create
-      render :json => @repository.backend_content_service(::SmartProxy.pulp_master).create_upload(params[:size])
+      content_type = params[:content_type] || ::Katello::RepositoryTypeManager.find(@repository.content_type).default_managed_content_type.label
+      unit_type_id = SmartProxy.pulp_master.content_service(content_type)::CONTENT_TYPE
+      render :json => @repository.backend_content_service(::SmartProxy.pulp_master).create_upload(params[:size], params[:checksum], unit_type_id)
     end
 
     api :PUT, "/repositories/:repository_id/content_uploads/:id", N_("Upload a chunk of the file's content")

--- a/app/controllers/katello/api/v2/content_uploads_controller.rb
+++ b/app/controllers/katello/api/v2/content_uploads_controller.rb
@@ -9,11 +9,11 @@ module Katello
     api :POST, "/repositories/:repository_id/content_uploads", N_("Create an upload request")
     param :repository_id, :number, :required => true, :desc => N_("repository id")
     param :size, :number, :required => true, :desc => N_("Size of file to upload")
-    param :checksum, String, :required => true, :desc => N_("Checksum of file to upload")
+    param :checksum, String, :required => false, :desc => N_("Checksum of file to upload")
     param :content_type, RepositoryTypeManager.uploadable_content_types.map(&:label), :required => false, :desc => N_("content type ('deb', 'docker_manifest', 'file', 'ostree', 'puppet_module', 'rpm', 'srpm')")
     def create
       content_type = params[:content_type] || ::Katello::RepositoryTypeManager.find(@repository.content_type).default_managed_content_type.label
-      unit_type_id = SmartProxy.pulp_master.content_service(content_type)::CONTENT_TYPE
+      unit_type_id = SmartProxy.pulp_master.content_service(content_type).content_type
       render :json => @repository.backend_content_service(::SmartProxy.pulp_master).create_upload(params[:size], params[:checksum], unit_type_id)
     end
 

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -387,6 +387,7 @@ module Katello
     param :content_type, RepositoryTypeManager.uploadable_content_types.map(&:label), :required => false, :desc => N_("content type ('deb', 'docker_manifest', 'file', 'ostree', 'puppet_module', 'rpm', 'srpm')")
     param :uploads, Array, :desc => N_("Array of uploads to import") do
       param 'id', String, :required => true
+      param 'content_unit_id', String
       param 'size', String
       param 'checksum', String
       param 'name', String, :desc => N_("Needs to only be set for file repositories or docker tags")
@@ -401,7 +402,7 @@ module Katello
       end
 
       uploads = (params[:uploads] || []).map do |upload|
-        upload.permit(:id, :size, :checksum, :name, :digest).to_h
+        upload.permit(:id, :content_unit_id, :size, :checksum, :name, :digest).to_h
       end
 
       if params.key?(:upload_ids)

--- a/app/lib/actions/pulp3/orchestration/repository/import_upload.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/import_upload.rb
@@ -7,14 +7,15 @@ module Actions
             file = {:filename => args.dig(:unit_key, :name)}
             content_unit_href = args.dig(:unit_key, :content_unit_id)
             sequence do
-              unless content_unit_href
+              if !content_unit_href
                 action_output = plan_self(:repository_id => repository.id, :smart_proxy_id => smart_proxy.id, :upload_href => "/pulp/api/v3/uploads/" + args.dig(:upload_id) + "/", :sha256 => args.dig(:unit_key, :checksum)).output
                 artifact_action_output = plan_action(Pulp3::Repository::SaveArtifact, file, repository, smart_proxy, action_output[:pulp_tasks], args.dig(:unit_type_id)).output
                 content_unit_href = artifact_action_output[:pulp_tasks]
+              else
+                plan_self(:skip => true)
               end
               action_output = plan_action(Pulp3::Repository::ImportUpload, content_unit_href, repository, smart_proxy).output
               plan_action(Pulp3::Repository::SaveVersion, repository, action_output[:pulp_tasks]).output
-              plan_self(:skip => true)
             end
           end
 

--- a/app/lib/actions/pulp3/orchestration/repository/import_upload.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/import_upload.rb
@@ -5,19 +5,28 @@ module Actions
         class ImportUpload < Pulp3::AbstractAsyncTask
           def plan(repository, smart_proxy, args)
             file = {:filename => args.dig(:unit_key, :name)}
+            content_unit_href = args.dig(:unit_key, :content_unit_id)
             sequence do
-              action_output = plan_self(:repository_id => repository.id, :smart_proxy_id => smart_proxy.id, :upload_href => "/pulp/api/v3/uploads/" + args.dig(:upload_id) + "/", :sha256 => args.dig(:unit_key, :checksum)).output
-              artifact_action_output = plan_action(Pulp3::Repository::SaveArtifact, file, repository, smart_proxy, action_output[:pulp_tasks], args.dig(:unit_type_id)).output
-              action_output = plan_action(Pulp3::Repository::ImportUpload, artifact_action_output[:pulp_tasks], repository, smart_proxy).output
+              unless content_unit_href
+                action_output = plan_self(:repository_id => repository.id, :smart_proxy_id => smart_proxy.id, :upload_href => "/pulp/api/v3/uploads/" + args.dig(:upload_id) + "/", :sha256 => args.dig(:unit_key, :checksum)).output
+                artifact_action_output = plan_action(Pulp3::Repository::SaveArtifact, file, repository, smart_proxy, action_output[:pulp_tasks], args.dig(:unit_type_id)).output
+                content_unit_href = artifact_action_output[:pulp_tasks]
+              end
+              action_output = plan_action(Pulp3::Repository::ImportUpload, content_unit_href, repository, smart_proxy).output
               plan_action(Pulp3::Repository::SaveVersion, repository, action_output[:pulp_tasks]).output
+              plan_self(:skip => true)
             end
           end
 
           def invoke_external_task
-            repo = ::Katello::Repository.find(input[:repository_id])
-            repo_backend_service = repo.backend_service(smart_proxy)
-            uploads_api = repo_backend_service.uploads_api
-            output[:pulp_tasks] = [uploads_api.commit(input[:upload_href], sha256: input[:sha256])]
+            if input[:skip]
+              output[:pulp_tasks] = nil
+            else
+              repo = ::Katello::Repository.find(input[:repository_id])
+              repo_backend_service = repo.backend_service(smart_proxy)
+              uploads_api = repo_backend_service.uploads_api
+              output[:pulp_tasks] = [uploads_api.commit(input[:upload_href], sha256: input[:sha256])]
+            end
           end
         end
       end

--- a/app/services/katello/pulp/content.rb
+++ b/app/services/katello/pulp/content.rb
@@ -3,7 +3,7 @@ module Katello
     class Content
       extend Katello::Abstract::Pulp::Content
       class << self
-        def create_upload(_size = 0)
+        def create_upload(_size = 0, _checksum = nil, _content_type = nil)
           pulp_content.create_upload_request
         end
 

--- a/app/services/katello/pulp/pulp_content_unit.rb
+++ b/app/services/katello/pulp/pulp_content_unit.rb
@@ -30,6 +30,10 @@ module Katello
         "_id"
       end
 
+      def self.content_type
+        self::CONTENT_TYPE
+      end
+
       def self.unit_handler
         Katello.pulp_server.extensions.send(self.name.demodulize.underscore)
       end

--- a/app/services/katello/pulp/repository/file.rb
+++ b/app/services/katello/pulp/repository/file.rb
@@ -4,7 +4,7 @@ module Katello
       class File < ::Katello::Pulp::Repository
         def unit_keys(uploads)
           uploads.map do |upload|
-            upload.except('id')
+            upload.except('id', 'content_unit_id')
           end
         end
 

--- a/app/services/katello/pulp3/content.rb
+++ b/app/services/katello/pulp3/content.rb
@@ -9,11 +9,11 @@ module Katello
           if checksum && content_type
             content_backend_service = SmartProxy.pulp_master.content_service(content_type)
             content_list = content_backend_service.content_api.list("digest": checksum)
-            content_unit_href = content_list.results.first._href unless content_list.results.empty?
+            content_unit_href = content_list.results.first.pulp_href unless content_list.results.empty?
             return {"content_unit_href" => content_unit_href} if content_unit_href
           end
-          upload_href = uploads_api.create(upload_class.new(size: size))._href
-          return {"upload_id" => upload_href.split("/").last}
+          upload_href = uploads_api.create(upload_class.new(size: size)).pulp_href
+          {"upload_id" => upload_href.split("/").last}
         end
 
         def delete_upload(upload_href)

--- a/app/services/katello/pulp3/content.rb
+++ b/app/services/katello/pulp3/content.rb
@@ -4,9 +4,16 @@ module Katello
     class Content
       extend Katello::Abstract::Pulp::Content
       class << self
-        def create_upload(size = 0)
-          upload_href = uploads_api.create(upload_class.new(size: size)).pulp_href
-          {"upload_id" => upload_href.split("/").last}
+        def create_upload(size = 0, checksum = nil, content_type = nil)
+          content_unit_href = nil
+          if checksum && content_type
+            content_backend_service = SmartProxy.pulp_master.content_service(content_type)
+            content_list = content_backend_service.content_api.list("digest": checksum)
+            content_unit_href = content_list.results.first._href unless content_list.results.empty?
+            return {"content_unit_href" => content_unit_href} if content_unit_href
+          end
+          upload_href = uploads_api.create(upload_class.new(size: size))._href
+          return {"upload_id" => upload_href.split("/").last}
         end
 
         def delete_upload(upload_href)

--- a/app/services/katello/pulp3/pulp_content_unit.rb
+++ b/app/services/katello/pulp3/pulp_content_unit.rb
@@ -34,6 +34,10 @@ module Katello
         "pulp_href"
       end
 
+      def self.content_type
+        self::CONTENT_TYPE
+      end
+
       def self.pulp_units_batch_for_repo(repository, options = {})
         fetch_identifiers = options.fetch(:fetch_identifiers, false)
         page_size = options.fetch(:page_size, SETTINGS[:katello][:pulp][:bulk_load_size])

--- a/test/controllers/api/v2/content_uploads_controller_test.rb
+++ b/test/controllers/api/v2/content_uploads_controller_test.rb
@@ -27,8 +27,8 @@ module Katello
 
     def test_create_upload_request
       mock_pulp_server(:create_upload_request => [])
-      post :create, params: { :repository_id => @repo.id }
-
+      post :create, params: { :repository_id => @repo.id, :size => 100, :checksum => 'test_checksum' }
+      puts response.to_s
       assert_response :success
     end
 
@@ -76,8 +76,10 @@ module Katello
     private
 
     def mock_pulp_server(content_hash)
+      puts content_hash
       content = mock(content_hash)
       resources = mock(:content => content)
+      puts resources
       pulp_server = mock(:resources => resources)
       pulp_master = mock(pulp_api: pulp_server, pulp3_support?: false)
       SmartProxy.expects(:pulp_master).at_least_once.returns(pulp_master)

--- a/test/controllers/api/v2/content_uploads_controller_test.rb
+++ b/test/controllers/api/v2/content_uploads_controller_test.rb
@@ -28,7 +28,6 @@ module Katello
     def test_create_upload_request
       mock_pulp_server(:create_upload_request => [])
       post :create, params: { :repository_id => @repo.id, :size => 100, :checksum => 'test_checksum' }
-      puts response.to_s
       assert_response :success
     end
 
@@ -76,12 +75,11 @@ module Katello
     private
 
     def mock_pulp_server(content_hash)
-      puts content_hash
       content = mock(content_hash)
       resources = mock(:content => content)
-      puts resources
       pulp_server = mock(:resources => resources)
       pulp_master = mock(pulp_api: pulp_server, pulp3_support?: false)
+      pulp_master.stubs(:content_service).returns(stub(:content_type => "rpm"))
       SmartProxy.expects(:pulp_master).at_least_once.returns(pulp_master)
     end
   end


### PR DESCRIPTION
This PR contains supporting changes to allow duplicate content uploads in pulp3 from hammer (https://github.com/Katello/hammer-cli-katello/pull/699).
