### PR TITLE
Fixes #27938 - methods to delete pulp3 orphan distributions

### DIFF
--- a/app/lib/actions/pulp3/orchestration/orphan_cleanup/remove_orphans.rb
+++ b/app/lib/actions/pulp3/orchestration/orphan_cleanup/remove_orphans.rb
@@ -6,10 +6,12 @@ module Actions
           def plan(proxy)
             if proxy.pulp3_enabled?
               sequence do
+                plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanRepositoryVersions, proxy)
                 if proxy.pulp_mirror?
                   plan_action(Actions::Pulp3::OrphanCleanup::RemoveUnneededRepos, proxy)
+                  plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanDistributions, proxy)
+                  plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanRemotes, proxy)
                 end
-                plan_action(Actions::Pulp3::OrphanCleanup::DeleteOrphanRepositoryVersions, proxy)
               end
             end
           end

--- a/app/lib/actions/pulp3/orphan_cleanup/delete_orphan_distributions.rb
+++ b/app/lib/actions/pulp3/orphan_cleanup/delete_orphan_distributions.rb
@@ -1,0 +1,16 @@
+module Actions
+  module Pulp3
+    module OrphanCleanup
+      class DeleteOrphanDistributions < Pulp3::AbstractAsyncTask
+        def plan(smart_proxy)
+          plan_self(:smart_proxy_id => smart_proxy.id)
+        end
+
+        def invoke_external_task
+          smart_proxy_service = ::Katello::Pulp3::SmartProxyRepository.new(smart_proxy)
+          smart_proxy_service.delete_orphaned_distributions_for_mirror_proxies
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/orphan_cleanup/delete_orphan_remotes.rb
+++ b/app/lib/actions/pulp3/orphan_cleanup/delete_orphan_remotes.rb
@@ -1,0 +1,16 @@
+module Actions
+  module Pulp3
+    module OrphanCleanup
+      class DeleteOrphanRemotes < Pulp3::AbstractAsyncTask
+        def plan(smart_proxy)
+          plan_self(:smart_proxy_id => smart_proxy.id)
+        end
+
+        def invoke_external_task
+          smart_proxy_service = ::Katello::Pulp3::SmartProxyRepository.new(smart_proxy)
+          smart_proxy_service.delete_orphaned_remotes_for_mirror_proxies
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/repository/ansible_collection.rb
+++ b/app/services/katello/pulp3/repository/ansible_collection.rb
@@ -12,7 +12,7 @@ module Katello
           PulpAnsibleClient
         end
 
-        def api_exception_class
+        def self.api_exception_class
           PulpAnsibleClient::ApiError
         end
 
@@ -20,16 +20,16 @@ module Katello
           PulpAnsibleClient::CollectionRemote
         end
 
-        def remotes_api
-          PulpAnsibleClient::RemotesCollectionApi.new(api_client)
+        def self.remotes_api(smart_proxy)
+          PulpAnsibleClient::RemotesCollectionApi.new(api_client(smart_proxy))
         end
 
         def distribution_class
           PulpAnsibleClient::AnsibleDistribution
         end
 
-        def distributions_api
-          PulpAnsibleClient::DistributionsAnsibleApi.new(api_client)
+        def self.distributions_api(smart_proxy)
+          PulpAnsibleClient::DistributionsAnsibleApi.new(api_client(smart_proxy))
         end
 
         def remote_options

--- a/app/services/katello/pulp3/repository/docker.rb
+++ b/app/services/katello/pulp3/repository/docker.rb
@@ -8,7 +8,7 @@ module Katello
           PulpDockerClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpDockerClient::Configuration))
         end
 
-        def api_exception_class
+        def self.api_exception_class
           PulpDockerClient::ApiError
         end
 
@@ -20,16 +20,16 @@ module Katello
           PulpDockerClient::DockerRemote
         end
 
-        def remotes_api
-          PulpDockerClient::RemotesDockerApi.new(api_client)
+        def self.remotes_api(smart_proxy)
+          PulpDockerClient::RemotesDockerApi.new(api_client(smart_proxy))
         end
 
         def distribution_class
           PulpDockerClient::DockerDistribution
         end
 
-        def distributions_api
-          PulpDockerClient::DistributionsDockerApi.new(api_client)
+        def self.distributions_api(smart_proxy)
+          PulpDockerClient::DistributionsDockerApi.new(api_client(smart_proxy))
         end
 
         def recursive_manage_class

--- a/app/services/katello/pulp3/repository/file.rb
+++ b/app/services/katello/pulp3/repository/file.rb
@@ -4,7 +4,7 @@ module Katello
   module Pulp3
     class Repository
       class File < ::Katello::Pulp3::Repository
-        def api_exception_class
+        def self.api_exception_class
           PulpFileClient::ApiError
         end
 
@@ -20,8 +20,8 @@ module Katello
           PulpFileClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpFileClient::Configuration))
         end
 
-        def remotes_api
-          PulpFileClient::RemotesFileApi.new(api_client)
+        def self.remotes_api(smart_proxy)
+          PulpFileClient::RemotesFileApi.new(api_client(smart_proxy))
         end
 
         def publication_class
@@ -36,8 +36,8 @@ module Katello
           PulpFileClient::FileDistribution
         end
 
-        def distributions_api
-          PulpFileClient::DistributionsFileApi.new(api_client)
+        def self.distributions_api(smart_proxy)
+          PulpFileClient::DistributionsFileApi.new(api_client(smart_proxy))
         end
 
         def copy_content_for_source(source_repository, _options = {})

--- a/app/services/katello/pulp3/repository/yum.rb
+++ b/app/services/katello/pulp3/repository/yum.rb
@@ -8,7 +8,7 @@ module Katello
           PulpRpmClient::ApiClient.new(smart_proxy.pulp3_configuration(PulpRpmClient::Configuration))
         end
 
-        def api_exception_class
+        def self.api_exception_class
           PulpRpmClient::ApiError
         end
 
@@ -20,8 +20,8 @@ module Katello
           PulpRpmClient::RpmRemote
         end
 
-        def remotes_api
-          PulpRpmClient::RemotesRpmApi.new(api_client)
+        def self.remotes_api(smart_proxy)
+          PulpRpmClient::RemotesRpmApi.new(api_client(smart_proxy))
         end
 
         def publication_class
