### PR TITLE
Fixes #27974 - RHSM checkin requests stuck for long time

### DIFF
--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -127,7 +127,8 @@ module Katello
             guest_ids = self.candlepin_consumer.virtual_guests.pluck(:id)
           end
 
-          subscription_facets = SubscriptionFacet.where(:host_id => guest_ids)
+          subscription_facets = SubscriptionFacet.where(:host_id => guest_ids).
+                                                  where("hypervisor_host_id != ? OR hypervisor_host_id is NULL", self.host.id)
           subscription_facets.update_all(:hypervisor_host_id => self.host.id)
         elsif (virtual_host = self.candlepin_consumer.virtual_host)
           self.hypervisor_host = virtual_host

--- a/app/services/katello/candlepin/consumer.rb
+++ b/app/services/katello/candlepin/consumer.rb
@@ -100,9 +100,10 @@ module Katello
       end
 
       def virtual_guests
+        return @virtual_guests unless @virtual_guests.nil?
         return [] if self.uuid.nil?
         guest_uuids = Resources::Candlepin::Consumer.virtual_guests(self.uuid).map { |guest| guest['uuid'] }
-        ::Host.joins(:subscription_facet).where("#{Katello::Host::SubscriptionFacet.table_name}.uuid" => guest_uuids)
+        @virtual_guests = ::Host.joins(:subscription_facet).where("#{Katello::Host::SubscriptionFacet.table_name}.uuid" => guest_uuids)
       end
 
       def virtual_host

--- a/test/services/katello/candlepin/consumer_test.rb
+++ b/test/services/katello/candlepin/consumer_test.rb
@@ -62,6 +62,16 @@ module Katello
 
         assert_equal nil, Candlepin::Consumer.distribution_to_puppet_os('RedHot')
       end
+
+      def test_virtual_guests
+        hosts = [hosts(:one), hosts(:two)]
+        guest_uuids = hosts.map { |host| { 'uuid' => host.subscription_facet.uuid } }
+
+        Resources::Candlepin::Consumer.expects(:virtual_guests).once.returns(guest_uuids)
+
+        assert_equal hosts, @consumer.virtual_guests.sort
+        assert_equal hosts, @consumer.virtual_guests.sort
+      end
     end
   end
 end


### PR DESCRIPTION
Cache the list of virtual guests of the hypervisors before going
into the database transaction. This will prevent the transaction
to lock the updating rows in subscription facet table for long time
and causes all RHSM checkin requests to stuck. Also improve the
update query to minimize the number of rows to be locked.