### PR TITLE
Fixes #25876 - Disable auditing on org destroy

### DIFF
--- a/app/lib/actions/katello/environment/destroy.rb
+++ b/app/lib/actions/katello/environment/destroy.rb
@@ -42,7 +42,11 @@ module Actions
 
         def finalize
           environment = ::Katello::KTEnvironment.find(input['kt_environment']['id'])
-          environment.destroy!
+
+          # CapsuleLifecycleEnvironment can cause issues when auditing, it will try to associate the audit to the deleted taxonomy
+          ::Katello::CapsuleLifecycleEnvironment.without_auditing do
+            environment.destroy!
+          end
         end
       end
     end


### PR DESCRIPTION
When destroying an organization and environment, audits are created that are linked back to the Taxonomy (org or loc). This creates an issue when the taxonomy has been deleted and audits are created referring to the taxonomy.

This only shows up during concurrent actions. I'm not sure exactly why, maybe because of the multiple tasks modifying the same table means the organization will be destroyed while the audits are taking longer to write.

I was able to reproduce pretty consistently with script run on a hammer devel box:
```ruby

require 'net/http'

ITERATIONS=5

hammer="BUNDLE_GEMFILE=~/hammer-cli-foreman/Gemfile bundle exec hammer"

org_names = []
ITERATIONS.times do
  org_names << (0...8).map { (65 + rand(26)).chr }.join
end

puts "Creating Orgs\n"

base_create_command = "organization create"

org_names.each_with_index do |org_name, i|
  puts "creating org #{i+1}"
  cmd = `#{hammer} #{base_create_command} --name #{org_name} --label #{org_name}`
  puts cmd
end

puts "Deleting Orgs\n"

base_delete_command = "organization delete"

threads = []

org_names.each_with_index do |org_name, i|
  # spawn a new thread for each url
  threads << Thread.new do
    sleep rand(0..1)
    cmd = `#{hammer} #{base_delete_command} --name #{org_name}`
    puts "\nOrg #{i+1} deletion task complete \n#{cmd}\n"
  end
end

threads.each { |t| t.join }

puts "All Done!"
```

With this patch, I'm able to do 20 iterations without seeing deadlock or race condition issues.