@@ -36,8 +36,8 @@ module Katello
           PulpRpmClient::RpmDistribution
         end
 
-        def distributions_api
-          PulpRpmClient::DistributionsRpmApi.new(api_client)
+        def self.distributions_api(smart_proxy)
+          PulpRpmClient::DistributionsRpmApi.new(api_client(smart_proxy))
         end
 
         def remote_options

--- a/app/services/katello/pulp3/smart_proxy_repository.rb
+++ b/app/services/katello/pulp3/smart_proxy_repository.rb
@@ -33,6 +33,14 @@ module Katello
           ::Katello::Pulp3::Repository.new(nil, smart_proxy).repositories_api.delete(repo.pulp_href)
         end
       end
+
+      def delete_orphaned_distributions_for_mirror_proxies
+        ::Katello::Pulp3::Repository.delete_orphan_distributions(smart_proxy)
+      end
+
+      def delete_orphaned_remotes_for_mirror_proxies
+        ::Katello::Pulp3::Repository.delete_orphan_remotes(smart_proxy)
+      end
     end
   end
 end

--- a/test/actions/katello/orphan_cleanup/remove_orphans_test.rb
+++ b/test/actions/katello/orphan_cleanup/remove_orphans_test.rb
@@ -34,22 +34,19 @@ module ::Actions::Katello::CapsuleContent
       smart_proxy = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
       tree = plan_action_tree(action_class, smart_proxy)
 
-      assert_tree_planned_with(tree, ::Actions::Pulp3::OrphanCleanup::DeleteOrphanRepositoryVersions) do |input|
-        assert_equal smart_proxy.id, input[:smart_proxy_id]
-      end
+      assert_tree_planned_with(tree, Actions::Pulp::OrphanCleanup::RemoveOrphans)
+      assert_tree_planned_with(tree, Actions::Pulp3::OrphanCleanup::DeleteOrphanRepositoryVersions)
     end
 
     it 'plans proxy orphans cleanup with pulp3 mirror' do
       smart_proxy = FactoryBot.create(:smart_proxy, :pulp_mirror, :with_pulp3)
       tree = plan_action_tree(action_class, smart_proxy)
 
-      assert_tree_planned_with(tree, ::Actions::Pulp3::OrphanCleanup::RemoveUnneededRepos) do |input|
-        assert_equal smart_proxy.id, input[:smart_proxy_id]
-      end
-
-      assert_tree_planned_with(tree, ::Actions::Pulp3::OrphanCleanup::DeleteOrphanRepositoryVersions) do |input|
-        assert_equal smart_proxy.id, input[:smart_proxy_id]
-      end
+      assert_tree_planned_with(tree, Actions::Pulp::OrphanCleanup::RemoveUnneededRepos)
+      assert_tree_planned_with(tree, Actions::Pulp::OrphanCleanup::RemoveOrphans)
+      assert_tree_planned_with(tree, Actions::Pulp3::OrphanCleanup::DeleteOrphanDistributions)
+      assert_tree_planned_with(tree, Actions::Pulp3::OrphanCleanup::DeleteOrphanRemotes)
+      assert_tree_planned_with(tree, Actions::Pulp3::OrphanCleanup::DeleteOrphanRepositoryVersions)
     end
   end
 

