### PR TITLE
Fixes #28185 - allows scoped search sort order by environment id

### DIFF
--- a/app/models/katello/kt_environment.rb
+++ b/app/models/katello/kt_environment.rb
@@ -76,6 +76,7 @@ module Katello
 
     scoped_search :on => :name, :complete_value => true
     scoped_search :on => :organization_id, :complete_value => true, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
+    scoped_search :on => :id, :complete_value => true, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
 
     def library?
       self.library

--- a/test/controllers/api/v2/environments_controller_test.rb
+++ b/test/controllers/api/v2/environments_controller_test.rb
@@ -232,6 +232,12 @@ module Katello
       assert_response :success
     end
 
+    def test_index_with_sort_by_id
+      get :index, params: { :sort_by => 'id' }
+
+      assert_response :success
+    end
+
     test_attributes :pid => 'cd5a97ca-c1e8-41c7-8d6b-f908916b24e1'
     def test_destroy
       destroyable_env = KTEnvironment.create!(:name => "DestroyAble",


### PR DESCRIPTION
This PR allows sort_by environment id for the GET /environments API endpoint, originally reported in https://bugzilla.redhat.com/show_bug.cgi?id=1710555.