### PR TITLE
Fixes #28049 - Index yum repo w/o errata refactoring w/ Pulp 3

### DIFF
--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -24,7 +24,8 @@ module Actions
           incremental = options.fetch(:incremental, false)
           validate_contents = options.fetch(:validate_contents, false)
           skip_metadata_check = options.fetch(:skip_metadata_check, false) || validate_contents
-          generate_applicability = repo.yum?
+          # TODO: Remove the check for Pulp 3 once Pulp 3 errata is working fully
+          generate_applicability = repo.yum? && !SmartProxy.pulp_master.pulp3_support?(repo)
 
           pulp_sync_options = {}
           pulp_sync_options[:download_policy] = ::Runcible::Models::YumImporter::DOWNLOAD_ON_DEMAND if validate_contents

--- a/app/models/katello/yum_metadata_file.rb
+++ b/app/models/katello/yum_metadata_file.rb
@@ -10,7 +10,7 @@ module Katello
       super(repository)
     end
 
-    # yum metadata file only has one repo
+    # yum metadata files are many-to-many in Pulp 3
     def repositories
       [repository]
     end

--- a/app/services/katello/pulp3/distribution.rb
+++ b/app/services/katello/pulp3/distribution.rb
@@ -1,0 +1,17 @@
+module Katello
+  module Pulp3
+    class Distribution < PulpContentUnit
+      include LazyAccessor
+
+      def self.content_api
+        PulpRpmClient::ContentDistributionTreesApi.new(Katello::Pulp3::Repository::Yum.api_client(SmartProxy.pulp_master!))
+      end
+
+      def self.ids_for_repository(repo_id)
+        repo = Katello::Pulp3::Repository::Yum.new(Katello::Repository.find(repo_id), SmartProxy.pulp_master)
+        repo_content_list = repo.content_list
+        repo_content_list.map { |content| content.try(:pulp_href) }
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/erratum.rb
+++ b/app/services/katello/pulp3/erratum.rb
@@ -1,0 +1,118 @@
+module Katello
+  module Pulp3
+    class Erratum < PulpContentUnit
+      include LazyAccessor
+
+      def self.content_api
+        PulpRpmClient::ContentAdvisoriesApi.new(Katello::Pulp3::Repository::Yum.api_client(SmartProxy.pulp_master!))
+      end
+
+      def self.ids_for_repository(repo_id)
+        repo = Katello::Pulp3::Repository::Erratum.new(Katello::Repository.find(repo_id), SmartProxy.pulp_master)
+        repo_content_list = repo.content_list
+        repo_content_list.map { |content| content.try(:pulp_href) }
+      end
+
+      def update_model(model)
+        #custom_json = {}
+        #custom_json['title'] = backend_data['title']
+        #model.update_attributes!(custom_json)
+        keys = %w(title id severity issued type description reboot_suggested solution updated summary)
+        custom_json = backend_data.slice(*keys)
+
+        # handle SUSE epoch dates
+        custom_json["issued"] = convert_date_if_epoch(custom_json["issued"])
+        custom_json["updated"] = convert_date_if_epoch(custom_json["updated"]) unless custom_json["updated"].blank?
+
+        if model.updated.blank? || (custom_json['updated'].to_datetime != model.updated.to_datetime)
+          custom_json['errata_id'] = custom_json.delete('id')
+          custom_json['errata_type'] = custom_json.delete('type')
+          custom_json['updated'] = custom_json['updated'].blank? ? custom_json['issued'] : custom_json['updated']
+          model.update_attributes!(custom_json)
+
+          unless backend_data['references'].blank?
+            update_bugzillas(model, backend_data['references'])
+            update_cves(model, backend_data['references'])
+          end
+        end
+        # FIXME There are hashes in pkglist that are strings, these should be JSON
+        update_packages(model, backend_data['pkglist']) unless backend_data['pkglist'].blank?
+        update_modules(model, backend_data['pkglist']) unless backend_data['pkglist'].blank?
+      end
+
+      def update_bugzillas(model, ref_list)
+        ref_list = ref_list.collect { |ref| ref = eval(ref) }
+        ref_list.select { |r| r[:type] == "bugzilla" }.each do |bugzilla|
+          Katello::Util::Support.active_record_retry do
+            model.bugzillas.where(bug_id: bugzilla[:id]).first_or_create!({bug_id: bugzilla[:id], href: bugzilla[:href], erratum_id: model.id})
+          end
+        end
+      end
+
+      def update_cves(model, ref_list)
+        ref_list = ref_list.collect { |ref| ref = eval(ref) }
+        ref_list.select { |r| r[:type] == "cve" }.each do |cve|
+          Katello::Util::Support.active_record_retry do
+            model.cves.where(cve_id: cve[:id]).first_or_create!({cve_id: cve[:id], href: cve[:href], erratum_id: model.id})
+          end
+        end
+      end
+
+      def update_packages(model, package_list)
+        #package_hashes = json.map { |list| list['packages'] }.flatten
+        package_list.each do |json|
+          json = eval(json)
+          package_hashes = json[:packages]
+          package_attributes = package_hashes.map do |hash|
+            nvrea = Util::Package.build_nvra(hash)
+            {'name' => hash[:name], 'nvrea' => nvrea, 'filename' => hash[:filename]}
+          end
+          existing_nvreas = model.packages.pluck(:nvrea)
+          package_attributes.delete_if { |pkg| existing_nvreas.include?(pkg[:nvrea]) }
+          package_attributes.uniq { |pkg| pkg[:nvrea] }.each do |package|
+            Katello::Util::Support.active_record_retry do
+              model.packages.where(filename: package["filename"]).first_or_create!(package)
+            end
+          end
+        end
+      end
+      
+      def update_modules(model, module_stream_list)
+        module_stream_attributes = []
+        module_stream_list.each do |package_item|
+          package_item = eval(package_item)
+          if package_item[:module]
+            module_stream = ::Katello::ModuleStream.where(package_item[:module]).first
+            next if module_stream.blank?
+            nvreas = package_item[:packages].map { |hash| Util::Package.build_nvra(hash) }
+            module_stream_id_column = "#{ModuleStreamErratumPackage.table_name}.module_stream_id"
+            existing = ErratumPackage.joins(:module_streams).
+                                      where(module_stream_id_column => module_stream.id,
+                                            :nvrea => nvreas).pluck(:nvrea)
+
+            (nvreas - existing).each do |nvrea|
+              package = model.packages.find_by(:nvrea => nvrea)
+              module_stream_attributes << { :module_stream_id => module_stream.id,
+                                            :erratum_package_id => package.id }
+            end
+          end
+        end
+        module_stream_attributes.uniq.each do |module_stream|
+          Katello::Util::Support.active_record_retry do
+            if model.module_streams.empty? || !model.module_streams.pluck(:module_stream_id).include?(module_stream[:module_stream_id])
+              ModuleStreamErratumPackage.create!(module_stream)
+            end
+          end
+        end
+      end
+
+      def convert_date_if_epoch(date)
+        date.to_i.to_s == date ? epoch_to_date(date) : date
+      end
+
+      def epoch_to_date(epoch)
+        Time.at(epoch.to_i).to_s
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/module_stream.rb
+++ b/app/services/katello/pulp3/module_stream.rb
@@ -1,0 +1,47 @@
+module Katello
+  module Pulp3
+    class ModuleStream < PulpContentUnit
+      include LazyAccessor
+
+      def self.content_api
+        PulpRpmClient::ContentModulemdApi.new(Katello::Pulp3::Repository::Yum.api_client(SmartProxy.pulp_master!))
+      end
+
+      def self.ids_for_repository(repo_id)
+        repo = Katello::Pulp3::Repository::ModuleStream.new(Katello::Repository.find(repo_id), SmartProxy.pulp_master)
+        repo_content_list = repo.content_list
+        repo_content_list.map { |content| content.try(:pulp_href) }
+      end
+
+      def create_stream_artifacts(model, artifacts_json)
+        artifacts_json.each do |name|
+          Katello::Util::Support.active_record_retry do
+            model.artifacts.where(name: name).first_or_create!
+          end
+        end
+      end
+
+      def create_profiles(model, profiles_json)
+        profiles_json.each do |profile, rpms|
+          Katello::Util::Support.active_record_retry do
+            profile = model.profiles.where(name: profile).first_or_create!
+          end
+          rpms.each do |rpm|
+            Katello::Util::Support.active_record_retry do
+              profile.rpms.where(name: rpm).first_or_create!
+            end
+          end
+        end
+      end
+
+      def update_model(model)
+        shared_attributes = backend_data.keys & model.class.column_names
+        shared_json = backend_data.select { |key, _v| shared_attributes.include?(key) }
+        model.update_attributes!(shared_json)
+
+        create_stream_artifacts(model, JSON.parse(backend_data['artifacts'])) if backend_data.key?('artifacts')
+        create_profiles(model, JSON.parse(backend_data['profiles'])) if backend_data.key?('profiles')
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/repository/yum.rb
+++ b/app/services/katello/pulp3/repository/yum.rb
@@ -55,6 +55,37 @@ module Katello
             name: "#{backend_object_name}"
           }
         end