--- a/test/fixtures/vcr_cassettes/katello/pulp3/smart_proxy_repository_orphan_distributions/orphan_distributions_are_removed.yml
+++ b/test/fixtures/vcr_cassettes/katello/pulp3/smart_proxy_repository_orphan_distributions/orphan_distributions_are_removed.yml
@@ -1,0 +1,1072 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:44 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '249'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        YzA2OWJhOWUtMDAwMS00NTc1LTkyN2QtZTZmYWMwZjdjMjQ5LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMTktMTAtMzFUMTg6NDE6MDIuMTE2NzI3WiIsInZlcnNp
+        b25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2MwNjliYTll
+        LTAwMDEtNDU3NS05MjdkLWU2ZmFjMGY3YzI0OS92ZXJzaW9ucy8iLCJsYXRl
+        c3RfdmVyc2lvbl9ocmVmIjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6
+        YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJwbHVnaW5fbWFuYWdlZCI6
+        ZmFsc2UsImRlc2NyaXB0aW9uIjpudWxsfV19
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:44 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/c069ba9e-0001-4575-927d-e6fac0f7c249/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:44 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RlN2ZmYmI5LTg1YmYtNGEw
+        Ny1hZTRlLWY0NjRiNTc2ZWRmMi8ifQ==
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:44 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:44 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '348'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUv
+        ZmlsZS9mOTM1NDRiOS1hYjJiLTQ0ZDQtOWNlMC00OGE0OTI2NGE4MWYvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAxOS0xMC0zMVQxODo0MTowMi4yOTMyMzlaIiwi
+        bmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmls
+        ZV8xIiwidXJsIjoiaHR0cHM6Ly9yZXBvcy5mZWRvcmFwZW9wbGUub3JnL3Jl
+        cG9zL3B1bHAvcHVscC9maXh0dXJlcy9maWxlMi8vUFVMUF9NQU5JRkVTVCIs
+        InNzbF9jYV9jZXJ0aWZpY2F0ZSI6bnVsbCwic3NsX2NsaWVudF9jZXJ0aWZp
+        Y2F0ZSI6bnVsbCwic3NsX2NsaWVudF9rZXkiOm51bGwsInNzbF92YWxpZGF0
+        aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAxOS0xMC0zMVQxODo0MTowMi4yOTMyNTZaIiwiZG93bmxvYWRfY29u
+        Y3VycmVuY3kiOjIwLCJwb2xpY3kiOiJpbW1lZGlhdGUifV19
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:44 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/f93544b9-ab2b-44d4-9ce0-48a49264a81f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:44 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzUyYmM5MmExLTFlODktNGU2
+        Ny05YTNiLWJjZDkxNmRjMTM0My8ifQ==
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:44 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:45 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:45 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:45 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:45 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:45 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:45 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:46 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/3a9a4a00-d3cf-4318-bf5f-186dc7ba2f15/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '335'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzNhOWE0
+        YTAwLWQzY2YtNDMxOC1iZjVmLTE4NmRjN2JhMmYxNS8iLCJwdWxwX2NyZWF0
+        ZWQiOiIyMDE5LTEwLTMxVDE4OjQyOjQ2LjU5ODEzM1oiLCJ2ZXJzaW9uc19o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy8zYTlhNGEwMC1kM2Nm
+        LTQzMTgtYmY1Zi0xODZkYzdiYTJmMTUvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
+        cnNpb25faHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9u
+        LUNhYmluZXQtcHVscDNfRmlsZV8xIiwicGx1Z2luX21hbmFnZWQiOmZhbHNl
+        LCJkZXNjcmlwdGlvbiI6bnVsbH0=
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:46 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEiLCJ1cmwiOiJodHRwczovL3JlcG9zLmZlZG9yYXBlb3BsZS5vcmcv
+        cmVwb3MvcHVscC9wdWxwL2ZpeHR1cmVzL2ZpbGUyLy9QVUxQX01BTklGRVNU
+        Iiwic3NsX3ZhbGlkYXRpb24iOnRydWUsInBvbGljeSI6ImltbWVkaWF0ZSJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:46 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/file/file/84181b43-1dda-4e6c-b6f4-040888bd3cbf/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '479'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
+        ODQxODFiNDMtMWRkYS00ZTZjLWI2ZjQtMDQwODg4YmQzY2JmLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMTktMTAtMzFUMTg6NDI6NDYuODI1NjQ5WiIsIm5hbWUi
+        OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIs
+        InVybCI6Imh0dHBzOi8vcmVwb3MuZmVkb3JhcGVvcGxlLm9yZy9yZXBvcy9w
+        dWxwL3B1bHAvZml4dHVyZXMvZmlsZTIvL1BVTFBfTUFOSUZFU1QiLCJzc2xf
+        Y2FfY2VydGlmaWNhdGUiOm51bGwsInNzbF9jbGllbnRfY2VydGlmaWNhdGUi
+        Om51bGwsInNzbF9jbGllbnRfa2V5IjpudWxsLCJzc2xfdmFsaWRhdGlvbiI6
+        dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
+        MTktMTAtMzFUMTg6NDI6NDYuODI1Njg3WiIsImRvd25sb2FkX2NvbmN1cnJl
+        bmN5IjoyMCwicG9saWN5IjoiaW1tZWRpYXRlIn0=
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:46 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi9saWJyYXJ5L3B1
+        bHAzX0ZpbGVfMSIsIm5hbWUiOiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
+        bmV0LXB1bHAzX0ZpbGVfMSJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EzZjRmMzNiLWFhMmItNGEx
+        Ny1hYTQ1LWVjMTc2MzExZWRmNS8ifQ==
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:47 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/tasks/a3f4f33b-aa2b-4a17-aa45-ec176311edf5/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:47 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '335'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTNmNGYzM2ItYWEy
+        Yi00YTE3LWFhNDUtZWMxNzYzMTFlZGY1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTAtMzFUMTg6NDI6NDcuMjMxMjI3WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTAtMzFUMTg6NDI6NDcuNDczMzI1
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMC0zMVQxODo0Mjo0Ny42ODI2NTRa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        Lzg3NDRhMjNmLWNiMTItNDdhNy1iZDk4LWJmNDU4Mjk4YTlkZC8iLCJwYXJl
+        bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
+        IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3Ry
+        aWJ1dGlvbnMvZmlsZS9maWxlL2NjMDE5ZGFmLWM3N2EtNGNkNi05MDU0LWJk
+        NDQ1ZTIwNDJlZC8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyIv
+        YXBpL3YzL2Rpc3RyaWJ1dGlvbnMvIl19
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:47 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/cc019daf-c77a-4cd6-9054-bd445e2042ed/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:48 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '256'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
+        L2ZpbGUvY2MwMTlkYWYtYzc3YS00Y2Q2LTkwNTQtYmQ0NDVlMjA0MmVkLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMTktMTAtMzFUMTg6NDI6NDcuNjYyMDc5WiIs
+        ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVs
+        cDNfRmlsZV8xIiwiYmFzZV91cmwiOiJjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        amplZmZlcnMuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3Jn
+        YW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xIiwiY29udGVudF9ndWFy
+        ZCI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQt
+        cHVscDNfRmlsZV8xIiwicHVibGljYXRpb24iOm51bGx9
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:48 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:48 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '402'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L2ZpbGUvZmlsZS80YTQ1YmMzNC1hOTVlLTQ5NTktOGEwZC0yYjM2MDlmNDE5
+        OTkvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMC0zMVQxNzoxNzowNC45Njgy
+        NjNaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vTGlicmFy
+        eS9jdXN0b20vdGVzdC9zaW1wbGUiLCJiYXNlX3VybCI6ImNlbnRvczcta2F0
+        ZWxsby1kZXZlbC5qamVmZmVycy5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQv
+        RGVmYXVsdF9Pcmdhbml6YXRpb24vTGlicmFyeS9jdXN0b20vdGVzdC9zaW1w
+        bGUiLCJjb250ZW50X2d1YXJkIjpudWxsLCJuYW1lIjoic2ltcGxlLTE0MDEi
+        LCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmls
+        ZS9maWxlL2QzOTYxNjdlLTQ4NjItNDQ5Yi04M2VmLWNmY2IxMjc0ZjZlNi8i
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2Zp
+        bGUvZmlsZS9jYzAxOWRhZi1jNzdhLTRjZDYtOTA1NC1iZDQ0NWUyMDQyZWQv
+        IiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMC0zMVQxODo0Mjo0Ny42NjIwNzla
+        IiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFyeS9w
+        dWxwM19GaWxlXzEiLCJiYXNlX3VybCI6ImNlbnRvczcta2F0ZWxsby1kZXZl
+        bC5qamVmZmVycy5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9P
+        cmdhbml6YXRpb24vbGlicmFyeS9wdWxwM19GaWxlXzEiLCJjb250ZW50X2d1
+        YXJkIjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5l
+        dC1wdWxwM19GaWxlXzEiLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:48 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:48 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '402'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L2ZpbGUvZmlsZS80YTQ1YmMzNC1hOTVlLTQ5NTktOGEwZC0yYjM2MDlmNDE5
+        OTkvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMC0zMVQxNzoxNzowNC45Njgy
+        NjNaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vTGlicmFy
+        eS9jdXN0b20vdGVzdC9zaW1wbGUiLCJiYXNlX3VybCI6ImNlbnRvczcta2F0
+        ZWxsby1kZXZlbC5qamVmZmVycy5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQv
+        RGVmYXVsdF9Pcmdhbml6YXRpb24vTGlicmFyeS9jdXN0b20vdGVzdC9zaW1w
+        bGUiLCJjb250ZW50X2d1YXJkIjpudWxsLCJuYW1lIjoic2ltcGxlLTE0MDEi
+        LCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmls
+        ZS9maWxlL2QzOTYxNjdlLTQ4NjItNDQ5Yi04M2VmLWNmY2IxMjc0ZjZlNi8i
+        fSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25zL2Zp
+        bGUvZmlsZS9jYzAxOWRhZi1jNzdhLTRjZDYtOTA1NC1iZDQ0NWUyMDQyZWQv
+        IiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMC0zMVQxODo0Mjo0Ny42NjIwNzla
+        IiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vbGlicmFyeS9w
+        dWxwM19GaWxlXzEiLCJiYXNlX3VybCI6ImNlbnRvczcta2F0ZWxsby1kZXZl
+        bC5qamVmZmVycy5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvRGVmYXVsdF9P
+        cmdhbml6YXRpb24vbGlicmFyeS9wdWxwM19GaWxlXzEiLCJjb250ZW50X2d1
+        YXJkIjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5l
+        dC1wdWxwM19GaWxlXzEiLCJwdWJsaWNhdGlvbiI6bnVsbH1dfQ==
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:48 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/4a45bc34-a95e-4959-8a0d-2b3609f41999/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:48 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '290'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
+        L2ZpbGUvNGE0NWJjMzQtYTk1ZS00OTU5LThhMGQtMmIzNjA5ZjQxOTk5LyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMTktMTAtMzFUMTc6MTc6MDQuOTY4MjYzWiIs
+        ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL0xpYnJhcnkvY3Vz
+        dG9tL3Rlc3Qvc2ltcGxlIiwiYmFzZV91cmwiOiJjZW50b3M3LWthdGVsbG8t
+        ZGV2ZWwuamplZmZlcnMuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1
+        bHRfT3JnYW5pemF0aW9uL0xpYnJhcnkvY3VzdG9tL3Rlc3Qvc2ltcGxlIiwi
+        Y29udGVudF9ndWFyZCI6bnVsbCwibmFtZSI6InNpbXBsZS0xNDAxIiwicHVi
+        bGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL2ZpbGUvZmls
+        ZS9kMzk2MTY3ZS00ODYyLTQ0OWItODNlZi1jZmNiMTI3NGY2ZTYvIn0=
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:48 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/cc019daf-c77a-4cd6-9054-bd445e2042ed/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:48 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '256'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9maWxl
+        L2ZpbGUvY2MwMTlkYWYtYzc3YS00Y2Q2LTkwNTQtYmQ0NDVlMjA0MmVkLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMTktMTAtMzFUMTg6NDI6NDcuNjYyMDc5WiIs
+        ImJhc2VfcGF0aCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uL2xpYnJhcnkvcHVs
+        cDNfRmlsZV8xIiwiYmFzZV91cmwiOiJjZW50b3M3LWthdGVsbG8tZGV2ZWwu
+        amplZmZlcnMuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0RlZmF1bHRfT3Jn
+        YW5pemF0aW9uL2xpYnJhcnkvcHVscDNfRmlsZV8xIiwiY29udGVudF9ndWFy
+        ZCI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQt
+        cHVscDNfRmlsZV8xIiwicHVibGljYXRpb24iOm51bGx9
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:48 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/cc019daf-c77a-4cd6-9054-bd445e2042ed/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:48 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2QxNGM0MWRkLTE3OWQtNGQz
+        NS1hZGI2LTVhZjhhYWEzMDI2OS8ifQ==
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:48 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:49 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '318'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L2ZpbGUvZmlsZS80YTQ1YmMzNC1hOTVlLTQ5NTktOGEwZC0yYjM2MDlmNDE5
+        OTkvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0xMC0zMVQxNzoxNzowNC45Njgy
+        NjNaIiwiYmFzZV9wYXRoIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24vTGlicmFy
+        eS9jdXN0b20vdGVzdC9zaW1wbGUiLCJiYXNlX3VybCI6ImNlbnRvczcta2F0
+        ZWxsby1kZXZlbC5qamVmZmVycy5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQv
+        RGVmYXVsdF9Pcmdhbml6YXRpb24vTGlicmFyeS9jdXN0b20vdGVzdC9zaW1w
+        bGUiLCJjb250ZW50X2d1YXJkIjpudWxsLCJuYW1lIjoic2ltcGxlLTE0MDEi
+        LCJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvZmls
+        ZS9maWxlL2QzOTYxNjdlLTQ4NjItNDQ5Yi04M2VmLWNmY2IxMjc0ZjZlNi8i
+        fV19
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:49 GMT
+recorded_with: VCR 3.0.3

