### PR TITLE
Fixes #28082 - allow listing packages in safemode

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -279,5 +279,6 @@ end
 
 class ::Host::Managed::Jail < Safemode::Jail
   allow :content_source, :subscription_manager_configuration_url, :rhsm_organization_label,
-        :host_collections, :comment, :pools, :hypervisor_host, :lifecycle_environment, :content_view
+        :host_collections, :comment, :pools, :hypervisor_host, :lifecycle_environment, :content_view,
+        :installed_packages
 end

--- a/app/models/katello/installed_package.rb
+++ b/app/models/katello/installed_package.rb
@@ -1,5 +1,9 @@
 module Katello
   class InstalledPackage < Katello::Model
+    class Jail < Safemode::Jail
+      allow :nvra, :nvrea, :name
+    end
+
     has_many :hosts, :through => :host_installed_packages, :class_name => "::Host"
     has_many :host_installed_packages, :class_name => "Katello::HostInstalledPackage", :dependent => :destroy, :inverse_of => :installed_package
 


### PR DESCRIPTION
This is all that is needed for naive host diff report implementation such as

```
<%#
name: Content host diff
snippet: false
template_inputs:
- name: Host 1
  required: false
  input_type: user
  description: FQDN of the first host to compare
  advanced: false
  value_type: plain
  resource_type: AnsibleRole
- name: Host 2
  required: false
  input_type: user
  description: FQDN of the second host to compare
  advanced: false
  value_type: plain
  resource_type: AnsibleRole
model: ReportTemplate
%>
<%- host1 = Host.find_by_name(input("Host 1")) -%>
<%- host2 = Host.find_by_name(input("Host 2")) -%>
<%- set1 = host1.installed_packages.group_by { |p| p.name } -%>
<%- set2 = host2.installed_packages.group_by { |p| p.name } -%>
<%- (set1.keys | set2.keys).uniq.each do |package_name| -%>
<%-   data = { 'Package' => package_name } -%>
<%-   data[host1.fqdn] = set1[package_name].try(:first).try(:nvra) || '-' -%>
<%-   data[host2.fqdn] = set2[package_name].try(:first).try(:nvra) || '-' -%>
<%-   report_row data -%>
<%- end -%>
<%= report_render -%>
```

of course the report template needs a bit more enhancements to be fully useful, but this can be used for testing