### PR TITLE
Fixes #28039 - shouldn't dep solve if no filters present

### DIFF
--- a/app/models/katello/glue/pulp/repo.rb
+++ b/app/models/katello/glue/pulp/repo.rb
@@ -47,7 +47,7 @@ module Katello
 
         def self.build_override_config(options)
           config = {}
-          if options[:solve_dependencies] || options[:resolve_dependencies]
+          if options[:filters].present? && (options[:solve_dependencies] || options[:resolve_dependencies])
             if Setting[:dependency_solving_algorithm] == 'greedy'
               config[:recursive] = true
             else

--- a/test/glue/pulp/repository_test.rb
+++ b/test/glue/pulp/repository_test.rb
@@ -94,6 +94,19 @@ module Katello
     SHA1 = "sha1".freeze
     SHA256 = "sha256".freeze
 
+    def test_build_override_config_dep_solve_and_filters
+      rule = FactoryBot.build(:katello_content_view_package_filter_rule)
+      options = { :solve_dependencies => true, :filters => rule.filter }
+      override_config = ::Katello::Repository.build_override_config(options)
+      assert_equal override_config[:recursive_conservative], true
+    end
+
+    def test_build_override_config_dep_solve_and_no_filters
+      options = { :solve_dependencies => true }
+      override_config = ::Katello::Repository.build_override_config(options)
+      assert_nil override_config[:recursive_conservative]
+    end
+
     def test_populate_from
       assert @fedora_17_x86_64.populate_from(@fedora_17_x86_64.pulp_id => {})
     end


### PR DESCRIPTION
Dep resolving during CV publish should only occur if there are filters.
To test:
1) Enable `katello/pulp_rest` under `loggers` in foreman/settings.yaml
2) Set logging level to debug in foreman/settings.yaml
3) Make a CV with dependency solving on
4) Add yum content to the CV and a filter and publish it
5) Search the Foreman logs for `recursive_conservative`.  The publish should have logged this.
6) Do another publish but this time without any filters
7) Search again for `recursive_conservative`.  You should see it only for the first publish you made, not the latest one without filters.