### PR TITLE
Fixes #28047 - View pulp 2/3 content support on smart proxy

### DIFF
--- a/app/views/katello/api/v2/smart_proxies/download_policy.json.rabl
+++ b/app/views/katello/api/v2/smart_proxies/download_policy.json.rabl
@@ -1,1 +1,0 @@
-attributes :download_policy

--- a/app/views/katello/api/v2/smart_proxies/pulp_info.json.rabl
+++ b/app/views/katello/api/v2/smart_proxies/pulp_info.json.rabl
@@ -1,0 +1,2 @@
+attributes :download_policy
+attributes :supported_pulp_types

--- a/app/views/smart_proxies/plugins/_pulp3.html.erb
+++ b/app/views/smart_proxies/plugins/_pulp3.html.erb
@@ -1,0 +1,19 @@
+<div class="row">
+  <h3><%= _('Pulp3') %></h3>
+</div>
+<%= show_feature_version('pulp3') %>
+<div class="row">
+  <div class="col-md-4">
+    <strong><%= _('Supported Content Types') %></strong>
+  </div>
+  <div class="col-md-8">
+    <ul style="list-style-type: none; padding: 0">
+    <% @smart_proxy.supported_pulp_types[:pulp3][:supported_types].each do |content_type| %>
+      <li><%= content_type %></li>
+    <% end %>
+    <% @smart_proxy.supported_pulp_types[:pulp3][:overriden_to_pulp2].each do |content_type| %>
+      <li><%= content_type + " (supported, but overridden to use Pulp 2)" %></li>
+    <% end %>
+    </ul>
+  </div>
+</div>

--- a/app/views/smart_proxies/pulp_status.html.erb
+++ b/app/views/smart_proxies/pulp_status.html.erb
@@ -22,3 +22,13 @@
 <div class="col-md-8">
   <%= @pulp_status['known_workers'].size %><br />
 </div>
+<div class="col-md-4">
+  <strong><%= _('Supported Content Types') %></strong>
+</div>
+<div class="col-md-8">
+  <ul style="list-style-type: none; padding: 0">
+  <% @smart_proxy.supported_pulp_types[:pulp2][:supported_types].each do |content_type| %>
+    <li><%= content_type %></li>
+  <% end %>
+  </ul>
+</div>

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -269,7 +269,7 @@ Foreman::Plugin.register :katello do
   register_ping_extension { Katello::Ping.ping }
   register_status_extension { Katello::Ping.status }
 
-  extend_rabl_template 'api/v2/smart_proxies/main', 'katello/api/v2/smart_proxies/download_policy'
+  extend_rabl_template 'api/v2/smart_proxies/main', 'katello/api/v2/smart_proxies/pulp_info'
   extend_rabl_template 'api/v2/hosts/show', 'katello/api/v2/hosts/host_collections'
 
   extend_page "smart_proxies/show" do |cx|

--- a/test/models/concerns/smart_proxy_extensions_test.rb
+++ b/test/models/concerns/smart_proxy_extensions_test.rb
@@ -91,5 +91,25 @@ module Katello
     ensure
       SETTINGS[:katello][:use_pulp_2_for_content_type][:file] = nil
     end
+
+    def test_pulp_supported_types_map
+      expected_types_map = @master.supported_pulp_types
+
+      assert_includes expected_types_map[:pulp3][:supported_types], "yum"
+      refute_includes expected_types_map[:pulp3][:overriden_to_pulp2], "file"
+      assert_includes expected_types_map[:pulp2][:supported_types], "puppet"
+    end
+
+    def test_pulp_supported_types_map_with_overrides
+      SETTINGS[:katello][:use_pulp_2_for_content_type] = {}
+      SETTINGS[:katello][:use_pulp_2_for_content_type][:file] = true
+
+      expected_types_map = @master.supported_pulp_types
+      assert_includes expected_types_map[:pulp3][:supported_types], "yum"
+      assert_includes expected_types_map[:pulp3][:overriden_to_pulp2], "file"
+      assert_includes expected_types_map[:pulp2][:supported_types], "puppet"
+    ensure
+      SETTINGS[:katello][:use_pulp_2_for_content_type][:file] = nil
+    end
   end
 end


### PR DESCRIPTION
Adds the ability to see the pulp 2 and 3 supported types on the Services page on a smart proxy. Also
shows if a pulp3 content type is overridden to pulp2