### PR TITLE
Fixes #27773 - Prefer Pulp 2 for some content types

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -143,10 +143,19 @@ module Katello
         pulp3_repository_type_support?(repository.content_type)
       end
 
+      def pulp2_preferred_for_type?(repository_type)
+        if SETTINGS[:katello][:use_pulp_2_for_content_type].nil? ||
+            SETTINGS[:katello][:use_pulp_2_for_content_type][repository_type.to_sym].nil?
+          return false
+        else
+          return SETTINGS[:katello][:use_pulp_2_for_content_type][repository_type.to_sym]
+        end
+      end
+
       def pulp3_repository_type_support?(repository_type)
         repository_type_obj = repository_type.is_a?(String) ? Katello::RepositoryTypeManager.repository_types[repository_type] : repository_type
         fail "Cannot find repository type #{repository_type}, is it enabled?" unless repository_type_obj
-        repository_type_obj.pulp3_plugin.present? && pulp3_enabled? && self.capabilities(PULP3_FEATURE).try(:include?, repository_type_obj.pulp3_plugin)
+        repository_type_obj.pulp3_plugin.present? && pulp3_enabled? && self.capabilities(PULP3_FEATURE).try(:include?, repository_type_obj.pulp3_plugin) && !pulp2_preferred_for_type?(repository_type_obj.id)
       end
 
       def pulp3_content_support?(content_type)

--- a/config/katello.yaml.example
+++ b/config/katello.yaml.example
@@ -76,6 +76,15 @@
     :crane_ca_cert_file: /etc/pki/katello/certs/katello-server-ca.crt
     :allow_push: false  # default false if omitted
 
+# Pulp 2 can be preferred over Pulp 3 for the desired content type.
+# Default is false.
+#  :use_pulp_2_for_content_type:
+#    :ansible_collection:       <true/false>
+#    :deb:                      <true/false>
+#    :docker:                   <true/false>
+#    :file:                     <true/false>
+#    :yum:                      <true/false>
+
 # Logging configuration can be changed by uncommenting the loggers
 # section and the logger configuration desired.
 #

--- a/test/models/concerns/smart_proxy_extensions_test.rb
+++ b/test/models/concerns/smart_proxy_extensions_test.rb
@@ -82,5 +82,14 @@ module Katello
       refute @master.pulp3_content_support?(Katello::PuppetModule::CONTENT_TYPE)
       assert @master.pulp3_content_support?(Katello::DockerManifest::CONTENT_TYPE)
     end
+
+    def test_pulp2_preferred_for_type
+      SETTINGS[:katello][:use_pulp_2_for_content_type] = {}
+      SETTINGS[:katello][:use_pulp_2_for_content_type][:file] = true
+      assert @master.pulp2_preferred_for_type?("file")
+      refute @master.pulp2_preferred_for_type?("docker")
+    ensure
+      SETTINGS[:katello][:use_pulp_2_for_content_type][:file] = nil
+    end
   end
 end

--- a/test/services/katello/pulp3/repository/file/update_remote_test.rb
+++ b/test/services/katello/pulp3/repository/file/update_remote_test.rb
@@ -13,6 +13,7 @@ module Katello
           @mock_pulp3_api.stubs(:create).returns(mock_remotes_create_response)
           @mock_smart_proxy = mock('smart_proxy')
           @mock_smart_proxy.stubs(:pulp3_support?).returns(true)
+          @mock_smart_proxy.stubs(:pulp2_preferred_for_type?).returns(false)
           @mock_smart_proxy.stubs(:pulp_master?).returns(true)
           @file_repo = katello_repositories(:generic_file)
           @file_repo_service = @file_repo.backend_service(@mock_smart_proxy)


### PR DESCRIPTION
This PR enables content types to be configured to use either Pulp 2 or Pulp 3 when both exist in one Katello environment.  The default is Pulp 3.

Things to test:
1) Create and sync some Pulp 2 repo
2) Create and sync some Pulp 3 repo
3) Proxy sync Pulp 2 and Pulp 3 repositories (note that Apache isn't configured to serve Pulp 2 content using the Pulp 3 dev environment, which will cause the proxy sync to fail)