+
+        def import_distribution_data
+          distribution = ::Katello::Pulp3::Distribution.fetch_content_list({ repository_version: repo.version_href })
+          if distribution.results.present?
+            repo.update_attributes!(
+              :distribution_version => distribution.results.first.release_version,
+              :distribution_arch => distribution.results.first.arch,
+              :distribution_family => distribution.results.first.release_name,
+              :distribution_variant => distribution.results.first.variants.first.name,
+              :distribution_uuid => distribution.results.first.pulp_href,
+              :distribution_bootable => self.class.distribution_bootable?(distribution)
+            )
+          end          
+        end
+
+        def self.distribution_bootable?(distribution)
+          file_paths = distribution.results.first.images.map(&:path)
+          file_paths.any? do |path|
+            path.include?('vmlinuz') || path.include?('pxeboot') || path.include?('kernel.img') || path.include?('initrd.img') || path.include?('boot.iso')
+          end
+        end
+
+        def copy_content
+          # TODO
+          fail NotImplementedError
+        end
+
+        def regenerate_applicability
+          # TODO
+          fail NotImplementedError
+        end
       end
     end
   end

--- a/app/services/katello/pulp3/rpm.rb
+++ b/app/services/katello/pulp3/rpm.rb
@@ -1,0 +1,62 @@
+module Katello
+  module Pulp3
+    class Rpm < PulpContentUnit
+      include LazyAccessor
+
+      PULP_INDEXED_FIELDS = %w(name version release arch epoch summary sourcerpm checksum filename is_modular).freeze
+
+      lazy_accessor :description, :license, :buildhost, :vendor, :relativepath, :children, :checksumtype,
+                    :changelog, :group, :size, :url, :build_time, :group,
+                    :initializer => :backend_data
+
+      def self.content_api
+        PulpRpmClient::ContentPackagesApi.new(Katello::Pulp3::Repository::Yum.api_client(SmartProxy.pulp_master!))
+      end
+
+      def self.ids_for_repository(repo_id)
+        repo = Katello::Pulp3::Repository::Rpm.new(Katello::Repository.find(repo_id), SmartProxy.pulp_master)
+        repo_content_list = repo.content_list
+        repo_content_list.map { |content| content.try(:pulp_href) }
+      end
+
+      def requires
+        if backend_data['requires']
+          backend_data['requires'].map { |entry| Katello::Util::Package.format_requires(entry) }.uniq.sort
+        else
+          []
+        end
+      end
+
+      def provides
+        if backend_data['provides']
+          backend_data['provides'].map { |entry| Katello::Util::Package.build_nvrea(entry, false) }.uniq.sort
+        else
+          []
+        end
+      end
+
+      def files
+        result = []
+        if backend_data['files']
+          if backend_data['files']['file']
+            result << backend_data['files']['file']
+          end
+          if backend_data['files']['dir']
+            result << backend_data['files']['dir']
+          end
+        end
+        result.flatten
+      end
+
+      def update_model(model)
+        custom_json = {}
+        custom_json['modular'] = backend_data['is_modular']
+        (PULP_INDEXED_FIELDS - ['is_modular']).each { |field| custom_json[field] = backend_data[field] }
+        custom_json['release_sortable'] = Util::Package.sortable_version(backend_data['release'])
+        custom_json['version_sortable'] = Util::Package.sortable_version(backend_data['version'])
+        custom_json['nvra'] = model.build_nvra
+        model.update_attributes!(custom_json)
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/yum_metadata_file.rb
+++ b/app/services/katello/pulp3/yum_metadata_file.rb
@@ -1,0 +1,20 @@
+module Katello
+  module Pulp3
+    class YumMetadataFile < PulpContentUnit
+      include LazyAccessor
+
+      def self.content_api
+        PulpRpmClient::ContentRepoMetadataFilesApi.new(Katello::Pulp3::Repository::Yum.api_client(SmartProxy.pulp_master!))
+      end
+
+      def self.ids_for_repository(repo_id)
+        repo = Katello::Pulp3::Repository::YumMetadataFile.new(Katello::Repository.find(repo_id), SmartProxy.pulp_master)
+        repo_content_list = repo.content_list
+        repo_content_list.map { |content| content.try(:pulp_href) }
+      end
+
+      # TODO: The Pulp 3 Yum Metadata File API doesn't expose names or file paths yet.
+      # Need to decide if we'll still index Yum Metadata Files in Pulp 3.
+    end
+  end
+end