--- a/test/fixtures/vcr_cassettes/katello/pulp3/smart_proxy_repository_orphan_distributions/orphan_remotes_are_removed.yml
+++ b/test/fixtures/vcr_cassettes/katello/pulp3/smart_proxy_repository_orphan_distributions/orphan_remotes_are_removed.yml
@@ -1,0 +1,871 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:50 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '249'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        M2E5YTRhMDAtZDNjZi00MzE4LWJmNWYtMTg2ZGM3YmEyZjE1LyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMTktMTAtMzFUMTg6NDI6NDYuNTk4MTMzWiIsInZlcnNp
+        b25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzNhOWE0YTAw
+        LWQzY2YtNDMxOC1iZjVmLTE4NmRjN2JhMmYxNS92ZXJzaW9ucy8iLCJsYXRl
+        c3RfdmVyc2lvbl9ocmVmIjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6
+        YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJwbHVnaW5fbWFuYWdlZCI6
+        ZmFsc2UsImRlc2NyaXB0aW9uIjpudWxsfV19
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:50 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/3a9a4a00-d3cf-4318-bf5f-186dc7ba2f15/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:50 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQ4NDgyMmZkLWNhZmMtNGM4
+        ZS04NTlkLTdmOWRjZTI1YmUxNy8ifQ==
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:50 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:50 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '349'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUv
+        ZmlsZS84NDE4MWI0My0xZGRhLTRlNmMtYjZmNC0wNDA4ODhiZDNjYmYvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAxOS0xMC0zMVQxODo0Mjo0Ni44MjU2NDlaIiwi
+        bmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmls
+        ZV8xIiwidXJsIjoiaHR0cHM6Ly9yZXBvcy5mZWRvcmFwZW9wbGUub3JnL3Jl
+        cG9zL3B1bHAvcHVscC9maXh0dXJlcy9maWxlMi8vUFVMUF9NQU5JRkVTVCIs
+        InNzbF9jYV9jZXJ0aWZpY2F0ZSI6bnVsbCwic3NsX2NsaWVudF9jZXJ0aWZp
+        Y2F0ZSI6bnVsbCwic3NsX2NsaWVudF9rZXkiOm51bGwsInNzbF92YWxpZGF0
+        aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAxOS0xMC0zMVQxODo0Mjo0Ni44MjU2ODdaIiwiZG93bmxvYWRfY29u
+        Y3VycmVuY3kiOjIwLCJwb2xpY3kiOiJpbW1lZGlhdGUifV19
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:50 GMT
+- request:
+    method: delete
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/84181b43-1dda-4e6c-b6f4-040888bd3cbf/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:51 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzA1Y2ZhYjVmLWJmYTctNDhi
+        MS05MjJhLWU1YmE3NjkyOGE3OS8ifQ==
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:51 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:51 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:51 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:51 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:51 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:51 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:51 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:51 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:51 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?name=Default_Organization-Cabinet-pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:51 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:51 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/distributions/file/file/?base_path=Default_Organization/library/pulp3_File_1
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:52 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/ba9298ed-d606-4b6f-9be4-59971f27f96c/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '335'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2JhOTI5
+        OGVkLWQ2MDYtNGI2Zi05YmU0LTU5OTcxZjI3Zjk2Yy8iLCJwdWxwX2NyZWF0
+        ZWQiOiIyMDE5LTEwLTMxVDE4OjQyOjUyLjM5MjQ2OVoiLCJ2ZXJzaW9uc19o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iYTkyOThlZC1kNjA2
+        LTRiNmYtOWJlNC01OTk3MWYyN2Y5NmMvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
+        cnNpb25faHJlZiI6bnVsbCwibmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9u
+        LUNhYmluZXQtcHVscDNfRmlsZV8xIiwicGx1Z2luX21hbmFnZWQiOmZhbHNl
+        LCJkZXNjcmlwdGlvbiI6bnVsbH0=
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:52 GMT
+- request:
+    method: post
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1wdWxwM19G
+        aWxlXzEiLCJ1cmwiOiJodHRwczovL3JlcG9zLmZlZG9yYXBlb3BsZS5vcmcv
+        cmVwb3MvcHVscC9wdWxwL2ZpeHR1cmVzL2ZpbGUyLy9QVUxQX01BTklGRVNU
+        Iiwic3NsX3ZhbGlkYXRpb24iOnRydWUsInBvbGljeSI6ImltbWVkaWF0ZSJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/file/file/0c4e3bbd-347d-41dc-a9e2-539666a0d8a2/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '479'
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9maWxlL2ZpbGUv
+        MGM0ZTNiYmQtMzQ3ZC00MWRjLWE5ZTItNTM5NjY2YTBkOGEyLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMTktMTAtMzFUMTg6NDI6NTIuNTY2ODIxWiIsIm5hbWUi
+        OiJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LXB1bHAzX0ZpbGVfMSIs
+        InVybCI6Imh0dHBzOi8vcmVwb3MuZmVkb3JhcGVvcGxlLm9yZy9yZXBvcy9w
+        dWxwL3B1bHAvZml4dHVyZXMvZmlsZTIvL1BVTFBfTUFOSUZFU1QiLCJzc2xf
+        Y2FfY2VydGlmaWNhdGUiOm51bGwsInNzbF9jbGllbnRfY2VydGlmaWNhdGUi
+        Om51bGwsInNzbF9jbGllbnRfa2V5IjpudWxsLCJzc2xfdmFsaWRhdGlvbiI6
+        dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
+        MTktMTAtMzFUMTg6NDI6NTIuNTY2ODM5WiIsImRvd25sb2FkX2NvbmN1cnJl
+        bmN5IjoyMCwicG9saWN5IjoiaW1tZWRpYXRlIn0=
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:52 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '525'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        YmE5Mjk4ZWQtZDYwNi00YjZmLTliZTQtNTk5NzFmMjdmOTZjLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMTktMTAtMzFUMTg6NDI6NTIuMzkyNDY5WiIsInZlcnNp
+        b25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2JhOTI5OGVk
+        LWQ2MDYtNGI2Zi05YmU0LTU5OTcxZjI3Zjk2Yy92ZXJzaW9ucy8iLCJsYXRl
+        c3RfdmVyc2lvbl9ocmVmIjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6
+        YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJwbHVnaW5fbWFuYWdlZCI6
+        ZmFsc2UsImRlc2NyaXB0aW9uIjpudWxsfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvYWRjNThjMGMtN2Q2Yy00NzRjLTg2NmYt
+        YTgzYWRkNTgxZmIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTAtMjlUMTg6
+        NTc6MDQuNDk3MDY5WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2FkYzU4YzBjLTdkNmMtNDc0Yy04NjZmLWE4M2FkZDU4
+        MWZiMy92ZXJzaW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjpudWxsLCJu
+        YW1lIjoiZmlsZV90ZXN0LTExOTEiLCJwbHVnaW5fbWFuYWdlZCI6ZmFsc2Us
+        ImRlc2NyaXB0aW9uIjpudWxsfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvMWJkNjJhYmItMjdhMC00OWYwLWJjNGItNTY0NGE1
+        NzgxMDlhLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTAtMzBUMTQ6NDA6NTYu
+        NjMzMzAyWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzLzFiZDYyYWJiLTI3YTAtNDlmMC1iYzRiLTU2NDRhNTc4MTA5YS92
+        ZXJzaW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjpudWxsLCJuYW1lIjoi
+        ZmlsZV90ZXN0LTMyODgwIiwicGx1Z2luX21hbmFnZWQiOmZhbHNlLCJkZXNj
+        cmlwdGlvbiI6bnVsbH0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVw
+        b3NpdG9yaWVzLzM3YTllMjczLWRjNjktNDM5ZS1hNTcxLTVkMWJmMmFjOGZh
+        NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEwLTMxVDE3OjE2OjU1LjgwMTI4
+        NFoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy8zN2E5ZTI3My1kYzY5LTQzOWUtYTU3MS01ZDFiZjJhYzhmYTQvdmVyc2lv
+        bnMvIiwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvMzdhOWUyNzMtZGM2OS00MzllLWE1NzEtNWQxYmYyYWM4ZmE0
+        L3ZlcnNpb25zLzIvIiwibmFtZSI6InNpbXBsZS0xMjQxNCIsInBsdWdpbl9t
+        YW5hZ2VkIjpmYWxzZSwiZGVzY3JpcHRpb24iOm51bGx9LHsicHVscF9ocmVm
+        IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iYTA3NzgwMC1lMTNhLTRl
+        OWYtYjAzMC1hZmExYjM4YmUxOTEvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0x
+        MC0zMVQxNToyMDo1NS43MDI4NzdaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvYmEwNzc4MDAtZTEzYS00ZTlmLWIwMzAt
+        YWZhMWIzOGJlMTkxL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYi
+        Om51bGwsIm5hbWUiOiJzaW1wbGUtNTQwNzgiLCJwbHVnaW5fbWFuYWdlZCI6
+        ZmFsc2UsImRlc2NyaXB0aW9uIjpudWxsfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvMWRiY2RkYjEtODUzZi00ZTU4LWJhODEt
+        NTYxYjliYjJiMDBjLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTAtMzBUMTQ6
+        Mjc6MTcuNjg1MTY0WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzFkYmNkZGIxLTg1M2YtNGU1OC1iYTgxLTU2MWI5YmIy
+        YjAwYy92ZXJzaW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjpudWxsLCJu
+        YW1lIjoidGVzdF9maWxlXzItMjg2OTEiLCJwbHVnaW5fbWFuYWdlZCI6ZmFs
+        c2UsImRlc2NyaXB0aW9uIjpudWxsfV19
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:52 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:52 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '348'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUv
+        ZmlsZS8wYzRlM2JiZC0zNDdkLTQxZGMtYTllMi01Mzk2NjZhMGQ4YTIvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAxOS0xMC0zMVQxODo0Mjo1Mi41NjY4MjFaIiwi
+        bmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmls
+        ZV8xIiwidXJsIjoiaHR0cHM6Ly9yZXBvcy5mZWRvcmFwZW9wbGUub3JnL3Jl
+        cG9zL3B1bHAvcHVscC9maXh0dXJlcy9maWxlMi8vUFVMUF9NQU5JRkVTVCIs
+        InNzbF9jYV9jZXJ0aWZpY2F0ZSI6bnVsbCwic3NsX2NsaWVudF9jZXJ0aWZp
+        Y2F0ZSI6bnVsbCwic3NsX2NsaWVudF9rZXkiOm51bGwsInNzbF92YWxpZGF0
+        aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAxOS0xMC0zMVQxODo0Mjo1Mi41NjY4MzlaIiwiZG93bmxvYWRfY29u
+        Y3VycmVuY3kiOjIwLCJwb2xpY3kiOiJpbW1lZGlhdGUifV19
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:52 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/repositories/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '525'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6NiwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
+        YmE5Mjk4ZWQtZDYwNi00YjZmLTliZTQtNTk5NzFmMjdmOTZjLyIsInB1bHBf
+        Y3JlYXRlZCI6IjIwMTktMTAtMzFUMTg6NDI6NTIuMzkyNDY5WiIsInZlcnNp
+        b25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2JhOTI5OGVk
+        LWQ2MDYtNGI2Zi05YmU0LTU5OTcxZjI3Zjk2Yy92ZXJzaW9ucy8iLCJsYXRl
+        c3RfdmVyc2lvbl9ocmVmIjpudWxsLCJuYW1lIjoiRGVmYXVsdF9Pcmdhbml6
+        YXRpb24tQ2FiaW5ldC1wdWxwM19GaWxlXzEiLCJwbHVnaW5fbWFuYWdlZCI6
+        ZmFsc2UsImRlc2NyaXB0aW9uIjpudWxsfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvYWRjNThjMGMtN2Q2Yy00NzRjLTg2NmYt
+        YTgzYWRkNTgxZmIzLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTAtMjlUMTg6
+        NTc6MDQuNDk3MDY5WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzL2FkYzU4YzBjLTdkNmMtNDc0Yy04NjZmLWE4M2FkZDU4
+        MWZiMy92ZXJzaW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjpudWxsLCJu
+        YW1lIjoiZmlsZV90ZXN0LTExOTEiLCJwbHVnaW5fbWFuYWdlZCI6ZmFsc2Us
+        ImRlc2NyaXB0aW9uIjpudWxsfSx7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92
+        My9yZXBvc2l0b3JpZXMvMWJkNjJhYmItMjdhMC00OWYwLWJjNGItNTY0NGE1
+        NzgxMDlhLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTAtMzBUMTQ6NDA6NTYu
+        NjMzMzAyWiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3Np
+        dG9yaWVzLzFiZDYyYWJiLTI3YTAtNDlmMC1iYzRiLTU2NDRhNTc4MTA5YS92
+        ZXJzaW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjpudWxsLCJuYW1lIjoi
+        ZmlsZV90ZXN0LTMyODgwIiwicGx1Z2luX21hbmFnZWQiOmZhbHNlLCJkZXNj
+        cmlwdGlvbiI6bnVsbH0seyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVw
+        b3NpdG9yaWVzLzM3YTllMjczLWRjNjktNDM5ZS1hNTcxLTVkMWJmMmFjOGZh
+        NC8iLCJwdWxwX2NyZWF0ZWQiOiIyMDE5LTEwLTMxVDE3OjE2OjU1LjgwMTI4
+        NFoiLCJ2ZXJzaW9uc19ocmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy8zN2E5ZTI3My1kYzY5LTQzOWUtYTU3MS01ZDFiZjJhYzhmYTQvdmVyc2lv
+        bnMvIiwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvMzdhOWUyNzMtZGM2OS00MzllLWE1NzEtNWQxYmYyYWM4ZmE0
+        L3ZlcnNpb25zLzIvIiwibmFtZSI6InNpbXBsZS0xMjQxNCIsInBsdWdpbl9t
+        YW5hZ2VkIjpmYWxzZSwiZGVzY3JpcHRpb24iOm51bGx9LHsicHVscF9ocmVm
+        IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9iYTA3NzgwMC1lMTNhLTRl
+        OWYtYjAzMC1hZmExYjM4YmUxOTEvIiwicHVscF9jcmVhdGVkIjoiMjAxOS0x
+        MC0zMVQxNToyMDo1NS43MDI4NzdaIiwidmVyc2lvbnNfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvYmEwNzc4MDAtZTEzYS00ZTlmLWIwMzAt
+        YWZhMWIzOGJlMTkxL3ZlcnNpb25zLyIsImxhdGVzdF92ZXJzaW9uX2hyZWYi
+        Om51bGwsIm5hbWUiOiJzaW1wbGUtNTQwNzgiLCJwbHVnaW5fbWFuYWdlZCI6
+        ZmFsc2UsImRlc2NyaXB0aW9uIjpudWxsfSx7InB1bHBfaHJlZiI6Ii9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvMWRiY2RkYjEtODUzZi00ZTU4LWJhODEt
+        NTYxYjliYjJiMDBjLyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTAtMzBUMTQ6
+        Mjc6MTcuNjg1MTY0WiIsInZlcnNpb25zX2hyZWYiOiIvcHVscC9hcGkvdjMv
+        cmVwb3NpdG9yaWVzLzFkYmNkZGIxLTg1M2YtNGU1OC1iYTgxLTU2MWI5YmIy
+        YjAwYy92ZXJzaW9ucy8iLCJsYXRlc3RfdmVyc2lvbl9ocmVmIjpudWxsLCJu
+        YW1lIjoidGVzdF9maWxlXzItMjg2OTEiLCJwbHVnaW5fbWFuYWdlZCI6ZmFs
+        c2UsImRlc2NyaXB0aW9uIjpudWxsfV19
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:53 GMT
+- request:
+    method: get
+    uri: https://centos7-katello-devel.jjeffers.example.com/pulp/api/v3/remotes/file/file/?limit=2000&offset=0
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.1.0b5.dev01571253617/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 31 Oct 2019 18:42:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 centos7-katello-devel.jjeffers.example.com
+      Content-Length:
+      - '348'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2ZpbGUv
+        ZmlsZS8wYzRlM2JiZC0zNDdkLTQxZGMtYTllMi01Mzk2NjZhMGQ4YTIvIiwi
+        cHVscF9jcmVhdGVkIjoiMjAxOS0xMC0zMVQxODo0Mjo1Mi41NjY4MjFaIiwi
+        bmFtZSI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtcHVscDNfRmls
+        ZV8xIiwidXJsIjoiaHR0cHM6Ly9yZXBvcy5mZWRvcmFwZW9wbGUub3JnL3Jl
+        cG9zL3B1bHAvcHVscC9maXh0dXJlcy9maWxlMi8vUFVMUF9NQU5JRkVTVCIs
+        InNzbF9jYV9jZXJ0aWZpY2F0ZSI6bnVsbCwic3NsX2NsaWVudF9jZXJ0aWZp
+        Y2F0ZSI6bnVsbCwic3NsX2NsaWVudF9rZXkiOm51bGwsInNzbF92YWxpZGF0
+        aW9uIjp0cnVlLCJwcm94eV91cmwiOm51bGwsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAxOS0xMC0zMVQxODo0Mjo1Mi41NjY4MzlaIiwiZG93bmxvYWRfY29u
+        Y3VycmVuY3kiOjIwLCJwb2xpY3kiOiJpbW1lZGlhdGUifV19
+    http_version: 
+  recorded_at: Thu, 31 Oct 2019 18:42:53 GMT
+recorded_with: VCR 3.0.3

