### PR TITLE
Fixes #27934 - Initial Content units migration task

### DIFF
--- a/app/lib/actions/pulp3/content_migration.rb
+++ b/app/lib/actions/pulp3/content_migration.rb
@@ -1,0 +1,17 @@
+module Actions
+  module Pulp3
+    class ContentMigration < Pulp3::AbstractAsyncTask
+      def plan(repository_type_labels, smart_proxy = SmartProxy.pulp_master)
+        sequence do
+          plan_self(repository_type_labels: repository_type_labels, smart_proxy_id: smart_proxy.id)
+          plan_action(Actions::Pulp3::ImportMigration, repository_type_labels)
+        end
+      end
+
+      def invoke_external_task
+        migration_service = ::Katello::Pulp3::Migration.new(smart_proxy, input[:repository_type_labels])
+        migration_service.create_and_run_migration
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/import_migration.rb
+++ b/app/lib/actions/pulp3/import_migration.rb
@@ -1,0 +1,14 @@
+module Actions
+  module Pulp3
+    class ImportMigration < Pulp3::Abstract
+      def plan(repository_type_labels)
+        plan_self(repository_type_labels: repository_type_labels)
+      end
+
+      def run
+        migration_service = ::Katello::Pulp3::Migration.new(SmartProxy.pulp_master, input[:repository_type_labels])
+        migration_service.import_pulp3_content
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp/repository/deb.rb
+++ b/app/services/katello/pulp/repository/deb.rb
@@ -2,6 +2,8 @@ module Katello
   module Pulp
     class Repository
       class Deb < ::Katello::Pulp::Repository
