### PR TITLE
Fixes #28103 - allow API user to search pools using upstream_pool_id

### DIFF
--- a/app/models/katello/pool.rb
+++ b/app/models/katello/pool.rb
@@ -22,6 +22,7 @@ module Katello
     include Glue::Candlepin::CandlepinObject
 
     scoped_search :on => :cp_id, :complete_value => true, :rename => :id, :only_explicit => true
+    scoped_search :on => :upstream_pool_id, :complete_value => true, :only_explicit => true
     scoped_search :on => :quantity, :complete_value => true, :validator => ScopedSearch::Validators::INTEGER, :only_explicit => true
     scoped_search :on => :start_date, :complete_value => true, :rename => :starts, :only_explicit => true
     scoped_search :on => :end_date, :complete_value => true, :rename => :expires, :only_explicit => true

--- a/test/models/pool_test.rb
+++ b/test/models/pool_test.rb
@@ -137,6 +137,11 @@ module Katello
       assert_includes subscriptions, @pool_one
     end
 
+    def test_search_upstream_id
+      subscriptions = Pool.search_for("upstream_pool_id = \"#{@pool_one.upstream_pool_id}\"")
+      assert_includes subscriptions, @pool_one
+    end
+
     def test_search_instance_multiplier
       subscriptions = Pool.search_for("instance_multiplier = \"#{@pool_one.instance_multiplier}\"")
       assert_includes subscriptions, @pool_one


### PR DESCRIPTION
In developing foreman ansible modules, it would be very nice for users of the modules to be able to use upstream_pool_id in playbooks which are written before Katello is deployed and any downstream pool ID has been created. Allowing users of the Katello API to search pools using upstream_pool_id will enable the module developers to use this functionality and create a better experience for users of the modules.