### PR TITLE
Fixes #28036: subscription-manager register facts create duplicate in…

### DIFF
--- a/app/models/katello/rhsm_fact_parser.rb
+++ b/app/models/katello/rhsm_fact_parser.rb
@@ -23,7 +23,7 @@ module Katello
     def get_facts_for_interface(interface)
       {
         'link' => true,
-        'macaddress' => facts["net.interface.#{interface}.mac_address"],
+        'macaddress' => get_rhsm_mac(interface),
         'ipaddress' => get_rhsm_ip(interface)
       }
     end
@@ -106,6 +106,11 @@ module Katello
     def get_rhsm_ip(interface)
       ip = facts["net.interface.#{interface}.ipv4_address"]
       Net::Validations.validate_ip(ip) ? ip : nil
+    end
+
+    def get_rhsm_mac(interface)
+      # if slave then permanent_mac_address contains the physical mac
+      facts["net.interface.#{interface}.permanent_mac_address"] || facts["net.interface.#{interface}.mac_address"]
     end
   end
 end


### PR DESCRIPTION
…terface with wrong mac for bond

* Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1528193

### To reproduce the issue
1. Configure a `katello-client` VM with the following settings in `boxes.d/99-local.yaml`:

```yml
katello-client:
  box: centos7
  memory: 512
  networks:
      - type: 'public_network'
        options:
          dev: virbr0
          mode: bridge
          type: bridge
      - type: 'public_network'
        options:
          dev: virbr0
          mode: bridge
          type: bridge
  ansible:
    playbook: 'playbooks/katello_client.yml'
    group: 'client'
    variables:
      katello_client_server: 'centos7-katello-devel'
      katello_client_cleanup: True
```
(Change `katello_client_server` value to the hostname of your Foreman server, if necessary)

2. `vagrant up katello-client` and ensure all provisioning steps complete successfully.
2. `vagrant ssh` into your `katello-client`.  `ip addr` should show multiple network interfaces, `eth0`, `eth1`, `eth2`
4. On `katello-client`, create the file `/etc/sysconfig/network-scripts/ifcfg-bond0` with the following contents (no need to change `IPADDR` to match your network):
(Note: We used this [article](https://www.unixmen.com/linux-basics-create-network-bonding-on-centos-76-5/) but skipped the network-manager stuff)
```bash
DEVICE=bond0
NAME=bond0
TYPE=Bond
BONDING_MASTER=yes
IPADDR=192.168.1.150
PREFIX=24
ONBOOT=yes
BOOTPROTO=none
BONDING_OPTS="mode=1 miimon=100"
```
5. In the same folder, modify the files `/etc/sysconfig/network-scripts/ifcfg-eth1` and `/etc/sysconfig/network-scripts/ifcfg-eth2` changing the following values to look like this:
```
BOOTPROTO="none"
ONBOOT="yes"
MASTER=bond0
SLAVE=yes
```
__Important:__ Leave `/etc/sysconfig/network-scripts/ifcfg-eth0` as-is and do not modify.

After changing, my files looked like this (I ignored the Vagrant warning):
```
#VAGRANT-BEGIN
# The contents below are automatically generated by Vagrant. Do not modify.
BOOTPROTO=none
ONBOOT=yes
DEVICE=eth1
NM_CONTROLLED=yes
MASTER=bond0
SLAVE=yes
#VAGRANT-END
```

6. Restart the network service:
```
sudo systemctl restart network
```

Output of `ip addr` will be similiar to the following:
```bash
[root@katello-client ~]# ip addr
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 52:54:00:70:1a:a7 brd ff:ff:ff:ff:ff:ff
    inet 192.168.122.50/24 brd 192.168.122.255 scope global noprefixroute dynamic eth0
       valid_lft 3166sec preferred_lft 3166sec
    inet6 fe80::5054:ff:fe70:1aa7/64 scope link 
       valid_lft forever preferred_lft forever
3: eth1: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast master bond0 state UP group default qlen 1000
    link/ether 52:54:00:6d:40:72 brd ff:ff:ff:ff:ff:ff
4: eth2: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast master bond0 state UP group default qlen 1000
    link/ether 52:54:00:6d:40:72 brd ff:ff:ff:ff:ff:ff
5: bond0: <BROADCAST,MULTICAST,MASTER,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 52:54:00:6d:40:72 brd ff:ff:ff:ff:ff:ff
    inet 192.168.1.150/24 brd 192.168.1.255 scope global noprefixroute bond0
       valid_lft forever preferred_lft forever
    inet6 fe80::5054:ff:fe6d:4072/64 scope link 
       valid_lft forever preferred_lft forever
```
* `eth1` and `eth2` are listed as `SLAVE`
* `bond0` is listed as `MASTER`
* All 3 above interfaces have `state UP` and list the same mac address

6. Register the client to Foreman:
```bash
[root@katello-client ~]# subscription-manager register --user admin --password changeme --env Library --org Default_Organization
Registering to: centos7-katello-devel.localhost.example.com:443/rhsm
The system has been registered with ID: 51ded6ad-18b4-49b1-b738-9d38a40cc1dc
The registered system name is: katello-client.redhatlaptop.example.com
```

7. Output of `subscription-manager facts` will be similar to the following:
```
subscription-manager facts | grep mac_address
net.interface.bond0.mac_address: 52:54:00:6D:40:72
net.interface.eth0.mac_address: 52:54:00:70:1A:A7
net.interface.eth1.mac_address: 52:54:00:6D:40:72
net.interface.eth1.permanent_mac_address: 52:54:00:6D:40:72
net.interface.eth2.mac_address: 52:54:00:6D:40:72
net.interface.eth2.permanent_mac_address: 52:54:00:D8:27:F7
```
* `bond0`, `eth1` and `eth2` mac address is all the same
* `eth1` and `eth2` list `permanent_mac_address` fields, which are their original, "physical" mac addresses.

8. In Foreman, go to `Hosts -> All Hosts` and `Edit` the host you just registered.
9. In the `Interfaces` tab, observe the issue:
* One of the interfaces may be listed twice
* The mac addresses listed match the `mac_address` field reported by `subscription-manager facts`, not the `permanent_mac_address`

### To test this PR

1. Follow all steps above to reproduce the issue
1. Unregister your client:
```
subscription-manager unregister
```
2. Check out the PR
3. Register again:
```
subscription-manager register --user admin --password changeme --env Library --org Default_Organization
```
4. In Foreman, navigate to `Hosts -> All Hosts -> <your katello-client> -> Edit -> Interfaces`
5. The interfaces list should now be correct:
* No interfaces are duplicated
* The mac address for each interface matches `permanent_mac_address` reported by `subscription-manager facts`