+        REPOSITORY_TYPE = 'deb'.freeze
+
         def generate_master_importer
           config = {
             feed: root.url,

--- a/app/services/katello/pulp/repository/docker.rb
+++ b/app/services/katello/pulp/repository/docker.rb
@@ -2,6 +2,8 @@ module Katello
   module Pulp
     class Repository
       class Docker < ::Katello::Pulp::Repository
+        REPOSITORY_TYPE = 'docker'.freeze
+
         def unit_type_id(uploads = [])
           uploads.pluck('digest').any? ? 'docker_tag' : super
         end

--- a/app/services/katello/pulp/repository/file.rb
+++ b/app/services/katello/pulp/repository/file.rb
@@ -2,6 +2,8 @@ module Katello
   module Pulp
     class Repository
       class File < ::Katello::Pulp::Repository
+        REPOSITORY_TYPE = 'iso'.freeze
+
         def unit_keys(uploads)
           uploads.map do |upload|
             upload.except('id', 'content_unit_id')

--- a/app/services/katello/pulp/repository/yum.rb
+++ b/app/services/katello/pulp/repository/yum.rb
@@ -2,6 +2,8 @@ module Katello
   module Pulp
     class Repository
       class Yum < ::Katello::Pulp::Repository
+        REPOSITORY_TYPE = 'yum'.freeze
+
         def generate_master_importer
           config = {
             download_policy: root.download_policy,

--- a/app/services/katello/pulp3/migration.rb
+++ b/app/services/katello/pulp3/migration.rb
@@ -1,0 +1,58 @@
+require 'pulp_2to3_migration_client'
+
+module Katello
+  module Pulp3
+    class Migration
+      attr_accessor :smart_proxy
+      GET_QUERY_ID_LENGTH = 90
+
+      def initialize(smart_proxy, repository_type_labels)
+        @smart_proxy = smart_proxy
+        @repository_type_labels = repository_type_labels
+      end
+
+      def api_client
+        Pulp2to3MigrationClient::ApiClient.new(smart_proxy.pulp3_configuration(Pulp2to3MigrationClient::Configuration))
+      end
+
+      def migration_plan_api
+        Pulp2to3MigrationClient::MigrationPlansApi.new(api_client)
+      end
+
+      def pulp2_content_api
+        Pulp2to3MigrationClient::Pulp2contentApi.new(api_client)
+      end
+
+      def create_and_run_migration
+        start_migration(create_migration)
+      end
+
+      def import_pulp3_content
+        @repository_type_labels.each do |repository_type_label|
+          Katello::RepositoryTypeManager.repository_types[repository_type_label].content_types_to_index.each do |content_type|
+            import_content_type(content_type)
+          end
+        end
+      end
+
+      def create_migration
+        migration_plan = Katello::Pulp3::MigrationPlan.new(@repository_type_labels)
+        migration_plan_api.create(plan: migration_plan.generate).pulp_href
+      end
+
+      def start_migration(plan_href)
+        migration_plan_api.run(plan_href, dry_run: false)
+      end
+
+      def import_content_type(content_type)
+        content_type.model_class.where(:migrated_pulp3_href => nil).select(:id, :pulp_id).find_in_batches(batch_size: GET_QUERY_ID_LENGTH) do |needing_hrefs|
+          migrated_units = pulp2_content_api.list(pulp2_id__in: needing_hrefs.map { |unit| unit.pulp_id }.join(','))
+          migrated_units.results.each do |migrated_unit|
+            matching_record = needing_hrefs.find { |db_unit| db_unit.pulp_id == migrated_unit.pulp2_id }
+            matching_record.update_column(:migrated_pulp3_href, migrated_unit.pulp3_content) if matching_record
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/migration_plan.rb
+++ b/app/services/katello/pulp3/migration_plan.rb
@@ -1,0 +1,27 @@
+module Katello
+  module Pulp3
+    class MigrationPlan
+      def initialize(repository_type_labels)
+        @repository_types = repository_type_labels
+      end
+
+      def generate
+        plan = {}
+        plan[:plugins] = generate_plugins
+        plan
+      end
+
+      def generate_plugins
+        @repository_types.map do |repository_type|
+          {
+            type: pulp2_repository_type(repository_type)
+          }
+        end
+      end
+
+      def pulp2_repository_type(repository_type)
+        Katello::RepositoryTypeManager.repository_types[repository_type].service_class::REPOSITORY_TYPE
+      end
+    end
+  end
+end

--- a/db/migrate/20190930192813_add_pulp3_hrefs_to_content_types.rb
+++ b/db/migrate/20190930192813_add_pulp3_hrefs_to_content_types.rb
@@ -1,0 +1,10 @@
+class AddPulp3HrefsToContentTypes < ActiveRecord::Migration[5.2]
+  def change
+    content_models = [Katello::Rpm, Katello::ModuleStream, Katello::Erratum, Katello::PackageGroup, Katello::YumMetadataFile,
+                      Katello::Srpm, Katello::FileUnit, Katello::DockerManifestList, Katello::DockerManifest, Katello::DockerTag]
+
+    content_models.each do |model|
+      add_column model.table_name, :migrated_pulp3_href, :string, :default => nil, :null => true
+    end
+  end
+end

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -49,6 +49,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "pulp_ansible_client", "<= 0.2.0b6.dev01570985981"
   gem.add_dependency "pulp_docker_client", "<= 4.0.0b8.dev01571062112"
   gem.add_dependency "pulp_rpm_client", "<= 3.0.0b71571331815"
+  gem.add_dependency "pulp_2to3_migration_client", "<= 0.0.1a1.dev01572375132"
 
   # UI
   gem.add_dependency "deface", '>= 1.0.2', '< 2.0.0'

--- a/lib/katello/tasks/pulp3_migration.rake
+++ b/lib/katello/tasks/pulp3_migration.rake
@@ -1,0 +1,21 @@
+namespace :katello do
+  desc "Runs a Pulp 2 to 3 Content Migration for supported types.  May be run multiple times.  Use wait=false to immediately return with a task url."
+  task :pulp3_migration => ["environment", "disable_dynflow", "check_ping"] do
+    task = ForemanTasks.async_task(Actions::Pulp3::ContentMigration, [Katello::Repository::FILE_TYPE])
+
+    if ENV['wait'].nil? || ::Foreman::Cast.to_bool(ENV['wait'])
+      until !task.pending? || task.paused?
+        sleep(20)
+        task = ForemanTasks::Task.find(task.id)
+      end
+
+      if task.result == 'error' || task.result == 'pending'
+        fail ForemanTasks::TaskError, task
+      else
+        puts _("Content Migration completed successfully")
+      end
+    else
+      puts "Migration started, you may monitor it at: https://#{Socket.gethostname}/foreman_tasks/tasks/#{task.id}"
+    end
+  end
+end

--- a/test/fixtures/test_repos/file_migration/PULP_MANIFEST
+++ b/test/fixtures/test_repos/file_migration/PULP_MANIFEST
@@ -1,0 +1,1 @@
+migrate_test.bin,46d4d39df2695fb95866888d0f20b6d80faad70f9c72a950fe65bae8f46e7298,85

--- a/test/fixtures/test_repos/file_migration/migrate_test.bin
+++ b/test/fixtures/test_repos/file_migration/migrate_test.bin
@@ -1,0 +1,1 @@
+This is a file used to test pulp2 to 3 migrations, it should not be synced normally!

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/migration/file_migration.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/migration/file_migration.yml
@@ -1,0 +1,664 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 30 Oct 2019 18:35:19 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzFmYzg2NDgyLTcyZjUtNDNiNS05ODc5LTkwZTI1YTgyNjQ1MS8iLCAi
+        dGFza19pZCI6ICIxZmM4NjQ4Mi03MmY1LTQzYjUtOTg3OS05MGUyNWE4MjY0
+        NTEifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 30 Oct 2019 18:35:19 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/1fc86482-72f5-43b5-9879-90e25a826451/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 30 Oct 2019 18:35:19 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"d9d737982d72bcb833038b7041a3fe95-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '384'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        LnRhc2tzLnJlcG9zaXRvcnkuZGVsZXRlIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xZmM4NjQ4Mi03MmY1LTQzYjUtOTg3OS05MGUyNWE4MjY0
+        NTEvIiwgInRhc2tfaWQiOiAiMWZjODY0ODItNzJmNS00M2I1LTk4NzktOTBl
+        MjVhODI2NDUxIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwgInB1bHA6YWN0aW9u
+        OmRlbGV0ZSJdLCAiZmluaXNoX3RpbWUiOiAiMjAxOS0xMC0zMFQxODozNTox
+        OVoiLCAiX25zIjogInRhc2tfc3RhdHVzIiwgInN0YXJ0X3RpbWUiOiAiMjAx
+        OS0xMC0zMFQxODozNToxOVoiLCAidHJhY2ViYWNrIjogbnVsbCwgInNwYXdu
+        ZWRfdGFza3MiOiBbXSwgInByb2dyZXNzX3JlcG9ydCI6IHt9LCAicXVldWUi
+        OiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFsbW9yYS5l
+        eGFtcGxlLmNvbS5kcTIiLCAic3RhdGUiOiAiZmluaXNoZWQiLCAid29ya2Vy
+        X25hbWUiOiAicmVzZXJ2ZWRfcmVzb3VyY2Vfd29ya2VyLTBAZGV2ZWwuYmFs
+        bW9yYS5leGFtcGxlLmNvbSIsICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBu
+        dWxsLCAiX2lkIjogeyIkb2lkIjogIjVkYjlkN2U3MWJjM2ZhNDZmMzA4MTM3
+        NCJ9LCAiaWQiOiAiNWRiOWQ3ZTcxYmMzZmE0NmYzMDgxMzc0In0=
+    http_version: 
+  recorded_at: Wed, 30 Oct 2019 18:35:19 GMT
+- request:
+    method: post
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJpZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMi
+        LCJkaXNwbGF5X25hbWUiOiJNeSBGaWxlcyIsImltcG9ydGVyX3R5cGVfaWQi
+        OiJpc29faW1wb3J0ZXIiLCJpbXBvcnRlcl9jb25maWciOnsiZmVlZCI6ImZp
+        bGU6Ly8vdmFyL3d3dy90ZXN0X3JlcG9zL2ZpbGVfbWlncmF0aW9uLyIsImJh
+        c2ljX2F1dGhfdXNlcm5hbWUiOm51bGwsImJhc2ljX2F1dGhfcGFzc3dvcmQi
+        Om51bGwsInNzbF92YWxpZGF0aW9uIjp0cnVlLCJwcm94eV9ob3N0IjoiIiwi
+        c3NsX2NsaWVudF9jZXJ0IjpudWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwi
+        c3NsX2NhX2NlcnQiOm51bGx9LCJkaXN0cmlidXRvcnMiOlt7ImRpc3RyaWJ1
+        dG9yX3R5cGVfaWQiOiJpc29fZGlzdHJpYnV0b3IiLCJkaXN0cmlidXRvcl9j
+        b25maWciOnsicmVsYXRpdmVfdXJsIjoiRGVmYXVsdF9Pcmdhbml6YXRpb24v
+        bGlicmFyeS9NeV9GaWxlcyIsInNlcnZlX2h0dHAiOnRydWUsInNlcnZlX2h0
+        dHBzIjp0cnVlfSwiYXV0b19wdWJsaXNoIjp0cnVlLCJkaXN0cmlidXRvcl9p
+        ZCI6IkRlZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMifV19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '585'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Wed, 30 Oct 2019 18:35:19 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '344'
+      Location:
+      - "/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/"
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzY3JhdGNocGFkIjoge30sICJkaXNwbGF5X25hbWUiOiAiTXkgRmlsZXMi
+        LCAiZGVzY3JpcHRpb24iOiBudWxsLCAibGFzdF91bml0X2FkZGVkIjogbnVs
+        bCwgIm5vdGVzIjoge30sICJsYXN0X3VuaXRfcmVtb3ZlZCI6IG51bGwsICJj
+        b250ZW50X3VuaXRfY291bnRzIjoge30sICJfbnMiOiAicmVwb3MiLCAiX2lk
+        IjogeyIkb2lkIjogIjVkYjlkN2U3YjAyZTUzMDE1ODdjZDRmZCJ9LCAiaWQi
+        OiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIsICJf
+        aHJlZiI6ICIvcHVscC9hcGkvdjIvcmVwb3NpdG9yaWVzL0RlZmF1bHRfT3Jn
+        YW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMvIn0=
+    http_version: 
+  recorded_at: Wed, 30 Oct 2019 18:35:19 GMT
+- request:
+    method: post
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/actions/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJvdmVycmlkZV9jb25maWciOnsibnVtX3RocmVhZHMiOjQsInZhbGlkYXRl
+        Ijp0cnVlfX0=
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '53'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 30 Oct 2019 18:35:19 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '172'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzcGF3bmVkX3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rh
+        c2tzLzEyZWUzZmUyLWE1N2MtNGFkMy04NmZhLWFhZWMzNmU4OGFhYi8iLCAi
+        dGFza19pZCI6ICIxMmVlM2ZlMi1hNTdjLTRhZDMtODZmYS1hYWVjMzZlODhh
+        YWIifV0sICJyZXN1bHQiOiBudWxsLCAiZXJyb3IiOiBudWxsfQ==
+    http_version: 
+  recorded_at: Wed, 30 Oct 2019 18:35:19 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/12ee3fe2-a57c-4ad3-86fa-aaec36e88aab/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 30 Oct 2019 18:35:30 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"fb9910663c526109e0aefde06003a58a-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '673'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8uc3luYy5zeW5jIiwgIl9ocmVmIjogIi9wdWxwL2Fw
+        aS92Mi90YXNrcy8xMmVlM2ZlMi1hNTdjLTRhZDMtODZmYS1hYWVjMzZlODhh
+        YWIvIiwgInRhc2tfaWQiOiAiMTJlZTNmZTItYTU3Yy00YWQzLTg2ZmEtYWFl
+        YzM2ZTg4YWFiIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpEZWZhdWx0
+        X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwgInB1bHA6YWN0aW9u
+        OnN5bmMiXSwgImZpbmlzaF90aW1lIjogIjIwMTktMTAtMzBUMTg6MzU6MzBa
+        IiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1lIjogIjIwMTkt
+        MTAtMzBUMTg6MzU6MTlaIiwgInRyYWNlYmFjayI6IG51bGwsICJzcGF3bmVk
+        X3Rhc2tzIjogW3siX2hyZWYiOiAiL3B1bHAvYXBpL3YyL3Rhc2tzLzlkNWFm
+        YjIzLTRiYTItNDNkYy1iNjQ0LWE4NmEzYmRiY2Y4Zi8iLCAidGFza19pZCI6
+        ICI5ZDVhZmIyMy00YmEyLTQzZGMtYjY0NC1hODZhM2JkYmNmOGYifV0sICJw
+        cm9ncmVzc19yZXBvcnQiOiB7Imlzb19pbXBvcnRlciI6IHsiZXJyb3JfbWVz
+        c2FnZSI6IG51bGwsICJ0cmFjZWJhY2siOiBudWxsLCAiZmluaXNoZWRfYnl0
+        ZXMiOiAwLCAibnVtX2lzb3MiOiAwLCAic3RhdGUiOiAiY29tcGxldGUiLCAi
+        dG90YWxfYnl0ZXMiOiAwLCAic3RhdGVfdGltZXMiOiB7Im5vdF9zdGFydGVk
+        IjogIjIwMTktMTAtMzBUMTg6MzU6MTkiLCAibWFuaWZlc3RfaW5fcHJvZ3Jl
+        c3MiOiAiMjAxOS0xMC0zMFQxODozNToxOSIsICJjb21wbGV0ZSI6ICIyMDE5
+        LTEwLTMwVDE4OjM1OjMwIiwgImlzb3NfaW5fcHJvZ3Jlc3MiOiAiMjAxOS0x
+        MC0zMFQxODozNTozMCJ9LCAibnVtX2lzb3NfZmluaXNoZWQiOiAwLCAiaXNv
+        X2Vycm9yX21lc3NhZ2VzIjogW119fSwgInF1ZXVlIjogInJlc2VydmVkX3Jl
+        c291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5jb20uZHEy
+        IiwgInN0YXRlIjogImZpbmlzaGVkIiwgIndvcmtlcl9uYW1lIjogInJlc2Vy
+        dmVkX3Jlc291cmNlX3dvcmtlci0wQGRldmVsLmJhbG1vcmEuZXhhbXBsZS5j
+        b20iLCAicmVzdWx0IjogeyJyZXN1bHQiOiAic3VjY2VzcyIsICJpbXBvcnRl
+        cl9pZCI6ICJpc29faW1wb3J0ZXIiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJl
+        cG9faWQiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxl
+        cyIsICJ0cmFjZWJhY2siOiBudWxsLCAic3RhcnRlZCI6ICIyMDE5LTEwLTMw
+        VDE4OjM1OjE5WiIsICJfbnMiOiAicmVwb19zeW5jX3Jlc3VsdHMiLCAiY29t
+        cGxldGVkIjogIjIwMTktMTAtMzBUMTg6MzU6MzBaIiwgImltcG9ydGVyX3R5
+        cGVfaWQiOiAiaXNvX2ltcG9ydGVyIiwgImVycm9yX21lc3NhZ2UiOiBudWxs
+        LCAic3VtbWFyeSI6IHsidG90YWxfYnl0ZXMiOiAwLCAidHJhY2ViYWNrIjog
+        bnVsbCwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZmluaXNoZWRfYnl0ZXMi
+        OiAwLCAibnVtX2lzb3MiOiAwLCAic3RhdGUiOiAiY29tcGxldGUiLCAiaXNv
+        X2Vycm9yX21lc3NhZ2VzIjogW10sICJudW1faXNvc19maW5pc2hlZCI6IDAs
+        ICJzdGF0ZV90aW1lcyI6IHsibm90X3N0YXJ0ZWQiOiAiMjAxOS0xMC0zMFQx
+        ODozNToxOSIsICJtYW5pZmVzdF9pbl9wcm9ncmVzcyI6ICIyMDE5LTEwLTMw
+        VDE4OjM1OjE5IiwgImNvbXBsZXRlIjogIjIwMTktMTAtMzBUMTg6MzU6MzAi
+        LCAiaXNvc19pbl9wcm9ncmVzcyI6ICIyMDE5LTEwLTMwVDE4OjM1OjMwIn19
+        LCAiYWRkZWRfY291bnQiOiAxLCAicmVtb3ZlZF9jb3VudCI6IDAsICJ1cGRh
+        dGVkX2NvdW50IjogMCwgImlkIjogIjVkYjlkN2YyYjAyZTUzM2EyMDcyNmVh
+        NiIsICJkZXRhaWxzIjogbnVsbH0sICJlcnJvciI6IG51bGwsICJfaWQiOiB7
+        IiRvaWQiOiAiNWRiOWQ3ZTcxYmMzZmE0NmYzMDgxM2NjIn0sICJpZCI6ICI1
+        ZGI5ZDdlNzFiYzNmYTQ2ZjMwODEzY2MifQ==
+    http_version: 
+  recorded_at: Wed, 30 Oct 2019 18:35:30 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v2/tasks/9d5afb23-4ba2-43dc-b644-a86a3bdbcf8f/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 30 Oct 2019 18:35:30 GMT
+      Server:
+      - Apache
+      Etag:
+      - '"def7c2e3c3ff8c64dca85531ffc18f46-gzip"'
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '552'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJleGNlcHRpb24iOiBudWxsLCAidGFza190eXBlIjogInB1bHAuc2VydmVy
+        Lm1hbmFnZXJzLnJlcG8ucHVibGlzaC5wdWJsaXNoIiwgIl9ocmVmIjogIi9w
+        dWxwL2FwaS92Mi90YXNrcy85ZDVhZmIyMy00YmEyLTQzZGMtYjY0NC1hODZh
+        M2JkYmNmOGYvIiwgInRhc2tfaWQiOiAiOWQ1YWZiMjMtNGJhMi00M2RjLWI2
+        NDQtYTg2YTNiZGJjZjhmIiwgInRhZ3MiOiBbInB1bHA6cmVwb3NpdG9yeTpE
+        ZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJpbmV0LU15X0ZpbGVzIiwgInB1bHA6
+        YWN0aW9uOnB1Ymxpc2giXSwgImZpbmlzaF90aW1lIjogIjIwMTktMTAtMzBU
+        MTg6MzU6MzBaIiwgIl9ucyI6ICJ0YXNrX3N0YXR1cyIsICJzdGFydF90aW1l
+        IjogIjIwMTktMTAtMzBUMTg6MzU6MzBaIiwgInRyYWNlYmFjayI6IG51bGws
+        ICJzcGF3bmVkX3Rhc2tzIjogW10sICJwcm9ncmVzc19yZXBvcnQiOiB7IkRl
+        ZmF1bHRfT3JnYW5pemF0aW9uLUNhYmluZXQtTXlfRmlsZXMiOiB7InN0YXRl
+        X3RpbWVzIjogeyJub3Rfc3RhcnRlZCI6ICIyMDE5LTEwLTMwVDE4OjM1OjMw
+        IiwgImluX3Byb2dyZXNzIjogIjIwMTktMTAtMzBUMTg6MzU6MzAiLCAiY29t
+        cGxldGUiOiAiMjAxOS0xMC0zMFQxODozNTozMCJ9LCAic3RhdGUiOiAiY29t
+        cGxldGUiLCAiZXJyb3JfbWVzc2FnZSI6IG51bGwsICJ0cmFjZWJhY2siOiBu
+        dWxsfX0sICJxdWV1ZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3JrZXItMEBk
+        ZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tLmRxMiIsICJzdGF0ZSI6ICJmaW5p
+        c2hlZCIsICJ3b3JrZXJfbmFtZSI6ICJyZXNlcnZlZF9yZXNvdXJjZV93b3Jr
+        ZXItMEBkZXZlbC5iYWxtb3JhLmV4YW1wbGUuY29tIiwgInJlc3VsdCI6IHsi
+        cmVzdWx0IjogInN1Y2Nlc3MiLCAiZXhjZXB0aW9uIjogbnVsbCwgInJlcG9f
+        aWQiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIs
+        ICJzdGFydGVkIjogIjIwMTktMTAtMzBUMTg6MzU6MzBaIiwgIl9ucyI6ICJy
+        ZXBvX3B1Ymxpc2hfcmVzdWx0cyIsICJjb21wbGV0ZWQiOiAiMjAxOS0xMC0z
+        MFQxODozNTozMFoiLCAidHJhY2ViYWNrIjogbnVsbCwgImRpc3RyaWJ1dG9y
+        X3R5cGVfaWQiOiAiaXNvX2Rpc3RyaWJ1dG9yIiwgInN1bW1hcnkiOiB7InN0
+        YXRlIjogImNvbXBsZXRlIiwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAidHJh
+        Y2ViYWNrIjogbnVsbCwgInN0YXRlX3RpbWVzIjogeyJub3Rfc3RhcnRlZCI6
+        ICIyMDE5LTEwLTMwVDE4OjM1OjMwIiwgImluX3Byb2dyZXNzIjogIjIwMTkt
+        MTAtMzBUMTg6MzU6MzAiLCAiY29tcGxldGUiOiAiMjAxOS0xMC0zMFQxODoz
+        NTozMCJ9fSwgImVycm9yX21lc3NhZ2UiOiBudWxsLCAiZGlzdHJpYnV0b3Jf
+        aWQiOiAiRGVmYXVsdF9Pcmdhbml6YXRpb24tQ2FiaW5ldC1NeV9GaWxlcyIs
+        ICJpZCI6ICI1ZGI5ZDdmMmIwMmU1MzNhMjA3MjZlYTkiLCAiZGV0YWlscyI6
+        IG51bGx9LCAiZXJyb3IiOiBudWxsLCAiX2lkIjogeyIkb2lkIjogIjVkYjlk
+        N2YyMWJjM2ZhNDZmMzA4MWE5NCJ9LCAiaWQiOiAiNWRiOWQ3ZjIxYmMzZmE0
+        NmYzMDgxYTk0In0=
+    http_version: 
+  recorded_at: Wed, 30 Oct 2019 18:35:30 GMT
+- request:
+    method: post
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJpc28iXSwibGltaXQiOjIwMDAs
+        InNraXAiOjAsImZpZWxkcyI6eyJ1bml0IjpbIm5hbWUiLCJjaGVja3N1bSJd
+        fX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '93'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 30 Oct 2019 18:35:30 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '278'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        W3sibWV0YWRhdGEiOiB7ImNoZWNrc3VtIjogIjQ2ZDRkMzlkZjI2OTVmYjk1
+        ODY2ODg4ZDBmMjBiNmQ4MGZhYWQ3MGY5YzcyYTk1MGZlNjViYWU4ZjQ2ZTcy
+        OTgiLCAiX2lkIjogIjkyNTQyZmY4LTkwOWMtNDU5YS04Mzc5LTAxMTJhMzc2
+        YmE1MSIsICJuYW1lIjogIm1pZ3JhdGVfdGVzdC5iaW4iLCAiX2NvbnRlbnRf
+        dHlwZV9pZCI6ICJpc28ifSwgInVwZGF0ZWQiOiAiMjAxOS0xMC0zMFQxODoz
+        NTozMFoiLCAicmVwb19pZCI6ICJEZWZhdWx0X09yZ2FuaXphdGlvbi1DYWJp
+        bmV0LU15X0ZpbGVzIiwgImNyZWF0ZWQiOiAiMjAxOS0xMC0zMFQxODozNToz
+        MFoiLCAidW5pdF90eXBlX2lkIjogImlzbyIsICJ1bml0X2lkIjogIjkyNTQy
+        ZmY4LTkwOWMtNDU5YS04Mzc5LTAxMTJhMzc2YmE1MSIsICJfaWQiOiB7IiRv
+        aWQiOiAiNWRiOWQ3ZjIxYmMzZmE0NmYzMDgxYTc0In19XQ==
+    http_version: 
+  recorded_at: Wed, 30 Oct 2019 18:35:30 GMT
+- request:
+    method: post
+    uri: https://devel.balmora.example.com/pulp/api/v2/repositories/Default_Organization-Cabinet-My_Files/search/units/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjcml0ZXJpYSI6eyJ0eXBlX2lkcyI6WyJpc28iXSwibGltaXQiOjIwMDAs
+        InNraXAiOjIwMDAsImZpZWxkcyI6eyJ1bml0IjpbIm5hbWUiLCJjaGVja3N1
+        bSJdfX19
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.5p157
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '96'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 30 Oct 2019 18:35:30 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      base64_string: 'W10=
+
+'
+    http_version: 
+  recorded_at: Wed, 30 Oct 2019 18:35:30 GMT
+- request:
+    method: post
+    uri: https://devel.balmora.example.com/pulp/api/v3/migration-plans/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJwbGFuIjp7InBsdWdpbnMiOlt7InR5cGUiOiJpc28ifV19fQ==
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.0.1a1.dev01572375132/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 30 Oct 2019 18:35:30 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/migration-plans/482f4c11-1bf7-4e06-af73-e16a539a3832/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '163'
+      Via:
+      - 1.1 devel.balmora.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvbWlncmF0aW9uLXBsYW5zLzQ4
+        MmY0YzExLTFiZjctNGUwNi1hZjczLWUxNmE1MzlhMzgzMi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDE5LTEwLTMwVDE4OjM1OjMwLjg4NDcwNFoiLCJwbGFuIjp7
+        InBsdWdpbnMiOlt7InR5cGUiOiJpc28ifV19fQ==
+    http_version: 
+  recorded_at: Wed, 30 Oct 2019 18:35:30 GMT
+- request:
+    method: post
+    uri: https://devel.balmora.example.com/pulp/api/v3/migration-plans/482f4c11-1bf7-4e06-af73-e16a539a3832/run/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJkcnlfcnVuIjpmYWxzZX0=
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.0.1a1.dev01572375132/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 30 Oct 2019 18:35:31 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 devel.balmora.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzdkYjM0NmEyLWI2NDgtNGQz
+        OS1hZjlmLTJiOGVjZDY5MGJhZC8ifQ==
+    http_version: 
+  recorded_at: Wed, 30 Oct 2019 18:35:31 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v3/tasks/7db346a2-b648-4d39-af9f-2b8ecd690bad/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 30 Oct 2019 18:35:31 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 devel.balmora.example.com
+      Content-Length:
+      - '500'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvN2RiMzQ2YTItYjY0
+        OC00ZDM5LWFmOWYtMmI4ZWNkNjkwYmFkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTAtMzBUMTg6MzU6MzEuMDc5NDg4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfMnRvM19taWdyYXRpb24uYXBwLnRhc2tzLm1pZ3Jh
+        dGUubWlncmF0ZV9mcm9tX3B1bHAyIiwic3RhcnRlZF9hdCI6IjIwMTktMTAt
+        MzBUMTg6MzU6MzEuMTcxMzgyWiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMC0z
+        MFQxODozNTozMS41ODEyMTJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9w
+        dWxwL2FwaS92My93b3JrZXJzLzVmMzYxZWJlLTMwMzctNGRhYy04Y2ExLWE3
+        ZTJiYzQwZmM1Ny8iLCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3MiOltd
+        LCJwcm9ncmVzc19yZXBvcnRzIjpbeyJtZXNzYWdlIjoiUHJlLW1pZ3JhdGlu
+        ZyBQdWxwIDIgcmVwb3NpdG9yaWVzLCBpbXBvcnRlcnMsIGRpc3RyaWJ1dG9y
+        cyIsImNvZGUiOiJwcmVtaWdyYXRpbmcucmVwb3NpdG9yaWVzIiwic3RhdGUi
+        OiJjb21wbGV0ZWQiLCJ0b3RhbCI6MCwiZG9uZSI6MCwic3VmZml4IjpudWxs
+        fSx7Im1lc3NhZ2UiOiJDcmVhdGluZyByZXBvc2l0b3JpZXMgaW4gUHVscCAz
+        IiwiY29kZSI6ImNyZWF0aW5nLnJlcG9zaXRvcmllcyIsInN0YXRlIjoiY29t
+        cGxldGVkIiwidG90YWwiOjAsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJt
+        ZXNzYWdlIjoiTWlncmF0aW5nIGltcG9ydGVycyB0byBQdWxwIDMiLCJjb2Rl
+        IjoibWlncmF0aW5nLmltcG9ydGVycyIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOjAsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoi
+        UHJlLW1pZ3JhdGluZyBQdWxwIDIgSVNPIGNvbnRlbnQgKGRldGFpbCBpbmZv
+        KSIsImNvZGUiOiJwcmVtaWdyYXRpbmcuY29udGVudC5kZXRhaWwiLCJzdGF0
+        ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjowLCJkb25lIjowLCJzdWZmaXgiOm51
+        bGx9LHsibWVzc2FnZSI6IlByZS1taWdyYXRpbmcgUHVscCAyIElTTyBjb250
+        ZW50IChnZW5lcmFsIGluZm8pIiwiY29kZSI6InByZW1pZ3JhdGluZy5jb250
+        ZW50LmdlbmVyYWwiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjowLCJk
+        b25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6Ik1pZ3JhdGluZyBp
+        c28gY29udGVudCB0byBQdWxwIDMgaXNvIiwiY29kZSI6Im1pZ3JhdGluZy5p
+        c28uY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOjAsImRv
+        bmUiOjAsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiTWlncmF0aW5nIGNv
+        bnRlbnQgdG8gUHVscCAzIiwiY29kZSI6Im1pZ3JhdGluZy5jb250ZW50Iiwi
+        c3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6MCwiZG9uZSI6MCwic3VmZml4
+        IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVz
+        b3VyY2VzX3JlY29yZCI6WyJwdWxwXzJ0bzNfbWlncmF0aW9uIl19
+    http_version: 
+  recorded_at: Wed, 30 Oct 2019 18:35:31 GMT
+- request:
+    method: get
+    uri: https://devel.balmora.example.com/pulp/api/v3/pulp2content/?pulp2_id__in=fjd89-ad8d8-sdkas-adjja,123983-123812-123812-2131,92542ff8-909c-459a-8379-0112a376ba51
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/0.0.1a1.dev01572375132/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 30 Oct 2019 18:35:31 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 devel.balmora.example.com
+      Content-Length:
+      - '360'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9taWdyYXRpb24tcGxh
+        bnMvODk1NWUyMGYtZTljYi00Y2EzLWJhNWItMmFjMzM2ZTkxNTJmLyIsInB1
+        bHBfY3JlYXRlZCI6IjIwMTktMTAtMjlUMTU6NTk6MzUuNjMwNTQ0WiIsInB1
+        bHAyX2lkIjoiOTI1NDJmZjgtOTA5Yy00NTlhLTgzNzktMDExMmEzNzZiYTUx
+        IiwicHVscDJfY29udGVudF90eXBlX2lkIjoiaXNvIiwicHVscDJfbGFzdF91
+        cGRhdGVkIjoxNTcyMjU5NjU3LCJwdWxwMl9zdG9yYWdlX3BhdGgiOiIvdmFy
+        L2xpYi9wdWxwL2NvbnRlbnQvdW5pdHMvaXNvLzcyLzNlNzFiYjM3OWY5Mzhh
+        ZDFkZmJhMmYyZDZiZDBjN2Q3NDAyNzY2MTViODYzN2RkNWI3OWUwMjBjZGIw
+        OWMyL21pZ3JhdGVfdGVzdC5iaW4iLCJkb3dubG9hZGVkIjp0cnVlLCJwdWxw
+        M19jb250ZW50IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZmlsZS9maWxlcy80
+        NjZkYzYzNC0yNDY1LTQyNmUtOThjMS1hZDNkOTU0MGIwODkvIn1dfQ==
+    http_version: 
+  recorded_at: Wed, 30 Oct 2019 18:35:31 GMT
+recorded_with: VCR 3.0.3

--- a/test/services/katello/pulp3/migration_test.rb
+++ b/test/services/katello/pulp3/migration_test.rb
@@ -1,0 +1,45 @@
+require 'katello_test_helper'
+require 'support/pulp3_support'
+
+module Katello
+  module Service
+    module Pulp3
+      class MigrationTest < ActiveSupport::TestCase
+        include Pulp3Support
+        include VCR::TestCase
+
+        def setup
+          SETTINGS[:katello][:use_pulp_2_for_content_type] = {}
+          SETTINGS[:katello][:use_pulp_2_for_content_type][:file] = true
+
+          @master = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+          @repo = katello_repositories(:generic_file)
+          @repo.root.url = 'file:///var/www/test_repos/file_migration/'
+          @repo.root.save!
+
+          RepositorySupport.destroy_repo(@repo)
+          RepositorySupport.create_and_sync_repo(@repo)
+          @repo.index_content
+        end
+
+        def teardown
+          SETTINGS[:katello][:use_pulp_2_for_content_type][:file] = nil
+          RepositorySupport.destroy_repo(@repo)
+        end
+
+        def test_file_migration
+          unit = @repo.files.first
+
+          migration_service = Katello::Pulp3::Migration.new(SmartProxy.pulp_master, ['file'])
+
+          task = migration_service.create_and_run_migration
+          wait_on_task(@master, task)
+
+          migration_service.import_pulp3_content
+
+          refute_nil unit.reload.migrated_pulp3_href
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This provides the ability to migrate arbitrary
content units (file_units, docker tags, etc..) from
pulp2 to pulp3 and import the pulp3 to our database