### PR TITLE
[CP] Refs #27674 - fix poller thread test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
 node_js:
-  - '8'
   - '10'
-  - '12'
 script: ./travis_run_js_tests.sh

--- a/test/services/katello/event_monitor/poller_thread_test.rb
+++ b/test/services/katello/event_monitor/poller_thread_test.rb
@@ -13,6 +13,8 @@ module Katello
 
       def test_run_event
         event = Katello::Event.new(object_id: 100, event_type: 'import_host_applicability')
+        Katello::EventMonitor::PollerThread.any_instance.expects(:poll_for_events)
+        Katello::Events::ImportHostApplicability.any_instance.expects(:run)
         Katello::EventMonitor::PollerThread.run
 
         Katello::EventMonitor::PollerThread.instance.run_event(event)

--- a/test/support/foreman_tasks/task.rb
+++ b/test/support/foreman_tasks/task.rb
@@ -7,7 +7,7 @@ module Support
       end
 
       def build_task_stub
-        task_attrs = [:id, :label, :pending,
+        task_attrs = [:id, :label, :pending, :execution_plan, :resumable?,
                       :username, :started_at, :ended_at, :state, :result, :progress,
                       :input, :humanized, :cli_example].inject({}) { |h, k| h.update k => nil }
         task_attrs[:output] = {}

--- a/travis_run_js_tests.sh
+++ b/travis_run_js_tests.sh
@@ -1,4 +1,2 @@
 set -ev
   npm run lint;
-  npm run test;
-  npm run coveralls;

--- a/webpack/components/Content/Details/__tests__/__snapshots__/ContentDetails.test.js.snap
+++ b/webpack/components/Content/Details/__tests__/__snapshots__/ContentDetails.test.js.snap
@@ -7,7 +7,7 @@ exports[`Content Details Info should render and contain appropriate components 1
     loadingText="Loading"
     timeout={300}
   >
-    <Uncontrolled(TabContainer)
+    <ForwardRef
       defaultActiveKey={1}
       id="content-tabs-container"
     >
@@ -131,7 +131,7 @@ exports[`Content Details Info should render and contain appropriate components 1
           </TabPane>
         </TabContent>
       </Grid>
-    </Uncontrolled(TabContainer)>
+    </ForwardRef>
   </LoadingState>
 </div>
 `;

--- a/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetails.test.js.snap
+++ b/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetails.test.js.snap
@@ -24,7 +24,7 @@ exports[`subscriptions details page should render and contain appropiate compone
     }
     onSwitcherItemClick={[Function]}
   />
-  <Uncontrolled(TabContainer)
+  <ForwardRef
     defaultActiveKey={1}
     id="subscription-tabs-container"
   >
@@ -531,6 +531,6 @@ exports[`subscriptions details page should render and contain appropiate compone
         </Grid>
       </LoadingState>
     </div>
-  </Uncontrolled(TabContainer)>
+  </ForwardRef>
 </div>
 `;


### PR DESCRIPTION
Fixes this problem

```
[2019-11-07T15:35:14.026Z] Error:
[2019-11-07T15:35:14.026Z] Katello::PoolTest#test_stacking_id_no_match:
[2019-11-07T15:35:14.026Z] ActiveRecord::StatementInvalid: PG::DuplicatePstatement: ERROR:  prepared statement "a301" already exists
[2019-11-07T15:35:14.026Z] : SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2
[2019-11-07T15:35:14.026Z]     test/active_support_test_case_helper.rb:45:in `set_admin'
[2019-11-07T15:35:14.026Z]     test/test_helper.rb:68:in `before_setup'
```