### PR TITLE
Fixes #27679 - content hosts bulk errata modal stop using applicable_hosts

### DIFF
--- a/app/views/katello/api/v2/hosts_bulk_actions/erratum.json.rabl
+++ b/app/views/katello/api/v2/hosts_bulk_actions/erratum.json.rabl
@@ -5,3 +5,5 @@ node :applicable_hosts do |erratum|
   select(["#{::Host.table_name}.id", "#{::Host.table_name}.name"]).
   collect { |host| {:name => host.name, :id => host.id} }
 end
+
+node(:affected_hosts_count) { |erratum| erratum.hosts_available(params[:organization_id]).where("#{::Host.table_name}.id" => @hosts).count }

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/content-hosts-bulk-errata-modal.controller.js
@@ -81,12 +81,6 @@ angular.module('Bastion.content-hosts').controller('ContentHostsBulkErrataModalC
             $scope.showErrata = true;
         };
 
-        $scope.transitionToErrataContentHosts = function (erratum) {
-            $scope.erratum = erratum;
-            $scope.showHosts = true;
-        };
-
-
         $scope.installErrata = function () {
             if ($scope.remoteExecutionByDefault) {
                 $scope.installErrataViaRemoteExecution();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/bulk/views/content-hosts-bulk-errata-modal.html
@@ -89,9 +89,7 @@
              <td bst-table-cell>{{ erratum.title }}</td>
              <td class="small" bst-table-cell>{{ erratum.issued }}</td>
              <td class="small" bst-table-cell class="number-cell">
-               <a ng-click="transitionToErrataContentHosts(erratum)">
-                {{ erratum.applicable_hosts.length }}
-               </a>
+               <span> {{ erratum.affected_hosts_count }} </span>
              </td>
            </tr>
          </tbody>
@@ -179,37 +177,7 @@
           </div>
         </section>
       </div>
-  </div>
-
-    <div name="errataHostsDetails" ng-show="showHosts">
-      <a ng-click="showHosts = false">
-        <i class="fa fa-double-angle-left"></i>
-        {{ "Back To Errata List" | translate }}
-      </a>
-
-      <h3 translate>Applicable hosts for {{ erratum.errata_id }} </h3>
-
-      <div class="details details-full">
-        <section>
-          <table class="table">
-            <thead>
-            <tr>
-              <th translate>
-                Name
-              </th>
-            </tr>
-            </thead>
-
-            <tbody>
-            <tr ng-repeat="host in erratum.applicable_hosts">
-              <td>{{ host.name }}</td>
-            </tr>
-            </tbody>
-          </table>
-        </section>
-      </div>
-    </div>
-
+	</div>
   </div>
 
   <div data-block="modal-footer">


### PR DESCRIPTION
The `applicable_hosts` query in the content hosts bulk errata modal affects performance too much, so this PR reduces the query to a simple count after #7829 merges.

This is a precursor to https://github.com/Katello/katello/pull/7829/

To test:
1) Get a content host with some applicable errata.
2) Navigate to 'Content Hosts', select some, and click 'Select Action' -> 'Manage Errata'.
3) Notice that 'Affected Hosts' is a number without a link.  Without this PR, the number is a link that shows all of the affected hosts by name when clicked.