--- a/app/services/katello/repository_type.rb
+++ b/app/services/katello/repository_type.rb
@@ -31,7 +31,12 @@ module Katello
     end
 
     def content_types_to_index
-      @content_types.select { |type| type.index }
+      if (SmartProxy.pulp_master.pulp3_repository_type_support?(self))
+        # type.index being false supersedes type.index_on_pulp3 being true
+        @content_types.select { |type| type.index && type.index_on_pulp3 }
+      else
+        @content_types.select { |type| type.index }
+      end
     end
 
     def default_managed_content_type(model_class = nil)
@@ -68,7 +73,7 @@ module Katello
     end
 
     class ContentType
-      attr_accessor :model_class, :priority, :pulp2_service_class, :pulp3_service_class, :index, :uploadable, :removable
+      attr_accessor :model_class, :priority, :pulp2_service_class, :pulp3_service_class, :index, :uploadable, :removable, :index_on_pulp3
 
       def initialize(options)
         self.model_class = options[:model_class]
@@ -76,6 +81,7 @@ module Katello
         self.pulp2_service_class = options[:pulp2_service_class]
         self.pulp3_service_class = options[:pulp3_service_class]
         self.index = options[:index].nil? ? true : options[:index]
+        self.index_on_pulp3 = options[:index_on_pulp3].nil? ? true : options[:index_on_pulp3]
         self.uploadable = options[:uploadable] || false
         self.removable = options[:removable] || false
       end

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "pulp_file_client", "<= 0.1.0b5.dev01571253617"
   gem.add_dependency "pulp_ansible_client", "<= 0.2.0b6.dev01570985981"
   gem.add_dependency "pulp_docker_client", "<= 4.0.0b8.dev01571062112"
-  gem.add_dependency "pulp_rpm_client", "<= 3.0.0b71571331815"
+  gem.add_dependency "pulp_rpm_client", "<= 3.0.0b8.dev01572883308"
   gem.add_dependency "pulp_2to3_migration_client", "<= 0.0.1a1.dev01572375132"
 
   # UI

--- a/lib/katello/repository_types/yum.rb
+++ b/lib/katello/repository_types/yum.rb
@@ -5,13 +5,33 @@ Katello::RepositoryTypeManager.register(::Katello::Repository::YUM_TYPE) do
   prevent_unneeded_metadata_publish
 
   default_managed_content_type Katello::Rpm
