### PR TITLE
Fixes #28019 - Allow SafeMode for Content Host Description

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -279,5 +279,5 @@ end
 
 class ::Host::Managed::Jail < Safemode::Jail
   allow :content_source, :subscription_manager_configuration_url, :rhsm_organization_label,
-        :host_collections
+        :host_collections, :comment
 end


### PR DESCRIPTION
Allow Safemode render for Content Host description, which can be used in Foreman Report templates.