### PR TITLE
Fixes #27541 - Update cvv model for srpm listing

### DIFF
--- a/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
+++ b/app/controllers/katello/concerns/api/v2/repository_content_controller.rb
@@ -242,6 +242,8 @@ module Katello
           _("Deb Package")
         when "Katello::Rpm"
           _("Package")
+        when "Katello::Srpm"
+          _("Source RPM")
         when "Katello::PackageGroup"
           _("Package Group")
         when "Katello::PuppetModule"

--- a/app/models/katello/content_view_version.rb
+++ b/app/models/katello/content_view_version.rb
@@ -253,6 +253,10 @@ module Katello
       library_packages.where.not(:id => packages)
     end
 
+    def srpms
+      Katello::Srpm.in_repositories(self.repositories)
+    end
+
     def srpm_count
       Katello::Srpm.in_repositories(self.repositories.archived).count
     end


### PR DESCRIPTION
Before:

```ruby

[DEBUG 2019-10-18T17:55:31 Exception] Using exception handler HammerCLIKatello::ExceptionHandler#handle_internal_error
[ERROR 2019-10-18T17:55:31 Exception] undefined method `srpms' for #<Katello::ContentViewVersion:0x000000000f2df780>

```

After:

```ruby
[vagrant@centos7-katello-devel katello]$ hammer srpm list --content-view-version-id 2
---|--------|---------------------------
ID | NAME | FILENAME
---|--------|---------------------------
1 | g2clib | g2clib-1.4.0-9.el7.src.rpm
---|--------|---------------------------
```