### PR TITLE
Fixes #28143 - Don't look for OS without release name

### DIFF
--- a/app/models/katello/rhsm_fact_parser.rb
+++ b/app/models/katello/rhsm_fact_parser.rb
@@ -54,7 +54,13 @@ module Katello
       os_name = ::Katello::Candlepin::Consumer.distribution_to_puppet_os(name)
       major, minor = version.split('.')
       unless facts['ignore_os']
-        os_attributes = {:major => major, :minor => minor || '', :name => os_name, :release_name => os_release_name(os_name)}
+        os_attributes = {:major => major, :minor => minor || '', :name => os_name}
+
+        release_name = os_release_name(os_name)
+        if release_name
+          os_attributes[:release_name] = release_name
+        end
+
         ::Operatingsystem.find_by(os_attributes) || ::Operatingsystem.create!(os_attributes)
       end
     end

--- a/test/models/rhsm_fact_parser_test.rb
+++ b/test/models/rhsm_fact_parser_test.rb
@@ -88,6 +88,14 @@ module Katello
       assert_equal parser.operatingsystem.minor, '04'
     end
 
+    def test_operatingsystem_release
+      existing_os = FactoryBot.create(:operatingsystem, name: 'CentOS', major: '7', release_name: 'Core')
+      @facts['distribution.name'] = 'CentOS'
+      @facts['distribution.version'] = '7'
+
+      assert_equal existing_os.id, parser.operatingsystem.id
+    end
+
     def test_uname_architecture
       @facts['uname.machine'] = 'i686'
 


### PR DESCRIPTION
When an OS exists that has a release name set and a registration request is received from a client with the same OS (if it's not debian) then the registration will fail because we try to create the same OS without the release name set.

To test:

Assuming you have a centos7 client, create an OS such as this:

```
::Operatingsystem.create!(name: 'CentOS', major: '7', release_name: 'Core')
```

Register your centos7 client (katello-client for example) and see that is fails with error:

```
Validation failed: Name Operating system version already exists, Title has already been taken while trying to register physical server
```

After applying this patch the registration will succeed!