### PR TITLE
Fixes #28188 - audit repo syncs and fallback to audit times

### DIFF
--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -69,6 +69,10 @@ module Actions
         rescue ::Katello::Errors::CapsuleCannotBeReached # skip any capsules that cannot be connected to
         end
 
+        def finalize
+          ::Katello::Repository.find(input[:id])&.audit_sync
+        end
+
         def humanized_name
           if input && input[:validate_contents]
             _("Synchronize: Validate Content")

--- a/app/models/katello/glue/pulp/repos.rb
+++ b/app/models/katello/glue/pulp/repos.rb
@@ -76,9 +76,12 @@ module Katello
         summary
       end
 
+      def last_sync_audit
+        Audited::Audit.where(:auditable_id => self.repositories, :auditable_type => Katello::Repository.name).order(:created_at).last
+      end
+
       def last_sync
-        task = last_repo_sync_task
-        task.nil? ? nil : task.started_at.to_s
+        last_repo_sync_task&.started_at&.to_s || last_sync_audit&.created_at&.to_s
       end
 
       def last_repo_sync_task

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -1,6 +1,8 @@
 module Katello
   # rubocop:disable Metrics/ClassLength
   class Repository < Katello::Model
+    audited
+
     #pulp uses pulp id to sync with 'yum_distributor' on the end
     PULP_ID_MAX_LENGTH = 220
 
@@ -18,6 +20,8 @@ module Katello
 
     include ERB::Util
     include ::ScopedSearchExtensions
+
+    AUDIT_SYNC_ACTION = 'sync'.freeze
 
     DEB_TYPE = 'deb'.freeze
     YUM_TYPE = 'yum'.freeze
@@ -188,6 +192,10 @@ module Katello
       else
         self.content_view.organization
       end
+    end
+
+    def audit_sync
+      write_audit(action: AUDIT_SYNC_ACTION, comment: _('Successfully synchronized.'), audited_changes: {})
     end
 
     def set_pulp_id
@@ -459,6 +467,10 @@ module Katello
 
       clone.relative_path = clone.docker? ? clone.generate_docker_repo_path : clone.generate_repo_path
       clone
+    end
+
+    def latest_sync_audit
+      self.audits.where(:action => AUDIT_SYNC_ACTION).order(:created_at).last
     end
 
     def cancel_dynflow_sync

--- a/app/views/katello/api/v2/repositories/base.json.rabl
+++ b/app/views/katello/api/v2/repositories/base.json.rabl
@@ -49,6 +49,8 @@ end
 node :last_sync_words do |object|
   if (object.latest_dynflow_sync.respond_to?('ended_at') && object.latest_dynflow_sync.ended_at)
     time_ago_in_words(Time.parse(object.latest_dynflow_sync.ended_at.to_s))
+  elsif (audit = object.latest_sync_audit)
+    time_ago_in_words(audit.created_at)
   end
 end
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/views/product-repositories.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/views/product-repositories.html
@@ -88,8 +88,11 @@
           <td bst-table-cell>{{ repository.content_type }}</td>
           <td bst-table-cell>
             <span ng-show="repository.url">
-              <span ng-show="repository.last_sync == null" translate>
+              <span ng-show="repository.last_sync == null && repository.last_sync_words == null" translate>
                 Not Synced
+              </span>
+              <span ng-show="repository.last_sync == null && repository.last_sync_words" translate>
+                Completed {{ repository.last_sync_words }} ago
               </span>
               <span ng-show="repository.last_sync !== null && repository.last_sync.ended_at == null" translate>
                 <a href="/foreman_tasks/tasks/{{repository.last_sync.id}}">{{ repository.last_sync.result | capitalize}}</a>


### PR DESCRIPTION
this adds auditing of repository syncs, upon successful
syncs.  Display of last syncs times will use audit times
if the last sync tasks have been removed.