### PR TITLE
Fixes #28085 - fixing columns in content view history

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/content-view-details.controller.js
@@ -35,7 +35,7 @@ angular.module('Bastion.content-views').controller('ContentViewDetailsController
         $scope.taskTypes = {
             publish: "Actions::Katello::ContentView::Publish",
             promotion: "Actions::Katello::ContentView::Promote",
-            deletion: "Actions::Katello::ContentView::Remove",
+            removal: "Actions::Katello::ContentView::Remove",
             incrementalUpdate: "Actions::Katello::ContentView::IncrementalUpdates",
             export: "Actions::Katello::ContentViewVersion::Export"
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/histories/content-view-history.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/histories/content-view-history.controller.js
@@ -29,7 +29,7 @@ angular.module('Bastion.content-views').controller('ContentViewHistoryController
                 taskTypes = $scope.taskTypes,
                 taskType = history.task ? history.task.label : taskTypes[history.action];
 
-            if (taskType === taskTypes.deletion) {
+            if (taskType === taskTypes.removal) {
                 message = translate("Deleted from %s").replace('%s', history.environment.name);
             } else if (taskType === taskTypes.promotion) {
                 message = translate("Promoted to %s").replace('%s', history.environment.name);

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/histories/views/content-view-history.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/histories/views/content-view-history.html
@@ -28,7 +28,7 @@
            <td bst-table-cell class="preserve-newlines">{{ history.description }}</td>
           <td bst-table-cell>{{ actionText(history) }}</td>
           <td bst-table-cell>{{ history.user }}</td>
-          <td bst-table-cell>{{ history.task.result }}</td>
+          <td bst-table-cell>{{ history.status }}</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
Content view -> History -> Action column is broken when foreman tasks are deleted

Steps to Reproduce:
1. Create a content view, publish, promote and delete
2. Go to the content view page -> select the content view -> History tab
3. Action and status column displays correct information
4. Delete foreman-tasks and check Action and Status column

Actual results:
The Action column is blank for delete action and the Status column is blank for all the actions.

Expected results:
The action and status column should display normally after foreman tasks are deleted.