### PR TITLE
Fixes #28074 - Add deprecate to api/ui for puppet/ostree repos

### DIFF
--- a/app/lib/actions/katello/repository/create.rb
+++ b/app/lib/actions/katello/repository/create.rb
@@ -14,6 +14,10 @@ module Actions
             ::Foreman::Deprecation.api_deprecation_warning("Background download_policy will be removed in Katello 3.16.  Any background repositories will be converted to Immediate")
           end
 
+          if root['content_type'] == 'puppet' || root['content_type'] == 'ostree'
+            ::Foreman::Deprecation.api_deprecation_warning("Repository types of 'Puppet' and 'OSTree' will no longer be supported in Katello 3.16.")
+          end
+
           org = repository.organization
           pulp2_create_action = plan_create ? Actions::Pulp::Repository::CreateInPlan : Actions::Pulp::Repository::Create
           sequence do

--- a/app/lib/actions/katello/repository/update.rb
+++ b/app/lib/actions/katello/repository/update.rb
@@ -16,6 +16,10 @@ module Actions
             ::Foreman::Deprecation.api_deprecation_warning("Background download_policy will be removed in Katello 3.16.  Any background repositories will be converted to Immediate")
           end
 
+          if root['content_type'] == 'puppet' || root['content_type'] == 'ostree'
+            ::Foreman::Deprecation.api_deprecation_warning("Repository types of 'Puppet' and 'OSTree' will no longer be supported in Katello 3.16.")
+          end
+
           if update_content?(repository)
             content = root.content
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/views/repository-info.html
@@ -27,6 +27,11 @@
       <dd>{{ repository.content_type }}</dd>
     </dl>
 
+    <div class="alert alert-warning" ng-if="repository.content_type === 'ostree' || repository.content_type === 'puppet'">
+      <span class="pficon pficon-warning-triangle-o"></span>
+      <strong>Deprecation Warning: </strong>Puppet and OSTree will no longer be supported in Katello 3.16.
+    </div>
+
     <div class="divider"></div>
     <h4 translate>Sync Settings</h4>
     <dl class="dl-horizontal dl-horizontal-left">

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/views/new-repository.html
@@ -39,6 +39,11 @@
         </select>
       </div>
 
+      <div class="alert alert-warning" ng-if="repository.content_type === 'ostree' || repository.content_type === 'puppet'">
+        <span class="pficon pficon-warning-triangle-o"></span>
+        <strong>Deprecation Warning: </strong>Puppet and OSTree will no longer be supported in Katello 3.16.
+      </div>
+
       <div bst-form-group label="{{ 'Restrict to Architecture' | translate }}" ng-show="repository.content_type === 'yum'">
         <select id="architecture_restricted"
                 name="architecture_restricted"


### PR DESCRIPTION
This PR adds a deprecate message to new/update operations on repos with the content type ostree/puppet.

I have verified it works correctly with the API and the UI as I am seeing this when I create/update a repo of those content types:

`15:25:01 rails.1   | 2019-10-16T15:25:01 [W|app|] DEPRECATION WARNING: Your API call uses deprecated behavior, Repository types of 'Puppet' and 'ostree' will no longer be supported in Katello 3.16. (called from plan at /home/vagrant/katello/app/lib/actions/katello/repository/create.rb:18)`

I added this to the types in the UI, but it looks awful:

https://s.nimbusweb.me/share/3430766/dkoyy1t22417an74r5nl

@jeremylenz I am trying to do something like Justin did here:

https://github.com/Katello/katello/pull/8376

But it seems we are dynamically pulling the content types here:

https://github.com/Katello/katello/blob/master/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/repository.factory.js#L23

Do you have a better way to add `(depreciated)` next to ostree/puppet like Justin did with download-policy?