### PR TITLE
Fixes #16333 - fixes sorted order for CCV versions

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/components/views/content-view-composite-available-content-views.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/components/views/content-view-composite-available-content-views.html
@@ -52,7 +52,7 @@
                   ng-if="componentContentView.versions.length > 0"
                   ng-model="componentContentView.versionId"
                   ng-selected="latest"
-                  ng-options="cvv.id as cvv.version for cvv in availableVersions">
+                  ng-options="cvv.id as cvv.version for cvv in availableVersions | orderBy: '-version'">
           </select>
           <span ng-if="componentContentView.versions.length === 0" ng-model="componentContentView.version" translate>Always Use Latest (Currently no versions)</span>
         </td>

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/components/views/content-view-composite-content-views-list.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-views/details/components/views/content-view-composite-content-views-list.html
@@ -44,7 +44,7 @@
                   readonly="denied('edit_content_views', contentView)"
                   selector="contentViewComponent.versionId"
                   options="getAvailableVersions(contentViewComponent.content_view)"
-                  options-format="option.id as option.version for option in options"
+                  options-format="option.id as option.version for option in options | orderBy: '-version'"
                   on-save="saveContentViewComponent(contentViewComponent)"
                   ng-if="contentViewComponent.content_view.version_count > 0">
             </span>


### PR DESCRIPTION
Earling to this patch Composite Content View versions sometimes shows up unsorted as shown below

![2019-10-11_CCV_withCV20](https://user-images.githubusercontent.com/14857032/67091348-09b42700-f1ca-11e9-97f2-c9230e58208a.png)


**After Patch**

![Screenshot_20191018_170130](https://user-images.githubusercontent.com/14857032/67091424-36683e80-f1ca-11e9-909b-9d022f189db6.png)