--- a/test/services/katello/pulp3/repository/orphan_distributions_test.rb
+++ b/test/services/katello/pulp3/repository/orphan_distributions_test.rb
@@ -1,0 +1,36 @@
+require 'katello_test_helper'
+require 'support/pulp3_support'
+
+module Katello
+  module Service
+    class RepositoryIsOrphanDistributionTest < ActiveSupport::TestCase
+      include Katello::Pulp3Support
+
+      def test_distribution_with_publication_is_not_an_orphan
+        dist = PulpFileClient::FileDistribution.new(
+          publication: 'http://some.href')
+        refute Katello::Pulp3::Repository.orphan_distribution?(dist)
+      end
+
+      def test_distribution_without_a_publication_is_an_orphan
+        dist = PulpFileClient::FileDistribution.new(
+          publication: nil)
+        assert Katello::Pulp3::Repository.orphan_distribution?(dist)
+      end
+
+      def test_distribution_with_repository_and_repository_version_is_not_an_orphan
+        dist = PulpAnsibleClient::AnsibleDistribution.new(
+          repository: 'http://some.href',
+          repository_version: 'http://some.href/version/')
+        refute Katello::Pulp3::Repository.orphan_distribution?(dist)
+      end
+
+      def test_distribution_without_repository_and_repository_version_is_an_orphan
+        dist = PulpAnsibleClient::AnsibleDistribution.new(
+          repository: nil,
+          repository_version: nil)
+        assert Katello::Pulp3::Repository.orphan_distribution?(dist)
+      end
+    end
+  end
+end

