### PR TITLE
Fixes #28066 - fix key error in Subscriptions Page

### DIFF
--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTableHelpers.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/SubscriptionsTableHelpers.js
@@ -37,7 +37,7 @@ const buildTableRow = (subscription, availableQuantities, updatedQuantity) => {
 const buildTableCollapseRow = (subscriptionGroup) => {
   const first = subscriptionGroup.subscriptions[0];
   const heading = {
-    id: 0,
+    id: first.product_id,
     collapsible: true,
     contract_number: 'NA',
     start_date: 'NA',

--- a/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/SubscriptionsTable.fixtures.js
+++ b/webpack/scenes/Subscriptions/components/SubscriptionsTable/__tests__/SubscriptionsTable.fixtures.js
@@ -64,7 +64,7 @@ export const genericRow = Immutable({
   contract_number: 'NA',
   end_date: 'NA',
   hypervisor: undefined,
-  id: 0,
+  id: 'RH00001',
   name: 'Alpha',
   product_id: 'RH00001',
   start_date: 'NA',


### PR DESCRIPTION
**To test this PR -**
- Import a manifest with two or more subscriptions having multiple entitlements.
- Clicking on an expandable row should not result in a key error in the console.
