### PR TITLE
Fixes #28018 - Show installed pkgs for Report Template

### DIFF
--- a/app/lib/katello/concerns/base_template_scope_extensions.rb
+++ b/app/lib/katello/concerns/base_template_scope_extensions.rb
@@ -6,7 +6,8 @@ module Katello
       module Overrides
         def allowed_helpers
           super + [:errata, :host_subscriptions, :host_applicable_errata_ids, :host_applicable_errata_filtered,
-                   :host_latest_applicable_rpm_version, :load_pools, :load_errata_applications, :host_content_facet]
+                   :host_latest_applicable_rpm_version, :load_pools, :load_errata_applications, :host_content_facet,
+                   :host_installed_package_names]
         end
       end
 
@@ -36,6 +37,10 @@ module Katello
 
       def host_latest_applicable_rpm_version(host, package)
         host.applicable_rpms.where(name: package).order(:version_sortable).limit(1).pluck(:nvra).first
+      end
+
+      def host_installed_package_names(host)
+        host.installed_packages.map(&:name)
       end
 
       def load_pools(search: '', includes: nil)


### PR DESCRIPTION
Creating a new method `host_installed_packages` for it to be used in the Report Templates for fetching the installed packages on the host.

One of the use-case is to generate a report to see if a particular package is installed on all hosts example. If `katello-agent` is installed or not on all Content Hosts then we can do the below from the Report Templates

~~~
'Katello Agent Status': host_installed_packages(host).include?('katello-agent')
~~~
