### PR TITLE
Refs #27674 - start daemon threads in single worker

### DIFF
--- a/app/models/katello/ping.rb
+++ b/app/models/katello/ping.rb
@@ -53,7 +53,7 @@ module Katello
         exception_watch(result) do
           status = Katello::EventMonitor::PollerThread.status
 
-          if status[:queue_depth] > 1000
+          if status[:queue_depth] && status[:queue_depth] > 1000
             result[:status] = WARN_RETURN_CODE
           end
 
@@ -65,7 +65,7 @@ module Katello
         exception_watch(result) do
           status = Katello::CandlepinEventListener.status
 
-          if status[:queue_depth] > 1000
+          if status[:queue_depth] && status[:queue_depth] > 1000
             result[:status] = WARN_RETURN_CODE
           end
 

--- a/app/services/katello/candlepin_event_listener.rb
+++ b/app/services/katello/candlepin_event_listener.rb
@@ -64,7 +64,9 @@ module Katello
     end
 
     def self.act_on_event(event)
-      ::Katello::Candlepin::EventHandler.new(@logger).handle(event)
+      ::Katello::Util::Support.with_db_connection(@logger) do
+        ::Katello::Candlepin::EventHandler.new(@logger).handle(event)
+      end
       @processed_count += 1
 
       Rails.cache.write(PROCESSED_COUNT_CACHE_KEY, @processed_count, expires_in: 24.hours)

--- a/app/services/katello/event_daemon.rb
+++ b/app/services/katello/event_daemon.rb
@@ -76,7 +76,7 @@ module Katello
           return false
         end
 
-        if Rails.env.production? && $PROGRAM_NAME.match(/dynflow/)
+        if $PROGRAM_NAME.match(/dynflow/)
           Rails.logger.debug("This appears to be the Dynflow process; not starting Katello Event Daemon")
           return false
         end

--- a/app/services/katello/event_daemon.rb
+++ b/app/services/katello/event_daemon.rb
@@ -64,12 +64,7 @@ module Katello
       end
 
       def runnable?
-        return false if !settings[:enabled] || ::Foreman.in_rake? || Rails.env.test?
-
-        if started?
-          Rails.logger.debug("Katello Event Daemon already running; not attempting startup")
-          return false
-        end
+        return false if started? || !settings[:enabled] || ::Foreman.in_rake? || Rails.env.test?
 
         if defined?(Rails::Console)
           Rails.logger.debug("Not starting Katello Event Daemon in the Rails Console")

--- a/app/services/katello/event_daemon.rb
+++ b/app/services/katello/event_daemon.rb
@@ -16,7 +16,11 @@ module Katello
       end
 
       def pid_file
-        Rails.root.join('tmp', 'pids', 'katello_event_daemon.pid')
+        pid_dir.join('katello_event_daemon.pid')
+      end
+
+      def pid_dir
+        Rails.root.join('tmp', 'pids')
       end
 
       def lock_file
@@ -26,6 +30,7 @@ module Katello
       def write_pid_file
         return unless pid_file
 
+        FileUtils.mkdir_p(pid_dir)
         File.open(pid_file, 'w') { |f| f.puts Process.pid }
       end
 

--- a/app/services/katello/event_daemon.rb
+++ b/app/services/katello/event_daemon.rb
@@ -2,7 +2,7 @@ module Katello
   class EventDaemon
     class << self
       def initialize
-        FileUtils.touch(settings[:lock_file])
+        FileUtils.touch(lock_file)
       end
 
       def settings
@@ -16,7 +16,11 @@ module Katello
       end
 
       def pid_file
-        settings[:pid_file]
+        Rails.root.join('tmp', 'pids', 'katello_event_daemon.pid')
+      end
+
+      def lock_file
+        Rails.root.join('tmp', 'katello_event_daemon.lock')
       end
 
       def write_pid_file
@@ -34,7 +38,7 @@ module Katello
       def start(worker: false)
         return if !runnable? || settings[:multiprocess] && !worker
 