-  content_type Katello::Rpm, :priority => 1, :pulp2_service_class => ::Katello::Pulp::Rpm, :removable => true, :uploadable => true
-  content_type Katello::ModuleStream, :priority => 2, :pulp2_service_class => ::Katello::Pulp::ModuleStream
-  content_type Katello::Erratum, :priority => 3, :pulp2_service_class => ::Katello::Pulp::Erratum
-  content_type Katello::PackageGroup, :pulp2_service_class => ::Katello::Pulp::PackageGroup
-  content_type Katello::YumMetadataFile, :pulp2_service_class => ::Katello::Pulp::YumMetadataFile
-  content_type Katello::Srpm, :pulp2_service_class => ::Katello::Pulp::Srpm, :removable => true, :uploadable => true
-  content_type Katello::Distribution, :priority => 4, :pulp2_service_class => ::Katello::Pulp::Distribution, :index => false
+  content_type Katello::Rpm,
+    :priority => 1,
+    :pulp2_service_class => ::Katello::Pulp::Rpm,
+    :pulp3_service_class => ::Katello::Pulp3::Rpm,
+    :removable => true,
+    :uploadable => true
+  content_type Katello::ModuleStream,
+    :priority => 2,
+    :pulp2_service_class => ::Katello::Pulp::ModuleStream,
+    :pulp3_service_class => ::Katello::Pulp3::ModuleStream
+  content_type Katello::Erratum, :priority => 3,
+    :pulp2_service_class => ::Katello::Pulp::Erratum,
+    :pulp3_service_class => ::Katello::Pulp3::Erratum
+  content_type Katello::PackageGroup, :pulp2_service_class => ::Katello::Pulp::PackageGroup, :index_on_pulp3 => false
+  content_type Katello::YumMetadataFile,
+    :pulp2_service_class => ::Katello::Pulp::YumMetadataFile,
+    :pulp3_service_class => ::Katello::Pulp3::YumMetadataFile,
+    :index_on_pulp3 => false
+  #TODO: how to index SRPMs when Pulp 3 doesn't have an API for them?
+  content_type Katello::Srpm,
+    :pulp2_service_class => ::Katello::Pulp::Srpm,
+    :removable => true, :uploadable => true,
+    :index_on_pulp3 => false
+  content_type Katello::Distribution, :priority => 4,
+    :pulp2_service_class => ::Katello::Pulp::Distribution,
+    :pulp3_service_class => ::Katello::Pulp3::Distribution,
+    :index => false
   content_type Katello::PackageCategory, :priority => 4, :pulp2_service_class => ::Katello::Pulp::PackageCategory, :index => false
 
   index_additional_data { |repo, target_repo = nil| repo.import_distribution_data(target_repo) }

--- a/test/actions/pulp3/orchestration/yum_sync_test.rb
+++ b/test/actions/pulp3/orchestration/yum_sync_test.rb
@@ -1,0 +1,45 @@
+require 'katello_test_helper'
+
+module ::Actions::Pulp3
+  class YumSyncTest < ActiveSupport::TestCase
+    include Katello::Pulp3Support
+
+    def setup
+      @master = FactoryBot.create(:smart_proxy, :default_smart_proxy, :with_pulp3)
+      @repo = katello_repositories(:fedora_17_x86_64_duplicate)
+      @repo.root.update_attributes!(url: 'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/')
+      create_repo(@repo, @master)
+      ForemanTasks.sync_task(
+          ::Actions::Katello::Repository::MetadataGenerate, @repo,
+          repository_creation: true)
+
+      repository_reference = Katello::Pulp3::RepositoryReference.find_by(
+          :root_repository_id => @repo.root.id,
+          :content_view_id => @repo.content_view.id)
+
+      assert repository_reference
+      refute_empty repository_reference.repository_href
+      refute_empty Katello::Pulp3::DistributionReference.where(
+          root_repository_id: @repo.root.id)
+      @repo_version_href = @repo.version_href
+    end
+
+    def teardown
+      ForemanTasks.sync_task(
+          ::Actions::Pulp3::Orchestration::Repository::Delete, @repo, @master)
+      @repo.reload
+    end
+
+    def test_sync
+      sync_args = {:smart_proxy_id => @master.id, :repo_id => @repo.id}
+      ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::Sync, @repo, @master, sync_args)
+      @repo.reload
+      refute_equal @repo.version_href, @repo_version_href
+      repository_reference = Katello::Pulp3::RepositoryReference.find_by(
+          :root_repository_id => @repo.root.id,
+          :content_view_id => @repo.content_view.id)
+
+      assert_equal repository_reference.repository_href + "versions/2/", @repo.version_href
+    end
+  end
+end