--- a/test/services/katello/pulp3/smart_proxy_repository_test.rb
+++ b/test/services/katello/pulp3/smart_proxy_repository_test.rb
@@ -1,0 +1,65 @@
+require 'katello_test_helper'
+require 'support/pulp3_support'
+
+module Katello
+  module Pulp3
+    class SmartProxyRepositoryOrphanDistributionsTest < ActiveSupport::TestCase
+      include Katello::Pulp3Support
+
+      def setup
+        @settings = SETTINGS[:katello][:content_types]
+        SETTINGS[:katello][:content_types] = { file: nil }
+
+        User.current = users(:admin)
+        @master = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+        @repo = katello_repositories(:pulp3_file_1)
+        @repo.root.update_attributes(:url => 'https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/file2/')
+        ensure_creatable(@repo, @master)
+        create_repo(@repo, @master)
+      end
+
+      def teardown
+        SETTINGS[:katello][:content_types] = @settings
+      end
+
+      def test_orphan_distributions_are_removed
+        @repo.root.update_attributes(:url => 'https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/file/')
+        ForemanTasks.sync_task(
+          ::Actions::Pulp3::Repository::RefreshDistribution,
+          @repo,
+          @master, contents_changed: true)
+
+        pulp3_file_repo = Katello::Pulp3::Repository::File.new(@repo, @master)
+        distributions = pulp3_file_repo.lookup_distributions({})
+        dist = distributions.last
+        assert_nil dist.publication
+
+        smart_proxy_repository = Katello::Pulp3::SmartProxyRepository.new(@master)
+        smart_proxy_repository.delete_orphaned_distributions_for_mirror_proxies
+
+        distributions = pulp3_file_repo.lookup_distributions({})
+        refute_includes distributions, dist,
+          'Distributions from capsule included an orphaned distribution that should have been deleted.'
+      end
+
+      def test_orphan_remotes_are_removed
+        pulp3_file_repo = Katello::Pulp3::Repository.new(@repo, @master)
+        pulp3_file_repo.create
+
+        repo_href = pulp3_file_repo.repository_reference.repository_href
+        remote_href = pulp3_file_repo.repo.remote_href
+        assert remote_href, 'Remote href was nil or blank.'
+
+        repos = Katello::Pulp3::Repository.list(@master, {}).pluck(:_href)
+        refute_includes repos, repo_href
+
+        smart_proxy_repository = Katello::Pulp3::SmartProxyRepository.new(@master)
+        smart_proxy_repository.delete_orphaned_remotes_for_mirror_proxies
+
+        remote_hrefs = Katello::Pulp3::Repository::File.remotes_list(@master, {}).pluck(:_href)
+        refute_includes remote_hrefs, remote_href,
+          'Remotes from capsule included an orphaned remote that should have been deleted.'
+      end
+    end
+  end
+end

