### PR TITLE
Fixes #21182 - Proxy sync task inital output error

### DIFF
--- a/app/lib/actions/katello/capsule_content/sync.rb
+++ b/app/lib/actions/katello/capsule_content/sync.rb
@@ -15,7 +15,7 @@ module Actions
         end
 
         def humanized_input
-          ["'#{input['smart_proxy']['name']}'"] + super
+          input['smart_proxy'].nil? || input['smart_proxy']['name'].nil? ? super : ["'#{input['smart_proxy']['name']}'"] + super
         end
 
         # rubocop:disable MethodLength


### PR DESCRIPTION
When a smart proxy with content is synced, at first the task output is an error.  This occurs because `CapsuleContent::Sync` is called using `async_task()` in `CapsuleContentController::sync()` which in turn causes `input` to be empty for `CapsuleContent::Sync`.  To get around this I check the input and make the output just be `Synchronize smart proxy` if it's empty.  Then when `CapsuleContent::Sync` is called again later the task output is updated.

To test:
1) Start an optimized or a complete sync
2) Quickly load the tasks page
3) See that there's an error for the task's Action name: 
`undefined method '[]' for nil:NilClass(NoMethodError)`
4) Apply this PR
5) Follow steps 1-3 and see that, instead of an error, the output temporarily says `Synchronize smart proxy`

Note that sometimes the sync is too fast to see the error.  Doing a complete sync seems to give a better chance of seeing the error.  Alternatively, to test, you can put a `binding.pry` above the line that I fixed and see that, for the very first call to `Sync`, that input is empty.