--- a/test/fixtures/vcr_cassettes/actions/pulp3/yum_sync/sync.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/yum_sync/sync.yml
@@ -1,0 +1,1403 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/repositories/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:52:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:52:53 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0b71571331815/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:52:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:52:53 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?name=2_duplicate
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0b71571331815/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:52:53 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:52:53 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0b71571331815/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:52:54 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '52'
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:52:54 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/repositories/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJuYW1lIjoiMl9kdXBsaWNhdGUifQ==
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:52:54 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/repositories/311ce70e-2401-4424-9e99-51f1cc9eedd6/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '305'
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzMxMWNl
+        NzBlLTI0MDEtNDQyNC05ZTk5LTUxZjFjYzllZWRkNi8iLCJwdWxwX2NyZWF0
+        ZWQiOiIyMDE5LTEwLTIzVDE2OjUyOjU0LjQyMjkzNFoiLCJ2ZXJzaW9uc19o
+        cmVmIjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy8zMTFjZTcwZS0yNDAx
+        LTQ0MjQtOWU5OS01MWYxY2M5ZWVkZDYvdmVyc2lvbnMvIiwibGF0ZXN0X3Zl
+        cnNpb25faHJlZiI6bnVsbCwibmFtZSI6IjJfZHVwbGljYXRlIiwicGx1Z2lu
+        X21hbmFnZWQiOmZhbHNlLCJkZXNjcmlwdGlvbiI6bnVsbH0=
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:52:54 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiMl9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJp
+        bGwuZmVkb3JhcGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEv
+        Iiwic3NsX3ZhbGlkYXRpb24iOnRydWUsInBvbGljeSI6ImltbWVkaWF0ZSJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0b71571331815/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:52:54 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/remotes/rpm/rpm/04791f07-a5f2-4396-b410-c7c409899c3b/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '432'
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9ycG0vcnBtLzA0
+        NzkxZjA3LWE1ZjItNDM5Ni1iNDEwLWM3YzQwOTg5OWMzYi8iLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDE5LTEwLTIzVDE2OjUyOjU0LjYyMTI0MVoiLCJuYW1lIjoi
+        Ml9kdXBsaWNhdGUiLCJ1cmwiOiJodHRwczovL2psc2hlcnJpbGwuZmVkb3Jh
+        cGVvcGxlLm9yZy9mYWtlLXJlcG9zL25lZWRlZC1lcnJhdGEvIiwic3NsX2Nh
+        X2NlcnRpZmljYXRlIjpudWxsLCJzc2xfY2xpZW50X2NlcnRpZmljYXRlIjpu
+        dWxsLCJzc2xfY2xpZW50X2tleSI6bnVsbCwic3NsX3ZhbGlkYXRpb24iOnRy
+        dWUsInByb3h5X3VybCI6bnVsbCwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDE5
+        LTEwLTIzVDE2OjUyOjU0LjYyMTI1NFoiLCJkb3dubG9hZF9jb25jdXJyZW5j
+        eSI6MjAsInBvbGljeSI6ImltbWVkaWF0ZSJ9
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:52:54 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/repositories/311ce70e-2401-4424-9e99-51f1cc9eedd6/versions/
+    body:
+      encoding: UTF-8
+      base64_string: 'e30=
+
+'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:52:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQwZjk5OTA0LWZiZGUtNGRj
+        YS04MDM3LWU1NDAxMzNhZTIwZC8ifQ==
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:52:55 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/tasks/40f99904-fbde-4dca-8037-e540133ae20d/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:52:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+      Content-Length:
+      - '339'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDBmOTk5MDQtZmJk
+        ZS00ZGNhLTgwMzctZTU0MDEzM2FlMjBkLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTAtMjNUMTY6NTI6NTUuMTAzMTI4WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmFkZF9h
+        bmRfcmVtb3ZlIiwic3RhcnRlZF9hdCI6IjIwMTktMTAtMjNUMTY6NTI6NTUu
+        MjA2NjE1WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMC0yM1QxNjo1Mjo1NS4y
+        NTA3MDJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzL2NjM2QxODY1LWRiM2EtNGJkNi1hNDViLTk3NWIwZGFjMTI2My8i
+        LCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19y
+        ZXBvcnRzIjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3Yz
+        L3JlcG9zaXRvcmllcy8zMTFjZTcwZS0yNDAxLTQ0MjQtOWU5OS01MWYxY2M5
+        ZWVkZDYvdmVyc2lvbnMvMS8iXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
+        ZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzMxMWNlNzBlLTI0MDEt
+        NDQyNC05ZTk5LTUxZjFjYzllZWRkNi8iXX0=
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:52:55 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/repositories/311ce70e-2401-4424-9e99-51f1cc9eedd6/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:52:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+      Content-Length:
+      - '187'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzMxMWNl
+        NzBlLTI0MDEtNDQyNC05ZTk5LTUxZjFjYzllZWRkNi92ZXJzaW9ucy8xLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMTktMTAtMjNUMTY6NTI6NTUuMjMwMjc4WiIs
+        Im51bWJlciI6MSwiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250ZW50X3N1bW1h
+        cnkiOnsiYWRkZWQiOnt9LCJyZW1vdmVkIjp7fSwicHJlc2VudCI6e319fQ==
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:52:55 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/publications/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzMxMWNlNzBlLTI0MDEtNDQyNC05ZTk5LTUxZjFjYzllZWRkNi92ZXJz
+        aW9ucy8xLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0b71571331815/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:52:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2EwNGI2NjFhLTQ1M2MtNGNm
+        My1hZjY1LTdkM2U4NmM5NmU0MS8ifQ==
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:52:55 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/tasks/a04b661a-453c-4cf3-af65-7d3e86c96e41/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:52:55 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+      Content-Length:
+      - '361'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvYTA0YjY2MWEtNDUz
+        Yy00Y2YzLWFmNjUtN2QzZTg2Yzk2ZTQxLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTAtMjNUMTY6NTI6NTUuNTYwNTY5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
+        c2giLCJzdGFydGVkX2F0IjoiMjAxOS0xMC0yM1QxNjo1Mjo1NS42NjE2NDVa
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTEwLTIzVDE2OjUyOjU1Ljc3OTk0N1oi
+        LCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMv
+        ZWI3NDFjNDgtODZjYy00ZGM0LTgyZjgtYzYyNzAxMTIyY2YzLyIsInBhcmVu
+        dCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMi
+        OltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcHVibGlj
+        YXRpb25zL3JwbS9ycG0vOTNjYjA5MDEtNmQxNi00MWY2LTlkNjEtOWE2ZDUy
+        OWMwY2E1LyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvMzExY2U3MGUtMjQwMS00NDI0LTllOTkt
+        NTFmMWNjOWVlZGQ2LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:52:55 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdf
+        ZHVwbGljYXRlX2xhYmVsIiwibmFtZSI6IjJfZHVwbGljYXRlIiwicHVibGlj
+        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vOTNj
+        YjA5MDEtNmQxNi00MWY2LTlkNjEtOWE2ZDUyOWMwY2E1LyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0b71571331815/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:52:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzM5M2QwOGU0LTQ3NjItNDRj
+        Yy1iZjJiLTNjYjE0NDlkNjM0NS8ifQ==
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:52:56 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/tasks/393d08e4-4762-44cc-bf2b-3cb1449d6345/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:52:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+      Content-Length:
+      - '336'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMzkzZDA4ZTQtNDc2
+        Mi00NGNjLWJmMmItM2NiMTQ0OWQ2MzQ1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTAtMjNUMTY6NTI6NTYuMDc5NzEyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfY3Jl
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTAtMjNUMTY6NTI6NTYuMjA0MjEz
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMC0yM1QxNjo1Mjo1Ni4zNjM4ODha
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        L2NjM2QxODY1LWRiM2EtNGJkNi1hNDViLTk3NWIwZGFjMTI2My8iLCJwYXJl
+        bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
+        IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3Ry
+        aWJ1dGlvbnMvcnBtL3JwbS9lMGJjYjgwNy05MGExLTRiOWEtYTYzMS1mY2Uw
+        YWMxZTg2OWMvIl0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsiL2Fw
+        aS92My9kaXN0cmlidXRpb25zLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:52:56 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/e0bcb807-90a1-4b9a-a631-fce0ac1e869c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0b71571331815/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:52:56 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+      Content-Length:
+      - '275'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9ycG0v
+        cnBtL2UwYmNiODA3LTkwYTEtNGI5YS1hNjMxLWZjZTBhYzFlODY5Yy8iLCJw
+        dWxwX2NyZWF0ZWQiOiIyMDE5LTEwLTIzVDE2OjUyOjU2LjM1NjIwMVoiLCJi
+        YXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVw
+        bGljYXRlX2xhYmVsIiwiYmFzZV91cmwiOiJwdWxwMy1kZXZlbC1ycG0uY2Fu
+        bm9sby5leGFtcGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jwb3JhdGlv
+        bi9kZXYvZmVkb3JhXzE3X2R1cGxpY2F0ZV9sYWJlbCIsImNvbnRlbnRfZ3Vh
+        cmQiOm51bGwsIm5hbWUiOiIyX2R1cGxpY2F0ZSIsInB1YmxpY2F0aW9uIjoi
+        L3B1bHAvYXBpL3YzL3B1YmxpY2F0aW9ucy9ycG0vcnBtLzkzY2IwOTAxLTZk
+        MTYtNDFmNi05ZDYxLTlhNmQ1MjljMGNhNS8ifQ==
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:52:56 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/04791f07-a5f2-4396-b410-c7c409899c3b/sync/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy8zMTFj
+        ZTcwZS0yNDAxLTQ0MjQtOWU5OS01MWYxY2M5ZWVkZDYvIiwibWlycm9yIjp0
+        cnVlfQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0b71571331815/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:52:57 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzQyMzU1OGMxLTAzMjgtNDMz
+        Ny05YWUwLTg0NTkxMDg0ODk2Yi8ifQ==
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:52:57 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/tasks/423558c1-0328-4337-9ae0-84591084896b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:52:58 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+      Content-Length:
+      - '578'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNDIzNTU4YzEtMDMy
+        OC00MzM3LTlhZTAtODQ1OTEwODQ4OTZiLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTAtMjNUMTY6NTI6NTcuMDQ4MjgzWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5zeW5jaHJvbml6aW5nLnN5
+        bmNocm9uaXplIiwic3RhcnRlZF9hdCI6IjIwMTktMTAtMjNUMTY6NTI6NTcu
+        MTM4Mzc2WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMC0yM1QxNjo1Mjo1Ny45
+        MDgyNzJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93
+        b3JrZXJzL2ViNzQxYzQ4LTg2Y2MtNGRjNC04MmY4LWM2MjcwMTEyMmNmMy8i
+        LCJwYXJlbnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19y
+        ZXBvcnRzIjpbeyJtZXNzYWdlIjoiUGFyc2UgTW9kdWxlbWQiLCJjb2RlIjoi
+        cGFyc2luZy5tb2R1bGVtZHMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFs
+        IjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlBh
+        cnNlZCBFcnJhdHVtIiwiY29kZSI6InBhcnNpbmcuZXJyYXRhIiwic3RhdGUi
+        OiJjb21wbGV0ZWQiLCJ0b3RhbCI6NCwiZG9uZSI6NCwic3VmZml4IjpudWxs
+        fSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBNZXRhZGF0YSBGaWxlcyIsImNv
+        ZGUiOiJkb3dubG9hZGluZy5tZXRhZGF0YSIsInN0YXRlIjoiY29tcGxldGVk
+        IiwidG90YWwiOm51bGwsImRvbmUiOjUsInN1ZmZpeCI6bnVsbH0seyJtZXNz
+        YWdlIjoiUGFyc2VkIFBhY2thZ2VzIiwiY29kZSI6InBhcnNpbmcucGFja2Fn
+        ZXMiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjozMiwiZG9uZSI6MzIs
+        InN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiUGFyc2UgTW9kdWxlbWQtZGVm
+        YXVsdHMiLCJjb2RlIjoicGFyc2luZy5tb2R1bGVtZGRlZmF1bHRzIiwic3Rh
+        dGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4
+        IjpudWxsfSx7Im1lc3NhZ2UiOiJEb3dubG9hZGluZyBBcnRpZmFjdHMiLCJj
+        b2RlIjoiZG93bmxvYWRpbmcuYXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0
+        ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MCwic3VmZml4IjpudWxsfSx7Im1l
+        c3NhZ2UiOiJBc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6ImFzc29jaWF0
+        aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpudWxs
+        LCJkb25lIjozNiwic3VmZml4IjpudWxsfV0sImNyZWF0ZWRfcmVzb3VyY2Vz
+        IjpbIi9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvMzExY2U3MGUtMjQwMS00
+        NDI0LTllOTktNTFmMWNjOWVlZGQ2L3ZlcnNpb25zLzIvIl0sInJlc2VydmVk
+        X3Jlc291cmNlc19yZWNvcmQiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmll
+        cy8zMTFjZTcwZS0yNDAxLTQ0MjQtOWU5OS01MWYxY2M5ZWVkZDYvIiwiL3B1
+        bHAvYXBpL3YzL3JlbW90ZXMvcnBtL3JwbS8wNDc5MWYwNy1hNWYyLTQzOTYt
+        YjQxMC1jN2M0MDk4OTljM2IvIl19
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:52:58 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/repositories/311ce70e-2401-4424-9e99-51f1cc9eedd6/versions/2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:52:58 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+      Content-Length:
+      - '267'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzMxMWNl
+        NzBlLTI0MDEtNDQyNC05ZTk5LTUxZjFjYzllZWRkNi92ZXJzaW9ucy8yLyIs
+        InB1bHBfY3JlYXRlZCI6IjIwMTktMTAtMjNUMTY6NTI6NTcuNDE2MzE1WiIs
+        Im51bWJlciI6MiwiYmFzZV92ZXJzaW9uIjpudWxsLCJjb250ZW50X3N1bW1h
+        cnkiOnsiYWRkZWQiOnsicnBtLmFkdmlzb3J5Ijp7ImNvdW50Ijo0LCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3JpZXMvP3JlcG9z
+        aXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        LzMxMWNlNzBlLTI0MDEtNDQyNC05ZTk5LTUxZjFjYzllZWRkNi92ZXJzaW9u
+        cy8yLyJ9LCJycG0ucGFja2FnZSI6eyJjb3VudCI6MzIsImhyZWYiOiIvcHVs
+        cC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvP3JlcG9zaXRvcnlfdmVy
+        c2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzMxMWNlNzBl
+        LTI0MDEtNDQyNC05ZTk5LTUxZjFjYzllZWRkNi92ZXJzaW9ucy8yLyJ9fSwi
+        cmVtb3ZlZCI6e30sInByZXNlbnQiOnsicnBtLmFkdmlzb3J5Ijp7ImNvdW50
+        Ijo0LCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvcnBtL2Fkdmlzb3Jp
+        ZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzMxMWNlNzBlLTI0MDEtNDQyNC05ZTk5LTUxZjFjYzllZWRkNi92ZXJz
+        aW9ucy8yLyJ9LCJycG0ucGFja2FnZSI6eyJjb3VudCI6MzIsImhyZWYiOiIv
+        cHVscC9hcGkvdjMvY29udGVudC9ycG0vcGFja2FnZXMvP3JlcG9zaXRvcnlf
+        dmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzMxMWNlNzBlLTI0
+        MDEtNDQyNC05ZTk5LTUxZjFjYzllZWRkNi92ZXJzaW9ucy8yLyJ9fX19
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:52:58 GMT
+- request:
+    method: post
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/publications/rpm/rpm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzLzMxMWNlNzBlLTI0MDEtNDQyNC05ZTk5LTUxZjFjYzllZWRkNi92ZXJz
+        aW9ucy8yLyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0b71571331815/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:52:58 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzViZDBkNWFlLTdmZmYtNDlh
+        NS04ZjdjLWU2N2YyZjQzN2UwMy8ifQ==
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:52:58 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/tasks/5bd0d5ae-7fff-49a5-8f7c-e67f2f437e03/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:52:58 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+      Content-Length:
+      - '359'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvNWJkMGQ1YWUtN2Zm
+        Zi00OWE1LThmN2MtZTY3ZjJmNDM3ZTAzLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTAtMjNUMTY6NTI6NTguMzk4Nzk5WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBfcnBtLmFwcC50YXNrcy5wdWJsaXNoaW5nLnB1Ymxp
+        c2giLCJzdGFydGVkX2F0IjoiMjAxOS0xMC0yM1QxNjo1Mjo1OC41MTQ1Njla
+        IiwiZmluaXNoZWRfYXQiOiIyMDE5LTEwLTIzVDE2OjUyOjU4LjcwMjIxOFoi
+        LCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAvYXBpL3YzL3dvcmtlcnMv
+        ZWI3NDFjNDgtODZjYy00ZGM0LTgyZjgtYzYyNzAxMTIyY2YzLyIsInBhcmVu
+        dCI6bnVsbCwic3Bhd25lZF90YXNrcyI6W10sInByb2dyZXNzX3JlcG9ydHMi
+        OltdLCJjcmVhdGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcHVibGlj
+        YXRpb25zL3JwbS9ycG0vNzYxNTI3NjYtOTZlMC00YTQ4LWE0NjYtZjBiYTA0
+        NDRjYWEyLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbIi9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvMzExY2U3MGUtMjQwMS00NDI0LTllOTkt
+        NTFmMWNjOWVlZGQ2LyJdfQ==
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:52:58 GMT
+- request:
+    method: patch
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/e0bcb807-90a1-4b9a-a631-fce0ac1e869c/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWJsaWNhdGlvbiI6Ii9wdWxwL2FwaS92My9wdWJsaWNhdGlvbnMvcnBt
+        L3JwbS83NjE1Mjc2Ni05NmUwLTRhNDgtYTQ2Ni1mMGJhMDQ0NGNhYTIvIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0b71571331815/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:52:59 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2Q5MGZlNDdlLThmYTUtNDBm
+        Ny1hZTU4LTM5Zjk4MWY0OGUwNS8ifQ==
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:52:59 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/tasks/d90fe47e-8fa5-40f7-ae58-39f981f48e05/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:52:59 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+      Content-Length:
+      - '305'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZDkwZmU0N2UtOGZh
+        NS00MGY3LWFlNTgtMzlmOTgxZjQ4ZTA1LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTAtMjNUMTY6NTI6NTkuMDA3MjMyWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfdXBk
+        YXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTAtMjNUMTY6NTI6NTkuMTIxOTIw
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMC0yM1QxNjo1Mjo1OS4xOTUwNzBa
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        L2ViNzQxYzQ4LTg2Y2MtNGRjNC04MmY4LWM2MjcwMTEyMmNmMy8iLCJwYXJl
+        bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
+        IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJj
+        ZXNfcmVjb3JkIjpbIi9hcGkvdjMvZGlzdHJpYnV0aW9ucy8iXX0=
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:52:59 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/remotes/rpm/rpm/04791f07-a5f2-4396-b410-c7c409899c3b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0b71571331815/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:52:59 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzL2RlMjY0MTA5LTI4MDYtNGE3
+        ZS05Yjk3LWY0OGVhOTllZjhmMC8ifQ==
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:52:59 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/tasks/de264109-2806-4a7e-9b97-f48ea99ef8f0/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:53:00 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+      Content-Length:
+      - '328'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvZGUyNjQxMDktMjgw
+        Ni00YTdlLTliOTctZjQ4ZWE5OWVmOGYwLyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTAtMjNUMTY6NTI6NTkuNzMyNTUxWiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5iYXNlLmdlbmVyYWxfZGVs
+        ZXRlIiwic3RhcnRlZF9hdCI6IjIwMTktMTAtMjNUMTY6NTI6NTkuODM3ODA3
+        WiIsImZpbmlzaGVkX2F0IjoiMjAxOS0xMC0yM1QxNjo1Mjo1OS44Njc3Mzla
+        IiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92My93b3JrZXJz
+        L2ViNzQxYzQ4LTg2Y2MtNGRjNC04MmY4LWM2MjcwMTEyMmNmMy8iLCJwYXJl
+        bnQiOm51bGwsInNwYXduZWRfdGFza3MiOltdLCJwcm9ncmVzc19yZXBvcnRz
+        IjpbXSwiY3JlYXRlZF9yZXNvdXJjZXMiOltdLCJyZXNlcnZlZF9yZXNvdXJj
+        ZXNfcmVjb3JkIjpbIi9wdWxwL2FwaS92My9yZW1vdGVzL3JwbS9ycG0vMDQ3
+        OTFmMDctYTVmMi00Mzk2LWI0MTAtYzdjNDA5ODk5YzNiLyJdfQ==
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:53:00 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/?base_path=ACME_Corporation/dev/fedora_17_duplicate_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0b71571331815/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:53:00 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+      Content-Length:
+      - '304'
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
+        L3JwbS9ycG0vZTBiY2I4MDctOTBhMS00YjlhLWE2MzEtZmNlMGFjMWU4Njlj
+        LyIsInB1bHBfY3JlYXRlZCI6IjIwMTktMTAtMjNUMTY6NTI6NTYuMzU2MjAx
+        WiIsImJhc2VfcGF0aCI6IkFDTUVfQ29ycG9yYXRpb24vZGV2L2ZlZG9yYV8x
+        N19kdXBsaWNhdGVfbGFiZWwiLCJiYXNlX3VybCI6InB1bHAzLWRldmVsLXJw
+        bS5jYW5ub2xvLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01FX0NvcnBv
+        cmF0aW9uL2Rldi9mZWRvcmFfMTdfZHVwbGljYXRlX2xhYmVsIiwiY29udGVu
+        dF9ndWFyZCI6bnVsbCwibmFtZSI6IjJfZHVwbGljYXRlIiwicHVibGljYXRp
+        b24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL3JwbS9ycG0vNzYxNTI3
+        NjYtOTZlMC00YTQ4LWE0NjYtZjBiYTA0NDRjYWEyLyJ9XX0=
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:53:00 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/distributions/rpm/rpm/e0bcb807-90a1-4b9a-a631-fce0ac1e869c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0b71571331815/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:53:00 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzIyZmRhMDMxLWU0MTktNDEx
+        NS04ODE4LWYzMmRkMjY5MDRhNS8ifQ==
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:53:00 GMT
+- request:
+    method: delete
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/repositories/311ce70e-2401-4424-9e99-51f1cc9eedd6/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:53:00 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '67'
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzlkZjg5NGMzLTM0NjctNGY3
+        ZC1hMjNmLTkxN2M0ZmYxYzM1OC8ifQ==
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:53:00 GMT
+- request:
+    method: get
+    uri: https://pulp3-devel-rpm.cannolo.example.com/pulp/api/v3/tasks/9df894c3-3467-4f7d-a23f-917c4ff1c358/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.0.0rc8.dev01571235538/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic YWRtaW46cGFzc3dvcmQ=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 23 Oct 2019 16:53:00 GMT
+      Server:
+      - gunicorn/19.9.0
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie,Accept-Encoding
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 pulp3-devel-rpm.cannolo.example.com
+      Content-Length:
+      - '325'
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvOWRmODk0YzMtMzQ2
+        Ny00ZjdkLWEyM2YtOTE3YzRmZjFjMzU4LyIsInB1bHBfY3JlYXRlZCI6IjIw
+        MTktMTAtMjNUMTY6NTM6MDAuNDUwMzE0WiIsInN0YXRlIjoiY29tcGxldGVk
+        IiwibmFtZSI6InB1bHBjb3JlLmFwcC50YXNrcy5yZXBvc2l0b3J5LmRlbGV0
+        ZSIsInN0YXJ0ZWRfYXQiOiIyMDE5LTEwLTIzVDE2OjUzOjAwLjU0NzA2MVoi
+        LCJmaW5pc2hlZF9hdCI6IjIwMTktMTAtMjNUMTY6NTM6MDAuNjA4NzI4WiIs
+        ImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVscC9hcGkvdjMvd29ya2Vycy9j
+        YzNkMTg2NS1kYjNhLTRiZDYtYTQ1Yi05NzViMGRhYzEyNjMvIiwicGFyZW50
+        IjpudWxsLCJzcGF3bmVkX3Rhc2tzIjpbXSwicHJvZ3Jlc3NfcmVwb3J0cyI6
+        W10sImNyZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2Vz
+        X3JlY29yZCI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzLzMxMWNlNzBl
+        LTI0MDEtNDQyNC05ZTk5LTUxZjFjYzllZWRkNi8iXX0=
+    http_version: 
+  recorded_at: Wed, 23 Oct 2019 16:53:00 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
This PR enables yum content indexing with Pulp 3.  Limitations:
1) Kickstart repos might not work, but I am testing this currently.
2) Cannot index package groups, SRPMs, or yum metadata files.

TODO:
[ ] Write more tests
[ ] Test Kickstart repo
[ ] Get `eval` out of my code thanks to https://pulp.plan.io/issues/5650