--- a/test/support/pulp3_support.rb
+++ b/test/support/pulp3_support.rb
@@ -17,12 +17,11 @@ module Katello
       service.class.any_instance.stubs(:backend_object_name).returns(repo.pulp_id)
 
       tasks = []
-
       if (repo = service.list(name: service.backend_object_name).first)
         tasks << service.delete(repo.pulp_href)
       end
 
-      if (remote = service.list_remotes(name: service.backend_object_name).first)
+      if (remote = service.remotes_list(name: service.backend_object_name).first)
         tasks << service.delete_remote(remote.pulp_href)
       end
 


### PR DESCRIPTION
This PR adds actions to remove orphaned distributions in pulp3 mirrors (capsules).

Prepare a product with multiple pulp3 repositories (docker, ansible collection, and file).
Attach a capsule instance to your Katello server, and assign that capsule to a lifecycle environment.

Sync the capsule. 

You should then observe that the capsule pulp3 schema contains not only repositories and repository versions, but also distributions.

```pulp=# select _id, _type, name from core_basedistribution;
                 _id                  |      _type      |                        name                         
--------------------------------------+-----------------+-----------------------------------------------------
 c57a51de-f318-4704-a4fe-f32a859a826c | file.file       | 1-test-Library-51bbe6e4-7593-4815-a090-2a1c8857a5b5
 e18d9f12-1d35-4c51-94b2-4ad4f01cbd20 | docker.docker   | 1-test-library-9b75f462-ce2e-4b56-b212-e6f46a733c48
 bd74f80c-7f6e-48f0-9692-d597ac3de522 | docker.docker   | 9b75f462-ce2e-4b56-b212-e6f46a733c48
 b2066d5f-cb51-424a-a82e-42599e87b250 | ansible.ansible | 101fd25b-553f-409d-b450-720e0319abf0
(4 rows)

pulp=# select * from file_filedistribution;
       basedistribution_ptr_id        |            publication_id            
--------------------------------------+--------------------------------------
 c57a51de-f318-4704-a4fe-f32a859a826c | 2430c2c6-71ec-4b75-8dd2-9416ae179e05
(1 row)

pulp=# select * from ansible_ansibledistribution;
       basedistribution_ptr_id        | repository_id | repository_version_id 
--------------------------------------+---------------+-----------------------
 b2066d5f-cb51-424a-a82e-42599e87b250 |               | 
(1 row)

pulp=# select * from docker_dockerdistribution;
       basedistribution_ptr_id        | repository_id | repository_version_id 
--------------------------------------+---------------+-----------------------
 e18d9f12-1d35-4c51-94b2-4ad4f01cbd20 |               | 
 bd74f80c-7f6e-48f0-9692-d597ac3de522 |               | 
(2 rows)
```
After the sync and verifying the distributions exists, remove the capsule from any lifecycle environments. 

Run the delete orphans task `bundle exec rake katello:delete_orphaned_content`

Check the capsule pulp3 schema, and the repositories, repository versions, publications, and the distributions should be removed.

```
pulp=# select * from core_basedistribution;
 _id | _created | _last_updated | _type | name | base_path | content_guard_id | remote_id 
-----+----------+---------------+-------+------+-----------+------------------+-----------
(0 rows)

pulp=# select * from ansible_ansibledistribution;
 basedistribution_ptr_id | repository_id | repository_version_id 
-------------------------+---------------+-----------------------
(0 rows)

pulp=# select * from docker_dockerdistribution;
 basedistribution_ptr_id | repository_id | repository_version_id 
-------------------------+---------------+-----------------------
(0 rows)

pulp=# select * from file_filedistribution;
 basedistribution_ptr_id | publication_id 
-------------------------+----------------
(0 rows)
```