-        lockfile = File.open(settings[:lock_file], 'r')
+        lockfile = File.open(lock_file, 'r')
         begin
           lockfile.flock(File::LOCK_EX)
           return if started? # ensure it wasn't started while we waited for the lock

--- a/app/services/katello/event_daemon.rb
+++ b/app/services/katello/event_daemon.rb
@@ -1,60 +1,85 @@
 module Katello
   class EventDaemon
-    def self.runnable?
-      if defined?(Rails::Console)
-        Rails.logger.info("Not starting Katello Event Daemon in the Rails Console")
-        return false
+    PID_CACHE_KEY = 'katello_event_daemon_pid'.freeze
+
+    class << self
+      def settings
+        SETTINGS[:katello][:event_daemon]
       end
 
-      if $PROGRAM_NAME.match(/spring/)
-        Rails.logger.info("Spring is running in the environment; not starting Katello Event Daemon")
-        return false
+      def cached_pid
+        Rails.cache.fetch(PID_CACHE_KEY)
       end
 
-      if Rails.env.production? && $PROGRAM_NAME.match(/dynflow/)
-        Rails.logger.info("This appears to be the Dynflow process; not starting Katello Event Daemon")
-        return false
+      def stop
+        services.values.each(&:close)
+        Rails.cache.delete(PID_CACHE_KEY)
       end
 
-      if started?
-        Rails.logger.info("Katello Event Daemon already running; not attempting startup")
-        return false
+      def start(worker: false)
+        return if !runnable? || settings[:multiprocess] && !worker
+
+        lockfile = File.open(settings[:lock_file], 'r')
+        begin
+          lockfile.flock(File::LOCK_EX)
+          return if started? # ensure it wasn't started while we waited for the lock
+
+          start_services
+
+          Rails.cache.write(PID_CACHE_KEY, Process.pid)
+          Rails.logger.info("Katello event daemon started process=#{Process.pid} multiprocess=#{settings[:multiprocess]}")
+        ensure
+          lockfile.flock(File::LOCK_UN)
+        end
       end
 
-      !::Foreman.in_rake? && !Rails.env.test? && SETTINGS[:katello][:event_daemon_enabled]
-    end
+      def started?
+        Process.kill(0, cached_pid)
+        true
+      rescue Errno::ESRCH, TypeError # process no longer exists or we had no PID cached
+        false
+      end
 
-    def self.start
-      if runnable?
+      def start_services
         services.values.each(&:run)
 
         at_exit do
           stop
         end
-
-        @pid = Process.pid
       end
-    end
 
-    def self.stop
-      # in puma clustered mode, we should only stop the daemon
-      # from the parent process (where it actually is running), not forked workers
-      return unless @pid == Process.pid
+      def runnable?
+        return false if !settings[:enabled] || ::Foreman.in_rake? || Rails.env.test?
 
-      services.values.each(&:close)
+        if started?
+          Rails.logger.debug("Katello Event Daemon already running; not attempting startup")
+          return false
+        end
 
-      @pid = nil
-    end
+        if defined?(Rails::Console)
+          Rails.logger.debug("Not starting Katello Event Daemon in the Rails Console")
+          return false
+        end
 
-    def self.started?
-      @pid.present?
-    end
+        if $PROGRAM_NAME.match(/spring/)
+          Rails.logger.debug("Spring is running in the environment; not starting Katello Event Daemon")
+          return false
+        end
 
