### PR TITLE
Fixes #28080 - Remove RHSM facts when unregistering

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -79,6 +79,10 @@ module Katello
         self.organization.label
       end
 
+      def rhsm_fact_values
+        self.fact_values.joins(:fact_name).where("#{::FactName.table_name}.type = '#{Katello::RhsmFactName}'")
+      end
+
       def self.available_locks
         [:update]
       end

--- a/app/services/katello/registration_manager.rb
+++ b/app/services/katello/registration_manager.rb
@@ -296,6 +296,8 @@ module Katello
         host.get_status(::Katello::SubscriptionStatus).destroy
         host.get_status(::Katello::TraceStatus).destroy
         host.installed_packages.delete_all
+
+        host.rhsm_fact_values.destroy_all
       end
     end
   end

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -23,6 +23,14 @@ module Katello
   end
 
   class HostManagedExtensionsTest < HostManagedExtensionsTestBase
+    def test_rhsm_fact_values
+      assert_empty @foreman_host.rhsm_fact_values
+
+      fv = FactValue.create!(value: 'something', host: @foreman_host, fact_name: RhsmFactName.create(name: 'some-fact'))
+
+      assert_equal [fv], @foreman_host.rhsm_fact_values
+    end
+
     def test_destroy_host
       assert @foreman_host.destroy
     end

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -257,6 +257,14 @@ module Katello
         ::Katello::RegistrationManager.unregister_host(@host)
       end
 
+      def test_unregister_host_rhsm_facts
+        FactValue.create!(value: 'something', host: @host, fact_name: RhsmFactName.create(name: 'some-fact'))
+
+        ::Katello::RegistrationManager.unregister_host(@host, unregistering: true)
+
+        assert_empty @host.rhsm_fact_values
+      end
+
       def test_destroy_host_not_found
         @host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @content_view,
                                    :lifecycle_environment => @library, :organization => @content_view.organization)


### PR DESCRIPTION
**To test**

1. register a client ie host.example.com (subman register)
2. unregister the client (subman unregister)
3. change hostname to host-a.example.com (hostnamectl)
4. attempt re-register (subman register)

(4) would have failed with an error, but now it should succeed since we don't keep the old registration's facts around