### PR TITLE
Fixes #28223 - Don't reimport deb if unavailable

### DIFF
--- a/lib/katello/tasks/reimport.rake
+++ b/lib/katello/tasks/reimport.rake
@@ -24,7 +24,6 @@ namespace :katello do
               Katello::Srpm,
               Katello::ModuleStream,
               Katello::YumMetadataFile,
-              Katello::Deb,
               Katello::FileUnit,
               Katello::Subscription,
               Katello::Pool,
@@ -35,6 +34,7 @@ namespace :katello do
               Katello::Content]
 
     models << Katello::OstreeBranch if Katello::RepositoryTypeManager.find(Katello::Repository::OSTREE_TYPE).present?
+    models << Katello::Deb if Katello::RepositoryTypeManager.find(Katello::Repository::DEB_TYPE).present?
 
     models.each do |model|
       print "Importing #{model.name}\n"


### PR DESCRIPTION
When Deb content type is not enabled, we shouldn't run reimport rake task for it.