-    def self.services
-      {
-        candlepin_events: ::Katello::CandlepinEventListener,
-        katello_events: ::Katello::EventMonitor::PollerThread
-      }
+        if Rails.env.production? && $PROGRAM_NAME.match(/dynflow/)
+          Rails.logger.debug("This appears to be the Dynflow process; not starting Katello Event Daemon")
+          return false
+        end
+
+        true
+      end
+
+      def services
+        {
+          candlepin_events: ::Katello::CandlepinEventListener,
+          katello_events: ::Katello::EventMonitor::PollerThread
+        }
+      end
     end
   end
 end

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -28,9 +28,7 @@ module Katello
         :consumer_cert_sh => 'katello-rhsm-consumer',
         :event_daemon => {
           enabled: true,
-          multiprocess: true,
-          lock_file: '/tmp/katello_event_daemon.lock',
-          pid_file: "#{Rails.root.join('tmp')}/pids/katello_event_daemon.pid"
+          multiprocess: true
         },
         :pulp => {
           :default_login => 'admin',

--- a/lib/katello/engine.rb
+++ b/lib/katello/engine.rb
@@ -29,7 +29,8 @@ module Katello
         :event_daemon => {
           enabled: true,
           multiprocess: true,
-          lock_file: '/tmp/katello_event_daemon.lock'
+          lock_file: '/tmp/katello_event_daemon.lock',
+          pid_file: "#{Rails.root.join('tmp')}/pids/katello_event_daemon.pid"
         },
         :pulp => {
           :default_login => 'admin',
@@ -125,6 +126,8 @@ module Katello
       Katello::EventQueue.register_event(Katello::Events::ImportHostApplicability::EVENT_TYPE, Katello::Events::ImportHostApplicability)
       Katello::EventQueue.register_event(Katello::Events::ImportPool::EVENT_TYPE, Katello::Events::ImportPool)
       Katello::EventQueue.register_event(Katello::Events::AutoPublishCompositeView::EVENT_TYPE, Katello::Events::AutoPublishCompositeView)
+
+      Katello::EventDaemon.initialize
 
       if defined?(PhusionPassenger)
         PhusionPassenger.on_event(:starting_worker_process) do |forked|

--- a/lib/katello/middleware/event_daemon.rb
+++ b/lib/katello/middleware/event_daemon.rb
@@ -1,0 +1,14 @@
+module Katello
+  module Middleware
+    class EventDaemon
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        Katello::EventDaemon.start
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/test/services/katello/event_daemon_test.rb
+++ b/test/services/katello/event_daemon_test.rb
@@ -12,8 +12,7 @@ module Katello
 
     def setup
       @default_settings = {
-        enabled: true,
-        multiprocess: false
+        enabled: true
       }
 
       Katello::EventDaemon.stubs(:services).returns(mock_service: MockService)
@@ -33,14 +32,6 @@ module Katello
 
       assert Katello::EventDaemon.started?
       Katello::EventDaemon.stop
-    end
-
-    def test_start_multiprocess_non_worker
-      Katello::EventDaemon.stubs(:settings).returns(@default_settings.merge(multiprocess: true))
-
-      Katello::EventDaemon.start
-
-      refute Katello::EventDaemon.started?
     end
 
     def test_stop_close_services

--- a/test/services/katello/event_daemon_test.rb
+++ b/test/services/katello/event_daemon_test.rb
@@ -11,8 +11,10 @@ module Katello
     end
 
     def setup
+      @lockfile = Tempfile.new
       Katello::EventDaemon.stubs(:services).returns(mock_service: MockService)
       Katello::EventDaemon.stubs(:runnable?).returns(true)
+      Katello::EventDaemon.stubs(:settings).returns(enabled: true, multiprocess: false, lock_file: @lockfile.path)
     end
 
     def test_start_runs_services
@@ -20,7 +22,16 @@ module Katello
 
       Katello::EventDaemon.start
 
+      assert Katello::EventDaemon.started?
       Katello::EventDaemon.stop
+    end
+
+    def test_start_multiprocess_non_worker
+      Katello::EventDaemon.stubs(:settings).returns(enabled: true, multiprocess: true, lock_file: @lockfile.path)
+
+      Katello::EventDaemon.start
+
+      refute Katello::EventDaemon.started?
     end
 
     def test_stop_close_services

--- a/test/services/katello/event_daemon_test.rb
+++ b/test/services/katello/event_daemon_test.rb
@@ -11,16 +11,9 @@ module Katello
     end
 
     def setup
-      @default_settings = {
-        enabled: true
-      }
-
       Katello::EventDaemon.stubs(:services).returns(mock_service: MockService)
       Katello::EventDaemon.stubs(:runnable?).returns(true)
       Katello::EventDaemon.stubs(:pid_file).returns(Rails.root.join('tmp', 'test_katello_daemon.pid'))
-      Katello::EventDaemon.stubs(:settings).returns(@default_settings)
-
-      Katello::EventDaemon.initialize
 
       refute Katello::EventDaemon.started?
     end

--- a/test/services/katello/event_daemon_test.rb
+++ b/test/services/katello/event_daemon_test.rb
@@ -11,24 +11,18 @@ module Katello
     end
 
     def setup
-      Katello::EventDaemon.stubs(:services).returns(mock_service: MockService)
-      Katello::EventDaemon.stubs(:runnable?).returns(true)
-
       @default_settings = {
         enabled: true,
-        multiprocess: false,
-        lock_file: '/tmp/test_katello_daemon.lock',
-        pid_file: '/tmp/test_katello_daemon.pid'
+        multiprocess: false
       }
 
+      Katello::EventDaemon.stubs(:services).returns(mock_service: MockService)
+      Katello::EventDaemon.stubs(:runnable?).returns(true)
+      Katello::EventDaemon.stubs(:pid_file).returns(Rails.root.join('tmp', 'test_katello_daemon.pid'))
       Katello::EventDaemon.stubs(:settings).returns(@default_settings)
-      Katello::EventDaemon.initialize
-      refute Katello::EventDaemon.started?
-    end
 
-    def teardown
-      File.unlink(@default_settings[:lock_file]) if File.exist?(@default_settings[:lock_file])
-      File.unlink(@default_settings[:pid_file]) if File.exist?(@default_settings[:pid_file])
+      Katello::EventDaemon.initialize
+
       refute Katello::EventDaemon.started?
     end
 
@@ -47,7 +41,6 @@ module Katello
       Katello::EventDaemon.start
 
       refute Katello::EventDaemon.started?
-      Katello::EventDaemon.stop
     end
 
     def test_stop_close_services


### PR DESCRIPTION
This PR builds on the work I did in #8366 to address some feedback I received in discourse: https://community.theforeman.org/t/changes-to-event-handling-in-katello/15963

Concern was raised about running the threads in the Passenger or Puma 'preloader' (the process from which the workers are forked) since we lose the benefits of being managed in the worker pool which is useful in cases where memory bloat occurs, or something  else goes wrong.

Now, the event daemon will run in a single worker, whether there is one or 100 of them. The tricky part was to ensure that multiple workers would not try to start the daemon simultaneously. Since this is happening cross-process, I opted to use https://ruby-doc.org/core-2.5.0/File.html#method-i-flock which can maintain an exclusive lock on a file at the OS level, so it acts as a mutex.

**The flow is like this:**

- Worker A starts serving a request and checks to see if the Daemon is already started, if so, it does nothing and continues startup
- If the daemon is not running, a lock is placed on an arbitrary file, and daemon startup begins, writing its pidfile
- If Worker B serves a request at the same time and also finds the daemon not started it waits for the file lock to be released (it's imperceptible since daemon start is fast)
- Worker B sees that the daemon is already started by Worker A, and continues as usual

This approach gives improved resiliency to the event daemon. If the daemon's worker process dies another worker will take its place in 1 minute or less depending if the fact daemon run state is cached or not.

Watch the daemon recover if its current process is killed:

```
last_daemon_pid = nil

loop do
  log_line = `grep 'event daemon started' /var/log/foreman/production.log | tail -1`
  daemon_pid = log_line.match(/process=(\d+)/)[1]

  if daemon_pid.nil? || daemon_pid == last_daemon_pid
    puts "a daemon was never started, stopping"
    puts log_line
    break
  end

  last_daemon_pid = daemon_pid
  Process.kill('INT', daemon_pid.to_i)

  puts "killed daemon process=#{daemon_pid}"

  sleep 15
end
```


